### PR TITLE
Fix bpf2c output format

### DIFF
--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -118,19 +118,21 @@ func(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-         (r1, r2, r3, r4, r5);
-#line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=2 imm=0
+#line 28 "sample/undocked/atomic_instruction_fetch_add.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=2 imm=0
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r1 src=r0 offset=0 imm=1
+#line 29 "sample/undocked/atomic_instruction_fetch_add.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r1 src=r0 offset=0 imm=1
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_ATOMIC64_ADD pc=9 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -92,19 +92,21 @@ func(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-         (r1, r2, r3, r4, r5);
-#line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=2 imm=0
+#line 28 "sample/undocked/atomic_instruction_fetch_add.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=2 imm=0
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r1 src=r0 offset=0 imm=1
+#line 29 "sample/undocked/atomic_instruction_fetch_add.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r1 src=r0 offset=0 imm=1
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_ATOMIC64_ADD pc=9 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -253,19 +253,21 @@ func(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-         (r1, r2, r3, r4, r5);
-#line 28 "sample/undocked/atomic_instruction_fetch_add.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 28 "sample/undocked/atomic_instruction_fetch_add.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=2 imm=0
+#line 28 "sample/undocked/atomic_instruction_fetch_add.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=2 imm=0
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r1 src=r0 offset=0 imm=1
+#line 29 "sample/undocked/atomic_instruction_fetch_add.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r1 src=r0 offset=0 imm=1
 #line 29 "sample/undocked/atomic_instruction_fetch_add.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_ATOMIC64_ADD pc=9 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -118,14 +118,14 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 29 "sample/undocked/bad_map_name.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/undocked/bad_map_name.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/undocked/bad_map_name.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/undocked/bad_map_name.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 29 "sample/undocked/bad_map_name.c"
+    }
+    // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
 #line 29 "sample/undocked/bad_map_name.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
@@ -133,10 +133,12 @@ lookup(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
 #line 30 "sample/undocked/bad_map_name.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 30 "sample/undocked/bad_map_name.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 30 "sample/undocked/bad_map_name.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 30 "sample/undocked/bad_map_name.c"
     r0 = IMMEDIATE(0);
 label_1:

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -92,14 +92,14 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 29 "sample/undocked/bad_map_name.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/undocked/bad_map_name.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/undocked/bad_map_name.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/undocked/bad_map_name.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 29 "sample/undocked/bad_map_name.c"
+    }
+    // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
 #line 29 "sample/undocked/bad_map_name.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
@@ -107,10 +107,12 @@ lookup(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
 #line 30 "sample/undocked/bad_map_name.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 30 "sample/undocked/bad_map_name.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 30 "sample/undocked/bad_map_name.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 30 "sample/undocked/bad_map_name.c"
     r0 = IMMEDIATE(0);
 label_1:

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -253,14 +253,14 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 29 "sample/undocked/bad_map_name.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/undocked/bad_map_name.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/undocked/bad_map_name.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/undocked/bad_map_name.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 29 "sample/undocked/bad_map_name.c"
+    }
+    // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
 #line 29 "sample/undocked/bad_map_name.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
@@ -268,10 +268,12 @@ lookup(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
 #line 30 "sample/undocked/bad_map_name.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 30 "sample/undocked/bad_map_name.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 30 "sample/undocked/bad_map_name.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 30 "sample/undocked/bad_map_name.c"
     r0 = IMMEDIATE(0);
 label_1:

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -154,14 +154,14 @@ BindMonitor(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=19
 #line 61 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
+#line 61 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
 #line 61 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=5 dst=r10 src=r8 offset=-72 imm=0
@@ -175,14 +175,14 @@ BindMonitor(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=20
 #line 64 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
+#line 64 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
 #line 64 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r1 src=r6 offset=0 imm=0
@@ -190,14 +190,14 @@ BindMonitor(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=21
 #line 65 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[2].address
+    r0 = BindMonitor_helpers[2].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[2].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
+#line 65 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
 #line 65 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r2 src=r10 offset=0 imm=0
@@ -220,14 +220,14 @@ BindMonitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=2
 #line 67 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[3].address
+    r0 = BindMonitor_helpers[3].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
+#line 67 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
 #line 67 "sample/bindmonitor.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=22 dst=r2 src=r0 offset=0 imm=-84
@@ -238,30 +238,34 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
 #line 119 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 119 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 119 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 119 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
+#line 119 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
 #line 119 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=77 imm=0
 #line 120 "sample/bindmonitor.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 120 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
 #line 120 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=75 imm=0
 #line 120 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 120 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
+#line 120 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 73 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-8 imm=0
@@ -308,46 +312,54 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
 #line 78 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=47 dst=r9 src=r0 offset=0 imm=0
+#line 78 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=47 dst=r9 src=r0 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r9 = r0;
     // EBPF_OP_JNE_IMM pc=48 dst=r9 src=r0 offset=28 imm=0
 #line 79 "sample/bindmonitor.c"
-    if (r9 != IMMEDIATE(0))
+    if (r9 != IMMEDIATE(0)) {
 #line 79 "sample/bindmonitor.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
+#line 79 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=50 dst=r1 src=r0 offset=53 imm=0
 #line 83 "sample/bindmonitor.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 83 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
+#line 83 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=51 imm=0
 #line 87 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
+#line 87 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
 #line 87 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=54 dst=r1 src=r0 offset=49 imm=0
 #line 87 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
+#line 87 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
 #line 87 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=56 dst=r8 src=r0 offset=0 imm=-8
@@ -370,14 +382,14 @@ BindMonitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=2
 #line 91 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[3].address
+    r0 = BindMonitor_helpers[3].address(r1, r2, r3, r4, r5);
 #line 91 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0)) {
 #line 91 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_LDDW pc=64 dst=r1 src=r0 offset=0 imm=0
+#line 91 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDDW pc=64 dst=r1 src=r0 offset=0 imm=0
 #line 92 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=66 dst=r2 src=r8 offset=0 imm=0
@@ -385,22 +397,24 @@ BindMonitor(void* context)
     r2 = r8;
     // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=1
 #line 92 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 92 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 92 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=68 dst=r9 src=r0 offset=0 imm=0
+#line 92 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=68 dst=r9 src=r0 offset=0 imm=0
 #line 92 "sample/bindmonitor.c"
     r9 = r0;
     // EBPF_OP_JEQ_IMM pc=69 dst=r9 src=r0 offset=34 imm=0
 #line 93 "sample/bindmonitor.c"
-    if (r9 == IMMEDIATE(0))
+    if (r9 == IMMEDIATE(0)) {
 #line 93 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=70 dst=r3 src=r6 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=70 dst=r3 src=r6 offset=0 imm=0
 #line 97 "sample/bindmonitor.c"
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=71 dst=r4 src=r6 offset=8 imm=0
@@ -420,28 +434,32 @@ BindMonitor(void* context)
     r2 = IMMEDIATE(64);
     // EBPF_OP_CALL pc=76 dst=r0 src=r0 offset=0 imm=22
 #line 97 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[5].address
+    r0 = BindMonitor_helpers[5].address(r1, r2, r3, r4, r5);
 #line 97 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[5].tail_call) && (r0 == 0)) {
 #line 97 "sample/bindmonitor.c"
         return 0;
+#line 97 "sample/bindmonitor.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=77 dst=r1 src=r6 offset=44 imm=0
 #line 130 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=78 dst=r1 src=r0 offset=3 imm=0
 #line 130 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 130 "sample/bindmonitor.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=79 dst=r1 src=r0 offset=9 imm=2
 #line 130 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=79 dst=r1 src=r0 offset=9 imm=2
+#line 130 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 130 "sample/bindmonitor.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=80 dst=r1 src=r9 offset=0 imm=0
+#line 130 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=80 dst=r1 src=r9 offset=0 imm=0
 #line 147 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r9 + OFFSET(0));
     // EBPF_OP_JA pc=81 dst=r0 src=r0 offset=11 imm=0
@@ -459,10 +477,12 @@ label_2:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=85 dst=r1 src=r2 offset=19 imm=0
 #line 132 "sample/bindmonitor.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 132 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=1
+#line 132 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=1
 #line 136 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=87 dst=r9 src=r1 offset=0 imm=0
@@ -477,10 +497,12 @@ label_3:
     r1 = *(uint32_t*)(uintptr_t)(r9 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=90 dst=r1 src=r0 offset=6 imm=0
 #line 139 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 139 "sample/bindmonitor.c"
         goto label_5;
-        // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=-1
+#line 139 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=-1
 #line 140 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=92 dst=r9 src=r1 offset=0 imm=0
@@ -498,9 +520,11 @@ label_4:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=96 dst=r1 src=r0 offset=8 imm=0
 #line 147 "sample/bindmonitor.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 147 "sample/bindmonitor.c"
         goto label_7;
+#line 147 "sample/bindmonitor.c"
+    }
 label_5:
     // EBPF_OP_LDXDW pc=97 dst=r1 src=r6 offset=16 imm=0
 #line 148 "sample/bindmonitor.c"
@@ -519,13 +543,13 @@ label_5:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=3
 #line 149 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[6].address
+    r0 = BindMonitor_helpers[6].address(r1, r2, r3, r4, r5);
 #line 149 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[6].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[6].tail_call) && (r0 == 0)) {
 #line 149 "sample/bindmonitor.c"
         return 0;
+#line 149 "sample/bindmonitor.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=104 dst=r8 src=r0 offset=0 imm=0
 #line 149 "sample/bindmonitor.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -153,14 +153,14 @@ BindMonitor_Caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=13
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Caller_helpers[0].address
+    r0 = BindMonitor_Caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 33 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=22 dst=r2 src=r0 offset=0 imm=0
@@ -171,14 +171,14 @@ BindMonitor_Caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=5
 #line 34 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Caller_helpers[1].address
+    r0 = BindMonitor_Caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 34 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 34 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 34 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
+#line 34 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
@@ -270,14 +270,14 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -288,19 +288,21 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -341,13 +343,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 53 "sample/bindmonitor_mt_tailcall.c"
@@ -441,14 +443,14 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -459,19 +461,21 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -512,13 +516,13 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 54 "sample/bindmonitor_mt_tailcall.c"
@@ -612,14 +616,14 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[0].address
+    r0 = BindMonitor_Callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -630,19 +634,21 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[1].address
+    r0 = BindMonitor_Callee10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -683,13 +689,13 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[0].address
+    r0 = BindMonitor_Callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 63 "sample/bindmonitor_mt_tailcall.c"
@@ -783,14 +789,14 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[0].address
+    r0 = BindMonitor_Callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -801,19 +807,21 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[1].address
+    r0 = BindMonitor_Callee11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -854,13 +862,13 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[0].address
+    r0 = BindMonitor_Callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 64 "sample/bindmonitor_mt_tailcall.c"
@@ -954,14 +962,14 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[0].address
+    r0 = BindMonitor_Callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -972,19 +980,21 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[1].address
+    r0 = BindMonitor_Callee12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1025,13 +1035,13 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[0].address
+    r0 = BindMonitor_Callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 65 "sample/bindmonitor_mt_tailcall.c"
@@ -1125,14 +1135,14 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[0].address
+    r0 = BindMonitor_Callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1143,19 +1153,21 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[1].address
+    r0 = BindMonitor_Callee13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1196,13 +1208,13 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[0].address
+    r0 = BindMonitor_Callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 66 "sample/bindmonitor_mt_tailcall.c"
@@ -1296,14 +1308,14 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[0].address
+    r0 = BindMonitor_Callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1314,19 +1326,21 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[1].address
+    r0 = BindMonitor_Callee14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1367,13 +1381,13 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[0].address
+    r0 = BindMonitor_Callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 67 "sample/bindmonitor_mt_tailcall.c"
@@ -1467,14 +1481,14 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[0].address
+    r0 = BindMonitor_Callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1485,19 +1499,21 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[1].address
+    r0 = BindMonitor_Callee15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1538,13 +1554,13 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[0].address
+    r0 = BindMonitor_Callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 68 "sample/bindmonitor_mt_tailcall.c"
@@ -1638,14 +1654,14 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[0].address
+    r0 = BindMonitor_Callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1656,19 +1672,21 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[1].address
+    r0 = BindMonitor_Callee16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1709,13 +1727,13 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[0].address
+    r0 = BindMonitor_Callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 69 "sample/bindmonitor_mt_tailcall.c"
@@ -1809,14 +1827,14 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[0].address
+    r0 = BindMonitor_Callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1827,19 +1845,21 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[1].address
+    r0 = BindMonitor_Callee17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1880,13 +1900,13 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[0].address
+    r0 = BindMonitor_Callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/bindmonitor_mt_tailcall.c"
@@ -1980,14 +2000,14 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[0].address
+    r0 = BindMonitor_Callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1998,19 +2018,21 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[1].address
+    r0 = BindMonitor_Callee18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2051,13 +2073,13 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[0].address
+    r0 = BindMonitor_Callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 71 "sample/bindmonitor_mt_tailcall.c"
@@ -2151,14 +2173,14 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[0].address
+    r0 = BindMonitor_Callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2169,19 +2191,21 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[1].address
+    r0 = BindMonitor_Callee19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2222,13 +2246,13 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[0].address
+    r0 = BindMonitor_Callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 72 "sample/bindmonitor_mt_tailcall.c"
@@ -2322,14 +2346,14 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[0].address
+    r0 = BindMonitor_Callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2340,19 +2364,21 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[1].address
+    r0 = BindMonitor_Callee2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2393,13 +2419,13 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[0].address
+    r0 = BindMonitor_Callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 55 "sample/bindmonitor_mt_tailcall.c"
@@ -2493,14 +2519,14 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[0].address
+    r0 = BindMonitor_Callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2511,19 +2537,21 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[1].address
+    r0 = BindMonitor_Callee20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2564,13 +2592,13 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[0].address
+    r0 = BindMonitor_Callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 73 "sample/bindmonitor_mt_tailcall.c"
@@ -2664,14 +2692,14 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[0].address
+    r0 = BindMonitor_Callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2682,19 +2710,21 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[1].address
+    r0 = BindMonitor_Callee21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2735,13 +2765,13 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[0].address
+    r0 = BindMonitor_Callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 74 "sample/bindmonitor_mt_tailcall.c"
@@ -2835,14 +2865,14 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[0].address
+    r0 = BindMonitor_Callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2853,19 +2883,21 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[1].address
+    r0 = BindMonitor_Callee22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2906,13 +2938,13 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[0].address
+    r0 = BindMonitor_Callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 75 "sample/bindmonitor_mt_tailcall.c"
@@ -3006,14 +3038,14 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[0].address
+    r0 = BindMonitor_Callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3024,19 +3056,21 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[1].address
+    r0 = BindMonitor_Callee23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3077,13 +3111,13 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[0].address
+    r0 = BindMonitor_Callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/bindmonitor_mt_tailcall.c"
@@ -3177,14 +3211,14 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[0].address
+    r0 = BindMonitor_Callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3195,19 +3229,21 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[1].address
+    r0 = BindMonitor_Callee24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3248,13 +3284,13 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[0].address
+    r0 = BindMonitor_Callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 77 "sample/bindmonitor_mt_tailcall.c"
@@ -3348,14 +3384,14 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[0].address
+    r0 = BindMonitor_Callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3366,19 +3402,21 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[1].address
+    r0 = BindMonitor_Callee25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3419,13 +3457,13 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[0].address
+    r0 = BindMonitor_Callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 78 "sample/bindmonitor_mt_tailcall.c"
@@ -3519,14 +3557,14 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[0].address
+    r0 = BindMonitor_Callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3537,19 +3575,21 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[1].address
+    r0 = BindMonitor_Callee26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3590,13 +3630,13 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[0].address
+    r0 = BindMonitor_Callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 79 "sample/bindmonitor_mt_tailcall.c"
@@ -3690,14 +3730,14 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[0].address
+    r0 = BindMonitor_Callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3708,19 +3748,21 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[1].address
+    r0 = BindMonitor_Callee27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3761,13 +3803,13 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[0].address
+    r0 = BindMonitor_Callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/bindmonitor_mt_tailcall.c"
@@ -3861,14 +3903,14 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[0].address
+    r0 = BindMonitor_Callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3879,19 +3921,21 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[1].address
+    r0 = BindMonitor_Callee28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3932,13 +3976,13 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[0].address
+    r0 = BindMonitor_Callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 81 "sample/bindmonitor_mt_tailcall.c"
@@ -4032,14 +4076,14 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[0].address
+    r0 = BindMonitor_Callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4050,19 +4094,21 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[1].address
+    r0 = BindMonitor_Callee29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4103,13 +4149,13 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[0].address
+    r0 = BindMonitor_Callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 82 "sample/bindmonitor_mt_tailcall.c"
@@ -4203,14 +4249,14 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[0].address
+    r0 = BindMonitor_Callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4221,19 +4267,21 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[1].address
+    r0 = BindMonitor_Callee3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4274,13 +4322,13 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[0].address
+    r0 = BindMonitor_Callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/bindmonitor_mt_tailcall.c"
@@ -4374,14 +4422,14 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
+    r0 = BindMonitor_Callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 83 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4392,19 +4440,21 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[1].address
+    r0 = BindMonitor_Callee30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 83 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4445,13 +4495,13 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
+    r0 = BindMonitor_Callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 83 "sample/bindmonitor_mt_tailcall.c"
@@ -4545,14 +4595,14 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[0].address
+    r0 = BindMonitor_Callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 84 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4563,19 +4613,21 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[1].address
+    r0 = BindMonitor_Callee31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[1].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 84 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4616,13 +4668,13 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[0].address
+    r0 = BindMonitor_Callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 84 "sample/bindmonitor_mt_tailcall.c"
@@ -4752,14 +4804,14 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[0].address
+    r0 = BindMonitor_Callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4770,19 +4822,21 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[1].address
+    r0 = BindMonitor_Callee4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4823,13 +4877,13 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[0].address
+    r0 = BindMonitor_Callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/bindmonitor_mt_tailcall.c"
@@ -4923,14 +4977,14 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[0].address
+    r0 = BindMonitor_Callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4941,19 +4995,21 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[1].address
+    r0 = BindMonitor_Callee5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4994,13 +5050,13 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[0].address
+    r0 = BindMonitor_Callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/bindmonitor_mt_tailcall.c"
@@ -5094,14 +5150,14 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[0].address
+    r0 = BindMonitor_Callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5112,19 +5168,21 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[1].address
+    r0 = BindMonitor_Callee6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5165,13 +5223,13 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[0].address
+    r0 = BindMonitor_Callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 59 "sample/bindmonitor_mt_tailcall.c"
@@ -5265,14 +5323,14 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[0].address
+    r0 = BindMonitor_Callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5283,19 +5341,21 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[1].address
+    r0 = BindMonitor_Callee7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5336,13 +5396,13 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[0].address
+    r0 = BindMonitor_Callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/bindmonitor_mt_tailcall.c"
@@ -5436,14 +5496,14 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[0].address
+    r0 = BindMonitor_Callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5454,19 +5514,21 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[1].address
+    r0 = BindMonitor_Callee8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5507,13 +5569,13 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[0].address
+    r0 = BindMonitor_Callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 61 "sample/bindmonitor_mt_tailcall.c"
@@ -5612,14 +5674,14 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=13
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[0].address
+    r0 = BindMonitor_Callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
 #line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=16 dst=r2 src=r0 offset=0 imm=0
@@ -5630,19 +5692,21 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=5
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[1].address
+    r0 = BindMonitor_Callee9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
 #line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(1680154744);
     // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-8 imm=0
@@ -5680,13 +5744,13 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[0].address
+    r0 = BindMonitor_Callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 62 "sample/bindmonitor_mt_tailcall.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -127,14 +127,14 @@ BindMonitor_Caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=13
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Caller_helpers[0].address
+    r0 = BindMonitor_Caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 33 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=22 dst=r2 src=r0 offset=0 imm=0
@@ -145,14 +145,14 @@ BindMonitor_Caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=5
 #line 34 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Caller_helpers[1].address
+    r0 = BindMonitor_Caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 34 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 34 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 34 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
+#line 34 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
@@ -244,14 +244,14 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -262,19 +262,21 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -315,13 +317,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 53 "sample/bindmonitor_mt_tailcall.c"
@@ -415,14 +417,14 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -433,19 +435,21 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -486,13 +490,13 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 54 "sample/bindmonitor_mt_tailcall.c"
@@ -586,14 +590,14 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[0].address
+    r0 = BindMonitor_Callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -604,19 +608,21 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[1].address
+    r0 = BindMonitor_Callee10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -657,13 +663,13 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[0].address
+    r0 = BindMonitor_Callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 63 "sample/bindmonitor_mt_tailcall.c"
@@ -757,14 +763,14 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[0].address
+    r0 = BindMonitor_Callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -775,19 +781,21 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[1].address
+    r0 = BindMonitor_Callee11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -828,13 +836,13 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[0].address
+    r0 = BindMonitor_Callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 64 "sample/bindmonitor_mt_tailcall.c"
@@ -928,14 +936,14 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[0].address
+    r0 = BindMonitor_Callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -946,19 +954,21 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[1].address
+    r0 = BindMonitor_Callee12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -999,13 +1009,13 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[0].address
+    r0 = BindMonitor_Callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 65 "sample/bindmonitor_mt_tailcall.c"
@@ -1099,14 +1109,14 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[0].address
+    r0 = BindMonitor_Callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1117,19 +1127,21 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[1].address
+    r0 = BindMonitor_Callee13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1170,13 +1182,13 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[0].address
+    r0 = BindMonitor_Callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 66 "sample/bindmonitor_mt_tailcall.c"
@@ -1270,14 +1282,14 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[0].address
+    r0 = BindMonitor_Callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1288,19 +1300,21 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[1].address
+    r0 = BindMonitor_Callee14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1341,13 +1355,13 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[0].address
+    r0 = BindMonitor_Callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 67 "sample/bindmonitor_mt_tailcall.c"
@@ -1441,14 +1455,14 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[0].address
+    r0 = BindMonitor_Callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1459,19 +1473,21 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[1].address
+    r0 = BindMonitor_Callee15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1512,13 +1528,13 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[0].address
+    r0 = BindMonitor_Callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 68 "sample/bindmonitor_mt_tailcall.c"
@@ -1612,14 +1628,14 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[0].address
+    r0 = BindMonitor_Callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1630,19 +1646,21 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[1].address
+    r0 = BindMonitor_Callee16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1683,13 +1701,13 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[0].address
+    r0 = BindMonitor_Callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 69 "sample/bindmonitor_mt_tailcall.c"
@@ -1783,14 +1801,14 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[0].address
+    r0 = BindMonitor_Callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1801,19 +1819,21 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[1].address
+    r0 = BindMonitor_Callee17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1854,13 +1874,13 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[0].address
+    r0 = BindMonitor_Callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/bindmonitor_mt_tailcall.c"
@@ -1954,14 +1974,14 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[0].address
+    r0 = BindMonitor_Callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1972,19 +1992,21 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[1].address
+    r0 = BindMonitor_Callee18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2025,13 +2047,13 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[0].address
+    r0 = BindMonitor_Callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 71 "sample/bindmonitor_mt_tailcall.c"
@@ -2125,14 +2147,14 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[0].address
+    r0 = BindMonitor_Callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2143,19 +2165,21 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[1].address
+    r0 = BindMonitor_Callee19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2196,13 +2220,13 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[0].address
+    r0 = BindMonitor_Callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 72 "sample/bindmonitor_mt_tailcall.c"
@@ -2296,14 +2320,14 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[0].address
+    r0 = BindMonitor_Callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2314,19 +2338,21 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[1].address
+    r0 = BindMonitor_Callee2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2367,13 +2393,13 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[0].address
+    r0 = BindMonitor_Callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 55 "sample/bindmonitor_mt_tailcall.c"
@@ -2467,14 +2493,14 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[0].address
+    r0 = BindMonitor_Callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2485,19 +2511,21 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[1].address
+    r0 = BindMonitor_Callee20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2538,13 +2566,13 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[0].address
+    r0 = BindMonitor_Callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 73 "sample/bindmonitor_mt_tailcall.c"
@@ -2638,14 +2666,14 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[0].address
+    r0 = BindMonitor_Callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2656,19 +2684,21 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[1].address
+    r0 = BindMonitor_Callee21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2709,13 +2739,13 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[0].address
+    r0 = BindMonitor_Callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 74 "sample/bindmonitor_mt_tailcall.c"
@@ -2809,14 +2839,14 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[0].address
+    r0 = BindMonitor_Callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2827,19 +2857,21 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[1].address
+    r0 = BindMonitor_Callee22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2880,13 +2912,13 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[0].address
+    r0 = BindMonitor_Callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 75 "sample/bindmonitor_mt_tailcall.c"
@@ -2980,14 +3012,14 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[0].address
+    r0 = BindMonitor_Callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2998,19 +3030,21 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[1].address
+    r0 = BindMonitor_Callee23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3051,13 +3085,13 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[0].address
+    r0 = BindMonitor_Callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/bindmonitor_mt_tailcall.c"
@@ -3151,14 +3185,14 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[0].address
+    r0 = BindMonitor_Callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3169,19 +3203,21 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[1].address
+    r0 = BindMonitor_Callee24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3222,13 +3258,13 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[0].address
+    r0 = BindMonitor_Callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 77 "sample/bindmonitor_mt_tailcall.c"
@@ -3322,14 +3358,14 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[0].address
+    r0 = BindMonitor_Callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3340,19 +3376,21 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[1].address
+    r0 = BindMonitor_Callee25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3393,13 +3431,13 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[0].address
+    r0 = BindMonitor_Callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 78 "sample/bindmonitor_mt_tailcall.c"
@@ -3493,14 +3531,14 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[0].address
+    r0 = BindMonitor_Callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3511,19 +3549,21 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[1].address
+    r0 = BindMonitor_Callee26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3564,13 +3604,13 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[0].address
+    r0 = BindMonitor_Callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 79 "sample/bindmonitor_mt_tailcall.c"
@@ -3664,14 +3704,14 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[0].address
+    r0 = BindMonitor_Callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3682,19 +3722,21 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[1].address
+    r0 = BindMonitor_Callee27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3735,13 +3777,13 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[0].address
+    r0 = BindMonitor_Callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/bindmonitor_mt_tailcall.c"
@@ -3835,14 +3877,14 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[0].address
+    r0 = BindMonitor_Callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3853,19 +3895,21 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[1].address
+    r0 = BindMonitor_Callee28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3906,13 +3950,13 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[0].address
+    r0 = BindMonitor_Callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 81 "sample/bindmonitor_mt_tailcall.c"
@@ -4006,14 +4050,14 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[0].address
+    r0 = BindMonitor_Callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4024,19 +4068,21 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[1].address
+    r0 = BindMonitor_Callee29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4077,13 +4123,13 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[0].address
+    r0 = BindMonitor_Callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 82 "sample/bindmonitor_mt_tailcall.c"
@@ -4177,14 +4223,14 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[0].address
+    r0 = BindMonitor_Callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4195,19 +4241,21 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[1].address
+    r0 = BindMonitor_Callee3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4248,13 +4296,13 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[0].address
+    r0 = BindMonitor_Callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/bindmonitor_mt_tailcall.c"
@@ -4348,14 +4396,14 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
+    r0 = BindMonitor_Callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 83 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4366,19 +4414,21 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[1].address
+    r0 = BindMonitor_Callee30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 83 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4419,13 +4469,13 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
+    r0 = BindMonitor_Callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 83 "sample/bindmonitor_mt_tailcall.c"
@@ -4519,14 +4569,14 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[0].address
+    r0 = BindMonitor_Callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 84 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4537,19 +4587,21 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[1].address
+    r0 = BindMonitor_Callee31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[1].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 84 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4590,13 +4642,13 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[0].address
+    r0 = BindMonitor_Callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 84 "sample/bindmonitor_mt_tailcall.c"
@@ -4726,14 +4778,14 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[0].address
+    r0 = BindMonitor_Callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4744,19 +4796,21 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[1].address
+    r0 = BindMonitor_Callee4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4797,13 +4851,13 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[0].address
+    r0 = BindMonitor_Callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/bindmonitor_mt_tailcall.c"
@@ -4897,14 +4951,14 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[0].address
+    r0 = BindMonitor_Callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4915,19 +4969,21 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[1].address
+    r0 = BindMonitor_Callee5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4968,13 +5024,13 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[0].address
+    r0 = BindMonitor_Callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/bindmonitor_mt_tailcall.c"
@@ -5068,14 +5124,14 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[0].address
+    r0 = BindMonitor_Callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5086,19 +5142,21 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[1].address
+    r0 = BindMonitor_Callee6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5139,13 +5197,13 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[0].address
+    r0 = BindMonitor_Callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 59 "sample/bindmonitor_mt_tailcall.c"
@@ -5239,14 +5297,14 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[0].address
+    r0 = BindMonitor_Callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5257,19 +5315,21 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[1].address
+    r0 = BindMonitor_Callee7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5310,13 +5370,13 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[0].address
+    r0 = BindMonitor_Callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/bindmonitor_mt_tailcall.c"
@@ -5410,14 +5470,14 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[0].address
+    r0 = BindMonitor_Callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5428,19 +5488,21 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[1].address
+    r0 = BindMonitor_Callee8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5481,13 +5543,13 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[0].address
+    r0 = BindMonitor_Callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 61 "sample/bindmonitor_mt_tailcall.c"
@@ -5586,14 +5648,14 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=13
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[0].address
+    r0 = BindMonitor_Callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
 #line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=16 dst=r2 src=r0 offset=0 imm=0
@@ -5604,19 +5666,21 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=5
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[1].address
+    r0 = BindMonitor_Callee9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
 #line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(1680154744);
     // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-8 imm=0
@@ -5654,13 +5718,13 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[0].address
+    r0 = BindMonitor_Callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 62 "sample/bindmonitor_mt_tailcall.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -288,14 +288,14 @@ BindMonitor_Caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=13
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Caller_helpers[0].address
+    r0 = BindMonitor_Caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 33 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=22 dst=r2 src=r0 offset=0 imm=0
@@ -306,14 +306,14 @@ BindMonitor_Caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=5
 #line 34 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Caller_helpers[1].address
+    r0 = BindMonitor_Caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 34 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 34 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 34 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
+#line 34 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
@@ -405,14 +405,14 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -423,19 +423,21 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -476,13 +478,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 53 "sample/bindmonitor_mt_tailcall.c"
@@ -576,14 +578,14 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -594,19 +596,21 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -647,13 +651,13 @@ BindMonitor_Callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 54 "sample/bindmonitor_mt_tailcall.c"
@@ -747,14 +751,14 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[0].address
+    r0 = BindMonitor_Callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -765,19 +769,21 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[1].address
+    r0 = BindMonitor_Callee10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -818,13 +824,13 @@ BindMonitor_Callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee10_helpers[0].address
+    r0 = BindMonitor_Callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 63 "sample/bindmonitor_mt_tailcall.c"
@@ -918,14 +924,14 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[0].address
+    r0 = BindMonitor_Callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -936,19 +942,21 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[1].address
+    r0 = BindMonitor_Callee11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -989,13 +997,13 @@ BindMonitor_Callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee11_helpers[0].address
+    r0 = BindMonitor_Callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 64 "sample/bindmonitor_mt_tailcall.c"
@@ -1089,14 +1097,14 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[0].address
+    r0 = BindMonitor_Callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1107,19 +1115,21 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[1].address
+    r0 = BindMonitor_Callee12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1160,13 +1170,13 @@ BindMonitor_Callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee12_helpers[0].address
+    r0 = BindMonitor_Callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 65 "sample/bindmonitor_mt_tailcall.c"
@@ -1260,14 +1270,14 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[0].address
+    r0 = BindMonitor_Callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1278,19 +1288,21 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[1].address
+    r0 = BindMonitor_Callee13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1331,13 +1343,13 @@ BindMonitor_Callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee13_helpers[0].address
+    r0 = BindMonitor_Callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 66 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 66 "sample/bindmonitor_mt_tailcall.c"
@@ -1431,14 +1443,14 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[0].address
+    r0 = BindMonitor_Callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1449,19 +1461,21 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[1].address
+    r0 = BindMonitor_Callee14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1502,13 +1516,13 @@ BindMonitor_Callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee14_helpers[0].address
+    r0 = BindMonitor_Callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 67 "sample/bindmonitor_mt_tailcall.c"
@@ -1602,14 +1616,14 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[0].address
+    r0 = BindMonitor_Callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1620,19 +1634,21 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[1].address
+    r0 = BindMonitor_Callee15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1673,13 +1689,13 @@ BindMonitor_Callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee15_helpers[0].address
+    r0 = BindMonitor_Callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 68 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 68 "sample/bindmonitor_mt_tailcall.c"
@@ -1773,14 +1789,14 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[0].address
+    r0 = BindMonitor_Callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1791,19 +1807,21 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[1].address
+    r0 = BindMonitor_Callee16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -1844,13 +1862,13 @@ BindMonitor_Callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee16_helpers[0].address
+    r0 = BindMonitor_Callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 69 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 69 "sample/bindmonitor_mt_tailcall.c"
@@ -1944,14 +1962,14 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[0].address
+    r0 = BindMonitor_Callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -1962,19 +1980,21 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[1].address
+    r0 = BindMonitor_Callee17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2015,13 +2035,13 @@ BindMonitor_Callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee17_helpers[0].address
+    r0 = BindMonitor_Callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/bindmonitor_mt_tailcall.c"
@@ -2115,14 +2135,14 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[0].address
+    r0 = BindMonitor_Callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2133,19 +2153,21 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[1].address
+    r0 = BindMonitor_Callee18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2186,13 +2208,13 @@ BindMonitor_Callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee18_helpers[0].address
+    r0 = BindMonitor_Callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 71 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 71 "sample/bindmonitor_mt_tailcall.c"
@@ -2286,14 +2308,14 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[0].address
+    r0 = BindMonitor_Callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2304,19 +2326,21 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[1].address
+    r0 = BindMonitor_Callee19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2357,13 +2381,13 @@ BindMonitor_Callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee19_helpers[0].address
+    r0 = BindMonitor_Callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 72 "sample/bindmonitor_mt_tailcall.c"
@@ -2457,14 +2481,14 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[0].address
+    r0 = BindMonitor_Callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2475,19 +2499,21 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[1].address
+    r0 = BindMonitor_Callee2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2528,13 +2554,13 @@ BindMonitor_Callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee2_helpers[0].address
+    r0 = BindMonitor_Callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 55 "sample/bindmonitor_mt_tailcall.c"
@@ -2628,14 +2654,14 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[0].address
+    r0 = BindMonitor_Callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2646,19 +2672,21 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[1].address
+    r0 = BindMonitor_Callee20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2699,13 +2727,13 @@ BindMonitor_Callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee20_helpers[0].address
+    r0 = BindMonitor_Callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 73 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 73 "sample/bindmonitor_mt_tailcall.c"
@@ -2799,14 +2827,14 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[0].address
+    r0 = BindMonitor_Callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2817,19 +2845,21 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[1].address
+    r0 = BindMonitor_Callee21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -2870,13 +2900,13 @@ BindMonitor_Callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee21_helpers[0].address
+    r0 = BindMonitor_Callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 74 "sample/bindmonitor_mt_tailcall.c"
@@ -2970,14 +3000,14 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[0].address
+    r0 = BindMonitor_Callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -2988,19 +3018,21 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[1].address
+    r0 = BindMonitor_Callee22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3041,13 +3073,13 @@ BindMonitor_Callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee22_helpers[0].address
+    r0 = BindMonitor_Callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 75 "sample/bindmonitor_mt_tailcall.c"
@@ -3141,14 +3173,14 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[0].address
+    r0 = BindMonitor_Callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3159,19 +3191,21 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[1].address
+    r0 = BindMonitor_Callee23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3212,13 +3246,13 @@ BindMonitor_Callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee23_helpers[0].address
+    r0 = BindMonitor_Callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 76 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/bindmonitor_mt_tailcall.c"
@@ -3312,14 +3346,14 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[0].address
+    r0 = BindMonitor_Callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3330,19 +3364,21 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[1].address
+    r0 = BindMonitor_Callee24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3383,13 +3419,13 @@ BindMonitor_Callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee24_helpers[0].address
+    r0 = BindMonitor_Callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 77 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 77 "sample/bindmonitor_mt_tailcall.c"
@@ -3483,14 +3519,14 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[0].address
+    r0 = BindMonitor_Callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3501,19 +3537,21 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[1].address
+    r0 = BindMonitor_Callee25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3554,13 +3592,13 @@ BindMonitor_Callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee25_helpers[0].address
+    r0 = BindMonitor_Callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 78 "sample/bindmonitor_mt_tailcall.c"
@@ -3654,14 +3692,14 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[0].address
+    r0 = BindMonitor_Callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3672,19 +3710,21 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[1].address
+    r0 = BindMonitor_Callee26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3725,13 +3765,13 @@ BindMonitor_Callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee26_helpers[0].address
+    r0 = BindMonitor_Callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 79 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 79 "sample/bindmonitor_mt_tailcall.c"
@@ -3825,14 +3865,14 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[0].address
+    r0 = BindMonitor_Callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -3843,19 +3883,21 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[1].address
+    r0 = BindMonitor_Callee27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -3896,13 +3938,13 @@ BindMonitor_Callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee27_helpers[0].address
+    r0 = BindMonitor_Callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/bindmonitor_mt_tailcall.c"
@@ -3996,14 +4038,14 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[0].address
+    r0 = BindMonitor_Callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4014,19 +4056,21 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[1].address
+    r0 = BindMonitor_Callee28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4067,13 +4111,13 @@ BindMonitor_Callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee28_helpers[0].address
+    r0 = BindMonitor_Callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 81 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 81 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 81 "sample/bindmonitor_mt_tailcall.c"
@@ -4167,14 +4211,14 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[0].address
+    r0 = BindMonitor_Callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4185,19 +4229,21 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[1].address
+    r0 = BindMonitor_Callee29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4238,13 +4284,13 @@ BindMonitor_Callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee29_helpers[0].address
+    r0 = BindMonitor_Callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 82 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 82 "sample/bindmonitor_mt_tailcall.c"
@@ -4338,14 +4384,14 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[0].address
+    r0 = BindMonitor_Callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4356,19 +4402,21 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[1].address
+    r0 = BindMonitor_Callee3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4409,13 +4457,13 @@ BindMonitor_Callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee3_helpers[0].address
+    r0 = BindMonitor_Callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/bindmonitor_mt_tailcall.c"
@@ -4509,14 +4557,14 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
+    r0 = BindMonitor_Callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 83 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4527,19 +4575,21 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[1].address
+    r0 = BindMonitor_Callee30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 83 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4580,13 +4630,13 @@ BindMonitor_Callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
+    r0 = BindMonitor_Callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 83 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 83 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 83 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 83 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 83 "sample/bindmonitor_mt_tailcall.c"
@@ -4680,14 +4730,14 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[0].address
+    r0 = BindMonitor_Callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 84 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4698,19 +4748,21 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[1].address
+    r0 = BindMonitor_Callee31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[1].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 84 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4751,13 +4803,13 @@ BindMonitor_Callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee31_helpers[0].address
+    r0 = BindMonitor_Callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 84 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 84 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 84 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 84 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 84 "sample/bindmonitor_mt_tailcall.c"
@@ -4887,14 +4939,14 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[0].address
+    r0 = BindMonitor_Callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -4905,19 +4957,21 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[1].address
+    r0 = BindMonitor_Callee4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -4958,13 +5012,13 @@ BindMonitor_Callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee4_helpers[0].address
+    r0 = BindMonitor_Callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/bindmonitor_mt_tailcall.c"
@@ -5058,14 +5112,14 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[0].address
+    r0 = BindMonitor_Callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5076,19 +5130,21 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[1].address
+    r0 = BindMonitor_Callee5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5129,13 +5185,13 @@ BindMonitor_Callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee5_helpers[0].address
+    r0 = BindMonitor_Callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/bindmonitor_mt_tailcall.c"
@@ -5229,14 +5285,14 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[0].address
+    r0 = BindMonitor_Callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5247,19 +5303,21 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[1].address
+    r0 = BindMonitor_Callee6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5300,13 +5358,13 @@ BindMonitor_Callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee6_helpers[0].address
+    r0 = BindMonitor_Callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 59 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 59 "sample/bindmonitor_mt_tailcall.c"
@@ -5400,14 +5458,14 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[0].address
+    r0 = BindMonitor_Callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5418,19 +5476,21 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[1].address
+    r0 = BindMonitor_Callee7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5471,13 +5531,13 @@ BindMonitor_Callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee7_helpers[0].address
+    r0 = BindMonitor_Callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/bindmonitor_mt_tailcall.c"
@@ -5571,14 +5631,14 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[0].address
+    r0 = BindMonitor_Callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
@@ -5589,19 +5649,21 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[1].address
+    r0 = BindMonitor_Callee8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
 #line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
@@ -5642,13 +5704,13 @@ BindMonitor_Callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee8_helpers[0].address
+    r0 = BindMonitor_Callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 61 "sample/bindmonitor_mt_tailcall.c"
@@ -5747,14 +5809,14 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=13
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[0].address
+    r0 = BindMonitor_Callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
 #line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=16 dst=r2 src=r0 offset=0 imm=0
@@ -5765,19 +5827,21 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=5
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[1].address
+    r0 = BindMonitor_Callee9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
 #line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(1680154744);
     // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-8 imm=0
@@ -5815,13 +5879,13 @@ BindMonitor_Callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee9_helpers[0].address
+    r0 = BindMonitor_Callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 62 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
 #line 62 "sample/bindmonitor_mt_tailcall.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -128,14 +128,14 @@ BindMonitor(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=19
 #line 61 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
+#line 61 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
 #line 61 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=5 dst=r10 src=r8 offset=-72 imm=0
@@ -149,14 +149,14 @@ BindMonitor(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=20
 #line 64 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
+#line 64 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
 #line 64 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r1 src=r6 offset=0 imm=0
@@ -164,14 +164,14 @@ BindMonitor(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=21
 #line 65 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[2].address
+    r0 = BindMonitor_helpers[2].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[2].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
+#line 65 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
 #line 65 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r2 src=r10 offset=0 imm=0
@@ -194,14 +194,14 @@ BindMonitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=2
 #line 67 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[3].address
+    r0 = BindMonitor_helpers[3].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
+#line 67 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
 #line 67 "sample/bindmonitor.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=22 dst=r2 src=r0 offset=0 imm=-84
@@ -212,30 +212,34 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
 #line 119 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 119 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 119 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 119 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
+#line 119 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
 #line 119 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=77 imm=0
 #line 120 "sample/bindmonitor.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 120 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
 #line 120 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=75 imm=0
 #line 120 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 120 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
+#line 120 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 73 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-8 imm=0
@@ -282,46 +286,54 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
 #line 78 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=47 dst=r9 src=r0 offset=0 imm=0
+#line 78 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=47 dst=r9 src=r0 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r9 = r0;
     // EBPF_OP_JNE_IMM pc=48 dst=r9 src=r0 offset=28 imm=0
 #line 79 "sample/bindmonitor.c"
-    if (r9 != IMMEDIATE(0))
+    if (r9 != IMMEDIATE(0)) {
 #line 79 "sample/bindmonitor.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
+#line 79 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=50 dst=r1 src=r0 offset=53 imm=0
 #line 83 "sample/bindmonitor.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 83 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
+#line 83 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=51 imm=0
 #line 87 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
+#line 87 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
 #line 87 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=54 dst=r1 src=r0 offset=49 imm=0
 #line 87 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
+#line 87 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
 #line 87 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=56 dst=r8 src=r0 offset=0 imm=-8
@@ -344,14 +356,14 @@ BindMonitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=2
 #line 91 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[3].address
+    r0 = BindMonitor_helpers[3].address(r1, r2, r3, r4, r5);
 #line 91 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0)) {
 #line 91 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_LDDW pc=64 dst=r1 src=r0 offset=0 imm=0
+#line 91 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDDW pc=64 dst=r1 src=r0 offset=0 imm=0
 #line 92 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=66 dst=r2 src=r8 offset=0 imm=0
@@ -359,22 +371,24 @@ BindMonitor(void* context)
     r2 = r8;
     // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=1
 #line 92 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 92 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 92 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=68 dst=r9 src=r0 offset=0 imm=0
+#line 92 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=68 dst=r9 src=r0 offset=0 imm=0
 #line 92 "sample/bindmonitor.c"
     r9 = r0;
     // EBPF_OP_JEQ_IMM pc=69 dst=r9 src=r0 offset=34 imm=0
 #line 93 "sample/bindmonitor.c"
-    if (r9 == IMMEDIATE(0))
+    if (r9 == IMMEDIATE(0)) {
 #line 93 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=70 dst=r3 src=r6 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=70 dst=r3 src=r6 offset=0 imm=0
 #line 97 "sample/bindmonitor.c"
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=71 dst=r4 src=r6 offset=8 imm=0
@@ -394,28 +408,32 @@ BindMonitor(void* context)
     r2 = IMMEDIATE(64);
     // EBPF_OP_CALL pc=76 dst=r0 src=r0 offset=0 imm=22
 #line 97 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[5].address
+    r0 = BindMonitor_helpers[5].address(r1, r2, r3, r4, r5);
 #line 97 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[5].tail_call) && (r0 == 0)) {
 #line 97 "sample/bindmonitor.c"
         return 0;
+#line 97 "sample/bindmonitor.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=77 dst=r1 src=r6 offset=44 imm=0
 #line 130 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=78 dst=r1 src=r0 offset=3 imm=0
 #line 130 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 130 "sample/bindmonitor.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=79 dst=r1 src=r0 offset=9 imm=2
 #line 130 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=79 dst=r1 src=r0 offset=9 imm=2
+#line 130 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 130 "sample/bindmonitor.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=80 dst=r1 src=r9 offset=0 imm=0
+#line 130 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=80 dst=r1 src=r9 offset=0 imm=0
 #line 147 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r9 + OFFSET(0));
     // EBPF_OP_JA pc=81 dst=r0 src=r0 offset=11 imm=0
@@ -433,10 +451,12 @@ label_2:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=85 dst=r1 src=r2 offset=19 imm=0
 #line 132 "sample/bindmonitor.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 132 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=1
+#line 132 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=1
 #line 136 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=87 dst=r9 src=r1 offset=0 imm=0
@@ -451,10 +471,12 @@ label_3:
     r1 = *(uint32_t*)(uintptr_t)(r9 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=90 dst=r1 src=r0 offset=6 imm=0
 #line 139 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 139 "sample/bindmonitor.c"
         goto label_5;
-        // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=-1
+#line 139 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=-1
 #line 140 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=92 dst=r9 src=r1 offset=0 imm=0
@@ -472,9 +494,11 @@ label_4:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=96 dst=r1 src=r0 offset=8 imm=0
 #line 147 "sample/bindmonitor.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 147 "sample/bindmonitor.c"
         goto label_7;
+#line 147 "sample/bindmonitor.c"
+    }
 label_5:
     // EBPF_OP_LDXDW pc=97 dst=r1 src=r6 offset=16 imm=0
 #line 148 "sample/bindmonitor.c"
@@ -493,13 +517,13 @@ label_5:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=3
 #line 149 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[6].address
+    r0 = BindMonitor_helpers[6].address(r1, r2, r3, r4, r5);
 #line 149 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[6].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[6].tail_call) && (r0 == 0)) {
 #line 149 "sample/bindmonitor.c"
         return 0;
+#line 149 "sample/bindmonitor.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=104 dst=r8 src=r0 offset=0 imm=0
 #line 149 "sample/bindmonitor.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -108,10 +108,12 @@ bind_monitor(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=1 dst=r2 src=r0 offset=8 imm=0
 #line 26 "sample/bindmonitor_ringbuf.c"
-    if (r2 != IMMEDIATE(0))
+    if (r2 != IMMEDIATE(0)) {
 #line 26 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+#line 26 "sample/bindmonitor_ringbuf.c"
+    }
+    // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 28 "sample/bindmonitor_ringbuf.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LDXDW pc=3 dst=r3 src=r1 offset=8 imm=0
@@ -119,10 +121,12 @@ bind_monitor(void* context)
     r3 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=4 dst=r2 src=r3 offset=5 imm=0
 #line 28 "sample/bindmonitor_ringbuf.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 28 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-        // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
+#line 28 "sample/bindmonitor_ringbuf.c"
+    }
+    // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
 #line 29 "sample/bindmonitor_ringbuf.c"
     r3 -= r2;
     // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=0
@@ -133,13 +137,13 @@ bind_monitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=9 dst=r0 src=r0 offset=0 imm=11
 #line 29 "sample/bindmonitor_ringbuf.c"
-    r0 = bind_monitor_helpers[0].address
+    r0 = bind_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/bindmonitor_ringbuf.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/bindmonitor_ringbuf.c"
-    if ((bind_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/bindmonitor_ringbuf.c"
         return 0;
+#line 29 "sample/bindmonitor_ringbuf.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 36 "sample/bindmonitor_ringbuf.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -82,10 +82,12 @@ bind_monitor(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=1 dst=r2 src=r0 offset=8 imm=0
 #line 26 "sample/bindmonitor_ringbuf.c"
-    if (r2 != IMMEDIATE(0))
+    if (r2 != IMMEDIATE(0)) {
 #line 26 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+#line 26 "sample/bindmonitor_ringbuf.c"
+    }
+    // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 28 "sample/bindmonitor_ringbuf.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LDXDW pc=3 dst=r3 src=r1 offset=8 imm=0
@@ -93,10 +95,12 @@ bind_monitor(void* context)
     r3 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=4 dst=r2 src=r3 offset=5 imm=0
 #line 28 "sample/bindmonitor_ringbuf.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 28 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-        // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
+#line 28 "sample/bindmonitor_ringbuf.c"
+    }
+    // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
 #line 29 "sample/bindmonitor_ringbuf.c"
     r3 -= r2;
     // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=0
@@ -107,13 +111,13 @@ bind_monitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=9 dst=r0 src=r0 offset=0 imm=11
 #line 29 "sample/bindmonitor_ringbuf.c"
-    r0 = bind_monitor_helpers[0].address
+    r0 = bind_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/bindmonitor_ringbuf.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/bindmonitor_ringbuf.c"
-    if ((bind_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/bindmonitor_ringbuf.c"
         return 0;
+#line 29 "sample/bindmonitor_ringbuf.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 36 "sample/bindmonitor_ringbuf.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -243,10 +243,12 @@ bind_monitor(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=1 dst=r2 src=r0 offset=8 imm=0
 #line 26 "sample/bindmonitor_ringbuf.c"
-    if (r2 != IMMEDIATE(0))
+    if (r2 != IMMEDIATE(0)) {
 #line 26 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+#line 26 "sample/bindmonitor_ringbuf.c"
+    }
+    // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 28 "sample/bindmonitor_ringbuf.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LDXDW pc=3 dst=r3 src=r1 offset=8 imm=0
@@ -254,10 +256,12 @@ bind_monitor(void* context)
     r3 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=4 dst=r2 src=r3 offset=5 imm=0
 #line 28 "sample/bindmonitor_ringbuf.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 28 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-        // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
+#line 28 "sample/bindmonitor_ringbuf.c"
+    }
+    // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
 #line 29 "sample/bindmonitor_ringbuf.c"
     r3 -= r2;
     // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=0
@@ -268,13 +272,13 @@ bind_monitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=9 dst=r0 src=r0 offset=0 imm=11
 #line 29 "sample/bindmonitor_ringbuf.c"
-    r0 = bind_monitor_helpers[0].address
+    r0 = bind_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/bindmonitor_ringbuf.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/bindmonitor_ringbuf.c"
-    if ((bind_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/bindmonitor_ringbuf.c"
         return 0;
+#line 29 "sample/bindmonitor_ringbuf.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 36 "sample/bindmonitor_ringbuf.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -289,14 +289,14 @@ BindMonitor(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=19
 #line 61 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 61 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 61 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
+#line 61 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
 #line 61 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=5 dst=r10 src=r8 offset=-72 imm=0
@@ -310,14 +310,14 @@ BindMonitor(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=20
 #line 64 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 64 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 64 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
+#line 64 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
 #line 64 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r1 src=r6 offset=0 imm=0
@@ -325,14 +325,14 @@ BindMonitor(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=21
 #line 65 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[2].address
+    r0 = BindMonitor_helpers[2].address(r1, r2, r3, r4, r5);
 #line 65 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[2].tail_call) && (r0 == 0)) {
 #line 65 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
+#line 65 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
 #line 65 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r2 src=r10 offset=0 imm=0
@@ -355,14 +355,14 @@ BindMonitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=2
 #line 67 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[3].address
+    r0 = BindMonitor_helpers[3].address(r1, r2, r3, r4, r5);
 #line 67 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0)) {
 #line 67 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
+#line 67 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
 #line 67 "sample/bindmonitor.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=22 dst=r2 src=r0 offset=0 imm=-84
@@ -373,30 +373,34 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
 #line 119 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 119 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 119 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 119 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
+#line 119 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
 #line 119 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=77 imm=0
 #line 120 "sample/bindmonitor.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 120 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
 #line 120 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=75 imm=0
 #line 120 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 120 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
+#line 120 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 73 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-8 imm=0
@@ -443,46 +447,54 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
 #line 78 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 78 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 78 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=47 dst=r9 src=r0 offset=0 imm=0
+#line 78 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=47 dst=r9 src=r0 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r9 = r0;
     // EBPF_OP_JNE_IMM pc=48 dst=r9 src=r0 offset=28 imm=0
 #line 79 "sample/bindmonitor.c"
-    if (r9 != IMMEDIATE(0))
+    if (r9 != IMMEDIATE(0)) {
 #line 79 "sample/bindmonitor.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
+#line 79 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=50 dst=r1 src=r0 offset=53 imm=0
 #line 83 "sample/bindmonitor.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 83 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
+#line 83 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=51 imm=0
 #line 87 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
+#line 87 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
 #line 87 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=54 dst=r1 src=r0 offset=49 imm=0
 #line 87 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
+#line 87 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
 #line 87 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=56 dst=r8 src=r0 offset=0 imm=-8
@@ -505,14 +517,14 @@ BindMonitor(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=2
 #line 91 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[3].address
+    r0 = BindMonitor_helpers[3].address(r1, r2, r3, r4, r5);
 #line 91 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[3].tail_call) && (r0 == 0)) {
 #line 91 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_LDDW pc=64 dst=r1 src=r0 offset=0 imm=0
+#line 91 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDDW pc=64 dst=r1 src=r0 offset=0 imm=0
 #line 92 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=66 dst=r2 src=r8 offset=0 imm=0
@@ -520,22 +532,24 @@ BindMonitor(void* context)
     r2 = r8;
     // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=1
 #line 92 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[4].address
+    r0 = BindMonitor_helpers[4].address(r1, r2, r3, r4, r5);
 #line 92 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[4].tail_call) && (r0 == 0)) {
 #line 92 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=68 dst=r9 src=r0 offset=0 imm=0
+#line 92 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_MOV64_REG pc=68 dst=r9 src=r0 offset=0 imm=0
 #line 92 "sample/bindmonitor.c"
     r9 = r0;
     // EBPF_OP_JEQ_IMM pc=69 dst=r9 src=r0 offset=34 imm=0
 #line 93 "sample/bindmonitor.c"
-    if (r9 == IMMEDIATE(0))
+    if (r9 == IMMEDIATE(0)) {
 #line 93 "sample/bindmonitor.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=70 dst=r3 src=r6 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXDW pc=70 dst=r3 src=r6 offset=0 imm=0
 #line 97 "sample/bindmonitor.c"
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=71 dst=r4 src=r6 offset=8 imm=0
@@ -555,28 +569,32 @@ BindMonitor(void* context)
     r2 = IMMEDIATE(64);
     // EBPF_OP_CALL pc=76 dst=r0 src=r0 offset=0 imm=22
 #line 97 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[5].address
+    r0 = BindMonitor_helpers[5].address(r1, r2, r3, r4, r5);
 #line 97 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[5].tail_call) && (r0 == 0)) {
 #line 97 "sample/bindmonitor.c"
         return 0;
+#line 97 "sample/bindmonitor.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=77 dst=r1 src=r6 offset=44 imm=0
 #line 130 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=78 dst=r1 src=r0 offset=3 imm=0
 #line 130 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 130 "sample/bindmonitor.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=79 dst=r1 src=r0 offset=9 imm=2
 #line 130 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=79 dst=r1 src=r0 offset=9 imm=2
+#line 130 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 130 "sample/bindmonitor.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=80 dst=r1 src=r9 offset=0 imm=0
+#line 130 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_LDXW pc=80 dst=r1 src=r9 offset=0 imm=0
 #line 147 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r9 + OFFSET(0));
     // EBPF_OP_JA pc=81 dst=r0 src=r0 offset=11 imm=0
@@ -594,10 +612,12 @@ label_2:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=85 dst=r1 src=r2 offset=19 imm=0
 #line 132 "sample/bindmonitor.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 132 "sample/bindmonitor.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=1
+#line 132 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=1
 #line 136 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=87 dst=r9 src=r1 offset=0 imm=0
@@ -612,10 +632,12 @@ label_3:
     r1 = *(uint32_t*)(uintptr_t)(r9 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=90 dst=r1 src=r0 offset=6 imm=0
 #line 139 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 139 "sample/bindmonitor.c"
         goto label_5;
-        // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=-1
+#line 139 "sample/bindmonitor.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=-1
 #line 140 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=92 dst=r9 src=r1 offset=0 imm=0
@@ -633,9 +655,11 @@ label_4:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=96 dst=r1 src=r0 offset=8 imm=0
 #line 147 "sample/bindmonitor.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 147 "sample/bindmonitor.c"
         goto label_7;
+#line 147 "sample/bindmonitor.c"
+    }
 label_5:
     // EBPF_OP_LDXDW pc=97 dst=r1 src=r6 offset=16 imm=0
 #line 148 "sample/bindmonitor.c"
@@ -654,13 +678,13 @@ label_5:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=3
 #line 149 "sample/bindmonitor.c"
-    r0 = BindMonitor_helpers[6].address
+    r0 = BindMonitor_helpers[6].address(r1, r2, r3, r4, r5);
 #line 149 "sample/bindmonitor.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/bindmonitor.c"
-    if ((BindMonitor_helpers[6].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[6].tail_call) && (r0 == 0)) {
 #line 149 "sample/bindmonitor.c"
         return 0;
+#line 149 "sample/bindmonitor.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=104 dst=r8 src=r0 offset=0 imm=0
 #line 149 "sample/bindmonitor.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -199,19 +199,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 123 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 123 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 123 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 125 "sample/bindmonitor_tailcall.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 125 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 128 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -222,13 +224,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 128 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 128 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 128 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 128 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 128 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/bindmonitor_tailcall.c"
@@ -306,19 +308,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 139 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 139 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 139 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 141 "sample/bindmonitor_tailcall.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 141 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 144 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -329,13 +333,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 144 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 144 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 144 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 144 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/bindmonitor_tailcall.c"
@@ -421,30 +425,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 156 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 156 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 156 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 156 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=77 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 157 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=75 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 157 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 81 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -491,46 +499,54 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 86 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 86 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 86 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r8 src=r0 offset=0 imm=0
+#line 86 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r8 src=r0 offset=0 imm=0
 #line 86 "sample/bindmonitor_tailcall.c"
     r8 = r0;
     // EBPF_OP_JNE_IMM pc=30 dst=r8 src=r0 offset=28 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
-    if (r8 != IMMEDIATE(0))
+    if (r8 != IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
+#line 87 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
 #line 91 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=53 imm=0
 #line 91 "sample/bindmonitor_tailcall.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 91 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 91 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=51 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 95 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=49 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 95 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -553,14 +569,14 @@ BindMonitor_Callee1(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=2
 #line 99 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 99 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 99 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=0
+#line 99 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 100 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r8 offset=0 imm=0
@@ -568,22 +584,24 @@ BindMonitor_Callee1(void* context)
     r2 = r8;
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 100 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 100 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 100 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
+#line 100 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
 #line 100 "sample/bindmonitor_tailcall.c"
     r8 = r0;
     // EBPF_OP_JEQ_IMM pc=51 dst=r8 src=r0 offset=34 imm=0
 #line 101 "sample/bindmonitor_tailcall.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 101 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=52 dst=r3 src=r6 offset=0 imm=0
+#line 101 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=52 dst=r3 src=r6 offset=0 imm=0
 #line 105 "sample/bindmonitor_tailcall.c"
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=53 dst=r4 src=r6 offset=8 imm=0
@@ -603,28 +621,32 @@ BindMonitor_Callee1(void* context)
     r2 = IMMEDIATE(64);
     // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=22
 #line 105 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 105 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=59 dst=r1 src=r6 offset=44 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=3 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 167 "sample/bindmonitor_tailcall.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=61 dst=r1 src=r0 offset=9 imm=2
 #line 167 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=61 dst=r1 src=r0 offset=9 imm=2
+#line 167 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 167 "sample/bindmonitor_tailcall.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=0 imm=0
 #line 184 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=11 imm=0
@@ -642,10 +664,12 @@ label_2:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=67 dst=r1 src=r2 offset=19 imm=0
 #line 169 "sample/bindmonitor_tailcall.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=68 dst=r1 src=r0 offset=0 imm=1
+#line 169 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=68 dst=r1 src=r0 offset=0 imm=1
 #line 173 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=69 dst=r8 src=r1 offset=0 imm=0
@@ -660,10 +684,12 @@ label_3:
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=72 dst=r1 src=r0 offset=6 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 176 "sample/bindmonitor_tailcall.c"
         goto label_5;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=-1
+#line 176 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=-1
 #line 177 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=74 dst=r8 src=r1 offset=0 imm=0
@@ -681,9 +707,11 @@ label_4:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=78 dst=r1 src=r0 offset=8 imm=0
 #line 184 "sample/bindmonitor_tailcall.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 184 "sample/bindmonitor_tailcall.c"
         goto label_7;
+#line 184 "sample/bindmonitor_tailcall.c"
+    }
 label_5:
     // EBPF_OP_LDXDW pc=79 dst=r1 src=r6 offset=16 imm=0
 #line 185 "sample/bindmonitor_tailcall.c"
@@ -702,13 +730,13 @@ label_5:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=3
 #line 186 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[3].address
+    r0 = BindMonitor_Callee1_helpers[3].address(r1, r2, r3, r4, r5);
 #line 186 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0)) {
 #line 186 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 186 "sample/bindmonitor_tailcall.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=86 dst=r9 src=r0 offset=0 imm=0
 #line 186 "sample/bindmonitor_tailcall.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -173,19 +173,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 123 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 123 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 123 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 125 "sample/bindmonitor_tailcall.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 125 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 128 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -196,13 +198,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 128 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 128 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 128 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 128 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 128 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/bindmonitor_tailcall.c"
@@ -280,19 +282,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 139 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 139 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 139 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 141 "sample/bindmonitor_tailcall.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 141 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 144 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -303,13 +307,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 144 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 144 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 144 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 144 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/bindmonitor_tailcall.c"
@@ -395,30 +399,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 156 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 156 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 156 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 156 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=77 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 157 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=75 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 157 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 81 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -465,46 +473,54 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 86 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 86 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 86 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r8 src=r0 offset=0 imm=0
+#line 86 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r8 src=r0 offset=0 imm=0
 #line 86 "sample/bindmonitor_tailcall.c"
     r8 = r0;
     // EBPF_OP_JNE_IMM pc=30 dst=r8 src=r0 offset=28 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
-    if (r8 != IMMEDIATE(0))
+    if (r8 != IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
+#line 87 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
 #line 91 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=53 imm=0
 #line 91 "sample/bindmonitor_tailcall.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 91 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 91 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=51 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 95 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=49 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 95 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -527,14 +543,14 @@ BindMonitor_Callee1(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=2
 #line 99 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 99 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 99 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=0
+#line 99 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 100 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r8 offset=0 imm=0
@@ -542,22 +558,24 @@ BindMonitor_Callee1(void* context)
     r2 = r8;
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 100 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 100 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 100 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
+#line 100 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
 #line 100 "sample/bindmonitor_tailcall.c"
     r8 = r0;
     // EBPF_OP_JEQ_IMM pc=51 dst=r8 src=r0 offset=34 imm=0
 #line 101 "sample/bindmonitor_tailcall.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 101 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=52 dst=r3 src=r6 offset=0 imm=0
+#line 101 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=52 dst=r3 src=r6 offset=0 imm=0
 #line 105 "sample/bindmonitor_tailcall.c"
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=53 dst=r4 src=r6 offset=8 imm=0
@@ -577,28 +595,32 @@ BindMonitor_Callee1(void* context)
     r2 = IMMEDIATE(64);
     // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=22
 #line 105 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 105 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=59 dst=r1 src=r6 offset=44 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=3 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 167 "sample/bindmonitor_tailcall.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=61 dst=r1 src=r0 offset=9 imm=2
 #line 167 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=61 dst=r1 src=r0 offset=9 imm=2
+#line 167 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 167 "sample/bindmonitor_tailcall.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=0 imm=0
 #line 184 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=11 imm=0
@@ -616,10 +638,12 @@ label_2:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=67 dst=r1 src=r2 offset=19 imm=0
 #line 169 "sample/bindmonitor_tailcall.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=68 dst=r1 src=r0 offset=0 imm=1
+#line 169 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=68 dst=r1 src=r0 offset=0 imm=1
 #line 173 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=69 dst=r8 src=r1 offset=0 imm=0
@@ -634,10 +658,12 @@ label_3:
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=72 dst=r1 src=r0 offset=6 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 176 "sample/bindmonitor_tailcall.c"
         goto label_5;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=-1
+#line 176 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=-1
 #line 177 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=74 dst=r8 src=r1 offset=0 imm=0
@@ -655,9 +681,11 @@ label_4:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=78 dst=r1 src=r0 offset=8 imm=0
 #line 184 "sample/bindmonitor_tailcall.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 184 "sample/bindmonitor_tailcall.c"
         goto label_7;
+#line 184 "sample/bindmonitor_tailcall.c"
+    }
 label_5:
     // EBPF_OP_LDXDW pc=79 dst=r1 src=r6 offset=16 imm=0
 #line 185 "sample/bindmonitor_tailcall.c"
@@ -676,13 +704,13 @@ label_5:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=3
 #line 186 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[3].address
+    r0 = BindMonitor_Callee1_helpers[3].address(r1, r2, r3, r4, r5);
 #line 186 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0)) {
 #line 186 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 186 "sample/bindmonitor_tailcall.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=86 dst=r9 src=r0 offset=0 imm=0
 #line 186 "sample/bindmonitor_tailcall.c"

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -334,19 +334,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 123 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 123 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 123 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 125 "sample/bindmonitor_tailcall.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 125 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 128 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -357,13 +359,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 128 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 128 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 128 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 128 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 128 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/bindmonitor_tailcall.c"
@@ -441,19 +443,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 139 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 139 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 139 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 141 "sample/bindmonitor_tailcall.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 141 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 144 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -464,13 +468,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 144 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 144 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 144 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 144 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/bindmonitor_tailcall.c"
@@ -556,30 +560,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 156 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 156 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 156 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 156 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=77 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 157 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=75 imm=0
 #line 157 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 157 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 81 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -626,46 +634,54 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 86 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 86 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 86 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r8 src=r0 offset=0 imm=0
+#line 86 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r8 src=r0 offset=0 imm=0
 #line 86 "sample/bindmonitor_tailcall.c"
     r8 = r0;
     // EBPF_OP_JNE_IMM pc=30 dst=r8 src=r0 offset=28 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
-    if (r8 != IMMEDIATE(0))
+    if (r8 != IMMEDIATE(0)) {
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
+#line 87 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
 #line 91 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=53 imm=0
 #line 91 "sample/bindmonitor_tailcall.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 91 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 91 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=51 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 95 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=49 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 95 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -688,14 +704,14 @@ BindMonitor_Callee1(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=2
 #line 99 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 99 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 99 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=0
+#line 99 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 100 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r8 offset=0 imm=0
@@ -703,22 +719,24 @@ BindMonitor_Callee1(void* context)
     r2 = r8;
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 100 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 100 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 100 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
+#line 100 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
 #line 100 "sample/bindmonitor_tailcall.c"
     r8 = r0;
     // EBPF_OP_JEQ_IMM pc=51 dst=r8 src=r0 offset=34 imm=0
 #line 101 "sample/bindmonitor_tailcall.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 101 "sample/bindmonitor_tailcall.c"
         goto label_6;
-        // EBPF_OP_LDXDW pc=52 dst=r3 src=r6 offset=0 imm=0
+#line 101 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXDW pc=52 dst=r3 src=r6 offset=0 imm=0
 #line 105 "sample/bindmonitor_tailcall.c"
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=53 dst=r4 src=r6 offset=8 imm=0
@@ -738,28 +756,32 @@ BindMonitor_Callee1(void* context)
     r2 = IMMEDIATE(64);
     // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=22
 #line 105 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 105 "sample/bindmonitor_tailcall.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=59 dst=r1 src=r6 offset=44 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=3 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 167 "sample/bindmonitor_tailcall.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=61 dst=r1 src=r0 offset=9 imm=2
 #line 167 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=61 dst=r1 src=r0 offset=9 imm=2
+#line 167 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 167 "sample/bindmonitor_tailcall.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=0 imm=0
 #line 184 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=11 imm=0
@@ -777,10 +799,12 @@ label_2:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=67 dst=r1 src=r2 offset=19 imm=0
 #line 169 "sample/bindmonitor_tailcall.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=68 dst=r1 src=r0 offset=0 imm=1
+#line 169 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=68 dst=r1 src=r0 offset=0 imm=1
 #line 173 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=69 dst=r8 src=r1 offset=0 imm=0
@@ -795,10 +819,12 @@ label_3:
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=72 dst=r1 src=r0 offset=6 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 176 "sample/bindmonitor_tailcall.c"
         goto label_5;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=-1
+#line 176 "sample/bindmonitor_tailcall.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=-1
 #line 177 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=74 dst=r8 src=r1 offset=0 imm=0
@@ -816,9 +842,11 @@ label_4:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=78 dst=r1 src=r0 offset=8 imm=0
 #line 184 "sample/bindmonitor_tailcall.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 184 "sample/bindmonitor_tailcall.c"
         goto label_7;
+#line 184 "sample/bindmonitor_tailcall.c"
+    }
 label_5:
     // EBPF_OP_LDXDW pc=79 dst=r1 src=r6 offset=16 imm=0
 #line 185 "sample/bindmonitor_tailcall.c"
@@ -837,13 +865,13 @@ label_5:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=3
 #line 186 "sample/bindmonitor_tailcall.c"
-    r0 = BindMonitor_Callee1_helpers[3].address
+    r0 = BindMonitor_Callee1_helpers[3].address(r1, r2, r3, r4, r5);
 #line 186 "sample/bindmonitor_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/bindmonitor_tailcall.c"
-    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0)) {
 #line 186 "sample/bindmonitor_tailcall.c"
         return 0;
+#line 186 "sample/bindmonitor_tailcall.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=86 dst=r9 src=r0 offset=0 imm=0
 #line 186 "sample/bindmonitor_tailcall.c"

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -133,14 +133,14 @@ func(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=2
 #line 29 "sample/undocked/bpf_call.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/undocked/bpf_call.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/undocked/bpf_call.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/undocked/bpf_call.c"
         return 0;
-        // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
+#line 29 "sample/undocked/bpf_call.c"
+    }
+    // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
 #line 30 "sample/undocked/bpf_call.c"
     return r0;
 #line 30 "sample/undocked/bpf_call.c"

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -107,14 +107,14 @@ func(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=2
 #line 29 "sample/undocked/bpf_call.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/undocked/bpf_call.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/undocked/bpf_call.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/undocked/bpf_call.c"
         return 0;
-        // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
+#line 29 "sample/undocked/bpf_call.c"
+    }
+    // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
 #line 30 "sample/undocked/bpf_call.c"
     return r0;
 #line 30 "sample/undocked/bpf_call.c"

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -268,14 +268,14 @@ func(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=2
 #line 29 "sample/undocked/bpf_call.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 29 "sample/undocked/bpf_call.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/undocked/bpf_call.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 29 "sample/undocked/bpf_call.c"
         return 0;
-        // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
+#line 29 "sample/undocked/bpf_call.c"
+    }
+    // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
 #line 30 "sample/undocked/bpf_call.c"
     return r0;
 #line 30 "sample/undocked/bpf_call.c"

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -114,18 +114,22 @@ count_tcp_connect4(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=27 imm=6
 #line 34 "sample/cgroup_count_connect4.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 34 "sample/cgroup_count_connect4.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
+#line 34 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
 #line 40 "sample/cgroup_count_connect4.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_JNE_IMM pc=4 dst=r1 src=r0 offset=25 imm=7459
 #line 40 "sample/cgroup_count_connect4.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 40 "sample/cgroup_count_connect4.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/cgroup_count_connect4.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=6 dst=r10 src=r6 offset=-16 imm=0
@@ -148,19 +152,21 @@ count_tcp_connect4(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 48 "sample/cgroup_count_connect4.c"
-    r0 = count_tcp_connect4_helpers[0].address
+    r0 = count_tcp_connect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_count_connect4.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_count_connect4.c"
-    if ((count_tcp_connect4_helpers[0].tail_call) && (r0 == 0))
+    if ((count_tcp_connect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_count_connect4.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
+#line 48 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
 #line 49 "sample/cgroup_count_connect4.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 49 "sample/cgroup_count_connect4.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
+#line 49 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
 #line 49 "sample/cgroup_count_connect4.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-16 imm=0
@@ -189,14 +195,14 @@ count_tcp_connect4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_count_connect4.c"
-    r0 = count_tcp_connect4_helpers[1].address
+    r0 = count_tcp_connect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_count_connect4.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_count_connect4.c"
-    if ((count_tcp_connect4_helpers[1].tail_call) && (r0 == 0))
+    if ((count_tcp_connect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_count_connect4.c"
         return 0;
-        // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
+#line 51 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
 #line 51 "sample/cgroup_count_connect4.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
@@ -88,18 +88,22 @@ count_tcp_connect4(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=27 imm=6
 #line 34 "sample/cgroup_count_connect4.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 34 "sample/cgroup_count_connect4.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
+#line 34 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
 #line 40 "sample/cgroup_count_connect4.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_JNE_IMM pc=4 dst=r1 src=r0 offset=25 imm=7459
 #line 40 "sample/cgroup_count_connect4.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 40 "sample/cgroup_count_connect4.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/cgroup_count_connect4.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=6 dst=r10 src=r6 offset=-16 imm=0
@@ -122,19 +126,21 @@ count_tcp_connect4(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 48 "sample/cgroup_count_connect4.c"
-    r0 = count_tcp_connect4_helpers[0].address
+    r0 = count_tcp_connect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_count_connect4.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_count_connect4.c"
-    if ((count_tcp_connect4_helpers[0].tail_call) && (r0 == 0))
+    if ((count_tcp_connect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_count_connect4.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
+#line 48 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
 #line 49 "sample/cgroup_count_connect4.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 49 "sample/cgroup_count_connect4.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
+#line 49 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
 #line 49 "sample/cgroup_count_connect4.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-16 imm=0
@@ -163,14 +169,14 @@ count_tcp_connect4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_count_connect4.c"
-    r0 = count_tcp_connect4_helpers[1].address
+    r0 = count_tcp_connect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_count_connect4.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_count_connect4.c"
-    if ((count_tcp_connect4_helpers[1].tail_call) && (r0 == 0))
+    if ((count_tcp_connect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_count_connect4.c"
         return 0;
-        // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
+#line 51 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
 #line 51 "sample/cgroup_count_connect4.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
@@ -249,18 +249,22 @@ count_tcp_connect4(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=27 imm=6
 #line 34 "sample/cgroup_count_connect4.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 34 "sample/cgroup_count_connect4.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
+#line 34 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
 #line 40 "sample/cgroup_count_connect4.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_JNE_IMM pc=4 dst=r1 src=r0 offset=25 imm=7459
 #line 40 "sample/cgroup_count_connect4.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 40 "sample/cgroup_count_connect4.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/cgroup_count_connect4.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=6 dst=r10 src=r6 offset=-16 imm=0
@@ -283,19 +287,21 @@ count_tcp_connect4(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 48 "sample/cgroup_count_connect4.c"
-    r0 = count_tcp_connect4_helpers[0].address
+    r0 = count_tcp_connect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_count_connect4.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_count_connect4.c"
-    if ((count_tcp_connect4_helpers[0].tail_call) && (r0 == 0))
+    if ((count_tcp_connect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_count_connect4.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
+#line 48 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
 #line 49 "sample/cgroup_count_connect4.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 49 "sample/cgroup_count_connect4.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
+#line 49 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
 #line 49 "sample/cgroup_count_connect4.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-16 imm=0
@@ -324,14 +330,14 @@ count_tcp_connect4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_count_connect4.c"
-    r0 = count_tcp_connect4_helpers[1].address
+    r0 = count_tcp_connect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_count_connect4.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_count_connect4.c"
-    if ((count_tcp_connect4_helpers[1].tail_call) && (r0 == 0))
+    if ((count_tcp_connect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_count_connect4.c"
         return 0;
-        // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
+#line 51 "sample/cgroup_count_connect4.c"
+    }
+    // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
 #line 51 "sample/cgroup_count_connect4.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -114,18 +114,22 @@ count_tcp_connect6(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=27 imm=6
 #line 34 "sample/cgroup_count_connect6.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 34 "sample/cgroup_count_connect6.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
+#line 34 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
 #line 40 "sample/cgroup_count_connect6.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_JNE_IMM pc=4 dst=r1 src=r0 offset=25 imm=7459
 #line 40 "sample/cgroup_count_connect6.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 40 "sample/cgroup_count_connect6.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/cgroup_count_connect6.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=6 dst=r10 src=r6 offset=-16 imm=0
@@ -148,19 +152,21 @@ count_tcp_connect6(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 48 "sample/cgroup_count_connect6.c"
-    r0 = count_tcp_connect6_helpers[0].address
+    r0 = count_tcp_connect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_count_connect6.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_count_connect6.c"
-    if ((count_tcp_connect6_helpers[0].tail_call) && (r0 == 0))
+    if ((count_tcp_connect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_count_connect6.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
+#line 48 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
 #line 49 "sample/cgroup_count_connect6.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 49 "sample/cgroup_count_connect6.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
+#line 49 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
 #line 49 "sample/cgroup_count_connect6.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-16 imm=0
@@ -189,14 +195,14 @@ count_tcp_connect6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_count_connect6.c"
-    r0 = count_tcp_connect6_helpers[1].address
+    r0 = count_tcp_connect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_count_connect6.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_count_connect6.c"
-    if ((count_tcp_connect6_helpers[1].tail_call) && (r0 == 0))
+    if ((count_tcp_connect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_count_connect6.c"
         return 0;
-        // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
+#line 51 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
 #line 51 "sample/cgroup_count_connect6.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
@@ -88,18 +88,22 @@ count_tcp_connect6(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=27 imm=6
 #line 34 "sample/cgroup_count_connect6.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 34 "sample/cgroup_count_connect6.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
+#line 34 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
 #line 40 "sample/cgroup_count_connect6.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_JNE_IMM pc=4 dst=r1 src=r0 offset=25 imm=7459
 #line 40 "sample/cgroup_count_connect6.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 40 "sample/cgroup_count_connect6.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/cgroup_count_connect6.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=6 dst=r10 src=r6 offset=-16 imm=0
@@ -122,19 +126,21 @@ count_tcp_connect6(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 48 "sample/cgroup_count_connect6.c"
-    r0 = count_tcp_connect6_helpers[0].address
+    r0 = count_tcp_connect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_count_connect6.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_count_connect6.c"
-    if ((count_tcp_connect6_helpers[0].tail_call) && (r0 == 0))
+    if ((count_tcp_connect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_count_connect6.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
+#line 48 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
 #line 49 "sample/cgroup_count_connect6.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 49 "sample/cgroup_count_connect6.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
+#line 49 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
 #line 49 "sample/cgroup_count_connect6.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-16 imm=0
@@ -163,14 +169,14 @@ count_tcp_connect6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_count_connect6.c"
-    r0 = count_tcp_connect6_helpers[1].address
+    r0 = count_tcp_connect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_count_connect6.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_count_connect6.c"
-    if ((count_tcp_connect6_helpers[1].tail_call) && (r0 == 0))
+    if ((count_tcp_connect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_count_connect6.c"
         return 0;
-        // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
+#line 51 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
 #line 51 "sample/cgroup_count_connect6.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
@@ -249,18 +249,22 @@ count_tcp_connect6(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=27 imm=6
 #line 34 "sample/cgroup_count_connect6.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 34 "sample/cgroup_count_connect6.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
+#line 34 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r1 src=r1 offset=40 imm=0
 #line 40 "sample/cgroup_count_connect6.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_JNE_IMM pc=4 dst=r1 src=r0 offset=25 imm=7459
 #line 40 "sample/cgroup_count_connect6.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 40 "sample/cgroup_count_connect6.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=5 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/cgroup_count_connect6.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=6 dst=r10 src=r6 offset=-16 imm=0
@@ -283,19 +287,21 @@ count_tcp_connect6(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 48 "sample/cgroup_count_connect6.c"
-    r0 = count_tcp_connect6_helpers[0].address
+    r0 = count_tcp_connect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_count_connect6.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_count_connect6.c"
-    if ((count_tcp_connect6_helpers[0].tail_call) && (r0 == 0))
+    if ((count_tcp_connect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_count_connect6.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
+#line 48 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=12 imm=0
 #line 49 "sample/cgroup_count_connect6.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 49 "sample/cgroup_count_connect6.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
+#line 49 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=1
 #line 49 "sample/cgroup_count_connect6.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-16 imm=0
@@ -324,14 +330,14 @@ count_tcp_connect6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_count_connect6.c"
-    r0 = count_tcp_connect6_helpers[1].address
+    r0 = count_tcp_connect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_count_connect6.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_count_connect6.c"
-    if ((count_tcp_connect6_helpers[1].tail_call) && (r0 == 0))
+    if ((count_tcp_connect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_count_connect6.c"
         return 0;
-        // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
+#line 51 "sample/cgroup_count_connect6.c"
+    }
+    // EBPF_OP_JA pc=26 dst=r0 src=r0 offset=3 imm=0
 #line 51 "sample/cgroup_count_connect6.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -86,10 +86,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=20 imm=6
 #line 27 "sample/cgroup_mt_connect4.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 27 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
+#line 27 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=7459
@@ -100,10 +102,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=16 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 33 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=8 dst=r3 src=r2 offset=0 imm=0
@@ -128,10 +132,12 @@ tcp_mt_connect4(void* context)
     r4 = (uint64_t)6148914691236517206;
     // EBPF_OP_JGT_REG pc=16 dst=r4 src=r5 offset=6 imm=0
 #line 41 "sample/cgroup_mt_connect4.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 41 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
+#line 41 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
 #line 46 "sample/cgroup_mt_connect4.c"
     r3 &= IMMEDIATE(1);
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
@@ -139,10 +145,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=19 dst=r3 src=r0 offset=3 imm=0
 #line 46 "sample/cgroup_mt_connect4.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 46 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
+#line 46 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
 #line 54 "sample/cgroup_mt_connect4.c"
     r2 += IMMEDIATE(-6141);
     // EBPF_OP_STXH pc=21 dst=r1 src=r2 offset=40 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
@@ -60,10 +60,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=20 imm=6
 #line 27 "sample/cgroup_mt_connect4.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 27 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
+#line 27 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=7459
@@ -74,10 +76,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=16 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 33 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=8 dst=r3 src=r2 offset=0 imm=0
@@ -102,10 +106,12 @@ tcp_mt_connect4(void* context)
     r4 = (uint64_t)6148914691236517206;
     // EBPF_OP_JGT_REG pc=16 dst=r4 src=r5 offset=6 imm=0
 #line 41 "sample/cgroup_mt_connect4.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 41 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
+#line 41 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
 #line 46 "sample/cgroup_mt_connect4.c"
     r3 &= IMMEDIATE(1);
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
@@ -113,10 +119,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=19 dst=r3 src=r0 offset=3 imm=0
 #line 46 "sample/cgroup_mt_connect4.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 46 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
+#line 46 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
 #line 54 "sample/cgroup_mt_connect4.c"
     r2 += IMMEDIATE(-6141);
     // EBPF_OP_STXH pc=21 dst=r1 src=r2 offset=40 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
@@ -221,10 +221,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=20 imm=6
 #line 27 "sample/cgroup_mt_connect4.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 27 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
+#line 27 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=7459
@@ -235,10 +237,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=16 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 33 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/cgroup_mt_connect4.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=8 dst=r3 src=r2 offset=0 imm=0
@@ -263,10 +267,12 @@ tcp_mt_connect4(void* context)
     r4 = (uint64_t)6148914691236517206;
     // EBPF_OP_JGT_REG pc=16 dst=r4 src=r5 offset=6 imm=0
 #line 41 "sample/cgroup_mt_connect4.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 41 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
+#line 41 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
 #line 46 "sample/cgroup_mt_connect4.c"
     r3 &= IMMEDIATE(1);
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
@@ -274,10 +280,12 @@ tcp_mt_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=19 dst=r3 src=r0 offset=3 imm=0
 #line 46 "sample/cgroup_mt_connect4.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 46 "sample/cgroup_mt_connect4.c"
         goto label_1;
-        // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
+#line 46 "sample/cgroup_mt_connect4.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
 #line 54 "sample/cgroup_mt_connect4.c"
     r2 += IMMEDIATE(-6141);
     // EBPF_OP_STXH pc=21 dst=r1 src=r2 offset=40 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -86,10 +86,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=20 imm=6
 #line 27 "sample/cgroup_mt_connect6.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 27 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
+#line 27 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=7459
@@ -100,10 +102,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=16 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 33 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=8 dst=r3 src=r2 offset=0 imm=0
@@ -128,10 +132,12 @@ tcp_mt_connect6(void* context)
     r4 = (uint64_t)6148914691236517206;
     // EBPF_OP_JGT_REG pc=16 dst=r4 src=r5 offset=6 imm=0
 #line 41 "sample/cgroup_mt_connect6.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 41 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
+#line 41 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
 #line 46 "sample/cgroup_mt_connect6.c"
     r3 &= IMMEDIATE(1);
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
@@ -139,10 +145,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=19 dst=r3 src=r0 offset=3 imm=0
 #line 46 "sample/cgroup_mt_connect6.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 46 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
+#line 46 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
 #line 54 "sample/cgroup_mt_connect6.c"
     r2 += IMMEDIATE(-6141);
     // EBPF_OP_STXH pc=21 dst=r1 src=r2 offset=40 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
@@ -60,10 +60,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=20 imm=6
 #line 27 "sample/cgroup_mt_connect6.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 27 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
+#line 27 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=7459
@@ -74,10 +76,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=16 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 33 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=8 dst=r3 src=r2 offset=0 imm=0
@@ -102,10 +106,12 @@ tcp_mt_connect6(void* context)
     r4 = (uint64_t)6148914691236517206;
     // EBPF_OP_JGT_REG pc=16 dst=r4 src=r5 offset=6 imm=0
 #line 41 "sample/cgroup_mt_connect6.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 41 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
+#line 41 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
 #line 46 "sample/cgroup_mt_connect6.c"
     r3 &= IMMEDIATE(1);
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
@@ -113,10 +119,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=19 dst=r3 src=r0 offset=3 imm=0
 #line 46 "sample/cgroup_mt_connect6.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 46 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
+#line 46 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
 #line 54 "sample/cgroup_mt_connect6.c"
     r2 += IMMEDIATE(-6141);
     // EBPF_OP_STXH pc=21 dst=r1 src=r2 offset=40 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
@@ -221,10 +221,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=2 dst=r2 src=r0 offset=20 imm=6
 #line 27 "sample/cgroup_mt_connect6.c"
-    if (r2 != IMMEDIATE(6))
+    if (r2 != IMMEDIATE(6)) {
 #line 27 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
+#line 27 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_LDXH pc=3 dst=r2 src=r1 offset=40 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=7459
@@ -235,10 +237,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=16 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 33 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/cgroup_mt_connect6.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=8 dst=r3 src=r2 offset=0 imm=0
@@ -263,10 +267,12 @@ tcp_mt_connect6(void* context)
     r4 = (uint64_t)6148914691236517206;
     // EBPF_OP_JGT_REG pc=16 dst=r4 src=r5 offset=6 imm=0
 #line 41 "sample/cgroup_mt_connect6.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 41 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
+#line 41 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_AND64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
 #line 46 "sample/cgroup_mt_connect6.c"
     r3 &= IMMEDIATE(1);
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
@@ -274,10 +280,12 @@ tcp_mt_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=19 dst=r3 src=r0 offset=3 imm=0
 #line 46 "sample/cgroup_mt_connect6.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 46 "sample/cgroup_mt_connect6.c"
         goto label_1;
-        // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
+#line 46 "sample/cgroup_mt_connect6.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=20 dst=r2 src=r0 offset=0 imm=-6141
 #line 54 "sample/cgroup_mt_connect6.c"
     r2 += IMMEDIATE(-6141);
     // EBPF_OP_STXH pc=21 dst=r1 src=r2 offset=40 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -178,24 +178,30 @@ connect_redirect4(void* context)
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
+    if (r1 == IMMEDIATE(17)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=80 imm=6
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
+    }
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=80 imm=6
+#line 61 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 61 "sample/cgroup_sock_addr2.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=78 imm=2
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(2))
+    if (r2 != IMMEDIATE(2)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
 #line 65 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_STXW pc=23 dst=r10 src=r2 offset=-32 imm=0
@@ -221,14 +227,14 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[0].address
+    r0 = connect_redirect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
 #line 70 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=33 dst=r9 src=r0 offset=0 imm=0
@@ -239,10 +245,12 @@ label_1:
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=35 dst=r8 src=r0 offset=37 imm=0
 #line 71 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 71 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
 #line 71 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=37 dst=r10 src=r7 offset=-70 imm=0
@@ -295,22 +303,24 @@ label_1:
     r2 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=14
 #line 72 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
+    r0 = connect_redirect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 72 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
     // EBPF_OP_JEQ_IMM pc=59 dst=r1 src=r0 offset=8 imm=3
 #line 78 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
+    if (r1 == IMMEDIATE(3)) {
 #line 78 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=61 dst=r2 src=r0 offset=0 imm=-64
@@ -324,14 +334,14 @@ label_1:
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=65537
 #line 79 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
+    r0 = connect_redirect4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 79 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0)) {
 #line 79 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
+#line 79 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
@@ -339,9 +349,11 @@ label_1:
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_REG pc=67 dst=r7 src=r0 offset=32 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
+    if ((int64_t)r7 > (int64_t)r0) {
 #line 79 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 79 "sample/cgroup_sock_addr2.c"
+    }
 label_2:
     // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
 #line 84 "sample/cgroup_sock_addr2.c"
@@ -373,14 +385,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[3].address
+    r0 = connect_redirect4_helpers[3].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
+#line 44 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
@@ -391,14 +403,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[4].address
+    r0 = connect_redirect4_helpers[4].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
@@ -406,14 +418,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[5].address
+    r0 = connect_redirect4_helpers[5].address(r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0)) {
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
@@ -427,14 +439,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[6].address
+    r0 = connect_redirect4_helpers[6].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=90 dst=r10 src=r0 offset=-80 imm=0
+#line 48 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r0 offset=-80 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
@@ -460,13 +472,13 @@ label_3:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=99 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[7].address
+    r0 = connect_redirect4_helpers[7].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[7].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[7].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_sock_addr2.c"
         return 0;
+#line 51 "sample/cgroup_sock_addr2.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=100 dst=r0 src=r7 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
@@ -583,24 +595,30 @@ connect_redirect6(void* context)
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
+    if (r1 == IMMEDIATE(17)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=91 imm=6
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
+    }
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=91 imm=6
+#line 102 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 102 "sample/cgroup_sock_addr2.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=89 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
+    if (r2 != IMMEDIATE(23)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 102 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
 #line 109 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
@@ -650,14 +668,14 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
 #line 114 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[0].address
+    r0 = connect_redirect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 114 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 114 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
@@ -668,10 +686,12 @@ label_1:
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 115 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-14 imm=0
@@ -712,22 +732,24 @@ label_1:
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
 #line 116 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[1].address
+    r0 = connect_redirect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 116 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 116 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
     // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
 #line 122 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
+    if (r1 == IMMEDIATE(3)) {
 #line 122 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-96
@@ -741,14 +763,14 @@ label_1:
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
 #line 123 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
+    r0 = connect_redirect6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 123 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0)) {
 #line 123 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 123 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
 #line 123 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
@@ -756,9 +778,11 @@ label_1:
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=40 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
+    if ((int64_t)r7 > (int64_t)r0) {
 #line 123 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 123 "sample/cgroup_sock_addr2.c"
+    }
 label_2:
     // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
@@ -814,14 +838,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[3].address
+    r0 = connect_redirect6_helpers[3].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+#line 44 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-32 imm=0
@@ -832,14 +856,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[4].address
+    r0 = connect_redirect6_helpers[4].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-40 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-40 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
@@ -847,14 +871,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[5].address
+    r0 = connect_redirect6_helpers[5].address(r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0)) {
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-24 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-24 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
@@ -868,14 +892,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[6].address
+    r0 = connect_redirect6_helpers[6].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=101 dst=r10 src=r0 offset=-16 imm=0
+#line 48 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=101 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=102 dst=r10 src=r8 offset=-8 imm=0
@@ -901,13 +925,13 @@ label_3:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=110 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[7].address
+    r0 = connect_redirect6_helpers[7].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[7].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[7].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_sock_addr2.c"
         return 0;
+#line 51 "sample/cgroup_sock_addr2.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=111 dst=r0 src=r7 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -152,24 +152,30 @@ connect_redirect4(void* context)
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
+    if (r1 == IMMEDIATE(17)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=80 imm=6
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
+    }
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=80 imm=6
+#line 61 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 61 "sample/cgroup_sock_addr2.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=78 imm=2
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(2))
+    if (r2 != IMMEDIATE(2)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
 #line 65 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_STXW pc=23 dst=r10 src=r2 offset=-32 imm=0
@@ -195,14 +201,14 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[0].address
+    r0 = connect_redirect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
 #line 70 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=33 dst=r9 src=r0 offset=0 imm=0
@@ -213,10 +219,12 @@ label_1:
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=35 dst=r8 src=r0 offset=37 imm=0
 #line 71 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 71 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
 #line 71 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=37 dst=r10 src=r7 offset=-70 imm=0
@@ -269,22 +277,24 @@ label_1:
     r2 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=14
 #line 72 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
+    r0 = connect_redirect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 72 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
     // EBPF_OP_JEQ_IMM pc=59 dst=r1 src=r0 offset=8 imm=3
 #line 78 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
+    if (r1 == IMMEDIATE(3)) {
 #line 78 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=61 dst=r2 src=r0 offset=0 imm=-64
@@ -298,14 +308,14 @@ label_1:
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=65537
 #line 79 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
+    r0 = connect_redirect4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 79 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0)) {
 #line 79 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
+#line 79 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
@@ -313,9 +323,11 @@ label_1:
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_REG pc=67 dst=r7 src=r0 offset=32 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
+    if ((int64_t)r7 > (int64_t)r0) {
 #line 79 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 79 "sample/cgroup_sock_addr2.c"
+    }
 label_2:
     // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
 #line 84 "sample/cgroup_sock_addr2.c"
@@ -347,14 +359,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[3].address
+    r0 = connect_redirect4_helpers[3].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
+#line 44 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
@@ -365,14 +377,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[4].address
+    r0 = connect_redirect4_helpers[4].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
@@ -380,14 +392,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[5].address
+    r0 = connect_redirect4_helpers[5].address(r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0)) {
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
@@ -401,14 +413,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[6].address
+    r0 = connect_redirect4_helpers[6].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=90 dst=r10 src=r0 offset=-80 imm=0
+#line 48 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r0 offset=-80 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
@@ -434,13 +446,13 @@ label_3:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=99 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[7].address
+    r0 = connect_redirect4_helpers[7].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[7].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[7].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_sock_addr2.c"
         return 0;
+#line 51 "sample/cgroup_sock_addr2.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=100 dst=r0 src=r7 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
@@ -557,24 +569,30 @@ connect_redirect6(void* context)
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
+    if (r1 == IMMEDIATE(17)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=91 imm=6
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
+    }
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=91 imm=6
+#line 102 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 102 "sample/cgroup_sock_addr2.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=89 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
+    if (r2 != IMMEDIATE(23)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 102 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
 #line 109 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
@@ -624,14 +642,14 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
 #line 114 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[0].address
+    r0 = connect_redirect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 114 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 114 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
@@ -642,10 +660,12 @@ label_1:
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 115 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-14 imm=0
@@ -686,22 +706,24 @@ label_1:
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
 #line 116 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[1].address
+    r0 = connect_redirect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 116 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 116 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
     // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
 #line 122 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
+    if (r1 == IMMEDIATE(3)) {
 #line 122 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-96
@@ -715,14 +737,14 @@ label_1:
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
 #line 123 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
+    r0 = connect_redirect6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 123 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0)) {
 #line 123 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 123 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
 #line 123 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
@@ -730,9 +752,11 @@ label_1:
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=40 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
+    if ((int64_t)r7 > (int64_t)r0) {
 #line 123 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 123 "sample/cgroup_sock_addr2.c"
+    }
 label_2:
     // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
@@ -788,14 +812,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[3].address
+    r0 = connect_redirect6_helpers[3].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+#line 44 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-32 imm=0
@@ -806,14 +830,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[4].address
+    r0 = connect_redirect6_helpers[4].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-40 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-40 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
@@ -821,14 +845,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[5].address
+    r0 = connect_redirect6_helpers[5].address(r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0)) {
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-24 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-24 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
@@ -842,14 +866,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[6].address
+    r0 = connect_redirect6_helpers[6].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=101 dst=r10 src=r0 offset=-16 imm=0
+#line 48 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=101 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=102 dst=r10 src=r8 offset=-8 imm=0
@@ -875,13 +899,13 @@ label_3:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=110 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[7].address
+    r0 = connect_redirect6_helpers[7].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[7].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[7].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_sock_addr2.c"
         return 0;
+#line 51 "sample/cgroup_sock_addr2.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=111 dst=r0 src=r7 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -313,24 +313,30 @@ connect_redirect4(void* context)
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
+    if (r1 == IMMEDIATE(17)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=80 imm=6
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
+    }
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=80 imm=6
+#line 61 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 61 "sample/cgroup_sock_addr2.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=78 imm=2
 #line 61 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(2))
+    if (r2 != IMMEDIATE(2)) {
 #line 61 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
 #line 65 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_STXW pc=23 dst=r10 src=r2 offset=-32 imm=0
@@ -356,14 +362,14 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[0].address
+    r0 = connect_redirect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
 #line 70 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=33 dst=r9 src=r0 offset=0 imm=0
@@ -374,10 +380,12 @@ label_1:
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=35 dst=r8 src=r0 offset=37 imm=0
 #line 71 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 71 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
 #line 71 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=37 dst=r10 src=r7 offset=-70 imm=0
@@ -430,22 +438,24 @@ label_1:
     r2 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=14
 #line 72 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
+    r0 = connect_redirect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 72 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
     // EBPF_OP_JEQ_IMM pc=59 dst=r1 src=r0 offset=8 imm=3
 #line 78 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
+    if (r1 == IMMEDIATE(3)) {
 #line 78 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=61 dst=r2 src=r0 offset=0 imm=-64
@@ -459,14 +469,14 @@ label_1:
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=65537
 #line 79 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
+    r0 = connect_redirect4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 79 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 79 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0)) {
 #line 79 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
+#line 79 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
@@ -474,9 +484,11 @@ label_1:
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_REG pc=67 dst=r7 src=r0 offset=32 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
+    if ((int64_t)r7 > (int64_t)r0) {
 #line 79 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 79 "sample/cgroup_sock_addr2.c"
+    }
 label_2:
     // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
 #line 84 "sample/cgroup_sock_addr2.c"
@@ -508,14 +520,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[3].address
+    r0 = connect_redirect4_helpers[3].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
+#line 44 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
@@ -526,14 +538,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[4].address
+    r0 = connect_redirect4_helpers[4].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
@@ -541,14 +553,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[5].address
+    r0 = connect_redirect4_helpers[5].address(r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0)) {
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
@@ -562,14 +574,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[6].address
+    r0 = connect_redirect4_helpers[6].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=90 dst=r10 src=r0 offset=-80 imm=0
+#line 48 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r0 offset=-80 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
@@ -595,13 +607,13 @@ label_3:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=99 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[7].address
+    r0 = connect_redirect4_helpers[7].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[7].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[7].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_sock_addr2.c"
         return 0;
+#line 51 "sample/cgroup_sock_addr2.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=100 dst=r0 src=r7 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
@@ -718,24 +730,30 @@ connect_redirect6(void* context)
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
+    if (r1 == IMMEDIATE(17)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=91 imm=6
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
+    }
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=91 imm=6
+#line 102 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 102 "sample/cgroup_sock_addr2.c"
+    }
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=89 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
+    if (r2 != IMMEDIATE(23)) {
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 102 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
 #line 109 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
@@ -785,14 +803,14 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
 #line 114 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[0].address
+    r0 = connect_redirect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 114 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 114 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
@@ -803,10 +821,12 @@ label_1:
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 115 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-14 imm=0
@@ -847,22 +867,24 @@ label_1:
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
 #line 116 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[1].address
+    r0 = connect_redirect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 116 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 116 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
     // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
 #line 122 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
+    if (r1 == IMMEDIATE(3)) {
 #line 122 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-96
@@ -876,14 +898,14 @@ label_1:
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
 #line 123 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
+    r0 = connect_redirect6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 123 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0)) {
 #line 123 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 123 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
 #line 123 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
@@ -891,9 +913,11 @@ label_1:
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=40 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
+    if ((int64_t)r7 > (int64_t)r0) {
 #line 123 "sample/cgroup_sock_addr2.c"
         goto label_4;
+#line 123 "sample/cgroup_sock_addr2.c"
+    }
 label_2:
     // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
@@ -949,14 +973,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[3].address
+    r0 = connect_redirect6_helpers[3].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+#line 44 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-32 imm=0
@@ -967,14 +991,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[4].address
+    r0 = connect_redirect6_helpers[4].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-40 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-40 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
@@ -982,14 +1006,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[5].address
+    r0 = connect_redirect6_helpers[5].address(r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0)) {
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-24 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-24 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
@@ -1003,14 +1027,14 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[6].address
+    r0 = connect_redirect6_helpers[6].address(r1, r2, r3, r4, r5);
 #line 48 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0)) {
 #line 48 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=101 dst=r10 src=r0 offset=-16 imm=0
+#line 48 "sample/cgroup_sock_addr2.c"
+    }
+    // EBPF_OP_STXDW pc=101 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=102 dst=r10 src=r8 offset=-8 imm=0
@@ -1036,13 +1060,13 @@ label_3:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=110 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[7].address
+    r0 = connect_redirect6_helpers[7].address(r1, r2, r3, r4, r5);
 #line 51 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[7].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[7].tail_call) && (r0 == 0)) {
 #line 51 "sample/cgroup_sock_addr2.c"
         return 0;
+#line 51 "sample/cgroup_sock_addr2.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=111 dst=r0 src=r7 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -176,14 +176,14 @@ authorize_connect4(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[0].address
+    r0 = authorize_connect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r6 src=r10 offset=0 imm=0
@@ -209,14 +209,14 @@ authorize_connect4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[1].address
+    r0 = authorize_connect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r6 offset=0 imm=0
@@ -224,14 +224,14 @@ authorize_connect4(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[2].address
+    r0 = authorize_connect4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 60 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[2].tail_call) && (r0 == 0)) {
 #line 60 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=30 dst=r0 src=r0 offset=0 imm=1
@@ -239,10 +239,12 @@ authorize_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=31 dst=r1 src=r0 offset=1 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 62 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
+#line 62 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -362,14 +364,14 @@ authorize_connect6(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[0].address
+    r0 = authorize_connect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=22 dst=r6 src=r10 offset=0 imm=0
@@ -395,14 +397,14 @@ authorize_connect6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[1].address
+    r0 = authorize_connect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=33 dst=r2 src=r6 offset=0 imm=0
@@ -410,14 +412,14 @@ authorize_connect6(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[2].address
+    r0 = authorize_connect6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 76 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[2].tail_call) && (r0 == 0)) {
 #line 76 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
@@ -425,10 +427,12 @@ authorize_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 78 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -530,14 +534,14 @@ authorize_recv_accept4(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[0].address
+    r0 = authorize_recv_accept4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r6 src=r10 offset=0 imm=0
@@ -563,14 +567,14 @@ authorize_recv_accept4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[1].address
+    r0 = authorize_recv_accept4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r6 offset=0 imm=0
@@ -578,14 +582,14 @@ authorize_recv_accept4(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[2].address
+    r0 = authorize_recv_accept4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 60 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[2].tail_call) && (r0 == 0)) {
 #line 60 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=30 dst=r0 src=r0 offset=0 imm=1
@@ -593,10 +597,12 @@ authorize_recv_accept4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=31 dst=r1 src=r0 offset=1 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 62 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
+#line 62 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -716,14 +722,14 @@ authorize_recv_accept6(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[0].address
+    r0 = authorize_recv_accept6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=22 dst=r6 src=r10 offset=0 imm=0
@@ -749,14 +755,14 @@ authorize_recv_accept6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[1].address
+    r0 = authorize_recv_accept6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_MOV64_REG pc=33 dst=r2 src=r6 offset=0 imm=0
@@ -764,14 +770,14 @@ authorize_recv_accept6(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[2].address
+    r0 = authorize_recv_accept6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 76 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[2].tail_call) && (r0 == 0)) {
 #line 76 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
@@ -779,10 +785,12 @@ authorize_recv_accept6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 78 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -150,14 +150,14 @@ authorize_connect4(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[0].address
+    r0 = authorize_connect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r6 src=r10 offset=0 imm=0
@@ -183,14 +183,14 @@ authorize_connect4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[1].address
+    r0 = authorize_connect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r6 offset=0 imm=0
@@ -198,14 +198,14 @@ authorize_connect4(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[2].address
+    r0 = authorize_connect4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 60 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[2].tail_call) && (r0 == 0)) {
 #line 60 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=30 dst=r0 src=r0 offset=0 imm=1
@@ -213,10 +213,12 @@ authorize_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=31 dst=r1 src=r0 offset=1 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 62 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
+#line 62 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -336,14 +338,14 @@ authorize_connect6(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[0].address
+    r0 = authorize_connect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=22 dst=r6 src=r10 offset=0 imm=0
@@ -369,14 +371,14 @@ authorize_connect6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[1].address
+    r0 = authorize_connect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=33 dst=r2 src=r6 offset=0 imm=0
@@ -384,14 +386,14 @@ authorize_connect6(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[2].address
+    r0 = authorize_connect6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 76 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[2].tail_call) && (r0 == 0)) {
 #line 76 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
@@ -399,10 +401,12 @@ authorize_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 78 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -504,14 +508,14 @@ authorize_recv_accept4(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[0].address
+    r0 = authorize_recv_accept4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r6 src=r10 offset=0 imm=0
@@ -537,14 +541,14 @@ authorize_recv_accept4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[1].address
+    r0 = authorize_recv_accept4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r6 offset=0 imm=0
@@ -552,14 +556,14 @@ authorize_recv_accept4(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[2].address
+    r0 = authorize_recv_accept4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 60 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[2].tail_call) && (r0 == 0)) {
 #line 60 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=30 dst=r0 src=r0 offset=0 imm=1
@@ -567,10 +571,12 @@ authorize_recv_accept4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=31 dst=r1 src=r0 offset=1 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 62 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
+#line 62 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -690,14 +696,14 @@ authorize_recv_accept6(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[0].address
+    r0 = authorize_recv_accept6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=22 dst=r6 src=r10 offset=0 imm=0
@@ -723,14 +729,14 @@ authorize_recv_accept6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[1].address
+    r0 = authorize_recv_accept6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_MOV64_REG pc=33 dst=r2 src=r6 offset=0 imm=0
@@ -738,14 +744,14 @@ authorize_recv_accept6(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[2].address
+    r0 = authorize_recv_accept6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 76 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[2].tail_call) && (r0 == 0)) {
 #line 76 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
@@ -753,10 +759,12 @@ authorize_recv_accept6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 78 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -311,14 +311,14 @@ authorize_connect4(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[0].address
+    r0 = authorize_connect4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r6 src=r10 offset=0 imm=0
@@ -344,14 +344,14 @@ authorize_connect4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[1].address
+    r0 = authorize_connect4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r6 offset=0 imm=0
@@ -359,14 +359,14 @@ authorize_connect4(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect4_helpers[2].address
+    r0 = authorize_connect4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 60 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect4_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_connect4_helpers[2].tail_call) && (r0 == 0)) {
 #line 60 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=30 dst=r0 src=r0 offset=0 imm=1
@@ -374,10 +374,12 @@ authorize_connect4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=31 dst=r1 src=r0 offset=1 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 62 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
+#line 62 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -497,14 +499,14 @@ authorize_connect6(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[0].address
+    r0 = authorize_connect6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=22 dst=r6 src=r10 offset=0 imm=0
@@ -530,14 +532,14 @@ authorize_connect6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[1].address
+    r0 = authorize_connect6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=33 dst=r2 src=r6 offset=0 imm=0
@@ -545,14 +547,14 @@ authorize_connect6(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/cgroup_sock_addr.c"
-    r0 = authorize_connect6_helpers[2].address
+    r0 = authorize_connect6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 76 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr.c"
-    if ((authorize_connect6_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_connect6_helpers[2].tail_call) && (r0 == 0)) {
 #line 76 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
@@ -560,10 +562,12 @@ authorize_connect6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 78 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -665,14 +669,14 @@ authorize_recv_accept4(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[0].address
+    r0 = authorize_recv_accept4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r6 src=r10 offset=0 imm=0
@@ -698,14 +702,14 @@ authorize_recv_accept4(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[1].address
+    r0 = authorize_recv_accept4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r6 offset=0 imm=0
@@ -713,14 +717,14 @@ authorize_recv_accept4(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept4_helpers[2].address
+    r0 = authorize_recv_accept4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 60 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept4_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept4_helpers[2].tail_call) && (r0 == 0)) {
 #line 60 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=29 dst=r1 src=r0 offset=0 imm=0
 #line 60 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=30 dst=r0 src=r0 offset=0 imm=1
@@ -728,10 +732,12 @@ authorize_recv_accept4(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=31 dst=r1 src=r0 offset=1 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 62 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
+#line 62 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=32 dst=r0 src=r1 offset=0 imm=0
 #line 62 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -851,14 +857,14 @@ authorize_recv_accept6(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=26
 #line 44 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[0].address
+    r0 = authorize_recv_accept6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
+#line 44 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-8 imm=0
 #line 44 "sample/cgroup_sock_addr.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=22 dst=r6 src=r10 offset=0 imm=0
@@ -884,14 +890,14 @@ authorize_recv_accept6(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
 #line 45 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[1].address
+    r0 = authorize_recv_accept6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[1].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDDW pc=31 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_MOV64_REG pc=33 dst=r2 src=r6 offset=0 imm=0
@@ -899,14 +905,14 @@ authorize_recv_accept6(void* context)
     r2 = r6;
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=1
 #line 76 "sample/cgroup_sock_addr.c"
-    r0 = authorize_recv_accept6_helpers[2].address
+    r0 = authorize_recv_accept6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 76 "sample/cgroup_sock_addr.c"
-         (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr.c"
-    if ((authorize_recv_accept6_helpers[2].tail_call) && (r0 == 0))
+    if ((authorize_recv_accept6_helpers[2].tail_call) && (r0 == 0)) {
 #line 76 "sample/cgroup_sock_addr.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 76 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
@@ -914,10 +920,12 @@ authorize_recv_accept6(void* context)
     r0 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 78 "sample/cgroup_sock_addr.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr.c"
+    }
+    // EBPF_OP_LDXW pc=38 dst=r0 src=r1 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -99,23 +99,29 @@ decapsulate_permit_packet(void* context)
     r4 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
 #line 94 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+#line 94 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
 #line 99 "sample/decap_permit_packet.c"
-    if (r5 == IMMEDIATE(56710))
+    if (r5 == IMMEDIATE(56710)) {
 #line 99 "sample/decap_permit_packet.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 99 "sample/decap_permit_packet.c"
-    if (r5 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+#line 99 "sample/decap_permit_packet.c"
+    if (r5 != IMMEDIATE(8)) {
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+#line 99 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -123,18 +129,22 @@ decapsulate_permit_packet(void* context)
     r5 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
 #line 100 "sample/decap_permit_packet.c"
-    if (r5 > r3)
+    if (r5 > r3) {
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+#line 100 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
 #line 106 "sample/decap_permit_packet.c"
-    if (r5 != IMMEDIATE(4))
+    if (r5 != IMMEDIATE(4)) {
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+#line 106 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 105 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
@@ -151,10 +161,12 @@ decapsulate_permit_packet(void* context)
     r4 += IMMEDIATE(20);
     // EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
 #line 107 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 107 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+#line 107 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -165,10 +177,12 @@ decapsulate_permit_packet(void* context)
     r0 = IMMEDIATE(2);
     // EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+#line 29 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -176,10 +190,12 @@ decapsulate_permit_packet(void* context)
     r5 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
-    if (r5 > r3)
+    if (r5 > r3) {
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+#line 29 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 38 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -268,14 +284,14 @@ decapsulate_permit_packet(void* context)
     r2 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 41 "sample/decap_permit_packet.c"
-    r0 = decapsulate_permit_packet_helpers[0].address
+    r0 = decapsulate_permit_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 41 "sample/decap_permit_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/decap_permit_packet.c"
-    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 41 "sample/decap_permit_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+#line 41 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
@@ -292,10 +308,12 @@ decapsulate_permit_packet(void* context)
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
 #line 41 "sample/decap_permit_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 41 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+#line 41 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 41 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -307,10 +325,12 @@ label_1:
     r4 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
 #line 114 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 114 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+#line 114 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 114 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -318,18 +338,22 @@ label_1:
     r4 += IMMEDIATE(94);
     // EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
 #line 120 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+#line 120 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 120 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
 #line 120 "sample/decap_permit_packet.c"
-    if (r3 != IMMEDIATE(41))
+    if (r3 != IMMEDIATE(41)) {
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+#line 120 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 67 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -418,14 +442,14 @@ label_1:
     r2 = IMMEDIATE(40);
     // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
 #line 70 "sample/decap_permit_packet.c"
-    r0 = decapsulate_permit_packet_helpers[0].address
+    r0 = decapsulate_permit_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/decap_permit_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/decap_permit_packet.c"
-    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/decap_permit_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+#line 70 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
@@ -442,9 +466,11 @@ label_1:
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
 #line 70 "sample/decap_permit_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 70 "sample/decap_permit_packet.c"
         goto label_3;
+#line 70 "sample/decap_permit_packet.c"
+    }
 label_2:
     // EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/decap_permit_packet.c"

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -73,23 +73,29 @@ decapsulate_permit_packet(void* context)
     r4 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
 #line 94 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+#line 94 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
 #line 99 "sample/decap_permit_packet.c"
-    if (r5 == IMMEDIATE(56710))
+    if (r5 == IMMEDIATE(56710)) {
 #line 99 "sample/decap_permit_packet.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 99 "sample/decap_permit_packet.c"
-    if (r5 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+#line 99 "sample/decap_permit_packet.c"
+    if (r5 != IMMEDIATE(8)) {
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+#line 99 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -97,18 +103,22 @@ decapsulate_permit_packet(void* context)
     r5 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
 #line 100 "sample/decap_permit_packet.c"
-    if (r5 > r3)
+    if (r5 > r3) {
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+#line 100 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
 #line 106 "sample/decap_permit_packet.c"
-    if (r5 != IMMEDIATE(4))
+    if (r5 != IMMEDIATE(4)) {
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+#line 106 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 105 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
@@ -125,10 +135,12 @@ decapsulate_permit_packet(void* context)
     r4 += IMMEDIATE(20);
     // EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
 #line 107 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 107 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+#line 107 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -139,10 +151,12 @@ decapsulate_permit_packet(void* context)
     r0 = IMMEDIATE(2);
     // EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+#line 29 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -150,10 +164,12 @@ decapsulate_permit_packet(void* context)
     r5 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
-    if (r5 > r3)
+    if (r5 > r3) {
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+#line 29 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 38 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -242,14 +258,14 @@ decapsulate_permit_packet(void* context)
     r2 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 41 "sample/decap_permit_packet.c"
-    r0 = decapsulate_permit_packet_helpers[0].address
+    r0 = decapsulate_permit_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 41 "sample/decap_permit_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/decap_permit_packet.c"
-    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 41 "sample/decap_permit_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+#line 41 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
@@ -266,10 +282,12 @@ decapsulate_permit_packet(void* context)
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
 #line 41 "sample/decap_permit_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 41 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+#line 41 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 41 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -281,10 +299,12 @@ label_1:
     r4 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
 #line 114 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 114 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+#line 114 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 114 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -292,18 +312,22 @@ label_1:
     r4 += IMMEDIATE(94);
     // EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
 #line 120 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+#line 120 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 120 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
 #line 120 "sample/decap_permit_packet.c"
-    if (r3 != IMMEDIATE(41))
+    if (r3 != IMMEDIATE(41)) {
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+#line 120 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 67 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -392,14 +416,14 @@ label_1:
     r2 = IMMEDIATE(40);
     // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
 #line 70 "sample/decap_permit_packet.c"
-    r0 = decapsulate_permit_packet_helpers[0].address
+    r0 = decapsulate_permit_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/decap_permit_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/decap_permit_packet.c"
-    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/decap_permit_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+#line 70 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
@@ -416,9 +440,11 @@ label_1:
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
 #line 70 "sample/decap_permit_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 70 "sample/decap_permit_packet.c"
         goto label_3;
+#line 70 "sample/decap_permit_packet.c"
+    }
 label_2:
     // EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/decap_permit_packet.c"

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -234,23 +234,29 @@ decapsulate_permit_packet(void* context)
     r4 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
 #line 94 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+#line 94 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
 #line 99 "sample/decap_permit_packet.c"
-    if (r5 == IMMEDIATE(56710))
+    if (r5 == IMMEDIATE(56710)) {
 #line 99 "sample/decap_permit_packet.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 99 "sample/decap_permit_packet.c"
-    if (r5 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+#line 99 "sample/decap_permit_packet.c"
+    if (r5 != IMMEDIATE(8)) {
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+#line 99 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -258,18 +264,22 @@ decapsulate_permit_packet(void* context)
     r5 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
 #line 100 "sample/decap_permit_packet.c"
-    if (r5 > r3)
+    if (r5 > r3) {
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+#line 100 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
 #line 106 "sample/decap_permit_packet.c"
-    if (r5 != IMMEDIATE(4))
+    if (r5 != IMMEDIATE(4)) {
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+#line 106 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 105 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
@@ -286,10 +296,12 @@ decapsulate_permit_packet(void* context)
     r4 += IMMEDIATE(20);
     // EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
 #line 107 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 107 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+#line 107 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -300,10 +312,12 @@ decapsulate_permit_packet(void* context)
     r0 = IMMEDIATE(2);
     // EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+#line 29 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -311,10 +325,12 @@ decapsulate_permit_packet(void* context)
     r5 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
-    if (r5 > r3)
+    if (r5 > r3) {
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+#line 29 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 38 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -403,14 +419,14 @@ decapsulate_permit_packet(void* context)
     r2 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 41 "sample/decap_permit_packet.c"
-    r0 = decapsulate_permit_packet_helpers[0].address
+    r0 = decapsulate_permit_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 41 "sample/decap_permit_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/decap_permit_packet.c"
-    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 41 "sample/decap_permit_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+#line 41 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
@@ -427,10 +443,12 @@ decapsulate_permit_packet(void* context)
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
 #line 41 "sample/decap_permit_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 41 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+#line 41 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 41 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -442,10 +460,12 @@ label_1:
     r4 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
 #line 114 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 114 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+#line 114 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 114 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -453,18 +473,22 @@ label_1:
     r4 += IMMEDIATE(94);
     // EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
 #line 120 "sample/decap_permit_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+#line 120 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 120 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
 #line 120 "sample/decap_permit_packet.c"
-    if (r3 != IMMEDIATE(41))
+    if (r3 != IMMEDIATE(41)) {
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+#line 120 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 67 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -553,14 +577,14 @@ label_1:
     r2 = IMMEDIATE(40);
     // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
 #line 70 "sample/decap_permit_packet.c"
-    r0 = decapsulate_permit_packet_helpers[0].address
+    r0 = decapsulate_permit_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 70 "sample/decap_permit_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 70 "sample/decap_permit_packet.c"
-    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 70 "sample/decap_permit_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+#line 70 "sample/decap_permit_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
@@ -577,9 +601,11 @@ label_1:
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
 #line 70 "sample/decap_permit_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 70 "sample/decap_permit_packet.c"
         goto label_3;
+#line 70 "sample/decap_permit_packet.c"
+    }
 label_2:
     // EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
 #line 70 "sample/decap_permit_packet.c"

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -122,19 +122,21 @@ divide_by_zero(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 35 "sample/undocked/divide_by_zero.c"
-    r0 = divide_by_zero_helpers[0].address
+    r0 = divide_by_zero_helpers[0].address(r1, r2, r3, r4, r5);
 #line 35 "sample/undocked/divide_by_zero.c"
-         (r1, r2, r3, r4, r5);
-#line 35 "sample/undocked/divide_by_zero.c"
-    if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0))
+    if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0)) {
 #line 35 "sample/undocked/divide_by_zero.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
+#line 35 "sample/undocked/divide_by_zero.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
 #line 36 "sample/undocked/divide_by_zero.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 36 "sample/undocked/divide_by_zero.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 36 "sample/undocked/divide_by_zero.c"
+    }
+    // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 37 "sample/undocked/divide_by_zero.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_MOV64_IMM pc=9 dst=r6 src=r0 offset=0 imm=100000

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -96,19 +96,21 @@ divide_by_zero(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 35 "sample/undocked/divide_by_zero.c"
-    r0 = divide_by_zero_helpers[0].address
+    r0 = divide_by_zero_helpers[0].address(r1, r2, r3, r4, r5);
 #line 35 "sample/undocked/divide_by_zero.c"
-         (r1, r2, r3, r4, r5);
-#line 35 "sample/undocked/divide_by_zero.c"
-    if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0))
+    if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0)) {
 #line 35 "sample/undocked/divide_by_zero.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
+#line 35 "sample/undocked/divide_by_zero.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
 #line 36 "sample/undocked/divide_by_zero.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 36 "sample/undocked/divide_by_zero.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 36 "sample/undocked/divide_by_zero.c"
+    }
+    // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 37 "sample/undocked/divide_by_zero.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_MOV64_IMM pc=9 dst=r6 src=r0 offset=0 imm=100000

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -257,19 +257,21 @@ divide_by_zero(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 35 "sample/undocked/divide_by_zero.c"
-    r0 = divide_by_zero_helpers[0].address
+    r0 = divide_by_zero_helpers[0].address(r1, r2, r3, r4, r5);
 #line 35 "sample/undocked/divide_by_zero.c"
-         (r1, r2, r3, r4, r5);
-#line 35 "sample/undocked/divide_by_zero.c"
-    if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0))
+    if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0)) {
 #line 35 "sample/undocked/divide_by_zero.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
+#line 35 "sample/undocked/divide_by_zero.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
 #line 36 "sample/undocked/divide_by_zero.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 36 "sample/undocked/divide_by_zero.c"
         goto label_1;
-        // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 36 "sample/undocked/divide_by_zero.c"
+    }
+    // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 37 "sample/undocked/divide_by_zero.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_MOV64_IMM pc=9 dst=r6 src=r0 offset=0 imm=100000

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -138,22 +138,24 @@ DropPacket(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/droppacket.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/droppacket.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/droppacket.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/droppacket.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 56 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
 #line 57 "sample/droppacket.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 57 "sample/droppacket.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+#line 57 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -164,9 +166,11 @@ DropPacket(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_JNE_REG pc=13 dst=r2 src=r1 offset=32 imm=0
 #line 58 "sample/droppacket.c"
-    if (r2 != r1)
+    if (r2 != r1) {
 #line 58 "sample/droppacket.c"
         goto label_2;
+#line 58 "sample/droppacket.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/droppacket.c"
@@ -185,26 +189,32 @@ label_1:
     r3 += IMMEDIATE(42);
     // EBPF_OP_JGT_REG pc=19 dst=r3 src=r2 offset=26 imm=0
 #line 64 "sample/droppacket.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 64 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+#line 64 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 69 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
 #line 69 "sample/droppacket.c"
-    if (r3 != IMMEDIATE(8))
+    if (r3 != IMMEDIATE(8)) {
 #line 69 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+#line 69 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 72 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
 #line 72 "sample/droppacket.c"
-    if (r3 != IMMEDIATE(17))
+    if (r3 != IMMEDIATE(17)) {
 #line 72 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+#line 72 "sample/droppacket.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 72 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -227,10 +237,12 @@ label_1:
     r3 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=31 dst=r3 src=r2 offset=14 imm=0
 #line 75 "sample/droppacket.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 75 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+#line 75 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 79 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -240,10 +252,12 @@ label_1:
     r1 &= UINT32_MAX;
     // EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 79 "sample/droppacket.c"
-    if (r1 > IMMEDIATE(8))
+    if (r1 > IMMEDIATE(8)) {
 #line 79 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 79 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 79 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -254,14 +268,14 @@ label_1:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/droppacket.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/droppacket.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/droppacket.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/droppacket.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+#line 80 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 80 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -269,10 +283,12 @@ label_1:
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=3 imm=0
 #line 81 "sample/droppacket.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 81 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+#line 81 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 82 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -112,22 +112,24 @@ DropPacket(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/droppacket.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/droppacket.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/droppacket.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/droppacket.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 56 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
 #line 57 "sample/droppacket.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 57 "sample/droppacket.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+#line 57 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -138,9 +140,11 @@ DropPacket(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_JNE_REG pc=13 dst=r2 src=r1 offset=32 imm=0
 #line 58 "sample/droppacket.c"
-    if (r2 != r1)
+    if (r2 != r1) {
 #line 58 "sample/droppacket.c"
         goto label_2;
+#line 58 "sample/droppacket.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/droppacket.c"
@@ -159,26 +163,32 @@ label_1:
     r3 += IMMEDIATE(42);
     // EBPF_OP_JGT_REG pc=19 dst=r3 src=r2 offset=26 imm=0
 #line 64 "sample/droppacket.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 64 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+#line 64 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 69 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
 #line 69 "sample/droppacket.c"
-    if (r3 != IMMEDIATE(8))
+    if (r3 != IMMEDIATE(8)) {
 #line 69 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+#line 69 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 72 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
 #line 72 "sample/droppacket.c"
-    if (r3 != IMMEDIATE(17))
+    if (r3 != IMMEDIATE(17)) {
 #line 72 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+#line 72 "sample/droppacket.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 72 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -201,10 +211,12 @@ label_1:
     r3 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=31 dst=r3 src=r2 offset=14 imm=0
 #line 75 "sample/droppacket.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 75 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+#line 75 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 79 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -214,10 +226,12 @@ label_1:
     r1 &= UINT32_MAX;
     // EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 79 "sample/droppacket.c"
-    if (r1 > IMMEDIATE(8))
+    if (r1 > IMMEDIATE(8)) {
 #line 79 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 79 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 79 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -228,14 +242,14 @@ label_1:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/droppacket.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/droppacket.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/droppacket.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/droppacket.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+#line 80 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 80 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -243,10 +257,12 @@ label_1:
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=3 imm=0
 #line 81 "sample/droppacket.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 81 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+#line 81 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 82 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -273,22 +273,24 @@ DropPacket(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/droppacket.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 56 "sample/droppacket.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/droppacket.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 56 "sample/droppacket.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 56 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
 #line 57 "sample/droppacket.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 57 "sample/droppacket.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+#line 57 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -299,9 +301,11 @@ DropPacket(void* context)
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_JNE_REG pc=13 dst=r2 src=r1 offset=32 imm=0
 #line 58 "sample/droppacket.c"
-    if (r2 != r1)
+    if (r2 != r1) {
 #line 58 "sample/droppacket.c"
         goto label_2;
+#line 58 "sample/droppacket.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/droppacket.c"
@@ -320,26 +324,32 @@ label_1:
     r3 += IMMEDIATE(42);
     // EBPF_OP_JGT_REG pc=19 dst=r3 src=r2 offset=26 imm=0
 #line 64 "sample/droppacket.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 64 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+#line 64 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 69 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
 #line 69 "sample/droppacket.c"
-    if (r3 != IMMEDIATE(8))
+    if (r3 != IMMEDIATE(8)) {
 #line 69 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+#line 69 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 72 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
 #line 72 "sample/droppacket.c"
-    if (r3 != IMMEDIATE(17))
+    if (r3 != IMMEDIATE(17)) {
 #line 72 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+#line 72 "sample/droppacket.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 72 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -362,10 +372,12 @@ label_1:
     r3 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=31 dst=r3 src=r2 offset=14 imm=0
 #line 75 "sample/droppacket.c"
-    if (r3 > r2)
+    if (r3 > r2) {
 #line 75 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+#line 75 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 79 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -375,10 +387,12 @@ label_1:
     r1 &= UINT32_MAX;
     // EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 79 "sample/droppacket.c"
-    if (r1 > IMMEDIATE(8))
+    if (r1 > IMMEDIATE(8)) {
 #line 79 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 79 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 79 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -389,14 +403,14 @@ label_1:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/droppacket.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 80 "sample/droppacket.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/droppacket.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 80 "sample/droppacket.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+#line 80 "sample/droppacket.c"
+    }
+    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 80 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -404,10 +418,12 @@ label_1:
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=3 imm=0
 #line 81 "sample/droppacket.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 81 "sample/droppacket.c"
         goto label_2;
-        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+#line 81 "sample/droppacket.c"
+    }
+    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 82 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
@@ -114,10 +114,12 @@ DropPacket(void* context)
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_JNE_IMM pc=3 dst=r2 src=r0 offset=15 imm=17
 #line 41 "sample/unsafe/droppacket_unsafe.c"
-    if (r2 != IMMEDIATE(17))
+    if (r2 != IMMEDIATE(17)) {
 #line 41 "sample/unsafe/droppacket_unsafe.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=4 dst=r1 src=r1 offset=24 imm=0
+#line 41 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_LDXH pc=4 dst=r1 src=r1 offset=24 imm=0
 #line 42 "sample/unsafe/droppacket_unsafe.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_BE pc=5 dst=r1 src=r0 offset=0 imm=16
@@ -127,10 +129,12 @@ DropPacket(void* context)
     r1 &= UINT32_MAX;
     // EBPF_OP_JGT_IMM pc=6 dst=r1 src=r0 offset=12 imm=8
 #line 42 "sample/unsafe/droppacket_unsafe.c"
-    if (r1 > IMMEDIATE(8))
+    if (r1 > IMMEDIATE(8)) {
 #line 42 "sample/unsafe/droppacket_unsafe.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 42 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=0
 #line 42 "sample/unsafe/droppacket_unsafe.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-8 imm=0
@@ -147,19 +151,21 @@ DropPacket(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 44 "sample/unsafe/droppacket_unsafe.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/unsafe/droppacket_unsafe.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/unsafe/droppacket_unsafe.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/unsafe/droppacket_unsafe.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=14 dst=r0 src=r0 offset=3 imm=0
+#line 44 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=14 dst=r0 src=r0 offset=3 imm=0
 #line 45 "sample/unsafe/droppacket_unsafe.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 45 "sample/unsafe/droppacket_unsafe.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=15 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_LDXDW pc=15 dst=r1 src=r0 offset=0 imm=0
 #line 46 "sample/unsafe/droppacket_unsafe.c"
     r1 = *(uint64_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=16 dst=r1 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_raw.c
@@ -88,10 +88,12 @@ DropPacket(void* context)
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_JNE_IMM pc=3 dst=r2 src=r0 offset=15 imm=17
 #line 41 "sample/unsafe/droppacket_unsafe.c"
-    if (r2 != IMMEDIATE(17))
+    if (r2 != IMMEDIATE(17)) {
 #line 41 "sample/unsafe/droppacket_unsafe.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=4 dst=r1 src=r1 offset=24 imm=0
+#line 41 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_LDXH pc=4 dst=r1 src=r1 offset=24 imm=0
 #line 42 "sample/unsafe/droppacket_unsafe.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_BE pc=5 dst=r1 src=r0 offset=0 imm=16
@@ -101,10 +103,12 @@ DropPacket(void* context)
     r1 &= UINT32_MAX;
     // EBPF_OP_JGT_IMM pc=6 dst=r1 src=r0 offset=12 imm=8
 #line 42 "sample/unsafe/droppacket_unsafe.c"
-    if (r1 > IMMEDIATE(8))
+    if (r1 > IMMEDIATE(8)) {
 #line 42 "sample/unsafe/droppacket_unsafe.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 42 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=0
 #line 42 "sample/unsafe/droppacket_unsafe.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-8 imm=0
@@ -121,19 +125,21 @@ DropPacket(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 44 "sample/unsafe/droppacket_unsafe.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/unsafe/droppacket_unsafe.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/unsafe/droppacket_unsafe.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/unsafe/droppacket_unsafe.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=14 dst=r0 src=r0 offset=3 imm=0
+#line 44 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=14 dst=r0 src=r0 offset=3 imm=0
 #line 45 "sample/unsafe/droppacket_unsafe.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 45 "sample/unsafe/droppacket_unsafe.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=15 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_LDXDW pc=15 dst=r1 src=r0 offset=0 imm=0
 #line 46 "sample/unsafe/droppacket_unsafe.c"
     r1 = *(uint64_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=16 dst=r1 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_sys.c
@@ -249,10 +249,12 @@ DropPacket(void* context)
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_JNE_IMM pc=3 dst=r2 src=r0 offset=15 imm=17
 #line 41 "sample/unsafe/droppacket_unsafe.c"
-    if (r2 != IMMEDIATE(17))
+    if (r2 != IMMEDIATE(17)) {
 #line 41 "sample/unsafe/droppacket_unsafe.c"
         goto label_2;
-        // EBPF_OP_LDXH pc=4 dst=r1 src=r1 offset=24 imm=0
+#line 41 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_LDXH pc=4 dst=r1 src=r1 offset=24 imm=0
 #line 42 "sample/unsafe/droppacket_unsafe.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_BE pc=5 dst=r1 src=r0 offset=0 imm=16
@@ -262,10 +264,12 @@ DropPacket(void* context)
     r1 &= UINT32_MAX;
     // EBPF_OP_JGT_IMM pc=6 dst=r1 src=r0 offset=12 imm=8
 #line 42 "sample/unsafe/droppacket_unsafe.c"
-    if (r1 > IMMEDIATE(8))
+    if (r1 > IMMEDIATE(8)) {
 #line 42 "sample/unsafe/droppacket_unsafe.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 42 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=0
 #line 42 "sample/unsafe/droppacket_unsafe.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-8 imm=0
@@ -282,19 +286,21 @@ DropPacket(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 44 "sample/unsafe/droppacket_unsafe.c"
-    r0 = DropPacket_helpers[0].address
+    r0 = DropPacket_helpers[0].address(r1, r2, r3, r4, r5);
 #line 44 "sample/unsafe/droppacket_unsafe.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/unsafe/droppacket_unsafe.c"
-    if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
+    if ((DropPacket_helpers[0].tail_call) && (r0 == 0)) {
 #line 44 "sample/unsafe/droppacket_unsafe.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=14 dst=r0 src=r0 offset=3 imm=0
+#line 44 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=14 dst=r0 src=r0 offset=3 imm=0
 #line 45 "sample/unsafe/droppacket_unsafe.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 45 "sample/unsafe/droppacket_unsafe.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=15 dst=r1 src=r0 offset=0 imm=0
+#line 45 "sample/unsafe/droppacket_unsafe.c"
+    }
+    // EBPF_OP_LDXDW pc=15 dst=r1 src=r0 offset=0 imm=0
 #line 46 "sample/unsafe/droppacket_unsafe.c"
     r1 = *(uint64_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=16 dst=r1 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -109,23 +109,29 @@ encap_reflect_packet(void* context)
     r3 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r1 offset=315 imm=0
 #line 173 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 173 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+#line 173 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 178 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=120 imm=56710
 #line 178 "sample/encap_reflect_packet.c"
-    if (r4 == IMMEDIATE(56710))
+    if (r4 == IMMEDIATE(56710)) {
 #line 178 "sample/encap_reflect_packet.c"
         goto label_2;
-        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=312 imm=8
 #line 178 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=312 imm=8
+#line 178 "sample/encap_reflect_packet.c"
+    if (r4 != IMMEDIATE(8)) {
 #line 178 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+#line 178 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 179 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -133,18 +139,22 @@ encap_reflect_packet(void* context)
     r4 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=12 dst=r4 src=r1 offset=309 imm=0
 #line 179 "sample/encap_reflect_packet.c"
-    if (r4 > r1)
+    if (r4 > r1) {
 #line 179 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+#line 179 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 185 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=307 imm=17
 #line 185 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(17))
+    if (r4 != IMMEDIATE(17)) {
 #line 185 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+#line 185 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 185 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
@@ -164,18 +174,22 @@ encap_reflect_packet(void* context)
     r2 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=21 dst=r2 src=r1 offset=300 imm=0
 #line 185 "sample/encap_reflect_packet.c"
-    if (r2 > r1)
+    if (r2 > r1) {
 #line 185 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+#line 185 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 191 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=298 imm=7459
 #line 191 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 191 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+#line 191 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -183,14 +197,14 @@ encap_reflect_packet(void* context)
     r2 = (uint64_t)4294967276;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=65536
 #line 22 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[0].address
+    r0 = encap_reflect_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 22 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+#line 22 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -207,10 +221,12 @@ encap_reflect_packet(void* context)
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r2 src=r1 offset=288 imm=0
 #line 22 "sample/encap_reflect_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 22 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+#line 22 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 28 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r7 src=r6 offset=0 imm=0
@@ -224,10 +240,12 @@ encap_reflect_packet(void* context)
     r3 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=38 dst=r3 src=r4 offset=283 imm=0
 #line 28 "sample/encap_reflect_packet.c"
-    if (r3 > r4)
+    if (r3 > r4) {
 #line 28 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r7 offset=0 imm=0
+#line 28 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r7 offset=0 imm=0
 #line 35 "sample/encap_reflect_packet.c"
     r2 = r7;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -235,10 +253,12 @@ encap_reflect_packet(void* context)
     r2 += IMMEDIATE(20);
     // EBPF_OP_JGT_REG pc=41 dst=r2 src=r4 offset=280 imm=0
 #line 35 "sample/encap_reflect_packet.c"
-    if (r2 > r4)
+    if (r2 > r4) {
 #line 35 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r7 offset=0 imm=0
+#line 35 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r7 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r1 = r7;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -246,10 +266,12 @@ encap_reflect_packet(void* context)
     r1 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=44 dst=r1 src=r4 offset=277 imm=0
 #line 43 "sample/encap_reflect_packet.c"
-    if (r1 > r4)
+    if (r1 > r4) {
 #line 43 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r7 offset=0 imm=0
+#line 43 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r7 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r5 = r7;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -257,10 +279,12 @@ encap_reflect_packet(void* context)
     r5 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=47 dst=r5 src=r4 offset=274 imm=0
 #line 43 "sample/encap_reflect_packet.c"
-    if (r5 > r4)
+    if (r5 > r4) {
 #line 43 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+#line 43 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 56 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r7 src=r4 offset=4 imm=0
@@ -367,18 +391,22 @@ encap_reflect_packet(void* context)
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGT_REG pc=83 dst=r4 src=r5 offset=238 imm=0
 #line 64 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 64 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=84 dst=r4 src=r2 offset=2 imm=0
+#line 64 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=84 dst=r4 src=r2 offset=2 imm=0
 #line 68 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=85 dst=r4 src=r0 offset=4 imm=7459
 #line 68 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(7459))
+    if (r4 != IMMEDIATE(7459)) {
 #line 68 "sample/encap_reflect_packet.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=86 dst=r4 src=r2 offset=0 imm=0
+#line 68 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=86 dst=r4 src=r2 offset=0 imm=0
 #line 40 "sample/./xdp_common.h"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(0));
     // EBPF_OP_STXH pc=87 dst=r2 src=r4 offset=2 imm=0
@@ -478,14 +506,14 @@ label_1:
     r5 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=117 dst=r0 src=r0 offset=0 imm=10
 #line 82 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[1].address
+    r0 = encap_reflect_packet_helpers[1].address(r1, r2, r3, r4, r5);
 #line 82 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0)) {
 #line 82 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=118 dst=r1 src=r0 offset=0 imm=0
+#line 82 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=118 dst=r1 src=r0 offset=0 imm=0
 #line 49 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=119 dst=r1 src=r0 offset=0 imm=65535
@@ -527,10 +555,12 @@ label_2:
     r3 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=131 dst=r3 src=r1 offset=190 imm=0
 #line 196 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 196 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=132 dst=r3 src=r2 offset=0 imm=0
+#line 196 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=132 dst=r3 src=r2 offset=0 imm=0
 #line 196 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=133 dst=r3 src=r0 offset=0 imm=62
@@ -538,26 +568,32 @@ label_2:
     r3 += IMMEDIATE(62);
     // EBPF_OP_JGT_REG pc=134 dst=r3 src=r1 offset=187 imm=0
 #line 202 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 202 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=135 dst=r1 src=r2 offset=20 imm=0
+#line 202 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=135 dst=r1 src=r2 offset=20 imm=0
 #line 202 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=136 dst=r1 src=r0 offset=185 imm=17
 #line 202 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(17))
+    if (r1 != IMMEDIATE(17)) {
 #line 202 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=137 dst=r1 src=r2 offset=56 imm=0
+#line 202 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=137 dst=r1 src=r2 offset=56 imm=0
 #line 208 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=138 dst=r1 src=r0 offset=183 imm=7459
 #line 208 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 208 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=139 dst=r1 src=r6 offset=0 imm=0
+#line 208 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=139 dst=r1 src=r6 offset=0 imm=0
 #line 96 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=140 dst=r2 src=r0 offset=0 imm=-40
@@ -565,14 +601,14 @@ label_2:
     r2 = (uint64_t)4294967256;
     // EBPF_OP_CALL pc=142 dst=r0 src=r0 offset=0 imm=65536
 #line 96 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[0].address
+    r0 = encap_reflect_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 96 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 96 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=143 dst=r1 src=r0 offset=0 imm=0
+#line 96 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=143 dst=r1 src=r0 offset=0 imm=0
 #line 96 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=144 dst=r0 src=r0 offset=0 imm=2
@@ -589,10 +625,12 @@ label_2:
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=148 dst=r2 src=r1 offset=173 imm=0
 #line 96 "sample/encap_reflect_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 96 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXDW pc=149 dst=r5 src=r6 offset=8 imm=0
+#line 96 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXDW pc=149 dst=r5 src=r6 offset=8 imm=0
 #line 102 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=150 dst=r1 src=r6 offset=0 imm=0
@@ -606,10 +644,12 @@ label_2:
     r2 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=153 dst=r2 src=r5 offset=168 imm=0
 #line 102 "sample/encap_reflect_packet.c"
-    if (r2 > r5)
+    if (r2 > r5) {
 #line 102 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=154 dst=r4 src=r1 offset=0 imm=0
+#line 102 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=154 dst=r4 src=r1 offset=0 imm=0
 #line 109 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=155 dst=r4 src=r0 offset=0 imm=40
@@ -617,10 +657,12 @@ label_2:
     r4 += IMMEDIATE(40);
     // EBPF_OP_JGT_REG pc=156 dst=r4 src=r5 offset=165 imm=0
 #line 109 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 109 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=157 dst=r3 src=r1 offset=0 imm=0
+#line 109 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=157 dst=r3 src=r1 offset=0 imm=0
 #line 117 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=158 dst=r3 src=r0 offset=0 imm=54
@@ -628,10 +670,12 @@ label_2:
     r3 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=159 dst=r3 src=r5 offset=162 imm=0
 #line 117 "sample/encap_reflect_packet.c"
-    if (r3 > r5)
+    if (r3 > r5) {
 #line 117 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=160 dst=r7 src=r1 offset=0 imm=0
+#line 117 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=160 dst=r7 src=r1 offset=0 imm=0
 #line 124 "sample/encap_reflect_packet.c"
     r7 = r1;
     // EBPF_OP_ADD64_IMM pc=161 dst=r7 src=r0 offset=0 imm=94
@@ -639,10 +683,12 @@ label_2:
     r7 += IMMEDIATE(94);
     // EBPF_OP_JGT_REG pc=162 dst=r7 src=r5 offset=159 imm=0
 #line 124 "sample/encap_reflect_packet.c"
-    if (r7 > r5)
+    if (r7 > r5) {
 #line 124 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=163 dst=r5 src=r4 offset=4 imm=0
+#line 124 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=163 dst=r5 src=r4 offset=4 imm=0
 #line 130 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=164 dst=r1 src=r5 offset=4 imm=0
@@ -1016,18 +1062,22 @@ label_2:
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGT_REG pc=287 dst=r4 src=r5 offset=34 imm=0
 #line 138 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 138 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=288 dst=r4 src=r1 offset=96 imm=0
+#line 138 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=288 dst=r4 src=r1 offset=96 imm=0
 #line 142 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(96));
     // EBPF_OP_JNE_IMM pc=289 dst=r4 src=r0 offset=4 imm=7459
 #line 142 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(7459))
+    if (r4 != IMMEDIATE(7459)) {
 #line 142 "sample/encap_reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=290 dst=r4 src=r1 offset=94 imm=0
+#line 142 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=290 dst=r4 src=r1 offset=94 imm=0
 #line 40 "sample/./xdp_common.h"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(94));
     // EBPF_OP_STXH pc=291 dst=r1 src=r4 offset=96 imm=0

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -83,23 +83,29 @@ encap_reflect_packet(void* context)
     r3 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r1 offset=315 imm=0
 #line 173 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 173 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+#line 173 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 178 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=120 imm=56710
 #line 178 "sample/encap_reflect_packet.c"
-    if (r4 == IMMEDIATE(56710))
+    if (r4 == IMMEDIATE(56710)) {
 #line 178 "sample/encap_reflect_packet.c"
         goto label_2;
-        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=312 imm=8
 #line 178 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=312 imm=8
+#line 178 "sample/encap_reflect_packet.c"
+    if (r4 != IMMEDIATE(8)) {
 #line 178 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+#line 178 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 179 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -107,18 +113,22 @@ encap_reflect_packet(void* context)
     r4 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=12 dst=r4 src=r1 offset=309 imm=0
 #line 179 "sample/encap_reflect_packet.c"
-    if (r4 > r1)
+    if (r4 > r1) {
 #line 179 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+#line 179 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 185 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=307 imm=17
 #line 185 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(17))
+    if (r4 != IMMEDIATE(17)) {
 #line 185 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+#line 185 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 185 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
@@ -138,18 +148,22 @@ encap_reflect_packet(void* context)
     r2 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=21 dst=r2 src=r1 offset=300 imm=0
 #line 185 "sample/encap_reflect_packet.c"
-    if (r2 > r1)
+    if (r2 > r1) {
 #line 185 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+#line 185 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 191 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=298 imm=7459
 #line 191 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 191 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+#line 191 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -157,14 +171,14 @@ encap_reflect_packet(void* context)
     r2 = (uint64_t)4294967276;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=65536
 #line 22 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[0].address
+    r0 = encap_reflect_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 22 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+#line 22 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -181,10 +195,12 @@ encap_reflect_packet(void* context)
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r2 src=r1 offset=288 imm=0
 #line 22 "sample/encap_reflect_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 22 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+#line 22 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 28 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r7 src=r6 offset=0 imm=0
@@ -198,10 +214,12 @@ encap_reflect_packet(void* context)
     r3 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=38 dst=r3 src=r4 offset=283 imm=0
 #line 28 "sample/encap_reflect_packet.c"
-    if (r3 > r4)
+    if (r3 > r4) {
 #line 28 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r7 offset=0 imm=0
+#line 28 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r7 offset=0 imm=0
 #line 35 "sample/encap_reflect_packet.c"
     r2 = r7;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -209,10 +227,12 @@ encap_reflect_packet(void* context)
     r2 += IMMEDIATE(20);
     // EBPF_OP_JGT_REG pc=41 dst=r2 src=r4 offset=280 imm=0
 #line 35 "sample/encap_reflect_packet.c"
-    if (r2 > r4)
+    if (r2 > r4) {
 #line 35 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r7 offset=0 imm=0
+#line 35 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r7 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r1 = r7;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -220,10 +240,12 @@ encap_reflect_packet(void* context)
     r1 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=44 dst=r1 src=r4 offset=277 imm=0
 #line 43 "sample/encap_reflect_packet.c"
-    if (r1 > r4)
+    if (r1 > r4) {
 #line 43 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r7 offset=0 imm=0
+#line 43 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r7 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r5 = r7;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -231,10 +253,12 @@ encap_reflect_packet(void* context)
     r5 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=47 dst=r5 src=r4 offset=274 imm=0
 #line 43 "sample/encap_reflect_packet.c"
-    if (r5 > r4)
+    if (r5 > r4) {
 #line 43 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+#line 43 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 56 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r7 src=r4 offset=4 imm=0
@@ -341,18 +365,22 @@ encap_reflect_packet(void* context)
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGT_REG pc=83 dst=r4 src=r5 offset=238 imm=0
 #line 64 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 64 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=84 dst=r4 src=r2 offset=2 imm=0
+#line 64 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=84 dst=r4 src=r2 offset=2 imm=0
 #line 68 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=85 dst=r4 src=r0 offset=4 imm=7459
 #line 68 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(7459))
+    if (r4 != IMMEDIATE(7459)) {
 #line 68 "sample/encap_reflect_packet.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=86 dst=r4 src=r2 offset=0 imm=0
+#line 68 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=86 dst=r4 src=r2 offset=0 imm=0
 #line 40 "sample/./xdp_common.h"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(0));
     // EBPF_OP_STXH pc=87 dst=r2 src=r4 offset=2 imm=0
@@ -452,14 +480,14 @@ label_1:
     r5 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=117 dst=r0 src=r0 offset=0 imm=10
 #line 82 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[1].address
+    r0 = encap_reflect_packet_helpers[1].address(r1, r2, r3, r4, r5);
 #line 82 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0)) {
 #line 82 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=118 dst=r1 src=r0 offset=0 imm=0
+#line 82 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=118 dst=r1 src=r0 offset=0 imm=0
 #line 49 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=119 dst=r1 src=r0 offset=0 imm=65535
@@ -501,10 +529,12 @@ label_2:
     r3 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=131 dst=r3 src=r1 offset=190 imm=0
 #line 196 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 196 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=132 dst=r3 src=r2 offset=0 imm=0
+#line 196 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=132 dst=r3 src=r2 offset=0 imm=0
 #line 196 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=133 dst=r3 src=r0 offset=0 imm=62
@@ -512,26 +542,32 @@ label_2:
     r3 += IMMEDIATE(62);
     // EBPF_OP_JGT_REG pc=134 dst=r3 src=r1 offset=187 imm=0
 #line 202 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 202 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=135 dst=r1 src=r2 offset=20 imm=0
+#line 202 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=135 dst=r1 src=r2 offset=20 imm=0
 #line 202 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=136 dst=r1 src=r0 offset=185 imm=17
 #line 202 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(17))
+    if (r1 != IMMEDIATE(17)) {
 #line 202 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=137 dst=r1 src=r2 offset=56 imm=0
+#line 202 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=137 dst=r1 src=r2 offset=56 imm=0
 #line 208 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=138 dst=r1 src=r0 offset=183 imm=7459
 #line 208 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 208 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=139 dst=r1 src=r6 offset=0 imm=0
+#line 208 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=139 dst=r1 src=r6 offset=0 imm=0
 #line 96 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=140 dst=r2 src=r0 offset=0 imm=-40
@@ -539,14 +575,14 @@ label_2:
     r2 = (uint64_t)4294967256;
     // EBPF_OP_CALL pc=142 dst=r0 src=r0 offset=0 imm=65536
 #line 96 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[0].address
+    r0 = encap_reflect_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 96 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 96 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=143 dst=r1 src=r0 offset=0 imm=0
+#line 96 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=143 dst=r1 src=r0 offset=0 imm=0
 #line 96 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=144 dst=r0 src=r0 offset=0 imm=2
@@ -563,10 +599,12 @@ label_2:
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=148 dst=r2 src=r1 offset=173 imm=0
 #line 96 "sample/encap_reflect_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 96 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXDW pc=149 dst=r5 src=r6 offset=8 imm=0
+#line 96 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXDW pc=149 dst=r5 src=r6 offset=8 imm=0
 #line 102 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=150 dst=r1 src=r6 offset=0 imm=0
@@ -580,10 +618,12 @@ label_2:
     r2 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=153 dst=r2 src=r5 offset=168 imm=0
 #line 102 "sample/encap_reflect_packet.c"
-    if (r2 > r5)
+    if (r2 > r5) {
 #line 102 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=154 dst=r4 src=r1 offset=0 imm=0
+#line 102 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=154 dst=r4 src=r1 offset=0 imm=0
 #line 109 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=155 dst=r4 src=r0 offset=0 imm=40
@@ -591,10 +631,12 @@ label_2:
     r4 += IMMEDIATE(40);
     // EBPF_OP_JGT_REG pc=156 dst=r4 src=r5 offset=165 imm=0
 #line 109 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 109 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=157 dst=r3 src=r1 offset=0 imm=0
+#line 109 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=157 dst=r3 src=r1 offset=0 imm=0
 #line 117 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=158 dst=r3 src=r0 offset=0 imm=54
@@ -602,10 +644,12 @@ label_2:
     r3 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=159 dst=r3 src=r5 offset=162 imm=0
 #line 117 "sample/encap_reflect_packet.c"
-    if (r3 > r5)
+    if (r3 > r5) {
 #line 117 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=160 dst=r7 src=r1 offset=0 imm=0
+#line 117 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=160 dst=r7 src=r1 offset=0 imm=0
 #line 124 "sample/encap_reflect_packet.c"
     r7 = r1;
     // EBPF_OP_ADD64_IMM pc=161 dst=r7 src=r0 offset=0 imm=94
@@ -613,10 +657,12 @@ label_2:
     r7 += IMMEDIATE(94);
     // EBPF_OP_JGT_REG pc=162 dst=r7 src=r5 offset=159 imm=0
 #line 124 "sample/encap_reflect_packet.c"
-    if (r7 > r5)
+    if (r7 > r5) {
 #line 124 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=163 dst=r5 src=r4 offset=4 imm=0
+#line 124 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=163 dst=r5 src=r4 offset=4 imm=0
 #line 130 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=164 dst=r1 src=r5 offset=4 imm=0
@@ -990,18 +1036,22 @@ label_2:
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGT_REG pc=287 dst=r4 src=r5 offset=34 imm=0
 #line 138 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 138 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=288 dst=r4 src=r1 offset=96 imm=0
+#line 138 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=288 dst=r4 src=r1 offset=96 imm=0
 #line 142 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(96));
     // EBPF_OP_JNE_IMM pc=289 dst=r4 src=r0 offset=4 imm=7459
 #line 142 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(7459))
+    if (r4 != IMMEDIATE(7459)) {
 #line 142 "sample/encap_reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=290 dst=r4 src=r1 offset=94 imm=0
+#line 142 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=290 dst=r4 src=r1 offset=94 imm=0
 #line 40 "sample/./xdp_common.h"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(94));
     // EBPF_OP_STXH pc=291 dst=r1 src=r4 offset=96 imm=0

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -244,23 +244,29 @@ encap_reflect_packet(void* context)
     r3 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=6 dst=r3 src=r1 offset=315 imm=0
 #line 173 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 173 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+#line 173 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 178 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=120 imm=56710
 #line 178 "sample/encap_reflect_packet.c"
-    if (r4 == IMMEDIATE(56710))
+    if (r4 == IMMEDIATE(56710)) {
 #line 178 "sample/encap_reflect_packet.c"
         goto label_2;
-        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=312 imm=8
 #line 178 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=312 imm=8
+#line 178 "sample/encap_reflect_packet.c"
+    if (r4 != IMMEDIATE(8)) {
 #line 178 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+#line 178 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 179 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -268,18 +274,22 @@ encap_reflect_packet(void* context)
     r4 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=12 dst=r4 src=r1 offset=309 imm=0
 #line 179 "sample/encap_reflect_packet.c"
-    if (r4 > r1)
+    if (r4 > r1) {
 #line 179 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+#line 179 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 185 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=307 imm=17
 #line 185 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(17))
+    if (r4 != IMMEDIATE(17)) {
 #line 185 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+#line 185 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 185 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
@@ -299,18 +309,22 @@ encap_reflect_packet(void* context)
     r2 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=21 dst=r2 src=r1 offset=300 imm=0
 #line 185 "sample/encap_reflect_packet.c"
-    if (r2 > r1)
+    if (r2 > r1) {
 #line 185 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+#line 185 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 191 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=298 imm=7459
 #line 191 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 191 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+#line 191 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -318,14 +332,14 @@ encap_reflect_packet(void* context)
     r2 = (uint64_t)4294967276;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=65536
 #line 22 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[0].address
+    r0 = encap_reflect_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 22 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+#line 22 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -342,10 +356,12 @@ encap_reflect_packet(void* context)
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r2 src=r1 offset=288 imm=0
 #line 22 "sample/encap_reflect_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 22 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+#line 22 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 28 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r7 src=r6 offset=0 imm=0
@@ -359,10 +375,12 @@ encap_reflect_packet(void* context)
     r3 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=38 dst=r3 src=r4 offset=283 imm=0
 #line 28 "sample/encap_reflect_packet.c"
-    if (r3 > r4)
+    if (r3 > r4) {
 #line 28 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r7 offset=0 imm=0
+#line 28 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r7 offset=0 imm=0
 #line 35 "sample/encap_reflect_packet.c"
     r2 = r7;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -370,10 +388,12 @@ encap_reflect_packet(void* context)
     r2 += IMMEDIATE(20);
     // EBPF_OP_JGT_REG pc=41 dst=r2 src=r4 offset=280 imm=0
 #line 35 "sample/encap_reflect_packet.c"
-    if (r2 > r4)
+    if (r2 > r4) {
 #line 35 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r7 offset=0 imm=0
+#line 35 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r7 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r1 = r7;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -381,10 +401,12 @@ encap_reflect_packet(void* context)
     r1 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=44 dst=r1 src=r4 offset=277 imm=0
 #line 43 "sample/encap_reflect_packet.c"
-    if (r1 > r4)
+    if (r1 > r4) {
 #line 43 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r7 offset=0 imm=0
+#line 43 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r7 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r5 = r7;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -392,10 +414,12 @@ encap_reflect_packet(void* context)
     r5 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=47 dst=r5 src=r4 offset=274 imm=0
 #line 43 "sample/encap_reflect_packet.c"
-    if (r5 > r4)
+    if (r5 > r4) {
 #line 43 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+#line 43 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 56 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r7 src=r4 offset=4 imm=0
@@ -502,18 +526,22 @@ encap_reflect_packet(void* context)
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGT_REG pc=83 dst=r4 src=r5 offset=238 imm=0
 #line 64 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 64 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=84 dst=r4 src=r2 offset=2 imm=0
+#line 64 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=84 dst=r4 src=r2 offset=2 imm=0
 #line 68 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=85 dst=r4 src=r0 offset=4 imm=7459
 #line 68 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(7459))
+    if (r4 != IMMEDIATE(7459)) {
 #line 68 "sample/encap_reflect_packet.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=86 dst=r4 src=r2 offset=0 imm=0
+#line 68 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=86 dst=r4 src=r2 offset=0 imm=0
 #line 40 "sample/./xdp_common.h"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(0));
     // EBPF_OP_STXH pc=87 dst=r2 src=r4 offset=2 imm=0
@@ -613,14 +641,14 @@ label_1:
     r5 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=117 dst=r0 src=r0 offset=0 imm=10
 #line 82 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[1].address
+    r0 = encap_reflect_packet_helpers[1].address(r1, r2, r3, r4, r5);
 #line 82 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0)) {
 #line 82 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=118 dst=r1 src=r0 offset=0 imm=0
+#line 82 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=118 dst=r1 src=r0 offset=0 imm=0
 #line 49 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=119 dst=r1 src=r0 offset=0 imm=65535
@@ -662,10 +690,12 @@ label_2:
     r3 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=131 dst=r3 src=r1 offset=190 imm=0
 #line 196 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 196 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=132 dst=r3 src=r2 offset=0 imm=0
+#line 196 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=132 dst=r3 src=r2 offset=0 imm=0
 #line 196 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=133 dst=r3 src=r0 offset=0 imm=62
@@ -673,26 +703,32 @@ label_2:
     r3 += IMMEDIATE(62);
     // EBPF_OP_JGT_REG pc=134 dst=r3 src=r1 offset=187 imm=0
 #line 202 "sample/encap_reflect_packet.c"
-    if (r3 > r1)
+    if (r3 > r1) {
 #line 202 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXB pc=135 dst=r1 src=r2 offset=20 imm=0
+#line 202 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=135 dst=r1 src=r2 offset=20 imm=0
 #line 202 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=136 dst=r1 src=r0 offset=185 imm=17
 #line 202 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(17))
+    if (r1 != IMMEDIATE(17)) {
 #line 202 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=137 dst=r1 src=r2 offset=56 imm=0
+#line 202 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=137 dst=r1 src=r2 offset=56 imm=0
 #line 208 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=138 dst=r1 src=r0 offset=183 imm=7459
 #line 208 "sample/encap_reflect_packet.c"
-    if (r1 != IMMEDIATE(7459))
+    if (r1 != IMMEDIATE(7459)) {
 #line 208 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=139 dst=r1 src=r6 offset=0 imm=0
+#line 208 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=139 dst=r1 src=r6 offset=0 imm=0
 #line 96 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=140 dst=r2 src=r0 offset=0 imm=-40
@@ -700,14 +736,14 @@ label_2:
     r2 = (uint64_t)4294967256;
     // EBPF_OP_CALL pc=142 dst=r0 src=r0 offset=0 imm=65536
 #line 96 "sample/encap_reflect_packet.c"
-    r0 = encap_reflect_packet_helpers[0].address
+    r0 = encap_reflect_packet_helpers[0].address(r1, r2, r3, r4, r5);
 #line 96 "sample/encap_reflect_packet.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/encap_reflect_packet.c"
-    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
+    if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0)) {
 #line 96 "sample/encap_reflect_packet.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=143 dst=r1 src=r0 offset=0 imm=0
+#line 96 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=143 dst=r1 src=r0 offset=0 imm=0
 #line 96 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=144 dst=r0 src=r0 offset=0 imm=2
@@ -724,10 +760,12 @@ label_2:
     r2 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=148 dst=r2 src=r1 offset=173 imm=0
 #line 96 "sample/encap_reflect_packet.c"
-    if ((int64_t)r2 > (int64_t)r1)
+    if ((int64_t)r2 > (int64_t)r1) {
 #line 96 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXDW pc=149 dst=r5 src=r6 offset=8 imm=0
+#line 96 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXDW pc=149 dst=r5 src=r6 offset=8 imm=0
 #line 102 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=150 dst=r1 src=r6 offset=0 imm=0
@@ -741,10 +779,12 @@ label_2:
     r2 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=153 dst=r2 src=r5 offset=168 imm=0
 #line 102 "sample/encap_reflect_packet.c"
-    if (r2 > r5)
+    if (r2 > r5) {
 #line 102 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=154 dst=r4 src=r1 offset=0 imm=0
+#line 102 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=154 dst=r4 src=r1 offset=0 imm=0
 #line 109 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=155 dst=r4 src=r0 offset=0 imm=40
@@ -752,10 +792,12 @@ label_2:
     r4 += IMMEDIATE(40);
     // EBPF_OP_JGT_REG pc=156 dst=r4 src=r5 offset=165 imm=0
 #line 109 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 109 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=157 dst=r3 src=r1 offset=0 imm=0
+#line 109 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=157 dst=r3 src=r1 offset=0 imm=0
 #line 117 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=158 dst=r3 src=r0 offset=0 imm=54
@@ -763,10 +805,12 @@ label_2:
     r3 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=159 dst=r3 src=r5 offset=162 imm=0
 #line 117 "sample/encap_reflect_packet.c"
-    if (r3 > r5)
+    if (r3 > r5) {
 #line 117 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_MOV64_REG pc=160 dst=r7 src=r1 offset=0 imm=0
+#line 117 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=160 dst=r7 src=r1 offset=0 imm=0
 #line 124 "sample/encap_reflect_packet.c"
     r7 = r1;
     // EBPF_OP_ADD64_IMM pc=161 dst=r7 src=r0 offset=0 imm=94
@@ -774,10 +818,12 @@ label_2:
     r7 += IMMEDIATE(94);
     // EBPF_OP_JGT_REG pc=162 dst=r7 src=r5 offset=159 imm=0
 #line 124 "sample/encap_reflect_packet.c"
-    if (r7 > r5)
+    if (r7 > r5) {
 #line 124 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=163 dst=r5 src=r4 offset=4 imm=0
+#line 124 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=163 dst=r5 src=r4 offset=4 imm=0
 #line 130 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=164 dst=r1 src=r5 offset=4 imm=0
@@ -1151,18 +1197,22 @@ label_2:
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGT_REG pc=287 dst=r4 src=r5 offset=34 imm=0
 #line 138 "sample/encap_reflect_packet.c"
-    if (r4 > r5)
+    if (r4 > r5) {
 #line 138 "sample/encap_reflect_packet.c"
         goto label_5;
-        // EBPF_OP_LDXH pc=288 dst=r4 src=r1 offset=96 imm=0
+#line 138 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=288 dst=r4 src=r1 offset=96 imm=0
 #line 142 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(96));
     // EBPF_OP_JNE_IMM pc=289 dst=r4 src=r0 offset=4 imm=7459
 #line 142 "sample/encap_reflect_packet.c"
-    if (r4 != IMMEDIATE(7459))
+    if (r4 != IMMEDIATE(7459)) {
 #line 142 "sample/encap_reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=290 dst=r4 src=r1 offset=94 imm=0
+#line 142 "sample/encap_reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=290 dst=r4 src=r1 offset=94 imm=0
 #line 40 "sample/./xdp_common.h"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(94));
     // EBPF_OP_STXH pc=291 dst=r1 src=r4 offset=96 imm=0

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -132,19 +132,21 @@ lookup(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/hash_of_map.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/hash_of_map.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/hash_of_map.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/hash_of_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/hash_of_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/hash_of_map.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/hash_of_map.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -161,19 +163,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/hash_of_map.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/hash_of_map.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/hash_of_map.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/hash_of_map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/hash_of_map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/hash_of_map.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/hash_of_map.c"
     goto label_2;
 label_1:
@@ -227,9 +231,11 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/hash_of_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_raw.c
@@ -106,19 +106,21 @@ lookup(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/hash_of_map.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/hash_of_map.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/hash_of_map.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/hash_of_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/hash_of_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/hash_of_map.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/hash_of_map.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -135,19 +137,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/hash_of_map.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/hash_of_map.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/hash_of_map.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/hash_of_map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/hash_of_map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/hash_of_map.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/hash_of_map.c"
     goto label_2;
 label_1:
@@ -201,9 +205,11 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/hash_of_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_sys.c
@@ -267,19 +267,21 @@ lookup(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/hash_of_map.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/hash_of_map.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/hash_of_map.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/hash_of_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/hash_of_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/hash_of_map.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/hash_of_map.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -296,19 +298,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/hash_of_map.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/hash_of_map.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/hash_of_map.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/hash_of_map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/hash_of_map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/hash_of_map.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/hash_of_map.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/hash_of_map.c"
     goto label_2;
 label_1:
@@ -362,9 +366,11 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -164,22 +164,24 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 60 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 60 "sample/undocked/inner_map.c"
     r6 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r6 src=r0 offset=11 imm=0
 #line 61 "sample/undocked/inner_map.c"
-    if (r6 == IMMEDIATE(0))
+    if (r6 == IMMEDIATE(0)) {
 #line 61 "sample/undocked/inner_map.c"
         goto label_3;
-        // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-12 imm=0
+#line 61 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-12 imm=0
 #line 62 "sample/undocked/inner_map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
@@ -193,18 +195,20 @@ lookup_update(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 63 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=15 dst=r0 src=r0 offset=5 imm=0
+#line 63 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=15 dst=r0 src=r0 offset=5 imm=0
 #line 64 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 64 "sample/undocked/inner_map.c"
         goto label_3;
+#line 64 "sample/undocked/inner_map.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=16 dst=r1 src=r0 offset=0 imm=1
 #line 64 "sample/undocked/inner_map.c"
@@ -234,22 +238,24 @@ label_3:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
 #line 72 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=26 dst=r7 src=r0 offset=0 imm=1
+#line 72 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=26 dst=r7 src=r0 offset=0 imm=1
 #line 72 "sample/undocked/inner_map.c"
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=27 dst=r0 src=r0 offset=-9 imm=0
 #line 73 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 73 "sample/undocked/inner_map.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=0
+#line 73 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 73 "sample/undocked/inner_map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=29 dst=r10 src=r1 offset=-16 imm=0
@@ -266,19 +272,21 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=1
 #line 75 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=34 dst=r0 src=r0 offset=-16 imm=0
+#line 75 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=34 dst=r0 src=r0 offset=-16 imm=0
 #line 76 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 76 "sample/undocked/inner_map.c"
         goto label_2;
-        // EBPF_OP_JA pc=35 dst=r0 src=r0 offset=-20 imm=0
+#line 76 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JA pc=35 dst=r0 src=r0 offset=-20 imm=0
 #line 76 "sample/undocked/inner_map.c"
     goto label_1;
 #line 76 "sample/undocked/inner_map.c"

--- a/tests/bpf2c_tests/expected/inner_map_raw.c
+++ b/tests/bpf2c_tests/expected/inner_map_raw.c
@@ -138,22 +138,24 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 60 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 60 "sample/undocked/inner_map.c"
     r6 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r6 src=r0 offset=11 imm=0
 #line 61 "sample/undocked/inner_map.c"
-    if (r6 == IMMEDIATE(0))
+    if (r6 == IMMEDIATE(0)) {
 #line 61 "sample/undocked/inner_map.c"
         goto label_3;
-        // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-12 imm=0
+#line 61 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-12 imm=0
 #line 62 "sample/undocked/inner_map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
@@ -167,18 +169,20 @@ lookup_update(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 63 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=15 dst=r0 src=r0 offset=5 imm=0
+#line 63 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=15 dst=r0 src=r0 offset=5 imm=0
 #line 64 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 64 "sample/undocked/inner_map.c"
         goto label_3;
+#line 64 "sample/undocked/inner_map.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=16 dst=r1 src=r0 offset=0 imm=1
 #line 64 "sample/undocked/inner_map.c"
@@ -208,22 +212,24 @@ label_3:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
 #line 72 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=26 dst=r7 src=r0 offset=0 imm=1
+#line 72 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=26 dst=r7 src=r0 offset=0 imm=1
 #line 72 "sample/undocked/inner_map.c"
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=27 dst=r0 src=r0 offset=-9 imm=0
 #line 73 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 73 "sample/undocked/inner_map.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=0
+#line 73 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 73 "sample/undocked/inner_map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=29 dst=r10 src=r1 offset=-16 imm=0
@@ -240,19 +246,21 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=1
 #line 75 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=34 dst=r0 src=r0 offset=-16 imm=0
+#line 75 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=34 dst=r0 src=r0 offset=-16 imm=0
 #line 76 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 76 "sample/undocked/inner_map.c"
         goto label_2;
-        // EBPF_OP_JA pc=35 dst=r0 src=r0 offset=-20 imm=0
+#line 76 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JA pc=35 dst=r0 src=r0 offset=-20 imm=0
 #line 76 "sample/undocked/inner_map.c"
     goto label_1;
 #line 76 "sample/undocked/inner_map.c"

--- a/tests/bpf2c_tests/expected/inner_map_sys.c
+++ b/tests/bpf2c_tests/expected/inner_map_sys.c
@@ -299,22 +299,24 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 60 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 60 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 60 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 60 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 60 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 60 "sample/undocked/inner_map.c"
     r6 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r6 src=r0 offset=11 imm=0
 #line 61 "sample/undocked/inner_map.c"
-    if (r6 == IMMEDIATE(0))
+    if (r6 == IMMEDIATE(0)) {
 #line 61 "sample/undocked/inner_map.c"
         goto label_3;
-        // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-12 imm=0
+#line 61 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-12 imm=0
 #line 62 "sample/undocked/inner_map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
@@ -328,18 +330,20 @@ lookup_update(void* context)
     r1 = r6;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 63 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 63 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 63 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=15 dst=r0 src=r0 offset=5 imm=0
+#line 63 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=15 dst=r0 src=r0 offset=5 imm=0
 #line 64 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 64 "sample/undocked/inner_map.c"
         goto label_3;
+#line 64 "sample/undocked/inner_map.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=16 dst=r1 src=r0 offset=0 imm=1
 #line 64 "sample/undocked/inner_map.c"
@@ -369,22 +373,24 @@ label_3:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
 #line 72 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 72 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 72 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=26 dst=r7 src=r0 offset=0 imm=1
+#line 72 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=26 dst=r7 src=r0 offset=0 imm=1
 #line 72 "sample/undocked/inner_map.c"
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=27 dst=r0 src=r0 offset=-9 imm=0
 #line 73 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 73 "sample/undocked/inner_map.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=0
+#line 73 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 73 "sample/undocked/inner_map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=29 dst=r10 src=r1 offset=-16 imm=0
@@ -401,19 +407,21 @@ label_3:
     r1 = r6;
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=1
 #line 75 "sample/undocked/inner_map.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 75 "sample/undocked/inner_map.c"
-         (r1, r2, r3, r4, r5);
-#line 75 "sample/undocked/inner_map.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 75 "sample/undocked/inner_map.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=34 dst=r0 src=r0 offset=-16 imm=0
+#line 75 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=34 dst=r0 src=r0 offset=-16 imm=0
 #line 76 "sample/undocked/inner_map.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 76 "sample/undocked/inner_map.c"
         goto label_2;
-        // EBPF_OP_JA pc=35 dst=r0 src=r0 offset=-20 imm=0
+#line 76 "sample/undocked/inner_map.c"
+    }
+    // EBPF_OP_JA pc=35 dst=r0 src=r0 offset=-20 imm=0
 #line 76 "sample/undocked/inner_map.c"
     goto label_1;
 #line 76 "sample/undocked/inner_map.c"

--- a/tests/bpf2c_tests/expected/invalid_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_dll.c
@@ -199,19 +199,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 131 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 131 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 131 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 131 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 133 "sample/unsafe/invalid_helpers.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 133 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 133 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 136 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -222,13 +224,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 136 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 136 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 136 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 136 "sample/unsafe/invalid_helpers.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/unsafe/invalid_helpers.c"
@@ -306,19 +308,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 147 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 149 "sample/unsafe/invalid_helpers.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 149 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 149 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 152 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -329,13 +333,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 152 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 152 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 152 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 152 "sample/unsafe/invalid_helpers.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 155 "sample/unsafe/invalid_helpers.c"
@@ -421,30 +425,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 164 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 164 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 164 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 164 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/unsafe/invalid_helpers.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=89 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 165 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=87 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 165 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 82 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -491,19 +499,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 87 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 87 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 87 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 87 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 88 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
+#line 88 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_1:
@@ -518,19 +528,21 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=999
 #line 92 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 92 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 92 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
+#line 92 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 93 "sample/unsafe/invalid_helpers.c"
         goto label_2;
-        // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
+#line 93 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_2:
@@ -539,26 +551,32 @@ label_2:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=39 dst=r1 src=r0 offset=58 imm=0
 #line 97 "sample/unsafe/invalid_helpers.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 97 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
+#line 97 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=41 dst=r1 src=r0 offset=56 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
+#line 101 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=43 dst=r1 src=r0 offset=54 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
+#line 101 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r8 src=r0 offset=0 imm=-8
@@ -584,14 +602,14 @@ label_2:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=53 dst=r0 src=r0 offset=0 imm=2
 #line 105 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
+#line 105 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
 #line 106 "sample/unsafe/invalid_helpers.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=56 dst=r2 src=r8 offset=0 imm=0
@@ -599,19 +617,21 @@ label_2:
     r2 = r8;
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=1
 #line 106 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 106 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 106 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
+#line 106 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 107 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
+#line 107 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=4
@@ -629,10 +649,12 @@ label_3:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=64 dst=r2 src=r3 offset=6 imm=0
 #line 112 "sample/unsafe/invalid_helpers.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 112 "sample/unsafe/invalid_helpers.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
+#line 112 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
 #line 116 "sample/unsafe/invalid_helpers.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=66 dst=r3 src=r9 offset=0 imm=0
@@ -649,24 +671,30 @@ label_3:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=70 dst=r9 src=r0 offset=-10 imm=64
 #line 111 "sample/unsafe/invalid_helpers.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 111 "sample/unsafe/invalid_helpers.c"
         goto label_3;
+#line 111 "sample/unsafe/invalid_helpers.c"
+    }
 label_4:
     // EBPF_OP_LDXW pc=71 dst=r1 src=r6 offset=44 imm=0
 #line 175 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=72 dst=r1 src=r0 offset=3 imm=0
 #line 175 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_5;
-        // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
 #line 175 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
+#line 175 "sample/unsafe/invalid_helpers.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_6;
-        // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
+#line 175 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=11 imm=0
@@ -684,10 +712,12 @@ label_5:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=79 dst=r1 src=r2 offset=19 imm=0
 #line 177 "sample/unsafe/invalid_helpers.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 177 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
+#line 177 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=81 dst=r0 src=r1 offset=0 imm=0
@@ -702,10 +732,12 @@ label_6:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=84 dst=r1 src=r0 offset=6 imm=0
 #line 184 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 184 "sample/unsafe/invalid_helpers.c"
         goto label_8;
-        // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
+#line 184 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
 #line 185 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=86 dst=r0 src=r1 offset=0 imm=0
@@ -723,9 +755,11 @@ label_7:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 192 "sample/unsafe/invalid_helpers.c"
         goto label_10;
+#line 192 "sample/unsafe/invalid_helpers.c"
+    }
 label_8:
     // EBPF_OP_LDXDW pc=91 dst=r1 src=r6 offset=16 imm=0
 #line 193 "sample/unsafe/invalid_helpers.c"
@@ -744,13 +778,13 @@ label_8:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=3
 #line 194 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[3].address
+    r0 = BindMonitor_Callee1_helpers[3].address(r1, r2, r3, r4, r5);
 #line 194 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 194 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0)) {
 #line 194 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 194 "sample/unsafe/invalid_helpers.c"
+    }
 label_9:
     // EBPF_OP_MOV64_IMM pc=98 dst=r8 src=r0 offset=0 imm=0
 #line 194 "sample/unsafe/invalid_helpers.c"

--- a/tests/bpf2c_tests/expected/invalid_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_raw.c
@@ -173,19 +173,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 131 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 131 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 131 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 131 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 133 "sample/unsafe/invalid_helpers.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 133 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 133 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 136 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -196,13 +198,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 136 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 136 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 136 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 136 "sample/unsafe/invalid_helpers.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/unsafe/invalid_helpers.c"
@@ -280,19 +282,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 147 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 149 "sample/unsafe/invalid_helpers.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 149 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 149 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 152 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -303,13 +307,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 152 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 152 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 152 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 152 "sample/unsafe/invalid_helpers.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 155 "sample/unsafe/invalid_helpers.c"
@@ -395,30 +399,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 164 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 164 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 164 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 164 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/unsafe/invalid_helpers.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=89 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 165 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=87 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 165 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 82 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -465,19 +473,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 87 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 87 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 87 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 87 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 88 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
+#line 88 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_1:
@@ -492,19 +502,21 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=999
 #line 92 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 92 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 92 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
+#line 92 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 93 "sample/unsafe/invalid_helpers.c"
         goto label_2;
-        // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
+#line 93 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_2:
@@ -513,26 +525,32 @@ label_2:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=39 dst=r1 src=r0 offset=58 imm=0
 #line 97 "sample/unsafe/invalid_helpers.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 97 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
+#line 97 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=41 dst=r1 src=r0 offset=56 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
+#line 101 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=43 dst=r1 src=r0 offset=54 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
+#line 101 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r8 src=r0 offset=0 imm=-8
@@ -558,14 +576,14 @@ label_2:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=53 dst=r0 src=r0 offset=0 imm=2
 #line 105 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
+#line 105 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
 #line 106 "sample/unsafe/invalid_helpers.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=56 dst=r2 src=r8 offset=0 imm=0
@@ -573,19 +591,21 @@ label_2:
     r2 = r8;
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=1
 #line 106 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 106 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 106 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
+#line 106 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 107 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
+#line 107 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=4
@@ -603,10 +623,12 @@ label_3:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=64 dst=r2 src=r3 offset=6 imm=0
 #line 112 "sample/unsafe/invalid_helpers.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 112 "sample/unsafe/invalid_helpers.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
+#line 112 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
 #line 116 "sample/unsafe/invalid_helpers.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=66 dst=r3 src=r9 offset=0 imm=0
@@ -623,24 +645,30 @@ label_3:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=70 dst=r9 src=r0 offset=-10 imm=64
 #line 111 "sample/unsafe/invalid_helpers.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 111 "sample/unsafe/invalid_helpers.c"
         goto label_3;
+#line 111 "sample/unsafe/invalid_helpers.c"
+    }
 label_4:
     // EBPF_OP_LDXW pc=71 dst=r1 src=r6 offset=44 imm=0
 #line 175 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=72 dst=r1 src=r0 offset=3 imm=0
 #line 175 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_5;
-        // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
 #line 175 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
+#line 175 "sample/unsafe/invalid_helpers.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_6;
-        // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
+#line 175 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=11 imm=0
@@ -658,10 +686,12 @@ label_5:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=79 dst=r1 src=r2 offset=19 imm=0
 #line 177 "sample/unsafe/invalid_helpers.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 177 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
+#line 177 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=81 dst=r0 src=r1 offset=0 imm=0
@@ -676,10 +706,12 @@ label_6:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=84 dst=r1 src=r0 offset=6 imm=0
 #line 184 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 184 "sample/unsafe/invalid_helpers.c"
         goto label_8;
-        // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
+#line 184 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
 #line 185 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=86 dst=r0 src=r1 offset=0 imm=0
@@ -697,9 +729,11 @@ label_7:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 192 "sample/unsafe/invalid_helpers.c"
         goto label_10;
+#line 192 "sample/unsafe/invalid_helpers.c"
+    }
 label_8:
     // EBPF_OP_LDXDW pc=91 dst=r1 src=r6 offset=16 imm=0
 #line 193 "sample/unsafe/invalid_helpers.c"
@@ -718,13 +752,13 @@ label_8:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=3
 #line 194 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[3].address
+    r0 = BindMonitor_Callee1_helpers[3].address(r1, r2, r3, r4, r5);
 #line 194 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 194 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0)) {
 #line 194 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 194 "sample/unsafe/invalid_helpers.c"
+    }
 label_9:
     // EBPF_OP_MOV64_IMM pc=98 dst=r8 src=r0 offset=0 imm=0
 #line 194 "sample/unsafe/invalid_helpers.c"

--- a/tests/bpf2c_tests/expected/invalid_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_sys.c
@@ -334,19 +334,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 131 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 131 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 131 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 131 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 133 "sample/unsafe/invalid_helpers.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 133 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 133 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 136 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -357,13 +359,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 136 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 136 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 136 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 136 "sample/unsafe/invalid_helpers.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/unsafe/invalid_helpers.c"
@@ -441,19 +443,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 147 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 149 "sample/unsafe/invalid_helpers.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 149 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 149 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 152 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -464,13 +468,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 152 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 152 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 152 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 152 "sample/unsafe/invalid_helpers.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 155 "sample/unsafe/invalid_helpers.c"
@@ -556,30 +560,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 164 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 164 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 164 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 164 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/unsafe/invalid_helpers.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=89 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 165 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=87 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 165 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 82 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -626,19 +634,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 87 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 87 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 87 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 87 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 88 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
+#line 88 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_1:
@@ -653,19 +663,21 @@ label_1:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=999
 #line 92 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 92 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 92 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
+#line 92 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 93 "sample/unsafe/invalid_helpers.c"
         goto label_2;
-        // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
+#line 93 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_2:
@@ -674,26 +686,32 @@ label_2:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=39 dst=r1 src=r0 offset=58 imm=0
 #line 97 "sample/unsafe/invalid_helpers.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 97 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
+#line 97 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=41 dst=r1 src=r0 offset=56 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
+#line 101 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=43 dst=r1 src=r0 offset=54 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
+#line 101 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r8 src=r0 offset=0 imm=-8
@@ -719,14 +737,14 @@ label_2:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=53 dst=r0 src=r0 offset=0 imm=2
 #line 105 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
+#line 105 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
 #line 106 "sample/unsafe/invalid_helpers.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=56 dst=r2 src=r8 offset=0 imm=0
@@ -734,19 +752,21 @@ label_2:
     r2 = r8;
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=1
 #line 106 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 106 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 106 "sample/unsafe/invalid_helpers.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
+#line 106 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 107 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-        // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
+#line 107 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=4
@@ -764,10 +784,12 @@ label_3:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=64 dst=r2 src=r3 offset=6 imm=0
 #line 112 "sample/unsafe/invalid_helpers.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 112 "sample/unsafe/invalid_helpers.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
+#line 112 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
 #line 116 "sample/unsafe/invalid_helpers.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=66 dst=r3 src=r9 offset=0 imm=0
@@ -784,24 +806,30 @@ label_3:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=70 dst=r9 src=r0 offset=-10 imm=64
 #line 111 "sample/unsafe/invalid_helpers.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 111 "sample/unsafe/invalid_helpers.c"
         goto label_3;
+#line 111 "sample/unsafe/invalid_helpers.c"
+    }
 label_4:
     // EBPF_OP_LDXW pc=71 dst=r1 src=r6 offset=44 imm=0
 #line 175 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=72 dst=r1 src=r0 offset=3 imm=0
 #line 175 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_5;
-        // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
 #line 175 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
+#line 175 "sample/unsafe/invalid_helpers.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_6;
-        // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
+#line 175 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=11 imm=0
@@ -819,10 +847,12 @@ label_5:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=79 dst=r1 src=r2 offset=19 imm=0
 #line 177 "sample/unsafe/invalid_helpers.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 177 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-        // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
+#line 177 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=81 dst=r0 src=r1 offset=0 imm=0
@@ -837,10 +867,12 @@ label_6:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=84 dst=r1 src=r0 offset=6 imm=0
 #line 184 "sample/unsafe/invalid_helpers.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 184 "sample/unsafe/invalid_helpers.c"
         goto label_8;
-        // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
+#line 184 "sample/unsafe/invalid_helpers.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
 #line 185 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=86 dst=r0 src=r1 offset=0 imm=0
@@ -858,9 +890,11 @@ label_7:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 192 "sample/unsafe/invalid_helpers.c"
         goto label_10;
+#line 192 "sample/unsafe/invalid_helpers.c"
+    }
 label_8:
     // EBPF_OP_LDXDW pc=91 dst=r1 src=r6 offset=16 imm=0
 #line 193 "sample/unsafe/invalid_helpers.c"
@@ -879,13 +913,13 @@ label_8:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=3
 #line 194 "sample/unsafe/invalid_helpers.c"
-    r0 = BindMonitor_Callee1_helpers[3].address
+    r0 = BindMonitor_Callee1_helpers[3].address(r1, r2, r3, r4, r5);
 #line 194 "sample/unsafe/invalid_helpers.c"
-         (r1, r2, r3, r4, r5);
-#line 194 "sample/unsafe/invalid_helpers.c"
-    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[3].tail_call) && (r0 == 0)) {
 #line 194 "sample/unsafe/invalid_helpers.c"
         return 0;
+#line 194 "sample/unsafe/invalid_helpers.c"
+    }
 label_9:
     // EBPF_OP_MOV64_IMM pc=98 dst=r8 src=r0 offset=0 imm=0
 #line 194 "sample/unsafe/invalid_helpers.c"

--- a/tests/bpf2c_tests/expected/invalid_maps1_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_dll.c
@@ -211,19 +211,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 138 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 138 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 140 "sample/unsafe/invalid_maps1.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 140 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 140 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 143 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -234,13 +236,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 143 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 143 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 143 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 143 "sample/unsafe/invalid_maps1.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 146 "sample/unsafe/invalid_maps1.c"
@@ -318,19 +320,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 154 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 154 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 154 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 154 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 156 "sample/unsafe/invalid_maps1.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 156 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 156 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 159 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -341,13 +345,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 159 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 159 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 159 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 159 "sample/unsafe/invalid_maps1.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 162 "sample/unsafe/invalid_maps1.c"
@@ -432,30 +436,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 171 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 171 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 171 "sample/unsafe/invalid_maps1.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 172 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 172 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 94 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -502,19 +510,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 99 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 99 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 99 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 99 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 100 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+#line 100 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     goto label_3;
 label_1:
@@ -523,26 +533,32 @@ label_1:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
 #line 104 "sample/unsafe/invalid_maps1.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 104 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 104 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 108 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 108 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -568,14 +584,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
 #line 112 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 112 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 112 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+#line 112 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 113 "sample/unsafe/invalid_maps1.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -583,19 +599,21 @@ label_1:
     r2 = r8;
     // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
 #line 113 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 113 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 113 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+#line 113 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 114 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 114 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -613,10 +631,12 @@ label_2:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
 #line 119 "sample/unsafe/invalid_maps1.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 119 "sample/unsafe/invalid_maps1.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+#line 119 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 123 "sample/unsafe/invalid_maps1.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -633,24 +653,30 @@ label_2:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
 #line 118 "sample/unsafe/invalid_maps1.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 118 "sample/unsafe/invalid_maps1.c"
         goto label_2;
+#line 118 "sample/unsafe/invalid_maps1.c"
+    }
 label_3:
     // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
 #line 182 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
 #line 182 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 182 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+#line 182 "sample/unsafe/invalid_maps1.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+#line 182 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -668,10 +694,12 @@ label_4:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
 #line 184 "sample/unsafe/invalid_maps1.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 184 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+#line 184 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 188 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -686,10 +714,12 @@ label_5:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
 #line 191 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 191 "sample/unsafe/invalid_maps1.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+#line 191 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 192 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -707,9 +737,11 @@ label_6:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 199 "sample/unsafe/invalid_maps1.c"
         goto label_9;
+#line 199 "sample/unsafe/invalid_maps1.c"
+    }
 label_7:
     // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
 #line 200 "sample/unsafe/invalid_maps1.c"
@@ -728,13 +760,13 @@ label_7:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
 #line 201 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 201 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 201 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 201 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 201 "sample/unsafe/invalid_maps1.c"
+    }
 label_8:
     // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 201 "sample/unsafe/invalid_maps1.c"

--- a/tests/bpf2c_tests/expected/invalid_maps1_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_raw.c
@@ -185,19 +185,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 138 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 138 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 140 "sample/unsafe/invalid_maps1.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 140 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 140 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 143 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -208,13 +210,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 143 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 143 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 143 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 143 "sample/unsafe/invalid_maps1.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 146 "sample/unsafe/invalid_maps1.c"
@@ -292,19 +294,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 154 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 154 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 154 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 154 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 156 "sample/unsafe/invalid_maps1.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 156 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 156 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 159 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -315,13 +319,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 159 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 159 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 159 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 159 "sample/unsafe/invalid_maps1.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 162 "sample/unsafe/invalid_maps1.c"
@@ -406,30 +410,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 171 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 171 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 171 "sample/unsafe/invalid_maps1.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 172 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 172 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 94 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -476,19 +484,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 99 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 99 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 99 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 99 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 100 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+#line 100 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     goto label_3;
 label_1:
@@ -497,26 +507,32 @@ label_1:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
 #line 104 "sample/unsafe/invalid_maps1.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 104 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 104 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 108 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 108 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -542,14 +558,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
 #line 112 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 112 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 112 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+#line 112 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 113 "sample/unsafe/invalid_maps1.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -557,19 +573,21 @@ label_1:
     r2 = r8;
     // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
 #line 113 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 113 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 113 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+#line 113 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 114 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 114 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -587,10 +605,12 @@ label_2:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
 #line 119 "sample/unsafe/invalid_maps1.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 119 "sample/unsafe/invalid_maps1.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+#line 119 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 123 "sample/unsafe/invalid_maps1.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -607,24 +627,30 @@ label_2:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
 #line 118 "sample/unsafe/invalid_maps1.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 118 "sample/unsafe/invalid_maps1.c"
         goto label_2;
+#line 118 "sample/unsafe/invalid_maps1.c"
+    }
 label_3:
     // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
 #line 182 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
 #line 182 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 182 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+#line 182 "sample/unsafe/invalid_maps1.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+#line 182 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -642,10 +668,12 @@ label_4:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
 #line 184 "sample/unsafe/invalid_maps1.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 184 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+#line 184 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 188 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -660,10 +688,12 @@ label_5:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
 #line 191 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 191 "sample/unsafe/invalid_maps1.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+#line 191 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 192 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -681,9 +711,11 @@ label_6:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 199 "sample/unsafe/invalid_maps1.c"
         goto label_9;
+#line 199 "sample/unsafe/invalid_maps1.c"
+    }
 label_7:
     // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
 #line 200 "sample/unsafe/invalid_maps1.c"
@@ -702,13 +734,13 @@ label_7:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
 #line 201 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 201 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 201 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 201 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 201 "sample/unsafe/invalid_maps1.c"
+    }
 label_8:
     // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 201 "sample/unsafe/invalid_maps1.c"

--- a/tests/bpf2c_tests/expected/invalid_maps1_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_sys.c
@@ -346,19 +346,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 138 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 138 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 140 "sample/unsafe/invalid_maps1.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 140 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 140 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 143 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -369,13 +371,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 143 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 143 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 143 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 143 "sample/unsafe/invalid_maps1.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 146 "sample/unsafe/invalid_maps1.c"
@@ -453,19 +455,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 154 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 154 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 154 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 154 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 156 "sample/unsafe/invalid_maps1.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 156 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 156 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 159 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -476,13 +480,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 159 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 159 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 159 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 159 "sample/unsafe/invalid_maps1.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 162 "sample/unsafe/invalid_maps1.c"
@@ -567,30 +571,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 171 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 171 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 171 "sample/unsafe/invalid_maps1.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 172 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 172 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 94 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -637,19 +645,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 99 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 99 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 99 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 99 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 100 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+#line 100 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     goto label_3;
 label_1:
@@ -658,26 +668,32 @@ label_1:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
 #line 104 "sample/unsafe/invalid_maps1.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 104 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 104 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 108 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 108 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -703,14 +719,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
 #line 112 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 112 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 112 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+#line 112 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 113 "sample/unsafe/invalid_maps1.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -718,19 +734,21 @@ label_1:
     r2 = r8;
     // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
 #line 113 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 113 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 113 "sample/unsafe/invalid_maps1.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+#line 113 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 114 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 114 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -748,10 +766,12 @@ label_2:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
 #line 119 "sample/unsafe/invalid_maps1.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 119 "sample/unsafe/invalid_maps1.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+#line 119 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 123 "sample/unsafe/invalid_maps1.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -768,24 +788,30 @@ label_2:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
 #line 118 "sample/unsafe/invalid_maps1.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 118 "sample/unsafe/invalid_maps1.c"
         goto label_2;
+#line 118 "sample/unsafe/invalid_maps1.c"
+    }
 label_3:
     // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
 #line 182 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
 #line 182 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 182 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+#line 182 "sample/unsafe/invalid_maps1.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+#line 182 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -803,10 +829,12 @@ label_4:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
 #line 184 "sample/unsafe/invalid_maps1.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 184 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+#line 184 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 188 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -821,10 +849,12 @@ label_5:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
 #line 191 "sample/unsafe/invalid_maps1.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 191 "sample/unsafe/invalid_maps1.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+#line 191 "sample/unsafe/invalid_maps1.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 192 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -842,9 +872,11 @@ label_6:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 199 "sample/unsafe/invalid_maps1.c"
         goto label_9;
+#line 199 "sample/unsafe/invalid_maps1.c"
+    }
 label_7:
     // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
 #line 200 "sample/unsafe/invalid_maps1.c"
@@ -863,13 +895,13 @@ label_7:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
 #line 201 "sample/unsafe/invalid_maps1.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 201 "sample/unsafe/invalid_maps1.c"
-         (r1, r2, r3, r4, r5);
-#line 201 "sample/unsafe/invalid_maps1.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 201 "sample/unsafe/invalid_maps1.c"
         return 0;
+#line 201 "sample/unsafe/invalid_maps1.c"
+    }
 label_8:
     // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 201 "sample/unsafe/invalid_maps1.c"

--- a/tests/bpf2c_tests/expected/invalid_maps2_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_dll.c
@@ -223,19 +223,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 149 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 149 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 149 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 149 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 151 "sample/unsafe/invalid_maps2.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 151 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 151 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 154 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -246,13 +248,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 154 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 154 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 154 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 154 "sample/unsafe/invalid_maps2.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 157 "sample/unsafe/invalid_maps2.c"
@@ -330,19 +332,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 165 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 165 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 167 "sample/unsafe/invalid_maps2.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 167 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 167 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 170 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -353,13 +357,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 170 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 170 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 170 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 170 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 170 "sample/unsafe/invalid_maps2.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 173 "sample/unsafe/invalid_maps2.c"
@@ -444,30 +448,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 182 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 182 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 182 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 182 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 182 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 182 "sample/unsafe/invalid_maps2.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 183 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 183 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 105 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -514,19 +522,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 110 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 110 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 110 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 110 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 111 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+#line 111 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     goto label_3;
 label_1:
@@ -535,26 +545,32 @@ label_1:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
 #line 115 "sample/unsafe/invalid_maps2.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 115 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 115 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 119 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 119 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -580,14 +596,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
 #line 123 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 123 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 123 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+#line 123 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 124 "sample/unsafe/invalid_maps2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -595,19 +611,21 @@ label_1:
     r2 = r8;
     // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
 #line 124 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 124 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 124 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 124 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+#line 124 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 125 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 125 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -625,10 +643,12 @@ label_2:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
 #line 130 "sample/unsafe/invalid_maps2.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 130 "sample/unsafe/invalid_maps2.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+#line 130 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 134 "sample/unsafe/invalid_maps2.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -645,24 +665,30 @@ label_2:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
 #line 129 "sample/unsafe/invalid_maps2.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 129 "sample/unsafe/invalid_maps2.c"
         goto label_2;
+#line 129 "sample/unsafe/invalid_maps2.c"
+    }
 label_3:
     // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
 #line 193 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
 #line 193 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 193 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+#line 193 "sample/unsafe/invalid_maps2.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+#line 193 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -680,10 +706,12 @@ label_4:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
 #line 195 "sample/unsafe/invalid_maps2.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 195 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+#line 195 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 199 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -698,10 +726,12 @@ label_5:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
 #line 202 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 202 "sample/unsafe/invalid_maps2.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+#line 202 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 203 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -719,9 +749,11 @@ label_6:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 210 "sample/unsafe/invalid_maps2.c"
         goto label_9;
+#line 210 "sample/unsafe/invalid_maps2.c"
+    }
 label_7:
     // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
 #line 211 "sample/unsafe/invalid_maps2.c"
@@ -740,13 +772,13 @@ label_7:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
 #line 212 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 212 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 212 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 212 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 212 "sample/unsafe/invalid_maps2.c"
+    }
 label_8:
     // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 212 "sample/unsafe/invalid_maps2.c"

--- a/tests/bpf2c_tests/expected/invalid_maps2_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_raw.c
@@ -197,19 +197,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 149 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 149 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 149 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 149 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 151 "sample/unsafe/invalid_maps2.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 151 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 151 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 154 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -220,13 +222,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 154 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 154 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 154 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 154 "sample/unsafe/invalid_maps2.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 157 "sample/unsafe/invalid_maps2.c"
@@ -304,19 +306,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 165 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 165 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 167 "sample/unsafe/invalid_maps2.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 167 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 167 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 170 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -327,13 +331,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 170 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 170 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 170 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 170 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 170 "sample/unsafe/invalid_maps2.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 173 "sample/unsafe/invalid_maps2.c"
@@ -418,30 +422,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 182 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 182 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 182 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 182 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 182 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 182 "sample/unsafe/invalid_maps2.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 183 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 183 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 105 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -488,19 +496,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 110 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 110 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 110 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 110 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 111 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+#line 111 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     goto label_3;
 label_1:
@@ -509,26 +519,32 @@ label_1:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
 #line 115 "sample/unsafe/invalid_maps2.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 115 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 115 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 119 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 119 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -554,14 +570,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
 #line 123 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 123 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 123 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+#line 123 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 124 "sample/unsafe/invalid_maps2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -569,19 +585,21 @@ label_1:
     r2 = r8;
     // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
 #line 124 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 124 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 124 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 124 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+#line 124 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 125 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 125 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -599,10 +617,12 @@ label_2:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
 #line 130 "sample/unsafe/invalid_maps2.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 130 "sample/unsafe/invalid_maps2.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+#line 130 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 134 "sample/unsafe/invalid_maps2.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -619,24 +639,30 @@ label_2:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
 #line 129 "sample/unsafe/invalid_maps2.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 129 "sample/unsafe/invalid_maps2.c"
         goto label_2;
+#line 129 "sample/unsafe/invalid_maps2.c"
+    }
 label_3:
     // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
 #line 193 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
 #line 193 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 193 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+#line 193 "sample/unsafe/invalid_maps2.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+#line 193 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -654,10 +680,12 @@ label_4:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
 #line 195 "sample/unsafe/invalid_maps2.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 195 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+#line 195 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 199 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -672,10 +700,12 @@ label_5:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
 #line 202 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 202 "sample/unsafe/invalid_maps2.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+#line 202 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 203 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -693,9 +723,11 @@ label_6:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 210 "sample/unsafe/invalid_maps2.c"
         goto label_9;
+#line 210 "sample/unsafe/invalid_maps2.c"
+    }
 label_7:
     // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
 #line 211 "sample/unsafe/invalid_maps2.c"
@@ -714,13 +746,13 @@ label_7:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
 #line 212 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 212 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 212 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 212 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 212 "sample/unsafe/invalid_maps2.c"
+    }
 label_8:
     // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 212 "sample/unsafe/invalid_maps2.c"

--- a/tests/bpf2c_tests/expected/invalid_maps2_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_sys.c
@@ -358,19 +358,21 @@ BindMonitor(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 149 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_helpers[0].address
+    r0 = BindMonitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 149 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 149 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 149 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 151 "sample/unsafe/invalid_maps2.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 151 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 151 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 154 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -381,13 +383,13 @@ BindMonitor(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 154 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_helpers[1].address
+    r0 = BindMonitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 154 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 154 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 154 "sample/unsafe/invalid_maps2.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 157 "sample/unsafe/invalid_maps2.c"
@@ -465,19 +467,21 @@ BindMonitor_Callee0(void* context)
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 165 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee0_helpers[0].address
+    r0 = BindMonitor_Callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+#line 165 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 167 "sample/unsafe/invalid_maps2.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 167 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+#line 167 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 170 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -488,13 +492,13 @@ BindMonitor_Callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
 #line 170 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee0_helpers[1].address
+    r0 = BindMonitor_Callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 170 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 170 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 170 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 170 "sample/unsafe/invalid_maps2.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 173 "sample/unsafe/invalid_maps2.c"
@@ -579,30 +583,34 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 182 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 182 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 182 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 182 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 182 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 182 "sample/unsafe/invalid_maps2.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+#line 183 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+#line 183 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 105 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -649,19 +657,21 @@ BindMonitor_Callee1(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=28 dst=r0 src=r0 offset=0 imm=1
 #line 110 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 110 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 110 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+#line 110 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 111 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+#line 111 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     goto label_3;
 label_1:
@@ -670,26 +680,32 @@ label_1:
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
 #line 115 "sample/unsafe/invalid_maps2.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 115 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+#line 115 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+#line 119 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+#line 119 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -715,14 +731,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
 #line 123 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[1].address
+    r0 = BindMonitor_Callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 123 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 123 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 123 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+#line 123 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 124 "sample/unsafe/invalid_maps2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -730,19 +746,21 @@ label_1:
     r2 = r8;
     // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
 #line 124 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[0].address
+    r0 = BindMonitor_Callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 124 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 124 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 124 "sample/unsafe/invalid_maps2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+#line 124 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 125 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 125 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -760,10 +778,12 @@ label_2:
     r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
 #line 130 "sample/unsafe/invalid_maps2.c"
-    if (r2 >= r3)
+    if (r2 >= r3) {
 #line 130 "sample/unsafe/invalid_maps2.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+#line 130 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 134 "sample/unsafe/invalid_maps2.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -780,24 +800,30 @@ label_2:
     r9 += IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
 #line 129 "sample/unsafe/invalid_maps2.c"
-    if (r9 != IMMEDIATE(64))
+    if (r9 != IMMEDIATE(64)) {
 #line 129 "sample/unsafe/invalid_maps2.c"
         goto label_2;
+#line 129 "sample/unsafe/invalid_maps2.c"
+    }
 label_3:
     // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
 #line 193 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
 #line 193 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 193 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+#line 193 "sample/unsafe/invalid_maps2.c"
+    if (r1 == IMMEDIATE(2)) {
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+#line 193 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -815,10 +841,12 @@ label_4:
     r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
 #line 195 "sample/unsafe/invalid_maps2.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 195 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+#line 195 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 199 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -833,10 +861,12 @@ label_5:
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
 #line 202 "sample/unsafe/invalid_maps2.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 202 "sample/unsafe/invalid_maps2.c"
         goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+#line 202 "sample/unsafe/invalid_maps2.c"
+    }
+    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 203 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -854,9 +884,11 @@ label_6:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 210 "sample/unsafe/invalid_maps2.c"
         goto label_9;
+#line 210 "sample/unsafe/invalid_maps2.c"
+    }
 label_7:
     // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
 #line 211 "sample/unsafe/invalid_maps2.c"
@@ -875,13 +907,13 @@ label_7:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
 #line 212 "sample/unsafe/invalid_maps2.c"
-    r0 = BindMonitor_Callee1_helpers[2].address
+    r0 = BindMonitor_Callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 212 "sample/unsafe/invalid_maps2.c"
-         (r1, r2, r3, r4, r5);
-#line 212 "sample/unsafe/invalid_maps2.c"
-    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 212 "sample/unsafe/invalid_maps2.c"
         return 0;
+#line 212 "sample/unsafe/invalid_maps2.c"
+    }
 label_8:
     // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 212 "sample/unsafe/invalid_maps2.c"

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -241,14 +241,14 @@ test_maps(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r6 offset=0 imm=0
@@ -262,9 +262,11 @@ test_maps(void* context)
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=16 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_2;
+#line 75 "sample/undocked/map.c"
+    }
 label_1:
     // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -296,19 +298,21 @@ label_2:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=33 dst=r10 src=r1 offset=-32 imm=0
@@ -350,14 +354,14 @@ label_2:
 label_3:
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=26 imm=0
@@ -375,14 +379,14 @@ label_4:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=59 dst=r3 src=r6 offset=0 imm=0
@@ -396,10 +400,12 @@ label_4:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=62 dst=r3 src=r0 offset=41 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_10;
-        // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-40 imm=0
@@ -435,13 +441,13 @@ label_5:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=79 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/undocked/map.c"
@@ -501,13 +507,13 @@ label_7:
 label_8:
     // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=13
 #line 293 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 293 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 293 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 293 "sample/undocked/map.c"
         return 0;
+#line 293 "sample/undocked/map.c"
+    }
 label_9:
     // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r6 offset=0 imm=0
 #line 306 "sample/undocked/map.c"
@@ -536,14 +542,14 @@ label_10:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=111 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=112 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=112 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=113 dst=r3 src=r6 offset=0 imm=0
@@ -557,10 +563,12 @@ label_10:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=116 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_11;
-        // EBPF_OP_JA pc=117 dst=r0 src=r0 offset=-101 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=117 dst=r0 src=r0 offset=-101 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_1;
 label_11:
@@ -575,19 +583,21 @@ label_11:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=122 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=123 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=123 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_12;
-        // EBPF_OP_MOV64_IMM pc=124 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=124 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=125 dst=r10 src=r1 offset=-20 imm=0
@@ -674,14 +684,14 @@ label_12:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=159 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=159 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=160 dst=r3 src=r6 offset=0 imm=0
@@ -695,9 +705,11 @@ label_12:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=163 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_14;
+#line 75 "sample/undocked/map.c"
+    }
 label_13:
     // EBPF_OP_LDDW pc=164 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -729,19 +741,21 @@ label_14:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=177 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=178 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=178 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_16;
-        // EBPF_OP_MOV64_IMM pc=179 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=179 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=180 dst=r10 src=r1 offset=-32 imm=0
@@ -783,14 +797,14 @@ label_14:
 label_15:
     // EBPF_OP_CALL pc=196 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=197 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=197 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=199 dst=r0 src=r0 offset=26 imm=0
@@ -808,14 +822,14 @@ label_16:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=204 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=205 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=205 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=206 dst=r3 src=r6 offset=0 imm=0
@@ -829,10 +843,12 @@ label_16:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=209 dst=r3 src=r0 offset=42 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_20;
-        // EBPF_OP_LDDW pc=210 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=210 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=212 dst=r10 src=r1 offset=-40 imm=0
@@ -868,13 +884,13 @@ label_17:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=225 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_18:
     // EBPF_OP_MOV64_IMM pc=226 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/undocked/map.c"
@@ -961,14 +977,14 @@ label_20:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=259 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=260 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=260 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=261 dst=r3 src=r6 offset=0 imm=0
@@ -982,10 +998,12 @@ label_20:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=264 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_21;
-        // EBPF_OP_JA pc=265 dst=r0 src=r0 offset=-102 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=265 dst=r0 src=r0 offset=-102 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_13;
 label_21:
@@ -1000,19 +1018,21 @@ label_21:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=270 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=271 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=271 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_22;
-        // EBPF_OP_MOV64_IMM pc=272 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=272 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=273 dst=r10 src=r1 offset=-20 imm=0
@@ -1099,14 +1119,14 @@ label_22:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=306 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=307 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=307 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=308 dst=r3 src=r6 offset=0 imm=0
@@ -1120,10 +1140,12 @@ label_22:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=311 dst=r3 src=r0 offset=1 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_23;
-        // EBPF_OP_JA pc=312 dst=r0 src=r0 offset=60 imm=0
+#line 75 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=312 dst=r0 src=r0 offset=60 imm=0
 #line 75 "sample/undocked/map.c"
     goto label_26;
 label_23:
@@ -1138,19 +1160,21 @@ label_23:
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=317 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=318 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=318 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_24;
-        // EBPF_OP_MOV64_IMM pc=319 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=319 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=320 dst=r10 src=r1 offset=-32 imm=0
@@ -1191,14 +1215,14 @@ label_23:
     r2 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=336 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=337 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=337 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=339 dst=r0 src=r0 offset=49 imm=0
@@ -1216,14 +1240,14 @@ label_24:
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=344 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=345 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=345 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=346 dst=r3 src=r6 offset=0 imm=0
@@ -1237,10 +1261,12 @@ label_24:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=349 dst=r3 src=r0 offset=9 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_25;
-        // EBPF_OP_LDDW pc=350 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=350 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=352 dst=r10 src=r1 offset=-40 imm=0
@@ -1282,14 +1308,14 @@ label_25:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=367 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=368 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=368 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=369 dst=r3 src=r6 offset=0 imm=0
@@ -1303,9 +1329,11 @@ label_25:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=372 dst=r3 src=r0 offset=41 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_29;
+#line 93 "sample/undocked/map.c"
+    }
 label_26:
     // EBPF_OP_LDDW pc=373 dst=r1 src=r0 offset=0 imm=1684369010
 #line 93 "sample/undocked/map.c"
@@ -1343,13 +1371,13 @@ label_27:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=388 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 93 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 93 "sample/undocked/map.c"
         return 0;
+#line 93 "sample/undocked/map.c"
+    }
 label_28:
     // EBPF_OP_MOV64_IMM pc=389 dst=r1 src=r0 offset=0 imm=0
 #line 93 "sample/undocked/map.c"
@@ -1444,14 +1472,14 @@ label_29:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=424 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=425 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=425 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=426 dst=r3 src=r6 offset=0 imm=0
@@ -1465,10 +1493,12 @@ label_29:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=429 dst=r3 src=r0 offset=1 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_30;
-        // EBPF_OP_JA pc=430 dst=r0 src=r0 offset=60 imm=0
+#line 75 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=430 dst=r0 src=r0 offset=60 imm=0
 #line 75 "sample/undocked/map.c"
     goto label_33;
 label_30:
@@ -1483,19 +1513,21 @@ label_30:
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=435 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=436 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=436 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_31;
-        // EBPF_OP_MOV64_IMM pc=437 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=437 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=438 dst=r10 src=r1 offset=-32 imm=0
@@ -1536,14 +1568,14 @@ label_30:
     r2 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=454 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=455 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=455 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=457 dst=r0 src=r0 offset=49 imm=0
@@ -1561,14 +1593,14 @@ label_31:
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=462 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=463 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=463 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=464 dst=r3 src=r6 offset=0 imm=0
@@ -1582,10 +1614,12 @@ label_31:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=467 dst=r3 src=r0 offset=9 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_32;
-        // EBPF_OP_LDDW pc=468 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=468 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=470 dst=r10 src=r1 offset=-40 imm=0
@@ -1627,14 +1661,14 @@ label_32:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=485 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=486 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=486 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=487 dst=r3 src=r6 offset=0 imm=0
@@ -1648,9 +1682,11 @@ label_32:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=490 dst=r3 src=r0 offset=42 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_36;
+#line 93 "sample/undocked/map.c"
+    }
 label_33:
     // EBPF_OP_LDDW pc=491 dst=r1 src=r0 offset=0 imm=1684369010
 #line 93 "sample/undocked/map.c"
@@ -1688,13 +1724,13 @@ label_34:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=506 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 93 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 93 "sample/undocked/map.c"
         return 0;
+#line 93 "sample/undocked/map.c"
+    }
 label_35:
     // EBPF_OP_MOV64_IMM pc=507 dst=r1 src=r0 offset=0 imm=100
 #line 93 "sample/undocked/map.c"
@@ -1789,14 +1825,14 @@ label_36:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=543 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=545 dst=r3 src=r6 offset=0 imm=0
@@ -1810,9 +1846,11 @@ label_36:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=548 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_38;
+#line 75 "sample/undocked/map.c"
+    }
 label_37:
     // EBPF_OP_LDDW pc=549 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -1844,19 +1882,21 @@ label_38:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=562 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=563 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=563 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_40;
-        // EBPF_OP_MOV64_IMM pc=564 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=564 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=565 dst=r10 src=r1 offset=-32 imm=0
@@ -1898,14 +1938,14 @@ label_38:
 label_39:
     // EBPF_OP_CALL pc=581 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=582 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=582 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=584 dst=r0 src=r0 offset=26 imm=0
@@ -1923,14 +1963,14 @@ label_40:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=589 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=590 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=590 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=591 dst=r3 src=r6 offset=0 imm=0
@@ -1944,10 +1984,12 @@ label_40:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=594 dst=r3 src=r0 offset=40 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_43;
-        // EBPF_OP_LDDW pc=595 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=595 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=597 dst=r10 src=r1 offset=-40 imm=0
@@ -1983,13 +2025,13 @@ label_41:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=610 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_42:
     // EBPF_OP_MOV64_IMM pc=611 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/undocked/map.c"
@@ -2069,14 +2111,14 @@ label_43:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=642 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=643 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=643 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=644 dst=r3 src=r6 offset=0 imm=0
@@ -2090,10 +2132,12 @@ label_43:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=647 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_44;
-        // EBPF_OP_JA pc=648 dst=r0 src=r0 offset=-100 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=648 dst=r0 src=r0 offset=-100 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_37;
 label_44:
@@ -2108,19 +2152,21 @@ label_44:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=653 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=654 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=654 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_45;
-        // EBPF_OP_MOV64_IMM pc=655 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=655 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=656 dst=r10 src=r1 offset=-20 imm=0
@@ -2207,14 +2253,14 @@ label_45:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=689 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=690 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=690 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=691 dst=r3 src=r6 offset=0 imm=0
@@ -2228,9 +2274,11 @@ label_45:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=694 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_47;
+#line 75 "sample/undocked/map.c"
+    }
 label_46:
     // EBPF_OP_LDDW pc=695 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -2262,19 +2310,21 @@ label_47:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=708 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=709 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=709 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_49;
-        // EBPF_OP_MOV64_IMM pc=710 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=710 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=711 dst=r10 src=r1 offset=-32 imm=0
@@ -2316,14 +2366,14 @@ label_47:
 label_48:
     // EBPF_OP_CALL pc=727 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=728 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=728 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=730 dst=r0 src=r0 offset=26 imm=0
@@ -2341,14 +2391,14 @@ label_49:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=735 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=737 dst=r3 src=r6 offset=0 imm=0
@@ -2362,10 +2412,12 @@ label_49:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=740 dst=r3 src=r0 offset=43 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_52;
-        // EBPF_OP_LDDW pc=741 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=741 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=743 dst=r10 src=r1 offset=-40 imm=0
@@ -2401,13 +2453,13 @@ label_50:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=756 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_51:
     // EBPF_OP_MOV64_IMM pc=757 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/undocked/map.c"
@@ -2493,14 +2545,14 @@ label_52:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=791 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=792 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=792 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=793 dst=r3 src=r6 offset=0 imm=0
@@ -2514,10 +2566,12 @@ label_52:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=796 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_53;
-        // EBPF_OP_JA pc=797 dst=r0 src=r0 offset=-103 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=797 dst=r0 src=r0 offset=-103 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_46;
 label_53:
@@ -2532,19 +2586,21 @@ label_53:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=802 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=803 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=803 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_54;
-        // EBPF_OP_MOV64_IMM pc=804 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=804 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=805 dst=r10 src=r1 offset=-20 imm=0
@@ -2631,14 +2687,14 @@ label_54:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=838 dst=r0 src=r0 offset=0 imm=2
 #line 129 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 129 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 129 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 129 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=839 dst=r6 src=r0 offset=0 imm=0
+#line 129 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=839 dst=r6 src=r0 offset=0 imm=0
 #line 129 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=840 dst=r3 src=r6 offset=0 imm=0
@@ -2652,10 +2708,12 @@ label_54:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=843 dst=r3 src=r0 offset=1 imm=-1
 #line 130 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 130 "sample/undocked/map.c"
         goto label_55;
-        // EBPF_OP_JA pc=844 dst=r0 src=r0 offset=159 imm=0
+#line 130 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=844 dst=r0 src=r0 offset=159 imm=0
 #line 130 "sample/undocked/map.c"
     goto label_65;
 label_55:
@@ -2682,14 +2740,14 @@ label_55:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=853 dst=r0 src=r0 offset=0 imm=2
 #line 135 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=854 dst=r6 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=854 dst=r6 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=855 dst=r3 src=r6 offset=0 imm=0
@@ -2703,10 +2761,12 @@ label_55:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=858 dst=r3 src=r0 offset=1 imm=-1
 #line 136 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 136 "sample/undocked/map.c"
         goto label_56;
-        // EBPF_OP_JA pc=859 dst=r0 src=r0 offset=144 imm=0
+#line 136 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=859 dst=r0 src=r0 offset=144 imm=0
 #line 136 "sample/undocked/map.c"
     goto label_65;
 label_56:
@@ -2736,14 +2796,14 @@ label_56:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=869 dst=r0 src=r0 offset=0 imm=2
 #line 141 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=870 dst=r6 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=870 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=871 dst=r3 src=r6 offset=0 imm=0
@@ -2757,10 +2817,12 @@ label_56:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=874 dst=r3 src=r0 offset=1 imm=-1
 #line 142 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 142 "sample/undocked/map.c"
         goto label_57;
-        // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=128 imm=0
+#line 142 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=128 imm=0
 #line 142 "sample/undocked/map.c"
     goto label_65;
 label_57:
@@ -2790,14 +2852,14 @@ label_57:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=885 dst=r0 src=r0 offset=0 imm=2
 #line 147 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=886 dst=r6 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=886 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=887 dst=r3 src=r6 offset=0 imm=0
@@ -2811,10 +2873,12 @@ label_57:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=890 dst=r3 src=r0 offset=1 imm=-1
 #line 148 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 148 "sample/undocked/map.c"
         goto label_58;
-        // EBPF_OP_JA pc=891 dst=r0 src=r0 offset=112 imm=0
+#line 148 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=891 dst=r0 src=r0 offset=112 imm=0
 #line 148 "sample/undocked/map.c"
     goto label_65;
 label_58:
@@ -2844,14 +2908,14 @@ label_58:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=901 dst=r0 src=r0 offset=0 imm=2
 #line 153 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=902 dst=r6 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=902 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=903 dst=r3 src=r6 offset=0 imm=0
@@ -2865,10 +2929,12 @@ label_58:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=906 dst=r3 src=r0 offset=1 imm=-1
 #line 154 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 154 "sample/undocked/map.c"
         goto label_59;
-        // EBPF_OP_JA pc=907 dst=r0 src=r0 offset=96 imm=0
+#line 154 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=907 dst=r0 src=r0 offset=96 imm=0
 #line 154 "sample/undocked/map.c"
     goto label_65;
 label_59:
@@ -2898,14 +2964,14 @@ label_59:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=917 dst=r0 src=r0 offset=0 imm=2
 #line 159 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=918 dst=r6 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=918 dst=r6 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=919 dst=r3 src=r6 offset=0 imm=0
@@ -2919,10 +2985,12 @@ label_59:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=922 dst=r3 src=r0 offset=1 imm=-1
 #line 160 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 160 "sample/undocked/map.c"
         goto label_60;
-        // EBPF_OP_JA pc=923 dst=r0 src=r0 offset=80 imm=0
+#line 160 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=923 dst=r0 src=r0 offset=80 imm=0
 #line 160 "sample/undocked/map.c"
     goto label_65;
 label_60:
@@ -2952,14 +3020,14 @@ label_60:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=933 dst=r0 src=r0 offset=0 imm=2
 #line 165 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=934 dst=r6 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=934 dst=r6 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=935 dst=r3 src=r6 offset=0 imm=0
@@ -2973,10 +3041,12 @@ label_60:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=938 dst=r3 src=r0 offset=1 imm=-1
 #line 166 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 166 "sample/undocked/map.c"
         goto label_61;
-        // EBPF_OP_JA pc=939 dst=r0 src=r0 offset=64 imm=0
+#line 166 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=939 dst=r0 src=r0 offset=64 imm=0
 #line 166 "sample/undocked/map.c"
     goto label_65;
 label_61:
@@ -3006,14 +3076,14 @@ label_61:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=949 dst=r0 src=r0 offset=0 imm=2
 #line 171 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=950 dst=r6 src=r0 offset=0 imm=0
+#line 171 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=950 dst=r6 src=r0 offset=0 imm=0
 #line 171 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=951 dst=r3 src=r6 offset=0 imm=0
@@ -3027,10 +3097,12 @@ label_61:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=954 dst=r3 src=r0 offset=1 imm=-1
 #line 172 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 172 "sample/undocked/map.c"
         goto label_62;
-        // EBPF_OP_JA pc=955 dst=r0 src=r0 offset=48 imm=0
+#line 172 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=955 dst=r0 src=r0 offset=48 imm=0
 #line 172 "sample/undocked/map.c"
     goto label_65;
 label_62:
@@ -3060,14 +3132,14 @@ label_62:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=965 dst=r0 src=r0 offset=0 imm=2
 #line 177 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 177 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 177 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=966 dst=r6 src=r0 offset=0 imm=0
+#line 177 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=966 dst=r6 src=r0 offset=0 imm=0
 #line 177 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=967 dst=r3 src=r6 offset=0 imm=0
@@ -3081,10 +3153,12 @@ label_62:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=970 dst=r3 src=r0 offset=1 imm=-1
 #line 178 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 178 "sample/undocked/map.c"
         goto label_63;
-        // EBPF_OP_JA pc=971 dst=r0 src=r0 offset=32 imm=0
+#line 178 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=971 dst=r0 src=r0 offset=32 imm=0
 #line 178 "sample/undocked/map.c"
     goto label_65;
 label_63:
@@ -3114,14 +3188,14 @@ label_63:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=981 dst=r0 src=r0 offset=0 imm=2
 #line 183 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 183 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 183 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=982 dst=r6 src=r0 offset=0 imm=0
+#line 183 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=982 dst=r6 src=r0 offset=0 imm=0
 #line 183 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=983 dst=r3 src=r6 offset=0 imm=0
@@ -3135,10 +3209,12 @@ label_63:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=986 dst=r3 src=r0 offset=1 imm=-1
 #line 184 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 184 "sample/undocked/map.c"
         goto label_64;
-        // EBPF_OP_JA pc=987 dst=r0 src=r0 offset=16 imm=0
+#line 184 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=987 dst=r0 src=r0 offset=16 imm=0
 #line 184 "sample/undocked/map.c"
     goto label_65;
 label_64:
@@ -3171,14 +3247,14 @@ label_64:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=998 dst=r0 src=r0 offset=0 imm=2
 #line 189 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 189 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 189 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
+#line 189 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
 #line 189 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1000 dst=r3 src=r6 offset=0 imm=0
@@ -3192,9 +3268,11 @@ label_64:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1003 dst=r3 src=r0 offset=32 imm=-1
 #line 190 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 190 "sample/undocked/map.c"
         goto label_66;
+#line 190 "sample/undocked/map.c"
+    }
 label_65:
     // EBPF_OP_LDDW pc=1004 dst=r1 src=r0 offset=0 imm=1684369010
 #line 190 "sample/undocked/map.c"
@@ -3231,14 +3309,14 @@ label_65:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=1019 dst=r0 src=r0 offset=0 imm=13
 #line 190 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 190 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 190 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1020 dst=r1 src=r0 offset=0 imm=100
+#line 190 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1020 dst=r1 src=r0 offset=0 imm=100
 #line 190 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1021 dst=r10 src=r1 offset=-28 imm=0
@@ -3304,14 +3382,14 @@ label_66:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1046 dst=r0 src=r0 offset=0 imm=2
 #line 129 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 129 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 129 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 129 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1047 dst=r6 src=r0 offset=0 imm=0
+#line 129 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1047 dst=r6 src=r0 offset=0 imm=0
 #line 129 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1048 dst=r3 src=r6 offset=0 imm=0
@@ -3325,10 +3403,12 @@ label_66:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1051 dst=r3 src=r0 offset=1 imm=-1
 #line 130 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 130 "sample/undocked/map.c"
         goto label_67;
-        // EBPF_OP_JA pc=1052 dst=r0 src=r0 offset=159 imm=0
+#line 130 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1052 dst=r0 src=r0 offset=159 imm=0
 #line 130 "sample/undocked/map.c"
     goto label_77;
 label_67:
@@ -3355,14 +3435,14 @@ label_67:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1061 dst=r0 src=r0 offset=0 imm=2
 #line 135 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1062 dst=r6 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1062 dst=r6 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1063 dst=r3 src=r6 offset=0 imm=0
@@ -3376,10 +3456,12 @@ label_67:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1066 dst=r3 src=r0 offset=1 imm=-1
 #line 136 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 136 "sample/undocked/map.c"
         goto label_68;
-        // EBPF_OP_JA pc=1067 dst=r0 src=r0 offset=144 imm=0
+#line 136 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1067 dst=r0 src=r0 offset=144 imm=0
 #line 136 "sample/undocked/map.c"
     goto label_77;
 label_68:
@@ -3409,14 +3491,14 @@ label_68:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1077 dst=r0 src=r0 offset=0 imm=2
 #line 141 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1078 dst=r6 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1078 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1079 dst=r3 src=r6 offset=0 imm=0
@@ -3430,10 +3512,12 @@ label_68:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1082 dst=r3 src=r0 offset=1 imm=-1
 #line 142 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 142 "sample/undocked/map.c"
         goto label_69;
-        // EBPF_OP_JA pc=1083 dst=r0 src=r0 offset=128 imm=0
+#line 142 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1083 dst=r0 src=r0 offset=128 imm=0
 #line 142 "sample/undocked/map.c"
     goto label_77;
 label_69:
@@ -3463,14 +3547,14 @@ label_69:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1093 dst=r0 src=r0 offset=0 imm=2
 #line 147 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1094 dst=r6 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1094 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1095 dst=r3 src=r6 offset=0 imm=0
@@ -3484,10 +3568,12 @@ label_69:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1098 dst=r3 src=r0 offset=1 imm=-1
 #line 148 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 148 "sample/undocked/map.c"
         goto label_70;
-        // EBPF_OP_JA pc=1099 dst=r0 src=r0 offset=112 imm=0
+#line 148 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1099 dst=r0 src=r0 offset=112 imm=0
 #line 148 "sample/undocked/map.c"
     goto label_77;
 label_70:
@@ -3517,14 +3603,14 @@ label_70:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1109 dst=r0 src=r0 offset=0 imm=2
 #line 153 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1110 dst=r6 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1110 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1111 dst=r3 src=r6 offset=0 imm=0
@@ -3538,10 +3624,12 @@ label_70:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1114 dst=r3 src=r0 offset=1 imm=-1
 #line 154 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 154 "sample/undocked/map.c"
         goto label_71;
-        // EBPF_OP_JA pc=1115 dst=r0 src=r0 offset=96 imm=0
+#line 154 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1115 dst=r0 src=r0 offset=96 imm=0
 #line 154 "sample/undocked/map.c"
     goto label_77;
 label_71:
@@ -3571,14 +3659,14 @@ label_71:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1125 dst=r0 src=r0 offset=0 imm=2
 #line 159 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1126 dst=r6 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1126 dst=r6 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1127 dst=r3 src=r6 offset=0 imm=0
@@ -3592,10 +3680,12 @@ label_71:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1130 dst=r3 src=r0 offset=1 imm=-1
 #line 160 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 160 "sample/undocked/map.c"
         goto label_72;
-        // EBPF_OP_JA pc=1131 dst=r0 src=r0 offset=80 imm=0
+#line 160 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1131 dst=r0 src=r0 offset=80 imm=0
 #line 160 "sample/undocked/map.c"
     goto label_77;
 label_72:
@@ -3625,14 +3715,14 @@ label_72:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1141 dst=r0 src=r0 offset=0 imm=2
 #line 165 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1142 dst=r6 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1142 dst=r6 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1143 dst=r3 src=r6 offset=0 imm=0
@@ -3646,10 +3736,12 @@ label_72:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1146 dst=r3 src=r0 offset=1 imm=-1
 #line 166 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 166 "sample/undocked/map.c"
         goto label_73;
-        // EBPF_OP_JA pc=1147 dst=r0 src=r0 offset=64 imm=0
+#line 166 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1147 dst=r0 src=r0 offset=64 imm=0
 #line 166 "sample/undocked/map.c"
     goto label_77;
 label_73:
@@ -3679,14 +3771,14 @@ label_73:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1157 dst=r0 src=r0 offset=0 imm=2
 #line 171 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1158 dst=r6 src=r0 offset=0 imm=0
+#line 171 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1158 dst=r6 src=r0 offset=0 imm=0
 #line 171 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1159 dst=r3 src=r6 offset=0 imm=0
@@ -3700,10 +3792,12 @@ label_73:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1162 dst=r3 src=r0 offset=1 imm=-1
 #line 172 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 172 "sample/undocked/map.c"
         goto label_74;
-        // EBPF_OP_JA pc=1163 dst=r0 src=r0 offset=48 imm=0
+#line 172 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1163 dst=r0 src=r0 offset=48 imm=0
 #line 172 "sample/undocked/map.c"
     goto label_77;
 label_74:
@@ -3733,14 +3827,14 @@ label_74:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1173 dst=r0 src=r0 offset=0 imm=2
 #line 177 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 177 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 177 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1174 dst=r6 src=r0 offset=0 imm=0
+#line 177 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1174 dst=r6 src=r0 offset=0 imm=0
 #line 177 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1175 dst=r3 src=r6 offset=0 imm=0
@@ -3754,10 +3848,12 @@ label_74:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1178 dst=r3 src=r0 offset=1 imm=-1
 #line 178 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 178 "sample/undocked/map.c"
         goto label_75;
-        // EBPF_OP_JA pc=1179 dst=r0 src=r0 offset=32 imm=0
+#line 178 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1179 dst=r0 src=r0 offset=32 imm=0
 #line 178 "sample/undocked/map.c"
     goto label_77;
 label_75:
@@ -3787,14 +3883,14 @@ label_75:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1189 dst=r0 src=r0 offset=0 imm=2
 #line 183 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 183 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 183 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1190 dst=r6 src=r0 offset=0 imm=0
+#line 183 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1190 dst=r6 src=r0 offset=0 imm=0
 #line 183 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1191 dst=r3 src=r6 offset=0 imm=0
@@ -3808,10 +3904,12 @@ label_75:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1194 dst=r3 src=r0 offset=1 imm=-1
 #line 184 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 184 "sample/undocked/map.c"
         goto label_76;
-        // EBPF_OP_JA pc=1195 dst=r0 src=r0 offset=16 imm=0
+#line 184 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1195 dst=r0 src=r0 offset=16 imm=0
 #line 184 "sample/undocked/map.c"
     goto label_77;
 label_76:
@@ -3844,14 +3942,14 @@ label_76:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1206 dst=r0 src=r0 offset=0 imm=2
 #line 189 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 189 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 189 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1207 dst=r6 src=r0 offset=0 imm=0
+#line 189 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1207 dst=r6 src=r0 offset=0 imm=0
 #line 189 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1208 dst=r3 src=r6 offset=0 imm=0
@@ -3865,9 +3963,11 @@ label_76:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1211 dst=r3 src=r0 offset=35 imm=-1
 #line 190 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 190 "sample/undocked/map.c"
         goto label_78;
+#line 190 "sample/undocked/map.c"
+    }
 label_77:
     // EBPF_OP_LDDW pc=1212 dst=r1 src=r0 offset=0 imm=1684369010
 #line 190 "sample/undocked/map.c"
@@ -3904,14 +4004,14 @@ label_77:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=1227 dst=r0 src=r0 offset=0 imm=13
 #line 190 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 190 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 190 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1228 dst=r1 src=r0 offset=0 imm=0
+#line 190 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1228 dst=r1 src=r0 offset=0 imm=0
 #line 190 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1229 dst=r10 src=r1 offset=-20 imm=0
@@ -3968,14 +4068,14 @@ label_78:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1252 dst=r0 src=r0 offset=0 imm=18
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1253 dst=r6 src=r0 offset=0 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1253 dst=r6 src=r0 offset=0 imm=0
 #line 240 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1254 dst=r4 src=r6 offset=0 imm=0
@@ -3995,9 +4095,11 @@ label_78:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1260 dst=r1 src=r2 offset=27 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 240 "sample/undocked/map.c"
         goto label_81;
+#line 240 "sample/undocked/map.c"
+    }
 label_79:
     // EBPF_OP_MOV64_IMM pc=1261 dst=r1 src=r0 offset=0 imm=100
 #line 240 "sample/undocked/map.c"
@@ -4059,14 +4161,14 @@ label_80:
     r3 = IMMEDIATE(-7);
     // EBPF_OP_CALL pc=1286 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1287 dst=r0 src=r0 offset=26 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1287 dst=r0 src=r0 offset=26 imm=0
 #line 240 "sample/undocked/map.c"
     goto label_85;
 label_81:
@@ -4075,9 +4177,11 @@ label_81:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1289 dst=r3 src=r0 offset=90 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 240 "sample/undocked/map.c"
         goto label_90;
+#line 240 "sample/undocked/map.c"
+    }
 label_82:
     // EBPF_OP_LDDW pc=1290 dst=r1 src=r0 offset=0 imm=1852404835
 #line 240 "sample/undocked/map.c"
@@ -4131,14 +4235,14 @@ label_83:
 label_84:
     // EBPF_OP_CALL pc=1311 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=1312 dst=r6 src=r0 offset=0 imm=-1
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1312 dst=r6 src=r0 offset=0 imm=-1
 #line 240 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
 label_85:
@@ -4153,10 +4257,12 @@ label_85:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1317 dst=r3 src=r0 offset=1 imm=-1
 #line 303 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 303 "sample/undocked/map.c"
         goto label_86;
-        // EBPF_OP_JA pc=1318 dst=r0 src=r0 offset=42 imm=0
+#line 303 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1318 dst=r0 src=r0 offset=42 imm=0
 #line 303 "sample/undocked/map.c"
     goto label_89;
 label_86:
@@ -4177,14 +4283,14 @@ label_86:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=1325 dst=r0 src=r0 offset=0 imm=18
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1326 dst=r7 src=r0 offset=0 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1326 dst=r7 src=r0 offset=0 imm=0
 #line 240 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1327 dst=r4 src=r7 offset=0 imm=0
@@ -4204,9 +4310,11 @@ label_86:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1333 dst=r1 src=r2 offset=865 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 240 "sample/undocked/map.c"
         goto label_137;
+#line 240 "sample/undocked/map.c"
+    }
 label_87:
     // EBPF_OP_MOV64_IMM pc=1334 dst=r1 src=r0 offset=0 imm=100
 #line 240 "sample/undocked/map.c"
@@ -4268,14 +4376,14 @@ label_88:
     r3 = IMMEDIATE(-7);
     // EBPF_OP_CALL pc=1359 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1360 dst=r0 src=r0 offset=864 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1360 dst=r0 src=r0 offset=864 imm=0
 #line 240 "sample/undocked/map.c"
     goto label_141;
 label_89:
@@ -4339,14 +4447,14 @@ label_90:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1386 dst=r0 src=r0 offset=0 imm=17
 #line 241 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 241 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 241 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 241 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1387 dst=r6 src=r0 offset=0 imm=0
+#line 241 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1387 dst=r6 src=r0 offset=0 imm=0
 #line 241 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1388 dst=r4 src=r6 offset=0 imm=0
@@ -4366,9 +4474,11 @@ label_90:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1394 dst=r1 src=r2 offset=24 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 241 "sample/undocked/map.c"
         goto label_92;
+#line 241 "sample/undocked/map.c"
+    }
 label_91:
     // EBPF_OP_STXB pc=1395 dst=r10 src=r7 offset=-16 imm=0
 #line 241 "sample/undocked/map.c"
@@ -4430,9 +4540,11 @@ label_92:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1420 dst=r3 src=r0 offset=19 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 241 "sample/undocked/map.c"
         goto label_94;
+#line 241 "sample/undocked/map.c"
+    }
 label_93:
     // EBPF_OP_LDDW pc=1421 dst=r1 src=r0 offset=0 imm=1735289204
 #line 241 "sample/undocked/map.c"
@@ -4497,14 +4609,14 @@ label_94:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1447 dst=r0 src=r0 offset=0 imm=16
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1448 dst=r6 src=r0 offset=0 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1448 dst=r6 src=r0 offset=0 imm=0
 #line 249 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1449 dst=r5 src=r6 offset=0 imm=0
@@ -4521,9 +4633,11 @@ label_94:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1453 dst=r1 src=r0 offset=31 imm=0
 #line 249 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 249 "sample/undocked/map.c"
         goto label_98;
+#line 249 "sample/undocked/map.c"
+    }
 label_95:
     // EBPF_OP_MOV64_IMM pc=1454 dst=r1 src=r0 offset=0 imm=25637
 #line 249 "sample/undocked/map.c"
@@ -4598,14 +4712,14 @@ label_96:
 label_97:
     // EBPF_OP_CALL pc=1483 dst=r0 src=r0 offset=0 imm=15
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[10].address
+    r0 = test_maps_helpers[10].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[10].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[10].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1484 dst=r0 src=r0 offset=-171 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1484 dst=r0 src=r0 offset=-171 imm=0
 #line 249 "sample/undocked/map.c"
     goto label_85;
 label_98:
@@ -4632,14 +4746,14 @@ label_98:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1493 dst=r0 src=r0 offset=0 imm=16
 #line 250 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 250 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 250 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 250 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1494 dst=r6 src=r0 offset=0 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1494 dst=r6 src=r0 offset=0 imm=0
 #line 250 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1495 dst=r5 src=r6 offset=0 imm=0
@@ -4656,10 +4770,12 @@ label_98:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1499 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 250 "sample/undocked/map.c"
         goto label_99;
-        // EBPF_OP_JA pc=1500 dst=r0 src=r0 offset=-47 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1500 dst=r0 src=r0 offset=-47 imm=0
 #line 250 "sample/undocked/map.c"
     goto label_95;
 label_99:
@@ -4686,14 +4802,14 @@ label_99:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1509 dst=r0 src=r0 offset=0 imm=16
 #line 251 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 251 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 251 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 251 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1510 dst=r6 src=r0 offset=0 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1510 dst=r6 src=r0 offset=0 imm=0
 #line 251 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1511 dst=r5 src=r6 offset=0 imm=0
@@ -4710,10 +4826,12 @@ label_99:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1515 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 251 "sample/undocked/map.c"
         goto label_100;
-        // EBPF_OP_JA pc=1516 dst=r0 src=r0 offset=-63 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1516 dst=r0 src=r0 offset=-63 imm=0
 #line 251 "sample/undocked/map.c"
     goto label_95;
 label_100:
@@ -4740,14 +4858,14 @@ label_100:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1525 dst=r0 src=r0 offset=0 imm=16
 #line 252 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 252 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 252 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 252 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1526 dst=r6 src=r0 offset=0 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1526 dst=r6 src=r0 offset=0 imm=0
 #line 252 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1527 dst=r5 src=r6 offset=0 imm=0
@@ -4764,10 +4882,12 @@ label_100:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1531 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 252 "sample/undocked/map.c"
         goto label_101;
-        // EBPF_OP_JA pc=1532 dst=r0 src=r0 offset=-79 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1532 dst=r0 src=r0 offset=-79 imm=0
 #line 252 "sample/undocked/map.c"
     goto label_95;
 label_101:
@@ -4794,14 +4914,14 @@ label_101:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1541 dst=r0 src=r0 offset=0 imm=16
 #line 253 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 253 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 253 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 253 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1542 dst=r6 src=r0 offset=0 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1542 dst=r6 src=r0 offset=0 imm=0
 #line 253 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1543 dst=r5 src=r6 offset=0 imm=0
@@ -4818,10 +4938,12 @@ label_101:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1547 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 253 "sample/undocked/map.c"
         goto label_102;
-        // EBPF_OP_JA pc=1548 dst=r0 src=r0 offset=-95 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1548 dst=r0 src=r0 offset=-95 imm=0
 #line 253 "sample/undocked/map.c"
     goto label_95;
 label_102:
@@ -4848,14 +4970,14 @@ label_102:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1557 dst=r0 src=r0 offset=0 imm=16
 #line 254 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 254 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 254 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 254 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1558 dst=r6 src=r0 offset=0 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1558 dst=r6 src=r0 offset=0 imm=0
 #line 254 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1559 dst=r5 src=r6 offset=0 imm=0
@@ -4872,10 +4994,12 @@ label_102:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1563 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 254 "sample/undocked/map.c"
         goto label_103;
-        // EBPF_OP_JA pc=1564 dst=r0 src=r0 offset=-111 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1564 dst=r0 src=r0 offset=-111 imm=0
 #line 254 "sample/undocked/map.c"
     goto label_95;
 label_103:
@@ -4902,14 +5026,14 @@ label_103:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1573 dst=r0 src=r0 offset=0 imm=16
 #line 255 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 255 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 255 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 255 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1574 dst=r6 src=r0 offset=0 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1574 dst=r6 src=r0 offset=0 imm=0
 #line 255 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1575 dst=r5 src=r6 offset=0 imm=0
@@ -4926,10 +5050,12 @@ label_103:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1579 dst=r1 src=r0 offset=1 imm=0
 #line 255 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 255 "sample/undocked/map.c"
         goto label_104;
-        // EBPF_OP_JA pc=1580 dst=r0 src=r0 offset=-127 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1580 dst=r0 src=r0 offset=-127 imm=0
 #line 255 "sample/undocked/map.c"
     goto label_95;
 label_104:
@@ -4956,14 +5082,14 @@ label_104:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1589 dst=r0 src=r0 offset=0 imm=16
 #line 256 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 256 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 256 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 256 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1590 dst=r6 src=r0 offset=0 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1590 dst=r6 src=r0 offset=0 imm=0
 #line 256 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1591 dst=r5 src=r6 offset=0 imm=0
@@ -4980,10 +5106,12 @@ label_104:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1595 dst=r1 src=r0 offset=1 imm=0
 #line 256 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 256 "sample/undocked/map.c"
         goto label_105;
-        // EBPF_OP_JA pc=1596 dst=r0 src=r0 offset=-143 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1596 dst=r0 src=r0 offset=-143 imm=0
 #line 256 "sample/undocked/map.c"
     goto label_95;
 label_105:
@@ -5010,14 +5138,14 @@ label_105:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1605 dst=r0 src=r0 offset=0 imm=16
 #line 257 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 257 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 257 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 257 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1606 dst=r6 src=r0 offset=0 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1606 dst=r6 src=r0 offset=0 imm=0
 #line 257 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1607 dst=r5 src=r6 offset=0 imm=0
@@ -5034,10 +5162,12 @@ label_105:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1611 dst=r1 src=r0 offset=1 imm=0
 #line 257 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 257 "sample/undocked/map.c"
         goto label_106;
-        // EBPF_OP_JA pc=1612 dst=r0 src=r0 offset=-159 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1612 dst=r0 src=r0 offset=-159 imm=0
 #line 257 "sample/undocked/map.c"
     goto label_95;
 label_106:
@@ -5064,14 +5194,14 @@ label_106:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1621 dst=r0 src=r0 offset=0 imm=16
 #line 258 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 258 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 258 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 258 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1622 dst=r6 src=r0 offset=0 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1622 dst=r6 src=r0 offset=0 imm=0
 #line 258 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1623 dst=r5 src=r6 offset=0 imm=0
@@ -5088,10 +5218,12 @@ label_106:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1627 dst=r1 src=r0 offset=1 imm=0
 #line 258 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 258 "sample/undocked/map.c"
         goto label_107;
-        // EBPF_OP_JA pc=1628 dst=r0 src=r0 offset=-175 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1628 dst=r0 src=r0 offset=-175 imm=0
 #line 258 "sample/undocked/map.c"
     goto label_95;
 label_107:
@@ -5118,14 +5250,14 @@ label_107:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1637 dst=r0 src=r0 offset=0 imm=16
 #line 261 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 261 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 261 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 261 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1638 dst=r6 src=r0 offset=0 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1638 dst=r6 src=r0 offset=0 imm=0
 #line 261 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1639 dst=r5 src=r6 offset=0 imm=0
@@ -5145,10 +5277,12 @@ label_107:
     r2 = (uint64_t)4294967267;
     // EBPF_OP_JEQ_REG pc=1645 dst=r1 src=r2 offset=30 imm=0
 #line 261 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 261 "sample/undocked/map.c"
         goto label_108;
-        // EBPF_OP_STXB pc=1646 dst=r10 src=r8 offset=-10 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_STXB pc=1646 dst=r10 src=r8 offset=-10 imm=0
 #line 261 "sample/undocked/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1647 dst=r1 src=r0 offset=0 imm=25637
@@ -5238,14 +5372,14 @@ label_108:
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=1682 dst=r0 src=r0 offset=0 imm=16
 #line 262 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 262 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 262 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 262 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1683 dst=r6 src=r0 offset=0 imm=0
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1683 dst=r6 src=r0 offset=0 imm=0
 #line 262 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1684 dst=r5 src=r6 offset=0 imm=0
@@ -5262,10 +5396,12 @@ label_108:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1688 dst=r1 src=r0 offset=25 imm=0
 #line 262 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 262 "sample/undocked/map.c"
         goto label_109;
-        // EBPF_OP_MOV64_IMM pc=1689 dst=r1 src=r0 offset=0 imm=25637
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1689 dst=r1 src=r0 offset=0 imm=25637
 #line 262 "sample/undocked/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1690 dst=r10 src=r1 offset=-12 imm=0
@@ -5340,14 +5476,14 @@ label_109:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1720 dst=r0 src=r0 offset=0 imm=18
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1721 dst=r6 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1721 dst=r6 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1722 dst=r4 src=r6 offset=0 imm=0
@@ -5364,10 +5500,12 @@ label_109:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1726 dst=r1 src=r0 offset=27 imm=0
 #line 264 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 264 "sample/undocked/map.c"
         goto label_111;
-        // EBPF_OP_MOV64_IMM pc=1727 dst=r1 src=r0 offset=0 imm=100
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1727 dst=r1 src=r0 offset=0 imm=100
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1728 dst=r10 src=r1 offset=-16 imm=0
@@ -5427,14 +5565,14 @@ label_110:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1752 dst=r0 src=r0 offset=0 imm=14
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1753 dst=r0 src=r0 offset=-440 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1753 dst=r0 src=r0 offset=-440 imm=0
 #line 264 "sample/undocked/map.c"
     goto label_85;
 label_111:
@@ -5443,10 +5581,12 @@ label_111:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1755 dst=r3 src=r0 offset=22 imm=1
 #line 264 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 264 "sample/undocked/map.c"
         goto label_112;
-        // EBPF_OP_MOV64_IMM pc=1756 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1756 dst=r1 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1757 dst=r10 src=r1 offset=-24 imm=0
@@ -5515,14 +5655,14 @@ label_112:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1784 dst=r0 src=r0 offset=0 imm=17
 #line 272 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 272 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 272 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 272 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1785 dst=r6 src=r0 offset=0 imm=0
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1785 dst=r6 src=r0 offset=0 imm=0
 #line 272 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1786 dst=r4 src=r6 offset=0 imm=0
@@ -5539,9 +5679,11 @@ label_112:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1790 dst=r1 src=r0 offset=24 imm=0
 #line 272 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 272 "sample/undocked/map.c"
         goto label_114;
+#line 272 "sample/undocked/map.c"
+    }
 label_113:
     // EBPF_OP_LDDW pc=1791 dst=r1 src=r0 offset=0 imm=1701737077
 #line 272 "sample/undocked/map.c"
@@ -5603,10 +5745,12 @@ label_114:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1816 dst=r3 src=r0 offset=20 imm=1
 #line 272 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 272 "sample/undocked/map.c"
         goto label_115;
-        // EBPF_OP_LDDW pc=1817 dst=r1 src=r0 offset=0 imm=1735289204
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1817 dst=r1 src=r0 offset=0 imm=1735289204
 #line 272 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1819 dst=r10 src=r1 offset=-32 imm=0
@@ -5669,14 +5813,14 @@ label_115:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1843 dst=r0 src=r0 offset=0 imm=17
 #line 273 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 273 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 273 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 273 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1844 dst=r6 src=r0 offset=0 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1844 dst=r6 src=r0 offset=0 imm=0
 #line 273 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1845 dst=r4 src=r6 offset=0 imm=0
@@ -5693,10 +5837,12 @@ label_115:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1849 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 273 "sample/undocked/map.c"
         goto label_116;
-        // EBPF_OP_JA pc=1850 dst=r0 src=r0 offset=-60 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1850 dst=r0 src=r0 offset=-60 imm=0
 #line 273 "sample/undocked/map.c"
     goto label_113;
 label_116:
@@ -5705,10 +5851,12 @@ label_116:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1852 dst=r3 src=r0 offset=20 imm=2
 #line 273 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(2))
+    if (r3 == IMMEDIATE(2)) {
 #line 273 "sample/undocked/map.c"
         goto label_117;
-        // EBPF_OP_LDDW pc=1853 dst=r1 src=r0 offset=0 imm=1735289204
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1853 dst=r1 src=r0 offset=0 imm=1735289204
 #line 273 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1855 dst=r10 src=r1 offset=-32 imm=0
@@ -5771,14 +5919,14 @@ label_117:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1879 dst=r0 src=r0 offset=0 imm=17
 #line 274 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 274 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 274 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 274 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1880 dst=r6 src=r0 offset=0 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1880 dst=r6 src=r0 offset=0 imm=0
 #line 274 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1881 dst=r4 src=r6 offset=0 imm=0
@@ -5795,10 +5943,12 @@ label_117:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1885 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 274 "sample/undocked/map.c"
         goto label_118;
-        // EBPF_OP_JA pc=1886 dst=r0 src=r0 offset=-96 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1886 dst=r0 src=r0 offset=-96 imm=0
 #line 274 "sample/undocked/map.c"
     goto label_113;
 label_118:
@@ -5807,10 +5957,12 @@ label_118:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1888 dst=r3 src=r0 offset=20 imm=3
 #line 274 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(3))
+    if (r3 == IMMEDIATE(3)) {
 #line 274 "sample/undocked/map.c"
         goto label_119;
-        // EBPF_OP_LDDW pc=1889 dst=r1 src=r0 offset=0 imm=1735289204
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1889 dst=r1 src=r0 offset=0 imm=1735289204
 #line 274 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1891 dst=r10 src=r1 offset=-32 imm=0
@@ -5873,14 +6025,14 @@ label_119:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1915 dst=r0 src=r0 offset=0 imm=17
 #line 275 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 275 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 275 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 275 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1916 dst=r6 src=r0 offset=0 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1916 dst=r6 src=r0 offset=0 imm=0
 #line 275 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1917 dst=r4 src=r6 offset=0 imm=0
@@ -5897,10 +6049,12 @@ label_119:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1921 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 275 "sample/undocked/map.c"
         goto label_120;
-        // EBPF_OP_JA pc=1922 dst=r0 src=r0 offset=-132 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1922 dst=r0 src=r0 offset=-132 imm=0
 #line 275 "sample/undocked/map.c"
     goto label_113;
 label_120:
@@ -5909,10 +6063,12 @@ label_120:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1924 dst=r3 src=r0 offset=20 imm=4
 #line 275 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(4))
+    if (r3 == IMMEDIATE(4)) {
 #line 275 "sample/undocked/map.c"
         goto label_121;
-        // EBPF_OP_LDDW pc=1925 dst=r1 src=r0 offset=0 imm=1735289204
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1925 dst=r1 src=r0 offset=0 imm=1735289204
 #line 275 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1927 dst=r10 src=r1 offset=-32 imm=0
@@ -5975,14 +6131,14 @@ label_121:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1951 dst=r0 src=r0 offset=0 imm=17
 #line 276 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 276 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 276 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 276 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1952 dst=r6 src=r0 offset=0 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1952 dst=r6 src=r0 offset=0 imm=0
 #line 276 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1953 dst=r4 src=r6 offset=0 imm=0
@@ -5999,10 +6155,12 @@ label_121:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1957 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 276 "sample/undocked/map.c"
         goto label_122;
-        // EBPF_OP_JA pc=1958 dst=r0 src=r0 offset=-168 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1958 dst=r0 src=r0 offset=-168 imm=0
 #line 276 "sample/undocked/map.c"
     goto label_113;
 label_122:
@@ -6011,10 +6169,12 @@ label_122:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1960 dst=r3 src=r0 offset=20 imm=5
 #line 276 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(5))
+    if (r3 == IMMEDIATE(5)) {
 #line 276 "sample/undocked/map.c"
         goto label_123;
-        // EBPF_OP_LDDW pc=1961 dst=r1 src=r0 offset=0 imm=1735289204
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1961 dst=r1 src=r0 offset=0 imm=1735289204
 #line 276 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1963 dst=r10 src=r1 offset=-32 imm=0
@@ -6077,14 +6237,14 @@ label_123:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1987 dst=r0 src=r0 offset=0 imm=17
 #line 277 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 277 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 277 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 277 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1988 dst=r6 src=r0 offset=0 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1988 dst=r6 src=r0 offset=0 imm=0
 #line 277 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1989 dst=r4 src=r6 offset=0 imm=0
@@ -6101,10 +6261,12 @@ label_123:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1993 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 277 "sample/undocked/map.c"
         goto label_124;
-        // EBPF_OP_JA pc=1994 dst=r0 src=r0 offset=-204 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1994 dst=r0 src=r0 offset=-204 imm=0
 #line 277 "sample/undocked/map.c"
     goto label_113;
 label_124:
@@ -6113,10 +6275,12 @@ label_124:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1996 dst=r3 src=r0 offset=20 imm=6
 #line 277 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(6))
+    if (r3 == IMMEDIATE(6)) {
 #line 277 "sample/undocked/map.c"
         goto label_125;
-        // EBPF_OP_LDDW pc=1997 dst=r1 src=r0 offset=0 imm=1735289204
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1997 dst=r1 src=r0 offset=0 imm=1735289204
 #line 277 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1999 dst=r10 src=r1 offset=-32 imm=0
@@ -6179,14 +6343,14 @@ label_125:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2023 dst=r0 src=r0 offset=0 imm=17
 #line 278 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 278 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 278 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 278 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2024 dst=r6 src=r0 offset=0 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2024 dst=r6 src=r0 offset=0 imm=0
 #line 278 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2025 dst=r4 src=r6 offset=0 imm=0
@@ -6203,10 +6367,12 @@ label_125:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2029 dst=r1 src=r0 offset=1 imm=0
 #line 278 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 278 "sample/undocked/map.c"
         goto label_126;
-        // EBPF_OP_JA pc=2030 dst=r0 src=r0 offset=-240 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2030 dst=r0 src=r0 offset=-240 imm=0
 #line 278 "sample/undocked/map.c"
     goto label_113;
 label_126:
@@ -6215,10 +6381,12 @@ label_126:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2032 dst=r3 src=r0 offset=20 imm=7
 #line 278 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(7))
+    if (r3 == IMMEDIATE(7)) {
 #line 278 "sample/undocked/map.c"
         goto label_127;
-        // EBPF_OP_LDDW pc=2033 dst=r1 src=r0 offset=0 imm=1735289204
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2033 dst=r1 src=r0 offset=0 imm=1735289204
 #line 278 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2035 dst=r10 src=r1 offset=-32 imm=0
@@ -6281,14 +6449,14 @@ label_127:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2059 dst=r0 src=r0 offset=0 imm=17
 #line 279 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 279 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 279 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 279 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2060 dst=r6 src=r0 offset=0 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2060 dst=r6 src=r0 offset=0 imm=0
 #line 279 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2061 dst=r4 src=r6 offset=0 imm=0
@@ -6305,10 +6473,12 @@ label_127:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2065 dst=r1 src=r0 offset=1 imm=0
 #line 279 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 279 "sample/undocked/map.c"
         goto label_128;
-        // EBPF_OP_JA pc=2066 dst=r0 src=r0 offset=-276 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2066 dst=r0 src=r0 offset=-276 imm=0
 #line 279 "sample/undocked/map.c"
     goto label_113;
 label_128:
@@ -6317,10 +6487,12 @@ label_128:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2068 dst=r3 src=r0 offset=20 imm=8
 #line 279 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(8))
+    if (r3 == IMMEDIATE(8)) {
 #line 279 "sample/undocked/map.c"
         goto label_129;
-        // EBPF_OP_LDDW pc=2069 dst=r1 src=r0 offset=0 imm=1735289204
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2069 dst=r1 src=r0 offset=0 imm=1735289204
 #line 279 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2071 dst=r10 src=r1 offset=-32 imm=0
@@ -6383,14 +6555,14 @@ label_129:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2095 dst=r0 src=r0 offset=0 imm=17
 #line 280 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 280 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 280 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 280 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2096 dst=r6 src=r0 offset=0 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2096 dst=r6 src=r0 offset=0 imm=0
 #line 280 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2097 dst=r4 src=r6 offset=0 imm=0
@@ -6407,10 +6579,12 @@ label_129:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2101 dst=r1 src=r0 offset=1 imm=0
 #line 280 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 280 "sample/undocked/map.c"
         goto label_130;
-        // EBPF_OP_JA pc=2102 dst=r0 src=r0 offset=-312 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2102 dst=r0 src=r0 offset=-312 imm=0
 #line 280 "sample/undocked/map.c"
     goto label_113;
 label_130:
@@ -6419,10 +6593,12 @@ label_130:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2104 dst=r3 src=r0 offset=20 imm=9
 #line 280 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(9))
+    if (r3 == IMMEDIATE(9)) {
 #line 280 "sample/undocked/map.c"
         goto label_131;
-        // EBPF_OP_LDDW pc=2105 dst=r1 src=r0 offset=0 imm=1735289204
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2105 dst=r1 src=r0 offset=0 imm=1735289204
 #line 280 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2107 dst=r10 src=r1 offset=-32 imm=0
@@ -6485,14 +6661,14 @@ label_131:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2131 dst=r0 src=r0 offset=0 imm=17
 #line 281 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 281 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 281 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 281 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2132 dst=r6 src=r0 offset=0 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2132 dst=r6 src=r0 offset=0 imm=0
 #line 281 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2133 dst=r4 src=r6 offset=0 imm=0
@@ -6509,10 +6685,12 @@ label_131:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2137 dst=r1 src=r0 offset=1 imm=0
 #line 281 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 281 "sample/undocked/map.c"
         goto label_132;
-        // EBPF_OP_JA pc=2138 dst=r0 src=r0 offset=-348 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2138 dst=r0 src=r0 offset=-348 imm=0
 #line 281 "sample/undocked/map.c"
     goto label_113;
 label_132:
@@ -6521,10 +6699,12 @@ label_132:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2140 dst=r3 src=r0 offset=20 imm=10
 #line 281 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 281 "sample/undocked/map.c"
         goto label_133;
-        // EBPF_OP_LDDW pc=2141 dst=r1 src=r0 offset=0 imm=1735289204
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2141 dst=r1 src=r0 offset=0 imm=1735289204
 #line 281 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2143 dst=r10 src=r1 offset=-32 imm=0
@@ -6587,14 +6767,14 @@ label_133:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2167 dst=r0 src=r0 offset=0 imm=18
 #line 284 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 284 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 284 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 284 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2168 dst=r6 src=r0 offset=0 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2168 dst=r6 src=r0 offset=0 imm=0
 #line 284 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2169 dst=r4 src=r6 offset=0 imm=0
@@ -6614,10 +6794,12 @@ label_133:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2175 dst=r1 src=r2 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 284 "sample/undocked/map.c"
         goto label_134;
-        // EBPF_OP_JA pc=2176 dst=r0 src=r0 offset=-916 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2176 dst=r0 src=r0 offset=-916 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_79;
 label_134:
@@ -6626,10 +6808,12 @@ label_134:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2178 dst=r3 src=r0 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 284 "sample/undocked/map.c"
         goto label_135;
-        // EBPF_OP_JA pc=2179 dst=r0 src=r0 offset=-890 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2179 dst=r0 src=r0 offset=-890 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_82;
 label_135:
@@ -6650,14 +6834,14 @@ label_135:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2186 dst=r0 src=r0 offset=0 imm=17
 #line 285 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 285 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 285 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 285 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2187 dst=r6 src=r0 offset=0 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2187 dst=r6 src=r0 offset=0 imm=0
 #line 285 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2188 dst=r4 src=r6 offset=0 imm=0
@@ -6677,10 +6861,12 @@ label_135:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2194 dst=r1 src=r2 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 285 "sample/undocked/map.c"
         goto label_136;
-        // EBPF_OP_JA pc=2195 dst=r0 src=r0 offset=-801 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2195 dst=r0 src=r0 offset=-801 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_91;
 label_136:
@@ -6689,10 +6875,12 @@ label_136:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2197 dst=r3 src=r0 offset=-879 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 285 "sample/undocked/map.c"
         goto label_86;
-        // EBPF_OP_JA pc=2198 dst=r0 src=r0 offset=-778 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2198 dst=r0 src=r0 offset=-778 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_93;
 label_137:
@@ -6701,9 +6889,11 @@ label_137:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2200 dst=r3 src=r0 offset=50 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 240 "sample/undocked/map.c"
         goto label_142;
+#line 240 "sample/undocked/map.c"
+    }
 label_138:
     // EBPF_OP_LDDW pc=2201 dst=r1 src=r0 offset=0 imm=1852404835
 #line 240 "sample/undocked/map.c"
@@ -6757,14 +6947,14 @@ label_139:
 label_140:
     // EBPF_OP_CALL pc=2222 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=2223 dst=r7 src=r0 offset=0 imm=-1
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2223 dst=r7 src=r0 offset=0 imm=-1
 #line 240 "sample/undocked/map.c"
     r7 = (uint64_t)4294967295;
 label_141:
@@ -6782,10 +6972,12 @@ label_141:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=2229 dst=r3 src=r0 offset=-2128 imm=-1
 #line 304 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 304 "sample/undocked/map.c"
         goto label_9;
-        // EBPF_OP_LDDW pc=2230 dst=r1 src=r0 offset=0 imm=1684369010
+#line 304 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2230 dst=r1 src=r0 offset=0 imm=1684369010
 #line 304 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=2232 dst=r10 src=r1 offset=-32 imm=0
@@ -6826,14 +7018,14 @@ label_141:
     r2 = IMMEDIATE(40);
     // EBPF_OP_CALL pc=2248 dst=r0 src=r0 offset=0 imm=13
 #line 304 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 304 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 304 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 304 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2249 dst=r6 src=r7 offset=0 imm=0
+#line 304 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2249 dst=r6 src=r7 offset=0 imm=0
 #line 304 "sample/undocked/map.c"
     r6 = r7;
     // EBPF_OP_JA pc=2250 dst=r0 src=r0 offset=-2149 imm=0
@@ -6857,14 +7049,14 @@ label_142:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2257 dst=r0 src=r0 offset=0 imm=17
 #line 241 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 241 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 241 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 241 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2258 dst=r7 src=r0 offset=0 imm=0
+#line 241 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2258 dst=r7 src=r0 offset=0 imm=0
 #line 241 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2259 dst=r4 src=r7 offset=0 imm=0
@@ -6884,9 +7076,11 @@ label_142:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2265 dst=r1 src=r2 offset=24 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 241 "sample/undocked/map.c"
         goto label_144;
+#line 241 "sample/undocked/map.c"
+    }
 label_143:
     // EBPF_OP_STXB pc=2266 dst=r10 src=r6 offset=-16 imm=0
 #line 241 "sample/undocked/map.c"
@@ -6948,9 +7142,11 @@ label_144:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2291 dst=r3 src=r0 offset=19 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 241 "sample/undocked/map.c"
         goto label_146;
+#line 241 "sample/undocked/map.c"
+    }
 label_145:
     // EBPF_OP_LDDW pc=2292 dst=r1 src=r0 offset=0 imm=1735289204
 #line 241 "sample/undocked/map.c"
@@ -7015,14 +7211,14 @@ label_146:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2318 dst=r0 src=r0 offset=0 imm=16
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2319 dst=r7 src=r0 offset=0 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2319 dst=r7 src=r0 offset=0 imm=0
 #line 249 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2320 dst=r5 src=r7 offset=0 imm=0
@@ -7039,9 +7235,11 @@ label_146:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2324 dst=r1 src=r0 offset=31 imm=0
 #line 249 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 249 "sample/undocked/map.c"
         goto label_150;
+#line 249 "sample/undocked/map.c"
+    }
 label_147:
     // EBPF_OP_MOV64_IMM pc=2325 dst=r1 src=r0 offset=0 imm=25637
 #line 249 "sample/undocked/map.c"
@@ -7116,14 +7314,14 @@ label_148:
 label_149:
     // EBPF_OP_CALL pc=2354 dst=r0 src=r0 offset=0 imm=15
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[10].address
+    r0 = test_maps_helpers[10].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[10].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[10].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=2355 dst=r0 src=r0 offset=-131 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2355 dst=r0 src=r0 offset=-131 imm=0
 #line 249 "sample/undocked/map.c"
     goto label_141;
 label_150:
@@ -7150,14 +7348,14 @@ label_150:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2364 dst=r0 src=r0 offset=0 imm=16
 #line 250 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 250 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 250 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 250 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2365 dst=r7 src=r0 offset=0 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2365 dst=r7 src=r0 offset=0 imm=0
 #line 250 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2366 dst=r5 src=r7 offset=0 imm=0
@@ -7174,10 +7372,12 @@ label_150:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2370 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 250 "sample/undocked/map.c"
         goto label_151;
-        // EBPF_OP_JA pc=2371 dst=r0 src=r0 offset=-47 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2371 dst=r0 src=r0 offset=-47 imm=0
 #line 250 "sample/undocked/map.c"
     goto label_147;
 label_151:
@@ -7204,14 +7404,14 @@ label_151:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2380 dst=r0 src=r0 offset=0 imm=16
 #line 251 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 251 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 251 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 251 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2381 dst=r7 src=r0 offset=0 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2381 dst=r7 src=r0 offset=0 imm=0
 #line 251 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2382 dst=r5 src=r7 offset=0 imm=0
@@ -7228,10 +7428,12 @@ label_151:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2386 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 251 "sample/undocked/map.c"
         goto label_152;
-        // EBPF_OP_JA pc=2387 dst=r0 src=r0 offset=-63 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2387 dst=r0 src=r0 offset=-63 imm=0
 #line 251 "sample/undocked/map.c"
     goto label_147;
 label_152:
@@ -7258,14 +7460,14 @@ label_152:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2396 dst=r0 src=r0 offset=0 imm=16
 #line 252 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 252 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 252 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 252 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2397 dst=r7 src=r0 offset=0 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2397 dst=r7 src=r0 offset=0 imm=0
 #line 252 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2398 dst=r5 src=r7 offset=0 imm=0
@@ -7282,10 +7484,12 @@ label_152:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2402 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 252 "sample/undocked/map.c"
         goto label_153;
-        // EBPF_OP_JA pc=2403 dst=r0 src=r0 offset=-79 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2403 dst=r0 src=r0 offset=-79 imm=0
 #line 252 "sample/undocked/map.c"
     goto label_147;
 label_153:
@@ -7312,14 +7516,14 @@ label_153:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2412 dst=r0 src=r0 offset=0 imm=16
 #line 253 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 253 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 253 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 253 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2413 dst=r7 src=r0 offset=0 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2413 dst=r7 src=r0 offset=0 imm=0
 #line 253 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2414 dst=r5 src=r7 offset=0 imm=0
@@ -7336,10 +7540,12 @@ label_153:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2418 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 253 "sample/undocked/map.c"
         goto label_154;
-        // EBPF_OP_JA pc=2419 dst=r0 src=r0 offset=-95 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2419 dst=r0 src=r0 offset=-95 imm=0
 #line 253 "sample/undocked/map.c"
     goto label_147;
 label_154:
@@ -7366,14 +7572,14 @@ label_154:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2428 dst=r0 src=r0 offset=0 imm=16
 #line 254 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 254 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 254 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 254 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2429 dst=r7 src=r0 offset=0 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2429 dst=r7 src=r0 offset=0 imm=0
 #line 254 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2430 dst=r5 src=r7 offset=0 imm=0
@@ -7390,10 +7596,12 @@ label_154:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2434 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 254 "sample/undocked/map.c"
         goto label_155;
-        // EBPF_OP_JA pc=2435 dst=r0 src=r0 offset=-111 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2435 dst=r0 src=r0 offset=-111 imm=0
 #line 254 "sample/undocked/map.c"
     goto label_147;
 label_155:
@@ -7420,14 +7628,14 @@ label_155:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2444 dst=r0 src=r0 offset=0 imm=16
 #line 255 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 255 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 255 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 255 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2445 dst=r7 src=r0 offset=0 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2445 dst=r7 src=r0 offset=0 imm=0
 #line 255 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2446 dst=r5 src=r7 offset=0 imm=0
@@ -7444,10 +7652,12 @@ label_155:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2450 dst=r1 src=r0 offset=1 imm=0
 #line 255 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 255 "sample/undocked/map.c"
         goto label_156;
-        // EBPF_OP_JA pc=2451 dst=r0 src=r0 offset=-127 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2451 dst=r0 src=r0 offset=-127 imm=0
 #line 255 "sample/undocked/map.c"
     goto label_147;
 label_156:
@@ -7474,14 +7684,14 @@ label_156:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2460 dst=r0 src=r0 offset=0 imm=16
 #line 256 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 256 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 256 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 256 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2461 dst=r7 src=r0 offset=0 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2461 dst=r7 src=r0 offset=0 imm=0
 #line 256 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2462 dst=r5 src=r7 offset=0 imm=0
@@ -7498,10 +7708,12 @@ label_156:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2466 dst=r1 src=r0 offset=1 imm=0
 #line 256 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 256 "sample/undocked/map.c"
         goto label_157;
-        // EBPF_OP_JA pc=2467 dst=r0 src=r0 offset=-143 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2467 dst=r0 src=r0 offset=-143 imm=0
 #line 256 "sample/undocked/map.c"
     goto label_147;
 label_157:
@@ -7528,14 +7740,14 @@ label_157:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2476 dst=r0 src=r0 offset=0 imm=16
 #line 257 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 257 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 257 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 257 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2477 dst=r7 src=r0 offset=0 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2477 dst=r7 src=r0 offset=0 imm=0
 #line 257 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2478 dst=r5 src=r7 offset=0 imm=0
@@ -7552,10 +7764,12 @@ label_157:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2482 dst=r1 src=r0 offset=1 imm=0
 #line 257 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 257 "sample/undocked/map.c"
         goto label_158;
-        // EBPF_OP_JA pc=2483 dst=r0 src=r0 offset=-159 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2483 dst=r0 src=r0 offset=-159 imm=0
 #line 257 "sample/undocked/map.c"
     goto label_147;
 label_158:
@@ -7582,14 +7796,14 @@ label_158:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2492 dst=r0 src=r0 offset=0 imm=16
 #line 258 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 258 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 258 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 258 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2493 dst=r7 src=r0 offset=0 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2493 dst=r7 src=r0 offset=0 imm=0
 #line 258 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2494 dst=r5 src=r7 offset=0 imm=0
@@ -7606,10 +7820,12 @@ label_158:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2498 dst=r1 src=r0 offset=1 imm=0
 #line 258 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 258 "sample/undocked/map.c"
         goto label_159;
-        // EBPF_OP_JA pc=2499 dst=r0 src=r0 offset=-175 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2499 dst=r0 src=r0 offset=-175 imm=0
 #line 258 "sample/undocked/map.c"
     goto label_147;
 label_159:
@@ -7636,14 +7852,14 @@ label_159:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2508 dst=r0 src=r0 offset=0 imm=16
 #line 261 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 261 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 261 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 261 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2509 dst=r7 src=r0 offset=0 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2509 dst=r7 src=r0 offset=0 imm=0
 #line 261 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2510 dst=r5 src=r7 offset=0 imm=0
@@ -7663,10 +7879,12 @@ label_159:
     r2 = (uint64_t)4294967267;
     // EBPF_OP_JEQ_REG pc=2516 dst=r1 src=r2 offset=30 imm=0
 #line 261 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 261 "sample/undocked/map.c"
         goto label_160;
-        // EBPF_OP_STXB pc=2517 dst=r10 src=r8 offset=-10 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_STXB pc=2517 dst=r10 src=r8 offset=-10 imm=0
 #line 261 "sample/undocked/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=2518 dst=r1 src=r0 offset=0 imm=25637
@@ -7756,14 +7974,14 @@ label_160:
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=2553 dst=r0 src=r0 offset=0 imm=16
 #line 262 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 262 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 262 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 262 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2554 dst=r7 src=r0 offset=0 imm=0
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2554 dst=r7 src=r0 offset=0 imm=0
 #line 262 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2555 dst=r5 src=r7 offset=0 imm=0
@@ -7780,10 +7998,12 @@ label_160:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2559 dst=r1 src=r0 offset=25 imm=0
 #line 262 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 262 "sample/undocked/map.c"
         goto label_161;
-        // EBPF_OP_MOV64_IMM pc=2560 dst=r1 src=r0 offset=0 imm=25637
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2560 dst=r1 src=r0 offset=0 imm=25637
 #line 262 "sample/undocked/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=2561 dst=r10 src=r1 offset=-12 imm=0
@@ -7858,14 +8078,14 @@ label_161:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2591 dst=r0 src=r0 offset=0 imm=18
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2592 dst=r7 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2592 dst=r7 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2593 dst=r4 src=r7 offset=0 imm=0
@@ -7882,10 +8102,12 @@ label_161:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2597 dst=r1 src=r0 offset=27 imm=0
 #line 264 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 264 "sample/undocked/map.c"
         goto label_163;
-        // EBPF_OP_MOV64_IMM pc=2598 dst=r1 src=r0 offset=0 imm=100
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2598 dst=r1 src=r0 offset=0 imm=100
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=2599 dst=r10 src=r1 offset=-16 imm=0
@@ -7945,14 +8167,14 @@ label_162:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2623 dst=r0 src=r0 offset=0 imm=14
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=2624 dst=r0 src=r0 offset=-400 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2624 dst=r0 src=r0 offset=-400 imm=0
 #line 264 "sample/undocked/map.c"
     goto label_141;
 label_163:
@@ -7961,10 +8183,12 @@ label_163:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2626 dst=r3 src=r0 offset=22 imm=10
 #line 264 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 264 "sample/undocked/map.c"
         goto label_164;
-        // EBPF_OP_MOV64_IMM pc=2627 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2627 dst=r1 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=2628 dst=r10 src=r1 offset=-24 imm=0
@@ -8033,14 +8257,14 @@ label_164:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2655 dst=r0 src=r0 offset=0 imm=17
 #line 272 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 272 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 272 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 272 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2656 dst=r7 src=r0 offset=0 imm=0
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2656 dst=r7 src=r0 offset=0 imm=0
 #line 272 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2657 dst=r4 src=r7 offset=0 imm=0
@@ -8057,9 +8281,11 @@ label_164:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2661 dst=r1 src=r0 offset=24 imm=0
 #line 272 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 272 "sample/undocked/map.c"
         goto label_166;
+#line 272 "sample/undocked/map.c"
+    }
 label_165:
     // EBPF_OP_LDDW pc=2662 dst=r1 src=r0 offset=0 imm=1701737077
 #line 272 "sample/undocked/map.c"
@@ -8121,10 +8347,12 @@ label_166:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2687 dst=r3 src=r0 offset=20 imm=10
 #line 272 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 272 "sample/undocked/map.c"
         goto label_167;
-        // EBPF_OP_LDDW pc=2688 dst=r1 src=r0 offset=0 imm=1735289204
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2688 dst=r1 src=r0 offset=0 imm=1735289204
 #line 272 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2690 dst=r10 src=r1 offset=-32 imm=0
@@ -8187,14 +8415,14 @@ label_167:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2714 dst=r0 src=r0 offset=0 imm=17
 #line 273 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 273 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 273 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 273 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2715 dst=r7 src=r0 offset=0 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2715 dst=r7 src=r0 offset=0 imm=0
 #line 273 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2716 dst=r4 src=r7 offset=0 imm=0
@@ -8211,10 +8439,12 @@ label_167:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2720 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 273 "sample/undocked/map.c"
         goto label_168;
-        // EBPF_OP_JA pc=2721 dst=r0 src=r0 offset=-60 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2721 dst=r0 src=r0 offset=-60 imm=0
 #line 273 "sample/undocked/map.c"
     goto label_165;
 label_168:
@@ -8223,10 +8453,12 @@ label_168:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2723 dst=r3 src=r0 offset=20 imm=9
 #line 273 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(9))
+    if (r3 == IMMEDIATE(9)) {
 #line 273 "sample/undocked/map.c"
         goto label_169;
-        // EBPF_OP_LDDW pc=2724 dst=r1 src=r0 offset=0 imm=1735289204
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2724 dst=r1 src=r0 offset=0 imm=1735289204
 #line 273 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2726 dst=r10 src=r1 offset=-32 imm=0
@@ -8289,14 +8521,14 @@ label_169:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2750 dst=r0 src=r0 offset=0 imm=17
 #line 274 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 274 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 274 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 274 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2751 dst=r7 src=r0 offset=0 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2751 dst=r7 src=r0 offset=0 imm=0
 #line 274 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2752 dst=r4 src=r7 offset=0 imm=0
@@ -8313,10 +8545,12 @@ label_169:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2756 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 274 "sample/undocked/map.c"
         goto label_170;
-        // EBPF_OP_JA pc=2757 dst=r0 src=r0 offset=-96 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2757 dst=r0 src=r0 offset=-96 imm=0
 #line 274 "sample/undocked/map.c"
     goto label_165;
 label_170:
@@ -8325,10 +8559,12 @@ label_170:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2759 dst=r3 src=r0 offset=20 imm=8
 #line 274 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(8))
+    if (r3 == IMMEDIATE(8)) {
 #line 274 "sample/undocked/map.c"
         goto label_171;
-        // EBPF_OP_LDDW pc=2760 dst=r1 src=r0 offset=0 imm=1735289204
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2760 dst=r1 src=r0 offset=0 imm=1735289204
 #line 274 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2762 dst=r10 src=r1 offset=-32 imm=0
@@ -8391,14 +8627,14 @@ label_171:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2786 dst=r0 src=r0 offset=0 imm=17
 #line 275 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 275 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 275 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 275 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2787 dst=r7 src=r0 offset=0 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2787 dst=r7 src=r0 offset=0 imm=0
 #line 275 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2788 dst=r4 src=r7 offset=0 imm=0
@@ -8415,10 +8651,12 @@ label_171:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2792 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 275 "sample/undocked/map.c"
         goto label_172;
-        // EBPF_OP_JA pc=2793 dst=r0 src=r0 offset=-132 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2793 dst=r0 src=r0 offset=-132 imm=0
 #line 275 "sample/undocked/map.c"
     goto label_165;
 label_172:
@@ -8427,10 +8665,12 @@ label_172:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2795 dst=r3 src=r0 offset=20 imm=7
 #line 275 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(7))
+    if (r3 == IMMEDIATE(7)) {
 #line 275 "sample/undocked/map.c"
         goto label_173;
-        // EBPF_OP_LDDW pc=2796 dst=r1 src=r0 offset=0 imm=1735289204
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2796 dst=r1 src=r0 offset=0 imm=1735289204
 #line 275 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2798 dst=r10 src=r1 offset=-32 imm=0
@@ -8493,14 +8733,14 @@ label_173:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2822 dst=r0 src=r0 offset=0 imm=17
 #line 276 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 276 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 276 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 276 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2823 dst=r7 src=r0 offset=0 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2823 dst=r7 src=r0 offset=0 imm=0
 #line 276 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2824 dst=r4 src=r7 offset=0 imm=0
@@ -8517,10 +8757,12 @@ label_173:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2828 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 276 "sample/undocked/map.c"
         goto label_174;
-        // EBPF_OP_JA pc=2829 dst=r0 src=r0 offset=-168 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2829 dst=r0 src=r0 offset=-168 imm=0
 #line 276 "sample/undocked/map.c"
     goto label_165;
 label_174:
@@ -8529,10 +8771,12 @@ label_174:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2831 dst=r3 src=r0 offset=20 imm=6
 #line 276 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(6))
+    if (r3 == IMMEDIATE(6)) {
 #line 276 "sample/undocked/map.c"
         goto label_175;
-        // EBPF_OP_LDDW pc=2832 dst=r1 src=r0 offset=0 imm=1735289204
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2832 dst=r1 src=r0 offset=0 imm=1735289204
 #line 276 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2834 dst=r10 src=r1 offset=-32 imm=0
@@ -8595,14 +8839,14 @@ label_175:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2858 dst=r0 src=r0 offset=0 imm=17
 #line 277 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 277 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 277 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 277 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2859 dst=r7 src=r0 offset=0 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2859 dst=r7 src=r0 offset=0 imm=0
 #line 277 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2860 dst=r4 src=r7 offset=0 imm=0
@@ -8619,10 +8863,12 @@ label_175:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2864 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 277 "sample/undocked/map.c"
         goto label_176;
-        // EBPF_OP_JA pc=2865 dst=r0 src=r0 offset=-204 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2865 dst=r0 src=r0 offset=-204 imm=0
 #line 277 "sample/undocked/map.c"
     goto label_165;
 label_176:
@@ -8631,10 +8877,12 @@ label_176:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2867 dst=r3 src=r0 offset=20 imm=5
 #line 277 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(5))
+    if (r3 == IMMEDIATE(5)) {
 #line 277 "sample/undocked/map.c"
         goto label_177;
-        // EBPF_OP_LDDW pc=2868 dst=r1 src=r0 offset=0 imm=1735289204
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2868 dst=r1 src=r0 offset=0 imm=1735289204
 #line 277 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2870 dst=r10 src=r1 offset=-32 imm=0
@@ -8697,14 +8945,14 @@ label_177:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2894 dst=r0 src=r0 offset=0 imm=17
 #line 278 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 278 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 278 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 278 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2895 dst=r7 src=r0 offset=0 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2895 dst=r7 src=r0 offset=0 imm=0
 #line 278 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2896 dst=r4 src=r7 offset=0 imm=0
@@ -8721,10 +8969,12 @@ label_177:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2900 dst=r1 src=r0 offset=1 imm=0
 #line 278 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 278 "sample/undocked/map.c"
         goto label_178;
-        // EBPF_OP_JA pc=2901 dst=r0 src=r0 offset=-240 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2901 dst=r0 src=r0 offset=-240 imm=0
 #line 278 "sample/undocked/map.c"
     goto label_165;
 label_178:
@@ -8733,10 +8983,12 @@ label_178:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2903 dst=r3 src=r0 offset=20 imm=4
 #line 278 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(4))
+    if (r3 == IMMEDIATE(4)) {
 #line 278 "sample/undocked/map.c"
         goto label_179;
-        // EBPF_OP_LDDW pc=2904 dst=r1 src=r0 offset=0 imm=1735289204
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2904 dst=r1 src=r0 offset=0 imm=1735289204
 #line 278 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2906 dst=r10 src=r1 offset=-32 imm=0
@@ -8799,14 +9051,14 @@ label_179:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2930 dst=r0 src=r0 offset=0 imm=17
 #line 279 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 279 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 279 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 279 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2931 dst=r7 src=r0 offset=0 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2931 dst=r7 src=r0 offset=0 imm=0
 #line 279 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2932 dst=r4 src=r7 offset=0 imm=0
@@ -8823,10 +9075,12 @@ label_179:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2936 dst=r1 src=r0 offset=1 imm=0
 #line 279 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 279 "sample/undocked/map.c"
         goto label_180;
-        // EBPF_OP_JA pc=2937 dst=r0 src=r0 offset=-276 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2937 dst=r0 src=r0 offset=-276 imm=0
 #line 279 "sample/undocked/map.c"
     goto label_165;
 label_180:
@@ -8835,10 +9089,12 @@ label_180:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2939 dst=r3 src=r0 offset=20 imm=3
 #line 279 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(3))
+    if (r3 == IMMEDIATE(3)) {
 #line 279 "sample/undocked/map.c"
         goto label_181;
-        // EBPF_OP_LDDW pc=2940 dst=r1 src=r0 offset=0 imm=1735289204
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2940 dst=r1 src=r0 offset=0 imm=1735289204
 #line 279 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2942 dst=r10 src=r1 offset=-32 imm=0
@@ -8901,14 +9157,14 @@ label_181:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2966 dst=r0 src=r0 offset=0 imm=17
 #line 280 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 280 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 280 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 280 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2967 dst=r7 src=r0 offset=0 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2967 dst=r7 src=r0 offset=0 imm=0
 #line 280 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2968 dst=r4 src=r7 offset=0 imm=0
@@ -8925,10 +9181,12 @@ label_181:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2972 dst=r1 src=r0 offset=1 imm=0
 #line 280 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 280 "sample/undocked/map.c"
         goto label_182;
-        // EBPF_OP_JA pc=2973 dst=r0 src=r0 offset=-312 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2973 dst=r0 src=r0 offset=-312 imm=0
 #line 280 "sample/undocked/map.c"
     goto label_165;
 label_182:
@@ -8937,10 +9195,12 @@ label_182:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2975 dst=r3 src=r0 offset=20 imm=2
 #line 280 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(2))
+    if (r3 == IMMEDIATE(2)) {
 #line 280 "sample/undocked/map.c"
         goto label_183;
-        // EBPF_OP_LDDW pc=2976 dst=r1 src=r0 offset=0 imm=1735289204
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2976 dst=r1 src=r0 offset=0 imm=1735289204
 #line 280 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2978 dst=r10 src=r1 offset=-32 imm=0
@@ -9003,14 +9263,14 @@ label_183:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3002 dst=r0 src=r0 offset=0 imm=17
 #line 281 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 281 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 281 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 281 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3003 dst=r7 src=r0 offset=0 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3003 dst=r7 src=r0 offset=0 imm=0
 #line 281 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3004 dst=r4 src=r7 offset=0 imm=0
@@ -9027,10 +9287,12 @@ label_183:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=3008 dst=r1 src=r0 offset=1 imm=0
 #line 281 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 281 "sample/undocked/map.c"
         goto label_184;
-        // EBPF_OP_JA pc=3009 dst=r0 src=r0 offset=-348 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3009 dst=r0 src=r0 offset=-348 imm=0
 #line 281 "sample/undocked/map.c"
     goto label_165;
 label_184:
@@ -9039,10 +9301,12 @@ label_184:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3011 dst=r3 src=r0 offset=20 imm=1
 #line 281 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 281 "sample/undocked/map.c"
         goto label_185;
-        // EBPF_OP_LDDW pc=3012 dst=r1 src=r0 offset=0 imm=1735289204
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=3012 dst=r1 src=r0 offset=0 imm=1735289204
 #line 281 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=3014 dst=r10 src=r1 offset=-32 imm=0
@@ -9105,14 +9369,14 @@ label_185:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3038 dst=r0 src=r0 offset=0 imm=18
 #line 284 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 284 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 284 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 284 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3039 dst=r7 src=r0 offset=0 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3039 dst=r7 src=r0 offset=0 imm=0
 #line 284 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3040 dst=r4 src=r7 offset=0 imm=0
@@ -9132,10 +9396,12 @@ label_185:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=3046 dst=r1 src=r2 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 284 "sample/undocked/map.c"
         goto label_186;
-        // EBPF_OP_JA pc=3047 dst=r0 src=r0 offset=-1714 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3047 dst=r0 src=r0 offset=-1714 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_87;
 label_186:
@@ -9144,10 +9410,12 @@ label_186:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3049 dst=r3 src=r0 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 284 "sample/undocked/map.c"
         goto label_187;
-        // EBPF_OP_JA pc=3050 dst=r0 src=r0 offset=-850 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3050 dst=r0 src=r0 offset=-850 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_138;
 label_187:
@@ -9168,14 +9436,14 @@ label_187:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3057 dst=r0 src=r0 offset=0 imm=17
 #line 285 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 285 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 285 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 285 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3058 dst=r7 src=r0 offset=0 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3058 dst=r7 src=r0 offset=0 imm=0
 #line 285 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3059 dst=r4 src=r7 offset=0 imm=0
@@ -9195,10 +9463,12 @@ label_187:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=3065 dst=r1 src=r2 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 285 "sample/undocked/map.c"
         goto label_188;
-        // EBPF_OP_JA pc=3066 dst=r0 src=r0 offset=-801 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3066 dst=r0 src=r0 offset=-801 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_143;
 label_188:
@@ -9207,10 +9477,12 @@ label_188:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3068 dst=r3 src=r0 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 285 "sample/undocked/map.c"
         goto label_189;
-        // EBPF_OP_JA pc=3069 dst=r0 src=r0 offset=-778 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3069 dst=r0 src=r0 offset=-778 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_145;
 label_189:

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -132,19 +132,21 @@ lookup(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/map_in_map_btf.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/map_in_map_btf.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/map_in_map_btf.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/map_in_map_btf.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/map_in_map_btf.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/map_in_map_btf.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/map_in_map_btf.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -161,19 +163,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/map_in_map_btf.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/map_in_map_btf.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/map_in_map_btf.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/map_in_map_btf.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_btf.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/map_in_map_btf.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_btf.c"
     goto label_2;
 label_1:
@@ -227,9 +231,11 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
@@ -106,19 +106,21 @@ lookup(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/map_in_map_btf.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/map_in_map_btf.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/map_in_map_btf.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/map_in_map_btf.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/map_in_map_btf.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/map_in_map_btf.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/map_in_map_btf.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -135,19 +137,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/map_in_map_btf.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/map_in_map_btf.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/map_in_map_btf.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/map_in_map_btf.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_btf.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/map_in_map_btf.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_btf.c"
     goto label_2;
 label_1:
@@ -201,9 +205,11 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
@@ -267,19 +267,21 @@ lookup(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/map_in_map_btf.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/map_in_map_btf.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/map_in_map_btf.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/map_in_map_btf.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/map_in_map_btf.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/map_in_map_btf.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/map_in_map_btf.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -296,19 +298,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/map_in_map_btf.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/map_in_map_btf.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/map_in_map_btf.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/map_in_map_btf.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_btf.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/map_in_map_btf.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/map_in_map_btf.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_btf.c"
     goto label_2;
 label_1:
@@ -362,9 +366,11 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -132,19 +132,21 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/map_in_map_legacy_id.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -161,19 +163,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/map_in_map_legacy_id.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
@@ -106,19 +106,21 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/map_in_map_legacy_id.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -135,19 +137,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/map_in_map_legacy_id.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
@@ -267,19 +267,21 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/map_in_map_legacy_id.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/map_in_map_legacy_id.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 39 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/map_in_map_legacy_id.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -296,19 +298,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/undocked/map_in_map_legacy_id.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/undocked/map_in_map_legacy_id.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 42 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 43 "sample/undocked/map_in_map_legacy_id.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 43 "sample/undocked/map_in_map_legacy_id.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -132,19 +132,21 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/undocked/map_in_map_legacy_idx.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 33 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -161,19 +163,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/undocked/map_in_map_legacy_idx.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 36 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 37 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
@@ -106,19 +106,21 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/undocked/map_in_map_legacy_idx.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 33 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -135,19 +137,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/undocked/map_in_map_legacy_idx.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 36 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 37 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
@@ -267,19 +267,21 @@ lookup(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/undocked/map_in_map_legacy_idx.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 33 "sample/undocked/map_in_map_legacy_idx.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 33 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 34 "sample/undocked/map_in_map_legacy_idx.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -296,19 +298,21 @@ lookup(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
-    r0 = lookup_helpers[0].address
+    r0 = lookup_helpers[0].address(r1, r2, r3, r4, r5);
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/undocked/map_in_map_legacy_idx.c"
-    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_helpers[0].tail_call) && (r0 == 0)) {
 #line 36 "sample/undocked/map_in_map_legacy_idx.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 36 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
         goto label_1;
-        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 37 "sample/undocked/map_in_map_legacy_idx.c"
+    }
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 37 "sample/undocked/map_in_map_legacy_idx.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -215,14 +215,14 @@ test_maps(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r6 offset=0 imm=0
@@ -236,9 +236,11 @@ test_maps(void* context)
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=16 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_2;
+#line 75 "sample/undocked/map.c"
+    }
 label_1:
     // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -270,19 +272,21 @@ label_2:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=33 dst=r10 src=r1 offset=-32 imm=0
@@ -324,14 +328,14 @@ label_2:
 label_3:
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=26 imm=0
@@ -349,14 +353,14 @@ label_4:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=59 dst=r3 src=r6 offset=0 imm=0
@@ -370,10 +374,12 @@ label_4:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=62 dst=r3 src=r0 offset=41 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_10;
-        // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-40 imm=0
@@ -409,13 +415,13 @@ label_5:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=79 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/undocked/map.c"
@@ -475,13 +481,13 @@ label_7:
 label_8:
     // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=13
 #line 293 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 293 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 293 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 293 "sample/undocked/map.c"
         return 0;
+#line 293 "sample/undocked/map.c"
+    }
 label_9:
     // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r6 offset=0 imm=0
 #line 306 "sample/undocked/map.c"
@@ -510,14 +516,14 @@ label_10:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=111 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=112 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=112 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=113 dst=r3 src=r6 offset=0 imm=0
@@ -531,10 +537,12 @@ label_10:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=116 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_11;
-        // EBPF_OP_JA pc=117 dst=r0 src=r0 offset=-101 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=117 dst=r0 src=r0 offset=-101 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_1;
 label_11:
@@ -549,19 +557,21 @@ label_11:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=122 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=123 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=123 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_12;
-        // EBPF_OP_MOV64_IMM pc=124 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=124 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=125 dst=r10 src=r1 offset=-20 imm=0
@@ -648,14 +658,14 @@ label_12:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=159 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=159 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=160 dst=r3 src=r6 offset=0 imm=0
@@ -669,9 +679,11 @@ label_12:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=163 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_14;
+#line 75 "sample/undocked/map.c"
+    }
 label_13:
     // EBPF_OP_LDDW pc=164 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -703,19 +715,21 @@ label_14:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=177 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=178 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=178 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_16;
-        // EBPF_OP_MOV64_IMM pc=179 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=179 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=180 dst=r10 src=r1 offset=-32 imm=0
@@ -757,14 +771,14 @@ label_14:
 label_15:
     // EBPF_OP_CALL pc=196 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=197 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=197 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=199 dst=r0 src=r0 offset=26 imm=0
@@ -782,14 +796,14 @@ label_16:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=204 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=205 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=205 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=206 dst=r3 src=r6 offset=0 imm=0
@@ -803,10 +817,12 @@ label_16:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=209 dst=r3 src=r0 offset=42 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_20;
-        // EBPF_OP_LDDW pc=210 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=210 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=212 dst=r10 src=r1 offset=-40 imm=0
@@ -842,13 +858,13 @@ label_17:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=225 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_18:
     // EBPF_OP_MOV64_IMM pc=226 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/undocked/map.c"
@@ -935,14 +951,14 @@ label_20:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=259 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=260 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=260 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=261 dst=r3 src=r6 offset=0 imm=0
@@ -956,10 +972,12 @@ label_20:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=264 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_21;
-        // EBPF_OP_JA pc=265 dst=r0 src=r0 offset=-102 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=265 dst=r0 src=r0 offset=-102 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_13;
 label_21:
@@ -974,19 +992,21 @@ label_21:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=270 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=271 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=271 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_22;
-        // EBPF_OP_MOV64_IMM pc=272 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=272 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=273 dst=r10 src=r1 offset=-20 imm=0
@@ -1073,14 +1093,14 @@ label_22:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=306 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=307 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=307 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=308 dst=r3 src=r6 offset=0 imm=0
@@ -1094,10 +1114,12 @@ label_22:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=311 dst=r3 src=r0 offset=1 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_23;
-        // EBPF_OP_JA pc=312 dst=r0 src=r0 offset=60 imm=0
+#line 75 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=312 dst=r0 src=r0 offset=60 imm=0
 #line 75 "sample/undocked/map.c"
     goto label_26;
 label_23:
@@ -1112,19 +1134,21 @@ label_23:
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=317 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=318 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=318 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_24;
-        // EBPF_OP_MOV64_IMM pc=319 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=319 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=320 dst=r10 src=r1 offset=-32 imm=0
@@ -1165,14 +1189,14 @@ label_23:
     r2 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=336 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=337 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=337 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=339 dst=r0 src=r0 offset=49 imm=0
@@ -1190,14 +1214,14 @@ label_24:
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=344 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=345 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=345 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=346 dst=r3 src=r6 offset=0 imm=0
@@ -1211,10 +1235,12 @@ label_24:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=349 dst=r3 src=r0 offset=9 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_25;
-        // EBPF_OP_LDDW pc=350 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=350 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=352 dst=r10 src=r1 offset=-40 imm=0
@@ -1256,14 +1282,14 @@ label_25:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=367 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=368 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=368 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=369 dst=r3 src=r6 offset=0 imm=0
@@ -1277,9 +1303,11 @@ label_25:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=372 dst=r3 src=r0 offset=41 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_29;
+#line 93 "sample/undocked/map.c"
+    }
 label_26:
     // EBPF_OP_LDDW pc=373 dst=r1 src=r0 offset=0 imm=1684369010
 #line 93 "sample/undocked/map.c"
@@ -1317,13 +1345,13 @@ label_27:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=388 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 93 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 93 "sample/undocked/map.c"
         return 0;
+#line 93 "sample/undocked/map.c"
+    }
 label_28:
     // EBPF_OP_MOV64_IMM pc=389 dst=r1 src=r0 offset=0 imm=0
 #line 93 "sample/undocked/map.c"
@@ -1418,14 +1446,14 @@ label_29:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=424 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=425 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=425 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=426 dst=r3 src=r6 offset=0 imm=0
@@ -1439,10 +1467,12 @@ label_29:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=429 dst=r3 src=r0 offset=1 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_30;
-        // EBPF_OP_JA pc=430 dst=r0 src=r0 offset=60 imm=0
+#line 75 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=430 dst=r0 src=r0 offset=60 imm=0
 #line 75 "sample/undocked/map.c"
     goto label_33;
 label_30:
@@ -1457,19 +1487,21 @@ label_30:
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=435 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=436 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=436 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_31;
-        // EBPF_OP_MOV64_IMM pc=437 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=437 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=438 dst=r10 src=r1 offset=-32 imm=0
@@ -1510,14 +1542,14 @@ label_30:
     r2 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=454 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=455 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=455 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=457 dst=r0 src=r0 offset=49 imm=0
@@ -1535,14 +1567,14 @@ label_31:
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=462 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=463 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=463 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=464 dst=r3 src=r6 offset=0 imm=0
@@ -1556,10 +1588,12 @@ label_31:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=467 dst=r3 src=r0 offset=9 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_32;
-        // EBPF_OP_LDDW pc=468 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=468 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=470 dst=r10 src=r1 offset=-40 imm=0
@@ -1601,14 +1635,14 @@ label_32:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=485 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=486 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=486 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=487 dst=r3 src=r6 offset=0 imm=0
@@ -1622,9 +1656,11 @@ label_32:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=490 dst=r3 src=r0 offset=42 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_36;
+#line 93 "sample/undocked/map.c"
+    }
 label_33:
     // EBPF_OP_LDDW pc=491 dst=r1 src=r0 offset=0 imm=1684369010
 #line 93 "sample/undocked/map.c"
@@ -1662,13 +1698,13 @@ label_34:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=506 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 93 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 93 "sample/undocked/map.c"
         return 0;
+#line 93 "sample/undocked/map.c"
+    }
 label_35:
     // EBPF_OP_MOV64_IMM pc=507 dst=r1 src=r0 offset=0 imm=100
 #line 93 "sample/undocked/map.c"
@@ -1763,14 +1799,14 @@ label_36:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=543 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=545 dst=r3 src=r6 offset=0 imm=0
@@ -1784,9 +1820,11 @@ label_36:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=548 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_38;
+#line 75 "sample/undocked/map.c"
+    }
 label_37:
     // EBPF_OP_LDDW pc=549 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -1818,19 +1856,21 @@ label_38:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=562 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=563 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=563 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_40;
-        // EBPF_OP_MOV64_IMM pc=564 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=564 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=565 dst=r10 src=r1 offset=-32 imm=0
@@ -1872,14 +1912,14 @@ label_38:
 label_39:
     // EBPF_OP_CALL pc=581 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=582 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=582 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=584 dst=r0 src=r0 offset=26 imm=0
@@ -1897,14 +1937,14 @@ label_40:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=589 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=590 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=590 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=591 dst=r3 src=r6 offset=0 imm=0
@@ -1918,10 +1958,12 @@ label_40:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=594 dst=r3 src=r0 offset=40 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_43;
-        // EBPF_OP_LDDW pc=595 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=595 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=597 dst=r10 src=r1 offset=-40 imm=0
@@ -1957,13 +1999,13 @@ label_41:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=610 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_42:
     // EBPF_OP_MOV64_IMM pc=611 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/undocked/map.c"
@@ -2043,14 +2085,14 @@ label_43:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=642 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=643 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=643 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=644 dst=r3 src=r6 offset=0 imm=0
@@ -2064,10 +2106,12 @@ label_43:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=647 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_44;
-        // EBPF_OP_JA pc=648 dst=r0 src=r0 offset=-100 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=648 dst=r0 src=r0 offset=-100 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_37;
 label_44:
@@ -2082,19 +2126,21 @@ label_44:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=653 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=654 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=654 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_45;
-        // EBPF_OP_MOV64_IMM pc=655 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=655 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=656 dst=r10 src=r1 offset=-20 imm=0
@@ -2181,14 +2227,14 @@ label_45:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=689 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=690 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=690 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=691 dst=r3 src=r6 offset=0 imm=0
@@ -2202,9 +2248,11 @@ label_45:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=694 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_47;
+#line 75 "sample/undocked/map.c"
+    }
 label_46:
     // EBPF_OP_LDDW pc=695 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -2236,19 +2284,21 @@ label_47:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=708 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=709 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=709 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_49;
-        // EBPF_OP_MOV64_IMM pc=710 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=710 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=711 dst=r10 src=r1 offset=-32 imm=0
@@ -2290,14 +2340,14 @@ label_47:
 label_48:
     // EBPF_OP_CALL pc=727 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=728 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=728 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=730 dst=r0 src=r0 offset=26 imm=0
@@ -2315,14 +2365,14 @@ label_49:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=735 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=737 dst=r3 src=r6 offset=0 imm=0
@@ -2336,10 +2386,12 @@ label_49:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=740 dst=r3 src=r0 offset=43 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_52;
-        // EBPF_OP_LDDW pc=741 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=741 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=743 dst=r10 src=r1 offset=-40 imm=0
@@ -2375,13 +2427,13 @@ label_50:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=756 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_51:
     // EBPF_OP_MOV64_IMM pc=757 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/undocked/map.c"
@@ -2467,14 +2519,14 @@ label_52:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=791 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=792 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=792 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=793 dst=r3 src=r6 offset=0 imm=0
@@ -2488,10 +2540,12 @@ label_52:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=796 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_53;
-        // EBPF_OP_JA pc=797 dst=r0 src=r0 offset=-103 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=797 dst=r0 src=r0 offset=-103 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_46;
 label_53:
@@ -2506,19 +2560,21 @@ label_53:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=802 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=803 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=803 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_54;
-        // EBPF_OP_MOV64_IMM pc=804 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=804 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=805 dst=r10 src=r1 offset=-20 imm=0
@@ -2605,14 +2661,14 @@ label_54:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=838 dst=r0 src=r0 offset=0 imm=2
 #line 129 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 129 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 129 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 129 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=839 dst=r6 src=r0 offset=0 imm=0
+#line 129 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=839 dst=r6 src=r0 offset=0 imm=0
 #line 129 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=840 dst=r3 src=r6 offset=0 imm=0
@@ -2626,10 +2682,12 @@ label_54:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=843 dst=r3 src=r0 offset=1 imm=-1
 #line 130 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 130 "sample/undocked/map.c"
         goto label_55;
-        // EBPF_OP_JA pc=844 dst=r0 src=r0 offset=159 imm=0
+#line 130 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=844 dst=r0 src=r0 offset=159 imm=0
 #line 130 "sample/undocked/map.c"
     goto label_65;
 label_55:
@@ -2656,14 +2714,14 @@ label_55:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=853 dst=r0 src=r0 offset=0 imm=2
 #line 135 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=854 dst=r6 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=854 dst=r6 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=855 dst=r3 src=r6 offset=0 imm=0
@@ -2677,10 +2735,12 @@ label_55:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=858 dst=r3 src=r0 offset=1 imm=-1
 #line 136 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 136 "sample/undocked/map.c"
         goto label_56;
-        // EBPF_OP_JA pc=859 dst=r0 src=r0 offset=144 imm=0
+#line 136 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=859 dst=r0 src=r0 offset=144 imm=0
 #line 136 "sample/undocked/map.c"
     goto label_65;
 label_56:
@@ -2710,14 +2770,14 @@ label_56:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=869 dst=r0 src=r0 offset=0 imm=2
 #line 141 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=870 dst=r6 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=870 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=871 dst=r3 src=r6 offset=0 imm=0
@@ -2731,10 +2791,12 @@ label_56:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=874 dst=r3 src=r0 offset=1 imm=-1
 #line 142 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 142 "sample/undocked/map.c"
         goto label_57;
-        // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=128 imm=0
+#line 142 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=128 imm=0
 #line 142 "sample/undocked/map.c"
     goto label_65;
 label_57:
@@ -2764,14 +2826,14 @@ label_57:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=885 dst=r0 src=r0 offset=0 imm=2
 #line 147 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=886 dst=r6 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=886 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=887 dst=r3 src=r6 offset=0 imm=0
@@ -2785,10 +2847,12 @@ label_57:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=890 dst=r3 src=r0 offset=1 imm=-1
 #line 148 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 148 "sample/undocked/map.c"
         goto label_58;
-        // EBPF_OP_JA pc=891 dst=r0 src=r0 offset=112 imm=0
+#line 148 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=891 dst=r0 src=r0 offset=112 imm=0
 #line 148 "sample/undocked/map.c"
     goto label_65;
 label_58:
@@ -2818,14 +2882,14 @@ label_58:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=901 dst=r0 src=r0 offset=0 imm=2
 #line 153 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=902 dst=r6 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=902 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=903 dst=r3 src=r6 offset=0 imm=0
@@ -2839,10 +2903,12 @@ label_58:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=906 dst=r3 src=r0 offset=1 imm=-1
 #line 154 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 154 "sample/undocked/map.c"
         goto label_59;
-        // EBPF_OP_JA pc=907 dst=r0 src=r0 offset=96 imm=0
+#line 154 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=907 dst=r0 src=r0 offset=96 imm=0
 #line 154 "sample/undocked/map.c"
     goto label_65;
 label_59:
@@ -2872,14 +2938,14 @@ label_59:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=917 dst=r0 src=r0 offset=0 imm=2
 #line 159 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=918 dst=r6 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=918 dst=r6 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=919 dst=r3 src=r6 offset=0 imm=0
@@ -2893,10 +2959,12 @@ label_59:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=922 dst=r3 src=r0 offset=1 imm=-1
 #line 160 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 160 "sample/undocked/map.c"
         goto label_60;
-        // EBPF_OP_JA pc=923 dst=r0 src=r0 offset=80 imm=0
+#line 160 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=923 dst=r0 src=r0 offset=80 imm=0
 #line 160 "sample/undocked/map.c"
     goto label_65;
 label_60:
@@ -2926,14 +2994,14 @@ label_60:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=933 dst=r0 src=r0 offset=0 imm=2
 #line 165 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=934 dst=r6 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=934 dst=r6 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=935 dst=r3 src=r6 offset=0 imm=0
@@ -2947,10 +3015,12 @@ label_60:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=938 dst=r3 src=r0 offset=1 imm=-1
 #line 166 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 166 "sample/undocked/map.c"
         goto label_61;
-        // EBPF_OP_JA pc=939 dst=r0 src=r0 offset=64 imm=0
+#line 166 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=939 dst=r0 src=r0 offset=64 imm=0
 #line 166 "sample/undocked/map.c"
     goto label_65;
 label_61:
@@ -2980,14 +3050,14 @@ label_61:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=949 dst=r0 src=r0 offset=0 imm=2
 #line 171 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=950 dst=r6 src=r0 offset=0 imm=0
+#line 171 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=950 dst=r6 src=r0 offset=0 imm=0
 #line 171 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=951 dst=r3 src=r6 offset=0 imm=0
@@ -3001,10 +3071,12 @@ label_61:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=954 dst=r3 src=r0 offset=1 imm=-1
 #line 172 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 172 "sample/undocked/map.c"
         goto label_62;
-        // EBPF_OP_JA pc=955 dst=r0 src=r0 offset=48 imm=0
+#line 172 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=955 dst=r0 src=r0 offset=48 imm=0
 #line 172 "sample/undocked/map.c"
     goto label_65;
 label_62:
@@ -3034,14 +3106,14 @@ label_62:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=965 dst=r0 src=r0 offset=0 imm=2
 #line 177 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 177 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 177 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=966 dst=r6 src=r0 offset=0 imm=0
+#line 177 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=966 dst=r6 src=r0 offset=0 imm=0
 #line 177 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=967 dst=r3 src=r6 offset=0 imm=0
@@ -3055,10 +3127,12 @@ label_62:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=970 dst=r3 src=r0 offset=1 imm=-1
 #line 178 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 178 "sample/undocked/map.c"
         goto label_63;
-        // EBPF_OP_JA pc=971 dst=r0 src=r0 offset=32 imm=0
+#line 178 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=971 dst=r0 src=r0 offset=32 imm=0
 #line 178 "sample/undocked/map.c"
     goto label_65;
 label_63:
@@ -3088,14 +3162,14 @@ label_63:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=981 dst=r0 src=r0 offset=0 imm=2
 #line 183 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 183 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 183 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=982 dst=r6 src=r0 offset=0 imm=0
+#line 183 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=982 dst=r6 src=r0 offset=0 imm=0
 #line 183 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=983 dst=r3 src=r6 offset=0 imm=0
@@ -3109,10 +3183,12 @@ label_63:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=986 dst=r3 src=r0 offset=1 imm=-1
 #line 184 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 184 "sample/undocked/map.c"
         goto label_64;
-        // EBPF_OP_JA pc=987 dst=r0 src=r0 offset=16 imm=0
+#line 184 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=987 dst=r0 src=r0 offset=16 imm=0
 #line 184 "sample/undocked/map.c"
     goto label_65;
 label_64:
@@ -3145,14 +3221,14 @@ label_64:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=998 dst=r0 src=r0 offset=0 imm=2
 #line 189 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 189 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 189 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
+#line 189 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
 #line 189 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1000 dst=r3 src=r6 offset=0 imm=0
@@ -3166,9 +3242,11 @@ label_64:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1003 dst=r3 src=r0 offset=32 imm=-1
 #line 190 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 190 "sample/undocked/map.c"
         goto label_66;
+#line 190 "sample/undocked/map.c"
+    }
 label_65:
     // EBPF_OP_LDDW pc=1004 dst=r1 src=r0 offset=0 imm=1684369010
 #line 190 "sample/undocked/map.c"
@@ -3205,14 +3283,14 @@ label_65:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=1019 dst=r0 src=r0 offset=0 imm=13
 #line 190 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 190 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 190 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1020 dst=r1 src=r0 offset=0 imm=100
+#line 190 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1020 dst=r1 src=r0 offset=0 imm=100
 #line 190 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1021 dst=r10 src=r1 offset=-28 imm=0
@@ -3278,14 +3356,14 @@ label_66:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1046 dst=r0 src=r0 offset=0 imm=2
 #line 129 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 129 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 129 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 129 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1047 dst=r6 src=r0 offset=0 imm=0
+#line 129 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1047 dst=r6 src=r0 offset=0 imm=0
 #line 129 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1048 dst=r3 src=r6 offset=0 imm=0
@@ -3299,10 +3377,12 @@ label_66:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1051 dst=r3 src=r0 offset=1 imm=-1
 #line 130 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 130 "sample/undocked/map.c"
         goto label_67;
-        // EBPF_OP_JA pc=1052 dst=r0 src=r0 offset=159 imm=0
+#line 130 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1052 dst=r0 src=r0 offset=159 imm=0
 #line 130 "sample/undocked/map.c"
     goto label_77;
 label_67:
@@ -3329,14 +3409,14 @@ label_67:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1061 dst=r0 src=r0 offset=0 imm=2
 #line 135 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1062 dst=r6 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1062 dst=r6 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1063 dst=r3 src=r6 offset=0 imm=0
@@ -3350,10 +3430,12 @@ label_67:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1066 dst=r3 src=r0 offset=1 imm=-1
 #line 136 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 136 "sample/undocked/map.c"
         goto label_68;
-        // EBPF_OP_JA pc=1067 dst=r0 src=r0 offset=144 imm=0
+#line 136 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1067 dst=r0 src=r0 offset=144 imm=0
 #line 136 "sample/undocked/map.c"
     goto label_77;
 label_68:
@@ -3383,14 +3465,14 @@ label_68:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1077 dst=r0 src=r0 offset=0 imm=2
 #line 141 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1078 dst=r6 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1078 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1079 dst=r3 src=r6 offset=0 imm=0
@@ -3404,10 +3486,12 @@ label_68:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1082 dst=r3 src=r0 offset=1 imm=-1
 #line 142 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 142 "sample/undocked/map.c"
         goto label_69;
-        // EBPF_OP_JA pc=1083 dst=r0 src=r0 offset=128 imm=0
+#line 142 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1083 dst=r0 src=r0 offset=128 imm=0
 #line 142 "sample/undocked/map.c"
     goto label_77;
 label_69:
@@ -3437,14 +3521,14 @@ label_69:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1093 dst=r0 src=r0 offset=0 imm=2
 #line 147 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1094 dst=r6 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1094 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1095 dst=r3 src=r6 offset=0 imm=0
@@ -3458,10 +3542,12 @@ label_69:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1098 dst=r3 src=r0 offset=1 imm=-1
 #line 148 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 148 "sample/undocked/map.c"
         goto label_70;
-        // EBPF_OP_JA pc=1099 dst=r0 src=r0 offset=112 imm=0
+#line 148 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1099 dst=r0 src=r0 offset=112 imm=0
 #line 148 "sample/undocked/map.c"
     goto label_77;
 label_70:
@@ -3491,14 +3577,14 @@ label_70:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1109 dst=r0 src=r0 offset=0 imm=2
 #line 153 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1110 dst=r6 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1110 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1111 dst=r3 src=r6 offset=0 imm=0
@@ -3512,10 +3598,12 @@ label_70:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1114 dst=r3 src=r0 offset=1 imm=-1
 #line 154 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 154 "sample/undocked/map.c"
         goto label_71;
-        // EBPF_OP_JA pc=1115 dst=r0 src=r0 offset=96 imm=0
+#line 154 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1115 dst=r0 src=r0 offset=96 imm=0
 #line 154 "sample/undocked/map.c"
     goto label_77;
 label_71:
@@ -3545,14 +3633,14 @@ label_71:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1125 dst=r0 src=r0 offset=0 imm=2
 #line 159 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1126 dst=r6 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1126 dst=r6 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1127 dst=r3 src=r6 offset=0 imm=0
@@ -3566,10 +3654,12 @@ label_71:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1130 dst=r3 src=r0 offset=1 imm=-1
 #line 160 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 160 "sample/undocked/map.c"
         goto label_72;
-        // EBPF_OP_JA pc=1131 dst=r0 src=r0 offset=80 imm=0
+#line 160 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1131 dst=r0 src=r0 offset=80 imm=0
 #line 160 "sample/undocked/map.c"
     goto label_77;
 label_72:
@@ -3599,14 +3689,14 @@ label_72:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1141 dst=r0 src=r0 offset=0 imm=2
 #line 165 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1142 dst=r6 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1142 dst=r6 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1143 dst=r3 src=r6 offset=0 imm=0
@@ -3620,10 +3710,12 @@ label_72:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1146 dst=r3 src=r0 offset=1 imm=-1
 #line 166 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 166 "sample/undocked/map.c"
         goto label_73;
-        // EBPF_OP_JA pc=1147 dst=r0 src=r0 offset=64 imm=0
+#line 166 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1147 dst=r0 src=r0 offset=64 imm=0
 #line 166 "sample/undocked/map.c"
     goto label_77;
 label_73:
@@ -3653,14 +3745,14 @@ label_73:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1157 dst=r0 src=r0 offset=0 imm=2
 #line 171 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1158 dst=r6 src=r0 offset=0 imm=0
+#line 171 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1158 dst=r6 src=r0 offset=0 imm=0
 #line 171 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1159 dst=r3 src=r6 offset=0 imm=0
@@ -3674,10 +3766,12 @@ label_73:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1162 dst=r3 src=r0 offset=1 imm=-1
 #line 172 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 172 "sample/undocked/map.c"
         goto label_74;
-        // EBPF_OP_JA pc=1163 dst=r0 src=r0 offset=48 imm=0
+#line 172 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1163 dst=r0 src=r0 offset=48 imm=0
 #line 172 "sample/undocked/map.c"
     goto label_77;
 label_74:
@@ -3707,14 +3801,14 @@ label_74:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1173 dst=r0 src=r0 offset=0 imm=2
 #line 177 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 177 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 177 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1174 dst=r6 src=r0 offset=0 imm=0
+#line 177 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1174 dst=r6 src=r0 offset=0 imm=0
 #line 177 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1175 dst=r3 src=r6 offset=0 imm=0
@@ -3728,10 +3822,12 @@ label_74:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1178 dst=r3 src=r0 offset=1 imm=-1
 #line 178 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 178 "sample/undocked/map.c"
         goto label_75;
-        // EBPF_OP_JA pc=1179 dst=r0 src=r0 offset=32 imm=0
+#line 178 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1179 dst=r0 src=r0 offset=32 imm=0
 #line 178 "sample/undocked/map.c"
     goto label_77;
 label_75:
@@ -3761,14 +3857,14 @@ label_75:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1189 dst=r0 src=r0 offset=0 imm=2
 #line 183 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 183 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 183 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1190 dst=r6 src=r0 offset=0 imm=0
+#line 183 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1190 dst=r6 src=r0 offset=0 imm=0
 #line 183 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1191 dst=r3 src=r6 offset=0 imm=0
@@ -3782,10 +3878,12 @@ label_75:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1194 dst=r3 src=r0 offset=1 imm=-1
 #line 184 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 184 "sample/undocked/map.c"
         goto label_76;
-        // EBPF_OP_JA pc=1195 dst=r0 src=r0 offset=16 imm=0
+#line 184 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1195 dst=r0 src=r0 offset=16 imm=0
 #line 184 "sample/undocked/map.c"
     goto label_77;
 label_76:
@@ -3818,14 +3916,14 @@ label_76:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1206 dst=r0 src=r0 offset=0 imm=2
 #line 189 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 189 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 189 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1207 dst=r6 src=r0 offset=0 imm=0
+#line 189 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1207 dst=r6 src=r0 offset=0 imm=0
 #line 189 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1208 dst=r3 src=r6 offset=0 imm=0
@@ -3839,9 +3937,11 @@ label_76:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1211 dst=r3 src=r0 offset=35 imm=-1
 #line 190 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 190 "sample/undocked/map.c"
         goto label_78;
+#line 190 "sample/undocked/map.c"
+    }
 label_77:
     // EBPF_OP_LDDW pc=1212 dst=r1 src=r0 offset=0 imm=1684369010
 #line 190 "sample/undocked/map.c"
@@ -3878,14 +3978,14 @@ label_77:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=1227 dst=r0 src=r0 offset=0 imm=13
 #line 190 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 190 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 190 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1228 dst=r1 src=r0 offset=0 imm=0
+#line 190 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1228 dst=r1 src=r0 offset=0 imm=0
 #line 190 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1229 dst=r10 src=r1 offset=-20 imm=0
@@ -3942,14 +4042,14 @@ label_78:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1252 dst=r0 src=r0 offset=0 imm=18
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1253 dst=r6 src=r0 offset=0 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1253 dst=r6 src=r0 offset=0 imm=0
 #line 240 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1254 dst=r4 src=r6 offset=0 imm=0
@@ -3969,9 +4069,11 @@ label_78:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1260 dst=r1 src=r2 offset=27 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 240 "sample/undocked/map.c"
         goto label_81;
+#line 240 "sample/undocked/map.c"
+    }
 label_79:
     // EBPF_OP_MOV64_IMM pc=1261 dst=r1 src=r0 offset=0 imm=100
 #line 240 "sample/undocked/map.c"
@@ -4033,14 +4135,14 @@ label_80:
     r3 = IMMEDIATE(-7);
     // EBPF_OP_CALL pc=1286 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1287 dst=r0 src=r0 offset=26 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1287 dst=r0 src=r0 offset=26 imm=0
 #line 240 "sample/undocked/map.c"
     goto label_85;
 label_81:
@@ -4049,9 +4151,11 @@ label_81:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1289 dst=r3 src=r0 offset=90 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 240 "sample/undocked/map.c"
         goto label_90;
+#line 240 "sample/undocked/map.c"
+    }
 label_82:
     // EBPF_OP_LDDW pc=1290 dst=r1 src=r0 offset=0 imm=1852404835
 #line 240 "sample/undocked/map.c"
@@ -4105,14 +4209,14 @@ label_83:
 label_84:
     // EBPF_OP_CALL pc=1311 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=1312 dst=r6 src=r0 offset=0 imm=-1
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1312 dst=r6 src=r0 offset=0 imm=-1
 #line 240 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
 label_85:
@@ -4127,10 +4231,12 @@ label_85:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1317 dst=r3 src=r0 offset=1 imm=-1
 #line 303 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 303 "sample/undocked/map.c"
         goto label_86;
-        // EBPF_OP_JA pc=1318 dst=r0 src=r0 offset=42 imm=0
+#line 303 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1318 dst=r0 src=r0 offset=42 imm=0
 #line 303 "sample/undocked/map.c"
     goto label_89;
 label_86:
@@ -4151,14 +4257,14 @@ label_86:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=1325 dst=r0 src=r0 offset=0 imm=18
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1326 dst=r7 src=r0 offset=0 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1326 dst=r7 src=r0 offset=0 imm=0
 #line 240 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1327 dst=r4 src=r7 offset=0 imm=0
@@ -4178,9 +4284,11 @@ label_86:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1333 dst=r1 src=r2 offset=865 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 240 "sample/undocked/map.c"
         goto label_137;
+#line 240 "sample/undocked/map.c"
+    }
 label_87:
     // EBPF_OP_MOV64_IMM pc=1334 dst=r1 src=r0 offset=0 imm=100
 #line 240 "sample/undocked/map.c"
@@ -4242,14 +4350,14 @@ label_88:
     r3 = IMMEDIATE(-7);
     // EBPF_OP_CALL pc=1359 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1360 dst=r0 src=r0 offset=864 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1360 dst=r0 src=r0 offset=864 imm=0
 #line 240 "sample/undocked/map.c"
     goto label_141;
 label_89:
@@ -4313,14 +4421,14 @@ label_90:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1386 dst=r0 src=r0 offset=0 imm=17
 #line 241 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 241 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 241 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 241 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1387 dst=r6 src=r0 offset=0 imm=0
+#line 241 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1387 dst=r6 src=r0 offset=0 imm=0
 #line 241 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1388 dst=r4 src=r6 offset=0 imm=0
@@ -4340,9 +4448,11 @@ label_90:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1394 dst=r1 src=r2 offset=24 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 241 "sample/undocked/map.c"
         goto label_92;
+#line 241 "sample/undocked/map.c"
+    }
 label_91:
     // EBPF_OP_STXB pc=1395 dst=r10 src=r7 offset=-16 imm=0
 #line 241 "sample/undocked/map.c"
@@ -4404,9 +4514,11 @@ label_92:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1420 dst=r3 src=r0 offset=19 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 241 "sample/undocked/map.c"
         goto label_94;
+#line 241 "sample/undocked/map.c"
+    }
 label_93:
     // EBPF_OP_LDDW pc=1421 dst=r1 src=r0 offset=0 imm=1735289204
 #line 241 "sample/undocked/map.c"
@@ -4471,14 +4583,14 @@ label_94:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1447 dst=r0 src=r0 offset=0 imm=16
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1448 dst=r6 src=r0 offset=0 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1448 dst=r6 src=r0 offset=0 imm=0
 #line 249 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1449 dst=r5 src=r6 offset=0 imm=0
@@ -4495,9 +4607,11 @@ label_94:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1453 dst=r1 src=r0 offset=31 imm=0
 #line 249 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 249 "sample/undocked/map.c"
         goto label_98;
+#line 249 "sample/undocked/map.c"
+    }
 label_95:
     // EBPF_OP_MOV64_IMM pc=1454 dst=r1 src=r0 offset=0 imm=25637
 #line 249 "sample/undocked/map.c"
@@ -4572,14 +4686,14 @@ label_96:
 label_97:
     // EBPF_OP_CALL pc=1483 dst=r0 src=r0 offset=0 imm=15
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[10].address
+    r0 = test_maps_helpers[10].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[10].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[10].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1484 dst=r0 src=r0 offset=-171 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1484 dst=r0 src=r0 offset=-171 imm=0
 #line 249 "sample/undocked/map.c"
     goto label_85;
 label_98:
@@ -4606,14 +4720,14 @@ label_98:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1493 dst=r0 src=r0 offset=0 imm=16
 #line 250 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 250 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 250 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 250 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1494 dst=r6 src=r0 offset=0 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1494 dst=r6 src=r0 offset=0 imm=0
 #line 250 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1495 dst=r5 src=r6 offset=0 imm=0
@@ -4630,10 +4744,12 @@ label_98:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1499 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 250 "sample/undocked/map.c"
         goto label_99;
-        // EBPF_OP_JA pc=1500 dst=r0 src=r0 offset=-47 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1500 dst=r0 src=r0 offset=-47 imm=0
 #line 250 "sample/undocked/map.c"
     goto label_95;
 label_99:
@@ -4660,14 +4776,14 @@ label_99:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1509 dst=r0 src=r0 offset=0 imm=16
 #line 251 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 251 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 251 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 251 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1510 dst=r6 src=r0 offset=0 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1510 dst=r6 src=r0 offset=0 imm=0
 #line 251 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1511 dst=r5 src=r6 offset=0 imm=0
@@ -4684,10 +4800,12 @@ label_99:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1515 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 251 "sample/undocked/map.c"
         goto label_100;
-        // EBPF_OP_JA pc=1516 dst=r0 src=r0 offset=-63 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1516 dst=r0 src=r0 offset=-63 imm=0
 #line 251 "sample/undocked/map.c"
     goto label_95;
 label_100:
@@ -4714,14 +4832,14 @@ label_100:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1525 dst=r0 src=r0 offset=0 imm=16
 #line 252 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 252 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 252 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 252 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1526 dst=r6 src=r0 offset=0 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1526 dst=r6 src=r0 offset=0 imm=0
 #line 252 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1527 dst=r5 src=r6 offset=0 imm=0
@@ -4738,10 +4856,12 @@ label_100:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1531 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 252 "sample/undocked/map.c"
         goto label_101;
-        // EBPF_OP_JA pc=1532 dst=r0 src=r0 offset=-79 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1532 dst=r0 src=r0 offset=-79 imm=0
 #line 252 "sample/undocked/map.c"
     goto label_95;
 label_101:
@@ -4768,14 +4888,14 @@ label_101:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1541 dst=r0 src=r0 offset=0 imm=16
 #line 253 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 253 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 253 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 253 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1542 dst=r6 src=r0 offset=0 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1542 dst=r6 src=r0 offset=0 imm=0
 #line 253 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1543 dst=r5 src=r6 offset=0 imm=0
@@ -4792,10 +4912,12 @@ label_101:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1547 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 253 "sample/undocked/map.c"
         goto label_102;
-        // EBPF_OP_JA pc=1548 dst=r0 src=r0 offset=-95 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1548 dst=r0 src=r0 offset=-95 imm=0
 #line 253 "sample/undocked/map.c"
     goto label_95;
 label_102:
@@ -4822,14 +4944,14 @@ label_102:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1557 dst=r0 src=r0 offset=0 imm=16
 #line 254 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 254 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 254 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 254 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1558 dst=r6 src=r0 offset=0 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1558 dst=r6 src=r0 offset=0 imm=0
 #line 254 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1559 dst=r5 src=r6 offset=0 imm=0
@@ -4846,10 +4968,12 @@ label_102:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1563 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 254 "sample/undocked/map.c"
         goto label_103;
-        // EBPF_OP_JA pc=1564 dst=r0 src=r0 offset=-111 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1564 dst=r0 src=r0 offset=-111 imm=0
 #line 254 "sample/undocked/map.c"
     goto label_95;
 label_103:
@@ -4876,14 +5000,14 @@ label_103:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1573 dst=r0 src=r0 offset=0 imm=16
 #line 255 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 255 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 255 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 255 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1574 dst=r6 src=r0 offset=0 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1574 dst=r6 src=r0 offset=0 imm=0
 #line 255 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1575 dst=r5 src=r6 offset=0 imm=0
@@ -4900,10 +5024,12 @@ label_103:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1579 dst=r1 src=r0 offset=1 imm=0
 #line 255 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 255 "sample/undocked/map.c"
         goto label_104;
-        // EBPF_OP_JA pc=1580 dst=r0 src=r0 offset=-127 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1580 dst=r0 src=r0 offset=-127 imm=0
 #line 255 "sample/undocked/map.c"
     goto label_95;
 label_104:
@@ -4930,14 +5056,14 @@ label_104:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1589 dst=r0 src=r0 offset=0 imm=16
 #line 256 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 256 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 256 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 256 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1590 dst=r6 src=r0 offset=0 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1590 dst=r6 src=r0 offset=0 imm=0
 #line 256 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1591 dst=r5 src=r6 offset=0 imm=0
@@ -4954,10 +5080,12 @@ label_104:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1595 dst=r1 src=r0 offset=1 imm=0
 #line 256 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 256 "sample/undocked/map.c"
         goto label_105;
-        // EBPF_OP_JA pc=1596 dst=r0 src=r0 offset=-143 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1596 dst=r0 src=r0 offset=-143 imm=0
 #line 256 "sample/undocked/map.c"
     goto label_95;
 label_105:
@@ -4984,14 +5112,14 @@ label_105:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1605 dst=r0 src=r0 offset=0 imm=16
 #line 257 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 257 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 257 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 257 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1606 dst=r6 src=r0 offset=0 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1606 dst=r6 src=r0 offset=0 imm=0
 #line 257 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1607 dst=r5 src=r6 offset=0 imm=0
@@ -5008,10 +5136,12 @@ label_105:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1611 dst=r1 src=r0 offset=1 imm=0
 #line 257 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 257 "sample/undocked/map.c"
         goto label_106;
-        // EBPF_OP_JA pc=1612 dst=r0 src=r0 offset=-159 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1612 dst=r0 src=r0 offset=-159 imm=0
 #line 257 "sample/undocked/map.c"
     goto label_95;
 label_106:
@@ -5038,14 +5168,14 @@ label_106:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1621 dst=r0 src=r0 offset=0 imm=16
 #line 258 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 258 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 258 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 258 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1622 dst=r6 src=r0 offset=0 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1622 dst=r6 src=r0 offset=0 imm=0
 #line 258 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1623 dst=r5 src=r6 offset=0 imm=0
@@ -5062,10 +5192,12 @@ label_106:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1627 dst=r1 src=r0 offset=1 imm=0
 #line 258 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 258 "sample/undocked/map.c"
         goto label_107;
-        // EBPF_OP_JA pc=1628 dst=r0 src=r0 offset=-175 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1628 dst=r0 src=r0 offset=-175 imm=0
 #line 258 "sample/undocked/map.c"
     goto label_95;
 label_107:
@@ -5092,14 +5224,14 @@ label_107:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1637 dst=r0 src=r0 offset=0 imm=16
 #line 261 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 261 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 261 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 261 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1638 dst=r6 src=r0 offset=0 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1638 dst=r6 src=r0 offset=0 imm=0
 #line 261 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1639 dst=r5 src=r6 offset=0 imm=0
@@ -5119,10 +5251,12 @@ label_107:
     r2 = (uint64_t)4294967267;
     // EBPF_OP_JEQ_REG pc=1645 dst=r1 src=r2 offset=30 imm=0
 #line 261 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 261 "sample/undocked/map.c"
         goto label_108;
-        // EBPF_OP_STXB pc=1646 dst=r10 src=r8 offset=-10 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_STXB pc=1646 dst=r10 src=r8 offset=-10 imm=0
 #line 261 "sample/undocked/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1647 dst=r1 src=r0 offset=0 imm=25637
@@ -5212,14 +5346,14 @@ label_108:
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=1682 dst=r0 src=r0 offset=0 imm=16
 #line 262 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 262 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 262 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 262 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1683 dst=r6 src=r0 offset=0 imm=0
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1683 dst=r6 src=r0 offset=0 imm=0
 #line 262 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1684 dst=r5 src=r6 offset=0 imm=0
@@ -5236,10 +5370,12 @@ label_108:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1688 dst=r1 src=r0 offset=25 imm=0
 #line 262 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 262 "sample/undocked/map.c"
         goto label_109;
-        // EBPF_OP_MOV64_IMM pc=1689 dst=r1 src=r0 offset=0 imm=25637
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1689 dst=r1 src=r0 offset=0 imm=25637
 #line 262 "sample/undocked/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1690 dst=r10 src=r1 offset=-12 imm=0
@@ -5314,14 +5450,14 @@ label_109:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1720 dst=r0 src=r0 offset=0 imm=18
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1721 dst=r6 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1721 dst=r6 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1722 dst=r4 src=r6 offset=0 imm=0
@@ -5338,10 +5474,12 @@ label_109:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1726 dst=r1 src=r0 offset=27 imm=0
 #line 264 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 264 "sample/undocked/map.c"
         goto label_111;
-        // EBPF_OP_MOV64_IMM pc=1727 dst=r1 src=r0 offset=0 imm=100
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1727 dst=r1 src=r0 offset=0 imm=100
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1728 dst=r10 src=r1 offset=-16 imm=0
@@ -5401,14 +5539,14 @@ label_110:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1752 dst=r0 src=r0 offset=0 imm=14
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1753 dst=r0 src=r0 offset=-440 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1753 dst=r0 src=r0 offset=-440 imm=0
 #line 264 "sample/undocked/map.c"
     goto label_85;
 label_111:
@@ -5417,10 +5555,12 @@ label_111:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1755 dst=r3 src=r0 offset=22 imm=1
 #line 264 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 264 "sample/undocked/map.c"
         goto label_112;
-        // EBPF_OP_MOV64_IMM pc=1756 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1756 dst=r1 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1757 dst=r10 src=r1 offset=-24 imm=0
@@ -5489,14 +5629,14 @@ label_112:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1784 dst=r0 src=r0 offset=0 imm=17
 #line 272 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 272 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 272 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 272 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1785 dst=r6 src=r0 offset=0 imm=0
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1785 dst=r6 src=r0 offset=0 imm=0
 #line 272 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1786 dst=r4 src=r6 offset=0 imm=0
@@ -5513,9 +5653,11 @@ label_112:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1790 dst=r1 src=r0 offset=24 imm=0
 #line 272 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 272 "sample/undocked/map.c"
         goto label_114;
+#line 272 "sample/undocked/map.c"
+    }
 label_113:
     // EBPF_OP_LDDW pc=1791 dst=r1 src=r0 offset=0 imm=1701737077
 #line 272 "sample/undocked/map.c"
@@ -5577,10 +5719,12 @@ label_114:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1816 dst=r3 src=r0 offset=20 imm=1
 #line 272 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 272 "sample/undocked/map.c"
         goto label_115;
-        // EBPF_OP_LDDW pc=1817 dst=r1 src=r0 offset=0 imm=1735289204
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1817 dst=r1 src=r0 offset=0 imm=1735289204
 #line 272 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1819 dst=r10 src=r1 offset=-32 imm=0
@@ -5643,14 +5787,14 @@ label_115:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1843 dst=r0 src=r0 offset=0 imm=17
 #line 273 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 273 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 273 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 273 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1844 dst=r6 src=r0 offset=0 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1844 dst=r6 src=r0 offset=0 imm=0
 #line 273 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1845 dst=r4 src=r6 offset=0 imm=0
@@ -5667,10 +5811,12 @@ label_115:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1849 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 273 "sample/undocked/map.c"
         goto label_116;
-        // EBPF_OP_JA pc=1850 dst=r0 src=r0 offset=-60 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1850 dst=r0 src=r0 offset=-60 imm=0
 #line 273 "sample/undocked/map.c"
     goto label_113;
 label_116:
@@ -5679,10 +5825,12 @@ label_116:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1852 dst=r3 src=r0 offset=20 imm=2
 #line 273 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(2))
+    if (r3 == IMMEDIATE(2)) {
 #line 273 "sample/undocked/map.c"
         goto label_117;
-        // EBPF_OP_LDDW pc=1853 dst=r1 src=r0 offset=0 imm=1735289204
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1853 dst=r1 src=r0 offset=0 imm=1735289204
 #line 273 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1855 dst=r10 src=r1 offset=-32 imm=0
@@ -5745,14 +5893,14 @@ label_117:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1879 dst=r0 src=r0 offset=0 imm=17
 #line 274 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 274 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 274 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 274 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1880 dst=r6 src=r0 offset=0 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1880 dst=r6 src=r0 offset=0 imm=0
 #line 274 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1881 dst=r4 src=r6 offset=0 imm=0
@@ -5769,10 +5917,12 @@ label_117:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1885 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 274 "sample/undocked/map.c"
         goto label_118;
-        // EBPF_OP_JA pc=1886 dst=r0 src=r0 offset=-96 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1886 dst=r0 src=r0 offset=-96 imm=0
 #line 274 "sample/undocked/map.c"
     goto label_113;
 label_118:
@@ -5781,10 +5931,12 @@ label_118:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1888 dst=r3 src=r0 offset=20 imm=3
 #line 274 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(3))
+    if (r3 == IMMEDIATE(3)) {
 #line 274 "sample/undocked/map.c"
         goto label_119;
-        // EBPF_OP_LDDW pc=1889 dst=r1 src=r0 offset=0 imm=1735289204
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1889 dst=r1 src=r0 offset=0 imm=1735289204
 #line 274 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1891 dst=r10 src=r1 offset=-32 imm=0
@@ -5847,14 +5999,14 @@ label_119:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1915 dst=r0 src=r0 offset=0 imm=17
 #line 275 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 275 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 275 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 275 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1916 dst=r6 src=r0 offset=0 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1916 dst=r6 src=r0 offset=0 imm=0
 #line 275 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1917 dst=r4 src=r6 offset=0 imm=0
@@ -5871,10 +6023,12 @@ label_119:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1921 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 275 "sample/undocked/map.c"
         goto label_120;
-        // EBPF_OP_JA pc=1922 dst=r0 src=r0 offset=-132 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1922 dst=r0 src=r0 offset=-132 imm=0
 #line 275 "sample/undocked/map.c"
     goto label_113;
 label_120:
@@ -5883,10 +6037,12 @@ label_120:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1924 dst=r3 src=r0 offset=20 imm=4
 #line 275 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(4))
+    if (r3 == IMMEDIATE(4)) {
 #line 275 "sample/undocked/map.c"
         goto label_121;
-        // EBPF_OP_LDDW pc=1925 dst=r1 src=r0 offset=0 imm=1735289204
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1925 dst=r1 src=r0 offset=0 imm=1735289204
 #line 275 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1927 dst=r10 src=r1 offset=-32 imm=0
@@ -5949,14 +6105,14 @@ label_121:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1951 dst=r0 src=r0 offset=0 imm=17
 #line 276 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 276 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 276 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 276 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1952 dst=r6 src=r0 offset=0 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1952 dst=r6 src=r0 offset=0 imm=0
 #line 276 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1953 dst=r4 src=r6 offset=0 imm=0
@@ -5973,10 +6129,12 @@ label_121:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1957 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 276 "sample/undocked/map.c"
         goto label_122;
-        // EBPF_OP_JA pc=1958 dst=r0 src=r0 offset=-168 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1958 dst=r0 src=r0 offset=-168 imm=0
 #line 276 "sample/undocked/map.c"
     goto label_113;
 label_122:
@@ -5985,10 +6143,12 @@ label_122:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1960 dst=r3 src=r0 offset=20 imm=5
 #line 276 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(5))
+    if (r3 == IMMEDIATE(5)) {
 #line 276 "sample/undocked/map.c"
         goto label_123;
-        // EBPF_OP_LDDW pc=1961 dst=r1 src=r0 offset=0 imm=1735289204
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1961 dst=r1 src=r0 offset=0 imm=1735289204
 #line 276 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1963 dst=r10 src=r1 offset=-32 imm=0
@@ -6051,14 +6211,14 @@ label_123:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1987 dst=r0 src=r0 offset=0 imm=17
 #line 277 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 277 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 277 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 277 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1988 dst=r6 src=r0 offset=0 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1988 dst=r6 src=r0 offset=0 imm=0
 #line 277 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1989 dst=r4 src=r6 offset=0 imm=0
@@ -6075,10 +6235,12 @@ label_123:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1993 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 277 "sample/undocked/map.c"
         goto label_124;
-        // EBPF_OP_JA pc=1994 dst=r0 src=r0 offset=-204 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1994 dst=r0 src=r0 offset=-204 imm=0
 #line 277 "sample/undocked/map.c"
     goto label_113;
 label_124:
@@ -6087,10 +6249,12 @@ label_124:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1996 dst=r3 src=r0 offset=20 imm=6
 #line 277 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(6))
+    if (r3 == IMMEDIATE(6)) {
 #line 277 "sample/undocked/map.c"
         goto label_125;
-        // EBPF_OP_LDDW pc=1997 dst=r1 src=r0 offset=0 imm=1735289204
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1997 dst=r1 src=r0 offset=0 imm=1735289204
 #line 277 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1999 dst=r10 src=r1 offset=-32 imm=0
@@ -6153,14 +6317,14 @@ label_125:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2023 dst=r0 src=r0 offset=0 imm=17
 #line 278 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 278 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 278 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 278 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2024 dst=r6 src=r0 offset=0 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2024 dst=r6 src=r0 offset=0 imm=0
 #line 278 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2025 dst=r4 src=r6 offset=0 imm=0
@@ -6177,10 +6341,12 @@ label_125:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2029 dst=r1 src=r0 offset=1 imm=0
 #line 278 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 278 "sample/undocked/map.c"
         goto label_126;
-        // EBPF_OP_JA pc=2030 dst=r0 src=r0 offset=-240 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2030 dst=r0 src=r0 offset=-240 imm=0
 #line 278 "sample/undocked/map.c"
     goto label_113;
 label_126:
@@ -6189,10 +6355,12 @@ label_126:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2032 dst=r3 src=r0 offset=20 imm=7
 #line 278 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(7))
+    if (r3 == IMMEDIATE(7)) {
 #line 278 "sample/undocked/map.c"
         goto label_127;
-        // EBPF_OP_LDDW pc=2033 dst=r1 src=r0 offset=0 imm=1735289204
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2033 dst=r1 src=r0 offset=0 imm=1735289204
 #line 278 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2035 dst=r10 src=r1 offset=-32 imm=0
@@ -6255,14 +6423,14 @@ label_127:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2059 dst=r0 src=r0 offset=0 imm=17
 #line 279 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 279 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 279 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 279 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2060 dst=r6 src=r0 offset=0 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2060 dst=r6 src=r0 offset=0 imm=0
 #line 279 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2061 dst=r4 src=r6 offset=0 imm=0
@@ -6279,10 +6447,12 @@ label_127:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2065 dst=r1 src=r0 offset=1 imm=0
 #line 279 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 279 "sample/undocked/map.c"
         goto label_128;
-        // EBPF_OP_JA pc=2066 dst=r0 src=r0 offset=-276 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2066 dst=r0 src=r0 offset=-276 imm=0
 #line 279 "sample/undocked/map.c"
     goto label_113;
 label_128:
@@ -6291,10 +6461,12 @@ label_128:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2068 dst=r3 src=r0 offset=20 imm=8
 #line 279 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(8))
+    if (r3 == IMMEDIATE(8)) {
 #line 279 "sample/undocked/map.c"
         goto label_129;
-        // EBPF_OP_LDDW pc=2069 dst=r1 src=r0 offset=0 imm=1735289204
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2069 dst=r1 src=r0 offset=0 imm=1735289204
 #line 279 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2071 dst=r10 src=r1 offset=-32 imm=0
@@ -6357,14 +6529,14 @@ label_129:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2095 dst=r0 src=r0 offset=0 imm=17
 #line 280 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 280 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 280 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 280 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2096 dst=r6 src=r0 offset=0 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2096 dst=r6 src=r0 offset=0 imm=0
 #line 280 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2097 dst=r4 src=r6 offset=0 imm=0
@@ -6381,10 +6553,12 @@ label_129:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2101 dst=r1 src=r0 offset=1 imm=0
 #line 280 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 280 "sample/undocked/map.c"
         goto label_130;
-        // EBPF_OP_JA pc=2102 dst=r0 src=r0 offset=-312 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2102 dst=r0 src=r0 offset=-312 imm=0
 #line 280 "sample/undocked/map.c"
     goto label_113;
 label_130:
@@ -6393,10 +6567,12 @@ label_130:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2104 dst=r3 src=r0 offset=20 imm=9
 #line 280 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(9))
+    if (r3 == IMMEDIATE(9)) {
 #line 280 "sample/undocked/map.c"
         goto label_131;
-        // EBPF_OP_LDDW pc=2105 dst=r1 src=r0 offset=0 imm=1735289204
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2105 dst=r1 src=r0 offset=0 imm=1735289204
 #line 280 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2107 dst=r10 src=r1 offset=-32 imm=0
@@ -6459,14 +6635,14 @@ label_131:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2131 dst=r0 src=r0 offset=0 imm=17
 #line 281 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 281 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 281 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 281 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2132 dst=r6 src=r0 offset=0 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2132 dst=r6 src=r0 offset=0 imm=0
 #line 281 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2133 dst=r4 src=r6 offset=0 imm=0
@@ -6483,10 +6659,12 @@ label_131:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2137 dst=r1 src=r0 offset=1 imm=0
 #line 281 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 281 "sample/undocked/map.c"
         goto label_132;
-        // EBPF_OP_JA pc=2138 dst=r0 src=r0 offset=-348 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2138 dst=r0 src=r0 offset=-348 imm=0
 #line 281 "sample/undocked/map.c"
     goto label_113;
 label_132:
@@ -6495,10 +6673,12 @@ label_132:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2140 dst=r3 src=r0 offset=20 imm=10
 #line 281 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 281 "sample/undocked/map.c"
         goto label_133;
-        // EBPF_OP_LDDW pc=2141 dst=r1 src=r0 offset=0 imm=1735289204
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2141 dst=r1 src=r0 offset=0 imm=1735289204
 #line 281 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2143 dst=r10 src=r1 offset=-32 imm=0
@@ -6561,14 +6741,14 @@ label_133:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2167 dst=r0 src=r0 offset=0 imm=18
 #line 284 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 284 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 284 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 284 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2168 dst=r6 src=r0 offset=0 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2168 dst=r6 src=r0 offset=0 imm=0
 #line 284 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2169 dst=r4 src=r6 offset=0 imm=0
@@ -6588,10 +6768,12 @@ label_133:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2175 dst=r1 src=r2 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 284 "sample/undocked/map.c"
         goto label_134;
-        // EBPF_OP_JA pc=2176 dst=r0 src=r0 offset=-916 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2176 dst=r0 src=r0 offset=-916 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_79;
 label_134:
@@ -6600,10 +6782,12 @@ label_134:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2178 dst=r3 src=r0 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 284 "sample/undocked/map.c"
         goto label_135;
-        // EBPF_OP_JA pc=2179 dst=r0 src=r0 offset=-890 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2179 dst=r0 src=r0 offset=-890 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_82;
 label_135:
@@ -6624,14 +6808,14 @@ label_135:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2186 dst=r0 src=r0 offset=0 imm=17
 #line 285 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 285 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 285 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 285 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2187 dst=r6 src=r0 offset=0 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2187 dst=r6 src=r0 offset=0 imm=0
 #line 285 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2188 dst=r4 src=r6 offset=0 imm=0
@@ -6651,10 +6835,12 @@ label_135:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2194 dst=r1 src=r2 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 285 "sample/undocked/map.c"
         goto label_136;
-        // EBPF_OP_JA pc=2195 dst=r0 src=r0 offset=-801 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2195 dst=r0 src=r0 offset=-801 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_91;
 label_136:
@@ -6663,10 +6849,12 @@ label_136:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2197 dst=r3 src=r0 offset=-879 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 285 "sample/undocked/map.c"
         goto label_86;
-        // EBPF_OP_JA pc=2198 dst=r0 src=r0 offset=-778 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2198 dst=r0 src=r0 offset=-778 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_93;
 label_137:
@@ -6675,9 +6863,11 @@ label_137:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2200 dst=r3 src=r0 offset=50 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 240 "sample/undocked/map.c"
         goto label_142;
+#line 240 "sample/undocked/map.c"
+    }
 label_138:
     // EBPF_OP_LDDW pc=2201 dst=r1 src=r0 offset=0 imm=1852404835
 #line 240 "sample/undocked/map.c"
@@ -6731,14 +6921,14 @@ label_139:
 label_140:
     // EBPF_OP_CALL pc=2222 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=2223 dst=r7 src=r0 offset=0 imm=-1
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2223 dst=r7 src=r0 offset=0 imm=-1
 #line 240 "sample/undocked/map.c"
     r7 = (uint64_t)4294967295;
 label_141:
@@ -6756,10 +6946,12 @@ label_141:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=2229 dst=r3 src=r0 offset=-2128 imm=-1
 #line 304 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 304 "sample/undocked/map.c"
         goto label_9;
-        // EBPF_OP_LDDW pc=2230 dst=r1 src=r0 offset=0 imm=1684369010
+#line 304 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2230 dst=r1 src=r0 offset=0 imm=1684369010
 #line 304 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=2232 dst=r10 src=r1 offset=-32 imm=0
@@ -6800,14 +6992,14 @@ label_141:
     r2 = IMMEDIATE(40);
     // EBPF_OP_CALL pc=2248 dst=r0 src=r0 offset=0 imm=13
 #line 304 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 304 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 304 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 304 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2249 dst=r6 src=r7 offset=0 imm=0
+#line 304 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2249 dst=r6 src=r7 offset=0 imm=0
 #line 304 "sample/undocked/map.c"
     r6 = r7;
     // EBPF_OP_JA pc=2250 dst=r0 src=r0 offset=-2149 imm=0
@@ -6831,14 +7023,14 @@ label_142:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2257 dst=r0 src=r0 offset=0 imm=17
 #line 241 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 241 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 241 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 241 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2258 dst=r7 src=r0 offset=0 imm=0
+#line 241 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2258 dst=r7 src=r0 offset=0 imm=0
 #line 241 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2259 dst=r4 src=r7 offset=0 imm=0
@@ -6858,9 +7050,11 @@ label_142:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2265 dst=r1 src=r2 offset=24 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 241 "sample/undocked/map.c"
         goto label_144;
+#line 241 "sample/undocked/map.c"
+    }
 label_143:
     // EBPF_OP_STXB pc=2266 dst=r10 src=r6 offset=-16 imm=0
 #line 241 "sample/undocked/map.c"
@@ -6922,9 +7116,11 @@ label_144:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2291 dst=r3 src=r0 offset=19 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 241 "sample/undocked/map.c"
         goto label_146;
+#line 241 "sample/undocked/map.c"
+    }
 label_145:
     // EBPF_OP_LDDW pc=2292 dst=r1 src=r0 offset=0 imm=1735289204
 #line 241 "sample/undocked/map.c"
@@ -6989,14 +7185,14 @@ label_146:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2318 dst=r0 src=r0 offset=0 imm=16
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2319 dst=r7 src=r0 offset=0 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2319 dst=r7 src=r0 offset=0 imm=0
 #line 249 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2320 dst=r5 src=r7 offset=0 imm=0
@@ -7013,9 +7209,11 @@ label_146:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2324 dst=r1 src=r0 offset=31 imm=0
 #line 249 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 249 "sample/undocked/map.c"
         goto label_150;
+#line 249 "sample/undocked/map.c"
+    }
 label_147:
     // EBPF_OP_MOV64_IMM pc=2325 dst=r1 src=r0 offset=0 imm=25637
 #line 249 "sample/undocked/map.c"
@@ -7090,14 +7288,14 @@ label_148:
 label_149:
     // EBPF_OP_CALL pc=2354 dst=r0 src=r0 offset=0 imm=15
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[10].address
+    r0 = test_maps_helpers[10].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[10].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[10].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=2355 dst=r0 src=r0 offset=-131 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2355 dst=r0 src=r0 offset=-131 imm=0
 #line 249 "sample/undocked/map.c"
     goto label_141;
 label_150:
@@ -7124,14 +7322,14 @@ label_150:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2364 dst=r0 src=r0 offset=0 imm=16
 #line 250 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 250 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 250 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 250 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2365 dst=r7 src=r0 offset=0 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2365 dst=r7 src=r0 offset=0 imm=0
 #line 250 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2366 dst=r5 src=r7 offset=0 imm=0
@@ -7148,10 +7346,12 @@ label_150:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2370 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 250 "sample/undocked/map.c"
         goto label_151;
-        // EBPF_OP_JA pc=2371 dst=r0 src=r0 offset=-47 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2371 dst=r0 src=r0 offset=-47 imm=0
 #line 250 "sample/undocked/map.c"
     goto label_147;
 label_151:
@@ -7178,14 +7378,14 @@ label_151:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2380 dst=r0 src=r0 offset=0 imm=16
 #line 251 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 251 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 251 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 251 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2381 dst=r7 src=r0 offset=0 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2381 dst=r7 src=r0 offset=0 imm=0
 #line 251 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2382 dst=r5 src=r7 offset=0 imm=0
@@ -7202,10 +7402,12 @@ label_151:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2386 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 251 "sample/undocked/map.c"
         goto label_152;
-        // EBPF_OP_JA pc=2387 dst=r0 src=r0 offset=-63 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2387 dst=r0 src=r0 offset=-63 imm=0
 #line 251 "sample/undocked/map.c"
     goto label_147;
 label_152:
@@ -7232,14 +7434,14 @@ label_152:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2396 dst=r0 src=r0 offset=0 imm=16
 #line 252 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 252 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 252 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 252 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2397 dst=r7 src=r0 offset=0 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2397 dst=r7 src=r0 offset=0 imm=0
 #line 252 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2398 dst=r5 src=r7 offset=0 imm=0
@@ -7256,10 +7458,12 @@ label_152:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2402 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 252 "sample/undocked/map.c"
         goto label_153;
-        // EBPF_OP_JA pc=2403 dst=r0 src=r0 offset=-79 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2403 dst=r0 src=r0 offset=-79 imm=0
 #line 252 "sample/undocked/map.c"
     goto label_147;
 label_153:
@@ -7286,14 +7490,14 @@ label_153:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2412 dst=r0 src=r0 offset=0 imm=16
 #line 253 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 253 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 253 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 253 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2413 dst=r7 src=r0 offset=0 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2413 dst=r7 src=r0 offset=0 imm=0
 #line 253 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2414 dst=r5 src=r7 offset=0 imm=0
@@ -7310,10 +7514,12 @@ label_153:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2418 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 253 "sample/undocked/map.c"
         goto label_154;
-        // EBPF_OP_JA pc=2419 dst=r0 src=r0 offset=-95 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2419 dst=r0 src=r0 offset=-95 imm=0
 #line 253 "sample/undocked/map.c"
     goto label_147;
 label_154:
@@ -7340,14 +7546,14 @@ label_154:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2428 dst=r0 src=r0 offset=0 imm=16
 #line 254 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 254 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 254 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 254 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2429 dst=r7 src=r0 offset=0 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2429 dst=r7 src=r0 offset=0 imm=0
 #line 254 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2430 dst=r5 src=r7 offset=0 imm=0
@@ -7364,10 +7570,12 @@ label_154:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2434 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 254 "sample/undocked/map.c"
         goto label_155;
-        // EBPF_OP_JA pc=2435 dst=r0 src=r0 offset=-111 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2435 dst=r0 src=r0 offset=-111 imm=0
 #line 254 "sample/undocked/map.c"
     goto label_147;
 label_155:
@@ -7394,14 +7602,14 @@ label_155:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2444 dst=r0 src=r0 offset=0 imm=16
 #line 255 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 255 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 255 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 255 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2445 dst=r7 src=r0 offset=0 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2445 dst=r7 src=r0 offset=0 imm=0
 #line 255 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2446 dst=r5 src=r7 offset=0 imm=0
@@ -7418,10 +7626,12 @@ label_155:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2450 dst=r1 src=r0 offset=1 imm=0
 #line 255 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 255 "sample/undocked/map.c"
         goto label_156;
-        // EBPF_OP_JA pc=2451 dst=r0 src=r0 offset=-127 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2451 dst=r0 src=r0 offset=-127 imm=0
 #line 255 "sample/undocked/map.c"
     goto label_147;
 label_156:
@@ -7448,14 +7658,14 @@ label_156:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2460 dst=r0 src=r0 offset=0 imm=16
 #line 256 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 256 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 256 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 256 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2461 dst=r7 src=r0 offset=0 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2461 dst=r7 src=r0 offset=0 imm=0
 #line 256 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2462 dst=r5 src=r7 offset=0 imm=0
@@ -7472,10 +7682,12 @@ label_156:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2466 dst=r1 src=r0 offset=1 imm=0
 #line 256 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 256 "sample/undocked/map.c"
         goto label_157;
-        // EBPF_OP_JA pc=2467 dst=r0 src=r0 offset=-143 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2467 dst=r0 src=r0 offset=-143 imm=0
 #line 256 "sample/undocked/map.c"
     goto label_147;
 label_157:
@@ -7502,14 +7714,14 @@ label_157:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2476 dst=r0 src=r0 offset=0 imm=16
 #line 257 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 257 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 257 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 257 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2477 dst=r7 src=r0 offset=0 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2477 dst=r7 src=r0 offset=0 imm=0
 #line 257 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2478 dst=r5 src=r7 offset=0 imm=0
@@ -7526,10 +7738,12 @@ label_157:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2482 dst=r1 src=r0 offset=1 imm=0
 #line 257 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 257 "sample/undocked/map.c"
         goto label_158;
-        // EBPF_OP_JA pc=2483 dst=r0 src=r0 offset=-159 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2483 dst=r0 src=r0 offset=-159 imm=0
 #line 257 "sample/undocked/map.c"
     goto label_147;
 label_158:
@@ -7556,14 +7770,14 @@ label_158:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2492 dst=r0 src=r0 offset=0 imm=16
 #line 258 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 258 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 258 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 258 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2493 dst=r7 src=r0 offset=0 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2493 dst=r7 src=r0 offset=0 imm=0
 #line 258 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2494 dst=r5 src=r7 offset=0 imm=0
@@ -7580,10 +7794,12 @@ label_158:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2498 dst=r1 src=r0 offset=1 imm=0
 #line 258 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 258 "sample/undocked/map.c"
         goto label_159;
-        // EBPF_OP_JA pc=2499 dst=r0 src=r0 offset=-175 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2499 dst=r0 src=r0 offset=-175 imm=0
 #line 258 "sample/undocked/map.c"
     goto label_147;
 label_159:
@@ -7610,14 +7826,14 @@ label_159:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2508 dst=r0 src=r0 offset=0 imm=16
 #line 261 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 261 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 261 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 261 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2509 dst=r7 src=r0 offset=0 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2509 dst=r7 src=r0 offset=0 imm=0
 #line 261 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2510 dst=r5 src=r7 offset=0 imm=0
@@ -7637,10 +7853,12 @@ label_159:
     r2 = (uint64_t)4294967267;
     // EBPF_OP_JEQ_REG pc=2516 dst=r1 src=r2 offset=30 imm=0
 #line 261 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 261 "sample/undocked/map.c"
         goto label_160;
-        // EBPF_OP_STXB pc=2517 dst=r10 src=r8 offset=-10 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_STXB pc=2517 dst=r10 src=r8 offset=-10 imm=0
 #line 261 "sample/undocked/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=2518 dst=r1 src=r0 offset=0 imm=25637
@@ -7730,14 +7948,14 @@ label_160:
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=2553 dst=r0 src=r0 offset=0 imm=16
 #line 262 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 262 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 262 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 262 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2554 dst=r7 src=r0 offset=0 imm=0
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2554 dst=r7 src=r0 offset=0 imm=0
 #line 262 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2555 dst=r5 src=r7 offset=0 imm=0
@@ -7754,10 +7972,12 @@ label_160:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2559 dst=r1 src=r0 offset=25 imm=0
 #line 262 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 262 "sample/undocked/map.c"
         goto label_161;
-        // EBPF_OP_MOV64_IMM pc=2560 dst=r1 src=r0 offset=0 imm=25637
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2560 dst=r1 src=r0 offset=0 imm=25637
 #line 262 "sample/undocked/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=2561 dst=r10 src=r1 offset=-12 imm=0
@@ -7832,14 +8052,14 @@ label_161:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2591 dst=r0 src=r0 offset=0 imm=18
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2592 dst=r7 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2592 dst=r7 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2593 dst=r4 src=r7 offset=0 imm=0
@@ -7856,10 +8076,12 @@ label_161:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2597 dst=r1 src=r0 offset=27 imm=0
 #line 264 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 264 "sample/undocked/map.c"
         goto label_163;
-        // EBPF_OP_MOV64_IMM pc=2598 dst=r1 src=r0 offset=0 imm=100
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2598 dst=r1 src=r0 offset=0 imm=100
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=2599 dst=r10 src=r1 offset=-16 imm=0
@@ -7919,14 +8141,14 @@ label_162:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2623 dst=r0 src=r0 offset=0 imm=14
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=2624 dst=r0 src=r0 offset=-400 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2624 dst=r0 src=r0 offset=-400 imm=0
 #line 264 "sample/undocked/map.c"
     goto label_141;
 label_163:
@@ -7935,10 +8157,12 @@ label_163:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2626 dst=r3 src=r0 offset=22 imm=10
 #line 264 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 264 "sample/undocked/map.c"
         goto label_164;
-        // EBPF_OP_MOV64_IMM pc=2627 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2627 dst=r1 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=2628 dst=r10 src=r1 offset=-24 imm=0
@@ -8007,14 +8231,14 @@ label_164:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2655 dst=r0 src=r0 offset=0 imm=17
 #line 272 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 272 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 272 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 272 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2656 dst=r7 src=r0 offset=0 imm=0
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2656 dst=r7 src=r0 offset=0 imm=0
 #line 272 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2657 dst=r4 src=r7 offset=0 imm=0
@@ -8031,9 +8255,11 @@ label_164:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2661 dst=r1 src=r0 offset=24 imm=0
 #line 272 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 272 "sample/undocked/map.c"
         goto label_166;
+#line 272 "sample/undocked/map.c"
+    }
 label_165:
     // EBPF_OP_LDDW pc=2662 dst=r1 src=r0 offset=0 imm=1701737077
 #line 272 "sample/undocked/map.c"
@@ -8095,10 +8321,12 @@ label_166:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2687 dst=r3 src=r0 offset=20 imm=10
 #line 272 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 272 "sample/undocked/map.c"
         goto label_167;
-        // EBPF_OP_LDDW pc=2688 dst=r1 src=r0 offset=0 imm=1735289204
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2688 dst=r1 src=r0 offset=0 imm=1735289204
 #line 272 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2690 dst=r10 src=r1 offset=-32 imm=0
@@ -8161,14 +8389,14 @@ label_167:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2714 dst=r0 src=r0 offset=0 imm=17
 #line 273 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 273 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 273 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 273 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2715 dst=r7 src=r0 offset=0 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2715 dst=r7 src=r0 offset=0 imm=0
 #line 273 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2716 dst=r4 src=r7 offset=0 imm=0
@@ -8185,10 +8413,12 @@ label_167:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2720 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 273 "sample/undocked/map.c"
         goto label_168;
-        // EBPF_OP_JA pc=2721 dst=r0 src=r0 offset=-60 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2721 dst=r0 src=r0 offset=-60 imm=0
 #line 273 "sample/undocked/map.c"
     goto label_165;
 label_168:
@@ -8197,10 +8427,12 @@ label_168:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2723 dst=r3 src=r0 offset=20 imm=9
 #line 273 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(9))
+    if (r3 == IMMEDIATE(9)) {
 #line 273 "sample/undocked/map.c"
         goto label_169;
-        // EBPF_OP_LDDW pc=2724 dst=r1 src=r0 offset=0 imm=1735289204
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2724 dst=r1 src=r0 offset=0 imm=1735289204
 #line 273 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2726 dst=r10 src=r1 offset=-32 imm=0
@@ -8263,14 +8495,14 @@ label_169:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2750 dst=r0 src=r0 offset=0 imm=17
 #line 274 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 274 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 274 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 274 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2751 dst=r7 src=r0 offset=0 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2751 dst=r7 src=r0 offset=0 imm=0
 #line 274 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2752 dst=r4 src=r7 offset=0 imm=0
@@ -8287,10 +8519,12 @@ label_169:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2756 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 274 "sample/undocked/map.c"
         goto label_170;
-        // EBPF_OP_JA pc=2757 dst=r0 src=r0 offset=-96 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2757 dst=r0 src=r0 offset=-96 imm=0
 #line 274 "sample/undocked/map.c"
     goto label_165;
 label_170:
@@ -8299,10 +8533,12 @@ label_170:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2759 dst=r3 src=r0 offset=20 imm=8
 #line 274 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(8))
+    if (r3 == IMMEDIATE(8)) {
 #line 274 "sample/undocked/map.c"
         goto label_171;
-        // EBPF_OP_LDDW pc=2760 dst=r1 src=r0 offset=0 imm=1735289204
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2760 dst=r1 src=r0 offset=0 imm=1735289204
 #line 274 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2762 dst=r10 src=r1 offset=-32 imm=0
@@ -8365,14 +8601,14 @@ label_171:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2786 dst=r0 src=r0 offset=0 imm=17
 #line 275 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 275 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 275 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 275 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2787 dst=r7 src=r0 offset=0 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2787 dst=r7 src=r0 offset=0 imm=0
 #line 275 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2788 dst=r4 src=r7 offset=0 imm=0
@@ -8389,10 +8625,12 @@ label_171:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2792 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 275 "sample/undocked/map.c"
         goto label_172;
-        // EBPF_OP_JA pc=2793 dst=r0 src=r0 offset=-132 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2793 dst=r0 src=r0 offset=-132 imm=0
 #line 275 "sample/undocked/map.c"
     goto label_165;
 label_172:
@@ -8401,10 +8639,12 @@ label_172:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2795 dst=r3 src=r0 offset=20 imm=7
 #line 275 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(7))
+    if (r3 == IMMEDIATE(7)) {
 #line 275 "sample/undocked/map.c"
         goto label_173;
-        // EBPF_OP_LDDW pc=2796 dst=r1 src=r0 offset=0 imm=1735289204
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2796 dst=r1 src=r0 offset=0 imm=1735289204
 #line 275 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2798 dst=r10 src=r1 offset=-32 imm=0
@@ -8467,14 +8707,14 @@ label_173:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2822 dst=r0 src=r0 offset=0 imm=17
 #line 276 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 276 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 276 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 276 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2823 dst=r7 src=r0 offset=0 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2823 dst=r7 src=r0 offset=0 imm=0
 #line 276 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2824 dst=r4 src=r7 offset=0 imm=0
@@ -8491,10 +8731,12 @@ label_173:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2828 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 276 "sample/undocked/map.c"
         goto label_174;
-        // EBPF_OP_JA pc=2829 dst=r0 src=r0 offset=-168 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2829 dst=r0 src=r0 offset=-168 imm=0
 #line 276 "sample/undocked/map.c"
     goto label_165;
 label_174:
@@ -8503,10 +8745,12 @@ label_174:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2831 dst=r3 src=r0 offset=20 imm=6
 #line 276 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(6))
+    if (r3 == IMMEDIATE(6)) {
 #line 276 "sample/undocked/map.c"
         goto label_175;
-        // EBPF_OP_LDDW pc=2832 dst=r1 src=r0 offset=0 imm=1735289204
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2832 dst=r1 src=r0 offset=0 imm=1735289204
 #line 276 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2834 dst=r10 src=r1 offset=-32 imm=0
@@ -8569,14 +8813,14 @@ label_175:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2858 dst=r0 src=r0 offset=0 imm=17
 #line 277 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 277 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 277 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 277 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2859 dst=r7 src=r0 offset=0 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2859 dst=r7 src=r0 offset=0 imm=0
 #line 277 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2860 dst=r4 src=r7 offset=0 imm=0
@@ -8593,10 +8837,12 @@ label_175:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2864 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 277 "sample/undocked/map.c"
         goto label_176;
-        // EBPF_OP_JA pc=2865 dst=r0 src=r0 offset=-204 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2865 dst=r0 src=r0 offset=-204 imm=0
 #line 277 "sample/undocked/map.c"
     goto label_165;
 label_176:
@@ -8605,10 +8851,12 @@ label_176:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2867 dst=r3 src=r0 offset=20 imm=5
 #line 277 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(5))
+    if (r3 == IMMEDIATE(5)) {
 #line 277 "sample/undocked/map.c"
         goto label_177;
-        // EBPF_OP_LDDW pc=2868 dst=r1 src=r0 offset=0 imm=1735289204
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2868 dst=r1 src=r0 offset=0 imm=1735289204
 #line 277 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2870 dst=r10 src=r1 offset=-32 imm=0
@@ -8671,14 +8919,14 @@ label_177:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2894 dst=r0 src=r0 offset=0 imm=17
 #line 278 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 278 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 278 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 278 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2895 dst=r7 src=r0 offset=0 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2895 dst=r7 src=r0 offset=0 imm=0
 #line 278 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2896 dst=r4 src=r7 offset=0 imm=0
@@ -8695,10 +8943,12 @@ label_177:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2900 dst=r1 src=r0 offset=1 imm=0
 #line 278 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 278 "sample/undocked/map.c"
         goto label_178;
-        // EBPF_OP_JA pc=2901 dst=r0 src=r0 offset=-240 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2901 dst=r0 src=r0 offset=-240 imm=0
 #line 278 "sample/undocked/map.c"
     goto label_165;
 label_178:
@@ -8707,10 +8957,12 @@ label_178:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2903 dst=r3 src=r0 offset=20 imm=4
 #line 278 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(4))
+    if (r3 == IMMEDIATE(4)) {
 #line 278 "sample/undocked/map.c"
         goto label_179;
-        // EBPF_OP_LDDW pc=2904 dst=r1 src=r0 offset=0 imm=1735289204
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2904 dst=r1 src=r0 offset=0 imm=1735289204
 #line 278 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2906 dst=r10 src=r1 offset=-32 imm=0
@@ -8773,14 +9025,14 @@ label_179:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2930 dst=r0 src=r0 offset=0 imm=17
 #line 279 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 279 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 279 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 279 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2931 dst=r7 src=r0 offset=0 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2931 dst=r7 src=r0 offset=0 imm=0
 #line 279 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2932 dst=r4 src=r7 offset=0 imm=0
@@ -8797,10 +9049,12 @@ label_179:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2936 dst=r1 src=r0 offset=1 imm=0
 #line 279 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 279 "sample/undocked/map.c"
         goto label_180;
-        // EBPF_OP_JA pc=2937 dst=r0 src=r0 offset=-276 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2937 dst=r0 src=r0 offset=-276 imm=0
 #line 279 "sample/undocked/map.c"
     goto label_165;
 label_180:
@@ -8809,10 +9063,12 @@ label_180:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2939 dst=r3 src=r0 offset=20 imm=3
 #line 279 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(3))
+    if (r3 == IMMEDIATE(3)) {
 #line 279 "sample/undocked/map.c"
         goto label_181;
-        // EBPF_OP_LDDW pc=2940 dst=r1 src=r0 offset=0 imm=1735289204
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2940 dst=r1 src=r0 offset=0 imm=1735289204
 #line 279 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2942 dst=r10 src=r1 offset=-32 imm=0
@@ -8875,14 +9131,14 @@ label_181:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2966 dst=r0 src=r0 offset=0 imm=17
 #line 280 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 280 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 280 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 280 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2967 dst=r7 src=r0 offset=0 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2967 dst=r7 src=r0 offset=0 imm=0
 #line 280 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2968 dst=r4 src=r7 offset=0 imm=0
@@ -8899,10 +9155,12 @@ label_181:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2972 dst=r1 src=r0 offset=1 imm=0
 #line 280 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 280 "sample/undocked/map.c"
         goto label_182;
-        // EBPF_OP_JA pc=2973 dst=r0 src=r0 offset=-312 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2973 dst=r0 src=r0 offset=-312 imm=0
 #line 280 "sample/undocked/map.c"
     goto label_165;
 label_182:
@@ -8911,10 +9169,12 @@ label_182:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2975 dst=r3 src=r0 offset=20 imm=2
 #line 280 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(2))
+    if (r3 == IMMEDIATE(2)) {
 #line 280 "sample/undocked/map.c"
         goto label_183;
-        // EBPF_OP_LDDW pc=2976 dst=r1 src=r0 offset=0 imm=1735289204
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2976 dst=r1 src=r0 offset=0 imm=1735289204
 #line 280 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2978 dst=r10 src=r1 offset=-32 imm=0
@@ -8977,14 +9237,14 @@ label_183:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3002 dst=r0 src=r0 offset=0 imm=17
 #line 281 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 281 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 281 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 281 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3003 dst=r7 src=r0 offset=0 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3003 dst=r7 src=r0 offset=0 imm=0
 #line 281 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3004 dst=r4 src=r7 offset=0 imm=0
@@ -9001,10 +9261,12 @@ label_183:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=3008 dst=r1 src=r0 offset=1 imm=0
 #line 281 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 281 "sample/undocked/map.c"
         goto label_184;
-        // EBPF_OP_JA pc=3009 dst=r0 src=r0 offset=-348 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3009 dst=r0 src=r0 offset=-348 imm=0
 #line 281 "sample/undocked/map.c"
     goto label_165;
 label_184:
@@ -9013,10 +9275,12 @@ label_184:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3011 dst=r3 src=r0 offset=20 imm=1
 #line 281 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 281 "sample/undocked/map.c"
         goto label_185;
-        // EBPF_OP_LDDW pc=3012 dst=r1 src=r0 offset=0 imm=1735289204
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=3012 dst=r1 src=r0 offset=0 imm=1735289204
 #line 281 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=3014 dst=r10 src=r1 offset=-32 imm=0
@@ -9079,14 +9343,14 @@ label_185:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3038 dst=r0 src=r0 offset=0 imm=18
 #line 284 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 284 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 284 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 284 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3039 dst=r7 src=r0 offset=0 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3039 dst=r7 src=r0 offset=0 imm=0
 #line 284 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3040 dst=r4 src=r7 offset=0 imm=0
@@ -9106,10 +9370,12 @@ label_185:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=3046 dst=r1 src=r2 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 284 "sample/undocked/map.c"
         goto label_186;
-        // EBPF_OP_JA pc=3047 dst=r0 src=r0 offset=-1714 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3047 dst=r0 src=r0 offset=-1714 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_87;
 label_186:
@@ -9118,10 +9384,12 @@ label_186:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3049 dst=r3 src=r0 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 284 "sample/undocked/map.c"
         goto label_187;
-        // EBPF_OP_JA pc=3050 dst=r0 src=r0 offset=-850 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3050 dst=r0 src=r0 offset=-850 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_138;
 label_187:
@@ -9142,14 +9410,14 @@ label_187:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3057 dst=r0 src=r0 offset=0 imm=17
 #line 285 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 285 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 285 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 285 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3058 dst=r7 src=r0 offset=0 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3058 dst=r7 src=r0 offset=0 imm=0
 #line 285 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3059 dst=r4 src=r7 offset=0 imm=0
@@ -9169,10 +9437,12 @@ label_187:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=3065 dst=r1 src=r2 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 285 "sample/undocked/map.c"
         goto label_188;
-        // EBPF_OP_JA pc=3066 dst=r0 src=r0 offset=-801 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3066 dst=r0 src=r0 offset=-801 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_143;
 label_188:
@@ -9181,10 +9451,12 @@ label_188:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3068 dst=r3 src=r0 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 285 "sample/undocked/map.c"
         goto label_189;
-        // EBPF_OP_JA pc=3069 dst=r0 src=r0 offset=-778 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3069 dst=r0 src=r0 offset=-778 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_145;
 label_189:

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -150,19 +150,21 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 55 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+#line 55 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 56 "sample/undocked/map_reuse_2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 56 "sample/undocked/map_reuse_2.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 56 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/undocked/map_reuse_2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -179,22 +181,24 @@ lookup_update(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+#line 58 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 58 "sample/undocked/map_reuse_2.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
 #line 59 "sample/undocked/map_reuse_2.c"
-    if (r7 != IMMEDIATE(0))
+    if (r7 != IMMEDIATE(0)) {
 #line 59 "sample/undocked/map_reuse_2.c"
         goto label_1;
-        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+#line 59 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 59 "sample/undocked/map_reuse_2.c"
     goto label_2;
 label_1:
@@ -227,14 +231,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=2
 #line 63 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[1].address
+    r0 = lookup_update_helpers[1].address(r1, r2, r3, r4, r5);
 #line 63 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[1].tail_call) && (r0 == 0)) {
 #line 63 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+#line 63 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 65 "sample/undocked/map_reuse_2.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -124,19 +124,21 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 55 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+#line 55 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 56 "sample/undocked/map_reuse_2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 56 "sample/undocked/map_reuse_2.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 56 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/undocked/map_reuse_2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -153,22 +155,24 @@ lookup_update(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+#line 58 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 58 "sample/undocked/map_reuse_2.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
 #line 59 "sample/undocked/map_reuse_2.c"
-    if (r7 != IMMEDIATE(0))
+    if (r7 != IMMEDIATE(0)) {
 #line 59 "sample/undocked/map_reuse_2.c"
         goto label_1;
-        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+#line 59 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 59 "sample/undocked/map_reuse_2.c"
     goto label_2;
 label_1:
@@ -201,14 +205,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=2
 #line 63 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[1].address
+    r0 = lookup_update_helpers[1].address(r1, r2, r3, r4, r5);
 #line 63 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[1].tail_call) && (r0 == 0)) {
 #line 63 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+#line 63 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 65 "sample/undocked/map_reuse_2.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -285,19 +285,21 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 55 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 55 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 55 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 55 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+#line 55 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 56 "sample/undocked/map_reuse_2.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 56 "sample/undocked/map_reuse_2.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 56 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/undocked/map_reuse_2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -314,22 +316,24 @@ lookup_update(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 58 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 58 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 58 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+#line 58 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 58 "sample/undocked/map_reuse_2.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
 #line 59 "sample/undocked/map_reuse_2.c"
-    if (r7 != IMMEDIATE(0))
+    if (r7 != IMMEDIATE(0)) {
 #line 59 "sample/undocked/map_reuse_2.c"
         goto label_1;
-        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+#line 59 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 59 "sample/undocked/map_reuse_2.c"
     goto label_2;
 label_1:
@@ -362,14 +366,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=2
 #line 63 "sample/undocked/map_reuse_2.c"
-    r0 = lookup_update_helpers[1].address
+    r0 = lookup_update_helpers[1].address(r1, r2, r3, r4, r5);
 #line 63 "sample/undocked/map_reuse_2.c"
-         (r1, r2, r3, r4, r5);
-#line 63 "sample/undocked/map_reuse_2.c"
-    if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[1].tail_call) && (r0 == 0)) {
 #line 63 "sample/undocked/map_reuse_2.c"
         return 0;
-        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+#line 63 "sample/undocked/map_reuse_2.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 65 "sample/undocked/map_reuse_2.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -150,19 +150,21 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 54 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+#line 54 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 55 "sample/undocked/map_reuse.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 55 "sample/undocked/map_reuse.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 55 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 55 "sample/undocked/map_reuse.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -179,22 +181,24 @@ lookup_update(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+#line 57 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 57 "sample/undocked/map_reuse.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
 #line 58 "sample/undocked/map_reuse.c"
-    if (r7 != IMMEDIATE(0))
+    if (r7 != IMMEDIATE(0)) {
 #line 58 "sample/undocked/map_reuse.c"
         goto label_1;
-        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+#line 58 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 58 "sample/undocked/map_reuse.c"
     goto label_2;
 label_1:
@@ -227,14 +231,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=2
 #line 62 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[1].address
+    r0 = lookup_update_helpers[1].address(r1, r2, r3, r4, r5);
 #line 62 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[1].tail_call) && (r0 == 0)) {
 #line 62 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+#line 62 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 64 "sample/undocked/map_reuse.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -124,19 +124,21 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 54 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+#line 54 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 55 "sample/undocked/map_reuse.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 55 "sample/undocked/map_reuse.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 55 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 55 "sample/undocked/map_reuse.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -153,22 +155,24 @@ lookup_update(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+#line 57 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 57 "sample/undocked/map_reuse.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
 #line 58 "sample/undocked/map_reuse.c"
-    if (r7 != IMMEDIATE(0))
+    if (r7 != IMMEDIATE(0)) {
 #line 58 "sample/undocked/map_reuse.c"
         goto label_1;
-        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+#line 58 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 58 "sample/undocked/map_reuse.c"
     goto label_2;
 label_1:
@@ -201,14 +205,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=2
 #line 62 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[1].address
+    r0 = lookup_update_helpers[1].address(r1, r2, r3, r4, r5);
 #line 62 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[1].tail_call) && (r0 == 0)) {
 #line 62 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+#line 62 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 64 "sample/undocked/map_reuse.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -285,19 +285,21 @@ lookup_update(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
 #line 54 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 54 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 54 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+#line 54 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 55 "sample/undocked/map_reuse.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 55 "sample/undocked/map_reuse.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 55 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 55 "sample/undocked/map_reuse.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -314,22 +316,24 @@ lookup_update(void* context)
     r1 = r0;
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
 #line 57 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[0].address
+    r0 = lookup_update_helpers[0].address(r1, r2, r3, r4, r5);
 #line 57 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 57 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[0].tail_call) && (r0 == 0)) {
 #line 57 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+#line 57 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 57 "sample/undocked/map_reuse.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
 #line 58 "sample/undocked/map_reuse.c"
-    if (r7 != IMMEDIATE(0))
+    if (r7 != IMMEDIATE(0)) {
 #line 58 "sample/undocked/map_reuse.c"
         goto label_1;
-        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+#line 58 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 58 "sample/undocked/map_reuse.c"
     goto label_2;
 label_1:
@@ -362,14 +366,14 @@ label_1:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=2
 #line 62 "sample/undocked/map_reuse.c"
-    r0 = lookup_update_helpers[1].address
+    r0 = lookup_update_helpers[1].address(r1, r2, r3, r4, r5);
 #line 62 "sample/undocked/map_reuse.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/undocked/map_reuse.c"
-    if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
+    if ((lookup_update_helpers[1].tail_call) && (r0 == 0)) {
 #line 62 "sample/undocked/map_reuse.c"
         return 0;
-        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+#line 62 "sample/undocked/map_reuse.c"
+    }
+    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 64 "sample/undocked/map_reuse.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -376,14 +376,14 @@ test_maps(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r6 offset=0 imm=0
@@ -397,9 +397,11 @@ test_maps(void* context)
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=16 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_2;
+#line 75 "sample/undocked/map.c"
+    }
 label_1:
     // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -431,19 +433,21 @@ label_2:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=33 dst=r10 src=r1 offset=-32 imm=0
@@ -485,14 +489,14 @@ label_2:
 label_3:
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=26 imm=0
@@ -510,14 +514,14 @@ label_4:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=59 dst=r3 src=r6 offset=0 imm=0
@@ -531,10 +535,12 @@ label_4:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=62 dst=r3 src=r0 offset=41 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_10;
-        // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-40 imm=0
@@ -570,13 +576,13 @@ label_5:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_6:
     // EBPF_OP_MOV64_IMM pc=79 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/undocked/map.c"
@@ -636,13 +642,13 @@ label_7:
 label_8:
     // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=13
 #line 293 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 293 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 293 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 293 "sample/undocked/map.c"
         return 0;
+#line 293 "sample/undocked/map.c"
+    }
 label_9:
     // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r6 offset=0 imm=0
 #line 306 "sample/undocked/map.c"
@@ -671,14 +677,14 @@ label_10:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=111 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=112 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=112 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=113 dst=r3 src=r6 offset=0 imm=0
@@ -692,10 +698,12 @@ label_10:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=116 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_11;
-        // EBPF_OP_JA pc=117 dst=r0 src=r0 offset=-101 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=117 dst=r0 src=r0 offset=-101 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_1;
 label_11:
@@ -710,19 +718,21 @@ label_11:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=122 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=123 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=123 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_12;
-        // EBPF_OP_MOV64_IMM pc=124 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=124 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=125 dst=r10 src=r1 offset=-20 imm=0
@@ -809,14 +819,14 @@ label_12:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=159 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=159 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=160 dst=r3 src=r6 offset=0 imm=0
@@ -830,9 +840,11 @@ label_12:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=163 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_14;
+#line 75 "sample/undocked/map.c"
+    }
 label_13:
     // EBPF_OP_LDDW pc=164 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -864,19 +876,21 @@ label_14:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=177 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=178 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=178 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_16;
-        // EBPF_OP_MOV64_IMM pc=179 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=179 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=180 dst=r10 src=r1 offset=-32 imm=0
@@ -918,14 +932,14 @@ label_14:
 label_15:
     // EBPF_OP_CALL pc=196 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=197 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=197 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=199 dst=r0 src=r0 offset=26 imm=0
@@ -943,14 +957,14 @@ label_16:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=204 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=205 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=205 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=206 dst=r3 src=r6 offset=0 imm=0
@@ -964,10 +978,12 @@ label_16:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=209 dst=r3 src=r0 offset=42 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_20;
-        // EBPF_OP_LDDW pc=210 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=210 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=212 dst=r10 src=r1 offset=-40 imm=0
@@ -1003,13 +1019,13 @@ label_17:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=225 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_18:
     // EBPF_OP_MOV64_IMM pc=226 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/undocked/map.c"
@@ -1096,14 +1112,14 @@ label_20:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=259 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=260 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=260 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=261 dst=r3 src=r6 offset=0 imm=0
@@ -1117,10 +1133,12 @@ label_20:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=264 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_21;
-        // EBPF_OP_JA pc=265 dst=r0 src=r0 offset=-102 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=265 dst=r0 src=r0 offset=-102 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_13;
 label_21:
@@ -1135,19 +1153,21 @@ label_21:
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=270 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=271 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=271 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_22;
-        // EBPF_OP_MOV64_IMM pc=272 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=272 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=273 dst=r10 src=r1 offset=-20 imm=0
@@ -1234,14 +1254,14 @@ label_22:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=306 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=307 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=307 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=308 dst=r3 src=r6 offset=0 imm=0
@@ -1255,10 +1275,12 @@ label_22:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=311 dst=r3 src=r0 offset=1 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_23;
-        // EBPF_OP_JA pc=312 dst=r0 src=r0 offset=60 imm=0
+#line 75 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=312 dst=r0 src=r0 offset=60 imm=0
 #line 75 "sample/undocked/map.c"
     goto label_26;
 label_23:
@@ -1273,19 +1295,21 @@ label_23:
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=317 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=318 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=318 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_24;
-        // EBPF_OP_MOV64_IMM pc=319 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=319 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=320 dst=r10 src=r1 offset=-32 imm=0
@@ -1326,14 +1350,14 @@ label_23:
     r2 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=336 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=337 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=337 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=339 dst=r0 src=r0 offset=49 imm=0
@@ -1351,14 +1375,14 @@ label_24:
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=344 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=345 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=345 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=346 dst=r3 src=r6 offset=0 imm=0
@@ -1372,10 +1396,12 @@ label_24:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=349 dst=r3 src=r0 offset=9 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_25;
-        // EBPF_OP_LDDW pc=350 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=350 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=352 dst=r10 src=r1 offset=-40 imm=0
@@ -1417,14 +1443,14 @@ label_25:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=367 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=368 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=368 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=369 dst=r3 src=r6 offset=0 imm=0
@@ -1438,9 +1464,11 @@ label_25:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=372 dst=r3 src=r0 offset=41 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_29;
+#line 93 "sample/undocked/map.c"
+    }
 label_26:
     // EBPF_OP_LDDW pc=373 dst=r1 src=r0 offset=0 imm=1684369010
 #line 93 "sample/undocked/map.c"
@@ -1478,13 +1506,13 @@ label_27:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=388 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 93 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 93 "sample/undocked/map.c"
         return 0;
+#line 93 "sample/undocked/map.c"
+    }
 label_28:
     // EBPF_OP_MOV64_IMM pc=389 dst=r1 src=r0 offset=0 imm=0
 #line 93 "sample/undocked/map.c"
@@ -1579,14 +1607,14 @@ label_29:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=424 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=425 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=425 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=426 dst=r3 src=r6 offset=0 imm=0
@@ -1600,10 +1628,12 @@ label_29:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=429 dst=r3 src=r0 offset=1 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_30;
-        // EBPF_OP_JA pc=430 dst=r0 src=r0 offset=60 imm=0
+#line 75 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=430 dst=r0 src=r0 offset=60 imm=0
 #line 75 "sample/undocked/map.c"
     goto label_33;
 label_30:
@@ -1618,19 +1648,21 @@ label_30:
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=435 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=436 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=436 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_31;
-        // EBPF_OP_MOV64_IMM pc=437 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=437 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=438 dst=r10 src=r1 offset=-32 imm=0
@@ -1671,14 +1703,14 @@ label_30:
     r2 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=454 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=455 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=455 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=457 dst=r0 src=r0 offset=49 imm=0
@@ -1696,14 +1728,14 @@ label_31:
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=462 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=463 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=463 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=464 dst=r3 src=r6 offset=0 imm=0
@@ -1717,10 +1749,12 @@ label_31:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=467 dst=r3 src=r0 offset=9 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_32;
-        // EBPF_OP_LDDW pc=468 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=468 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=470 dst=r10 src=r1 offset=-40 imm=0
@@ -1762,14 +1796,14 @@ label_32:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=485 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=486 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=486 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=487 dst=r3 src=r6 offset=0 imm=0
@@ -1783,9 +1817,11 @@ label_32:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=490 dst=r3 src=r0 offset=42 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_36;
+#line 93 "sample/undocked/map.c"
+    }
 label_33:
     // EBPF_OP_LDDW pc=491 dst=r1 src=r0 offset=0 imm=1684369010
 #line 93 "sample/undocked/map.c"
@@ -1823,13 +1859,13 @@ label_34:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=506 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 93 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 93 "sample/undocked/map.c"
         return 0;
+#line 93 "sample/undocked/map.c"
+    }
 label_35:
     // EBPF_OP_MOV64_IMM pc=507 dst=r1 src=r0 offset=0 imm=100
 #line 93 "sample/undocked/map.c"
@@ -1924,14 +1960,14 @@ label_36:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=543 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=545 dst=r3 src=r6 offset=0 imm=0
@@ -1945,9 +1981,11 @@ label_36:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=548 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_38;
+#line 75 "sample/undocked/map.c"
+    }
 label_37:
     // EBPF_OP_LDDW pc=549 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -1979,19 +2017,21 @@ label_38:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=562 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=563 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=563 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_40;
-        // EBPF_OP_MOV64_IMM pc=564 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=564 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=565 dst=r10 src=r1 offset=-32 imm=0
@@ -2033,14 +2073,14 @@ label_38:
 label_39:
     // EBPF_OP_CALL pc=581 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=582 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=582 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=584 dst=r0 src=r0 offset=26 imm=0
@@ -2058,14 +2098,14 @@ label_40:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=589 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=590 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=590 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=591 dst=r3 src=r6 offset=0 imm=0
@@ -2079,10 +2119,12 @@ label_40:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=594 dst=r3 src=r0 offset=40 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_43;
-        // EBPF_OP_LDDW pc=595 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=595 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=597 dst=r10 src=r1 offset=-40 imm=0
@@ -2118,13 +2160,13 @@ label_41:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=610 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_42:
     // EBPF_OP_MOV64_IMM pc=611 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/undocked/map.c"
@@ -2204,14 +2246,14 @@ label_43:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=642 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=643 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=643 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=644 dst=r3 src=r6 offset=0 imm=0
@@ -2225,10 +2267,12 @@ label_43:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=647 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_44;
-        // EBPF_OP_JA pc=648 dst=r0 src=r0 offset=-100 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=648 dst=r0 src=r0 offset=-100 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_37;
 label_44:
@@ -2243,19 +2287,21 @@ label_44:
     r1 = POINTER(_maps[4].address);
     // EBPF_OP_CALL pc=653 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=654 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=654 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_45;
-        // EBPF_OP_MOV64_IMM pc=655 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=655 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=656 dst=r10 src=r1 offset=-20 imm=0
@@ -2342,14 +2388,14 @@ label_45:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=689 dst=r0 src=r0 offset=0 imm=2
 #line 74 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 74 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 74 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=690 dst=r6 src=r0 offset=0 imm=0
+#line 74 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=690 dst=r6 src=r0 offset=0 imm=0
 #line 74 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=691 dst=r3 src=r6 offset=0 imm=0
@@ -2363,9 +2409,11 @@ label_45:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=694 dst=r3 src=r0 offset=9 imm=-1
 #line 75 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 75 "sample/undocked/map.c"
         goto label_47;
+#line 75 "sample/undocked/map.c"
+    }
 label_46:
     // EBPF_OP_LDDW pc=695 dst=r1 src=r0 offset=0 imm=1684369010
 #line 75 "sample/undocked/map.c"
@@ -2397,19 +2445,21 @@ label_47:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=708 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/undocked/map.c"
-    r0 = test_maps_helpers[1].address
+    r0 = test_maps_helpers[1].address(r1, r2, r3, r4, r5);
 #line 80 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/undocked/map.c"
-    if ((test_maps_helpers[1].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[1].tail_call) && (r0 == 0)) {
 #line 80 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=709 dst=r0 src=r0 offset=21 imm=0
+#line 80 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=709 dst=r0 src=r0 offset=21 imm=0
 #line 81 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 81 "sample/undocked/map.c"
         goto label_49;
-        // EBPF_OP_MOV64_IMM pc=710 dst=r1 src=r0 offset=0 imm=76
+#line 81 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=710 dst=r1 src=r0 offset=0 imm=76
 #line 81 "sample/undocked/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=711 dst=r10 src=r1 offset=-32 imm=0
@@ -2451,14 +2501,14 @@ label_47:
 label_48:
     // EBPF_OP_CALL pc=727 dst=r0 src=r0 offset=0 imm=12
 #line 82 "sample/undocked/map.c"
-    r0 = test_maps_helpers[2].address
+    r0 = test_maps_helpers[2].address(r1, r2, r3, r4, r5);
 #line 82 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 82 "sample/undocked/map.c"
-    if ((test_maps_helpers[2].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[2].tail_call) && (r0 == 0)) {
 #line 82 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=728 dst=r6 src=r0 offset=0 imm=-1
+#line 82 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=728 dst=r6 src=r0 offset=0 imm=-1
 #line 82 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=730 dst=r0 src=r0 offset=26 imm=0
@@ -2476,14 +2526,14 @@ label_49:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=735 dst=r0 src=r0 offset=0 imm=3
 #line 86 "sample/undocked/map.c"
-    r0 = test_maps_helpers[3].address
+    r0 = test_maps_helpers[3].address(r1, r2, r3, r4, r5);
 #line 86 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/undocked/map.c"
-    if ((test_maps_helpers[3].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[3].tail_call) && (r0 == 0)) {
 #line 86 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
+#line 86 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=737 dst=r3 src=r6 offset=0 imm=0
@@ -2497,10 +2547,12 @@ label_49:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=740 dst=r3 src=r0 offset=43 imm=-1
 #line 87 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 87 "sample/undocked/map.c"
         goto label_52;
-        // EBPF_OP_LDDW pc=741 dst=r1 src=r0 offset=0 imm=1684369010
+#line 87 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=741 dst=r1 src=r0 offset=0 imm=1684369010
 #line 87 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=743 dst=r10 src=r1 offset=-40 imm=0
@@ -2536,13 +2588,13 @@ label_50:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=756 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 88 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 88 "sample/undocked/map.c"
         return 0;
+#line 88 "sample/undocked/map.c"
+    }
 label_51:
     // EBPF_OP_MOV64_IMM pc=757 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/undocked/map.c"
@@ -2628,14 +2680,14 @@ label_52:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=791 dst=r0 src=r0 offset=0 imm=2
 #line 92 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=792 dst=r6 src=r0 offset=0 imm=0
+#line 92 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=792 dst=r6 src=r0 offset=0 imm=0
 #line 92 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=793 dst=r3 src=r6 offset=0 imm=0
@@ -2649,10 +2701,12 @@ label_52:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=796 dst=r3 src=r0 offset=1 imm=-1
 #line 93 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 93 "sample/undocked/map.c"
         goto label_53;
-        // EBPF_OP_JA pc=797 dst=r0 src=r0 offset=-103 imm=0
+#line 93 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=797 dst=r0 src=r0 offset=-103 imm=0
 #line 93 "sample/undocked/map.c"
     goto label_46;
 label_53:
@@ -2667,19 +2721,21 @@ label_53:
     r1 = POINTER(_maps[5].address);
     // EBPF_OP_CALL pc=802 dst=r0 src=r0 offset=0 imm=4
 #line 103 "sample/undocked/map.c"
-    r0 = test_maps_helpers[5].address
+    r0 = test_maps_helpers[5].address(r1, r2, r3, r4, r5);
 #line 103 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/undocked/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0)) {
 #line 103 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JNE_IMM pc=803 dst=r0 src=r0 offset=23 imm=0
+#line 103 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JNE_IMM pc=803 dst=r0 src=r0 offset=23 imm=0
 #line 104 "sample/undocked/map.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 104 "sample/undocked/map.c"
         goto label_54;
-        // EBPF_OP_MOV64_IMM pc=804 dst=r1 src=r0 offset=0 imm=0
+#line 104 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=804 dst=r1 src=r0 offset=0 imm=0
 #line 104 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=805 dst=r10 src=r1 offset=-20 imm=0
@@ -2766,14 +2822,14 @@ label_54:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=838 dst=r0 src=r0 offset=0 imm=2
 #line 129 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 129 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 129 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 129 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=839 dst=r6 src=r0 offset=0 imm=0
+#line 129 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=839 dst=r6 src=r0 offset=0 imm=0
 #line 129 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=840 dst=r3 src=r6 offset=0 imm=0
@@ -2787,10 +2843,12 @@ label_54:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=843 dst=r3 src=r0 offset=1 imm=-1
 #line 130 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 130 "sample/undocked/map.c"
         goto label_55;
-        // EBPF_OP_JA pc=844 dst=r0 src=r0 offset=159 imm=0
+#line 130 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=844 dst=r0 src=r0 offset=159 imm=0
 #line 130 "sample/undocked/map.c"
     goto label_65;
 label_55:
@@ -2817,14 +2875,14 @@ label_55:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=853 dst=r0 src=r0 offset=0 imm=2
 #line 135 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=854 dst=r6 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=854 dst=r6 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=855 dst=r3 src=r6 offset=0 imm=0
@@ -2838,10 +2896,12 @@ label_55:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=858 dst=r3 src=r0 offset=1 imm=-1
 #line 136 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 136 "sample/undocked/map.c"
         goto label_56;
-        // EBPF_OP_JA pc=859 dst=r0 src=r0 offset=144 imm=0
+#line 136 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=859 dst=r0 src=r0 offset=144 imm=0
 #line 136 "sample/undocked/map.c"
     goto label_65;
 label_56:
@@ -2871,14 +2931,14 @@ label_56:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=869 dst=r0 src=r0 offset=0 imm=2
 #line 141 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=870 dst=r6 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=870 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=871 dst=r3 src=r6 offset=0 imm=0
@@ -2892,10 +2952,12 @@ label_56:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=874 dst=r3 src=r0 offset=1 imm=-1
 #line 142 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 142 "sample/undocked/map.c"
         goto label_57;
-        // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=128 imm=0
+#line 142 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=128 imm=0
 #line 142 "sample/undocked/map.c"
     goto label_65;
 label_57:
@@ -2925,14 +2987,14 @@ label_57:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=885 dst=r0 src=r0 offset=0 imm=2
 #line 147 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=886 dst=r6 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=886 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=887 dst=r3 src=r6 offset=0 imm=0
@@ -2946,10 +3008,12 @@ label_57:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=890 dst=r3 src=r0 offset=1 imm=-1
 #line 148 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 148 "sample/undocked/map.c"
         goto label_58;
-        // EBPF_OP_JA pc=891 dst=r0 src=r0 offset=112 imm=0
+#line 148 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=891 dst=r0 src=r0 offset=112 imm=0
 #line 148 "sample/undocked/map.c"
     goto label_65;
 label_58:
@@ -2979,14 +3043,14 @@ label_58:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=901 dst=r0 src=r0 offset=0 imm=2
 #line 153 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=902 dst=r6 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=902 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=903 dst=r3 src=r6 offset=0 imm=0
@@ -3000,10 +3064,12 @@ label_58:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=906 dst=r3 src=r0 offset=1 imm=-1
 #line 154 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 154 "sample/undocked/map.c"
         goto label_59;
-        // EBPF_OP_JA pc=907 dst=r0 src=r0 offset=96 imm=0
+#line 154 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=907 dst=r0 src=r0 offset=96 imm=0
 #line 154 "sample/undocked/map.c"
     goto label_65;
 label_59:
@@ -3033,14 +3099,14 @@ label_59:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=917 dst=r0 src=r0 offset=0 imm=2
 #line 159 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=918 dst=r6 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=918 dst=r6 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=919 dst=r3 src=r6 offset=0 imm=0
@@ -3054,10 +3120,12 @@ label_59:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=922 dst=r3 src=r0 offset=1 imm=-1
 #line 160 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 160 "sample/undocked/map.c"
         goto label_60;
-        // EBPF_OP_JA pc=923 dst=r0 src=r0 offset=80 imm=0
+#line 160 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=923 dst=r0 src=r0 offset=80 imm=0
 #line 160 "sample/undocked/map.c"
     goto label_65;
 label_60:
@@ -3087,14 +3155,14 @@ label_60:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=933 dst=r0 src=r0 offset=0 imm=2
 #line 165 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=934 dst=r6 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=934 dst=r6 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=935 dst=r3 src=r6 offset=0 imm=0
@@ -3108,10 +3176,12 @@ label_60:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=938 dst=r3 src=r0 offset=1 imm=-1
 #line 166 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 166 "sample/undocked/map.c"
         goto label_61;
-        // EBPF_OP_JA pc=939 dst=r0 src=r0 offset=64 imm=0
+#line 166 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=939 dst=r0 src=r0 offset=64 imm=0
 #line 166 "sample/undocked/map.c"
     goto label_65;
 label_61:
@@ -3141,14 +3211,14 @@ label_61:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=949 dst=r0 src=r0 offset=0 imm=2
 #line 171 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=950 dst=r6 src=r0 offset=0 imm=0
+#line 171 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=950 dst=r6 src=r0 offset=0 imm=0
 #line 171 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=951 dst=r3 src=r6 offset=0 imm=0
@@ -3162,10 +3232,12 @@ label_61:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=954 dst=r3 src=r0 offset=1 imm=-1
 #line 172 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 172 "sample/undocked/map.c"
         goto label_62;
-        // EBPF_OP_JA pc=955 dst=r0 src=r0 offset=48 imm=0
+#line 172 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=955 dst=r0 src=r0 offset=48 imm=0
 #line 172 "sample/undocked/map.c"
     goto label_65;
 label_62:
@@ -3195,14 +3267,14 @@ label_62:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=965 dst=r0 src=r0 offset=0 imm=2
 #line 177 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 177 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 177 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=966 dst=r6 src=r0 offset=0 imm=0
+#line 177 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=966 dst=r6 src=r0 offset=0 imm=0
 #line 177 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=967 dst=r3 src=r6 offset=0 imm=0
@@ -3216,10 +3288,12 @@ label_62:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=970 dst=r3 src=r0 offset=1 imm=-1
 #line 178 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 178 "sample/undocked/map.c"
         goto label_63;
-        // EBPF_OP_JA pc=971 dst=r0 src=r0 offset=32 imm=0
+#line 178 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=971 dst=r0 src=r0 offset=32 imm=0
 #line 178 "sample/undocked/map.c"
     goto label_65;
 label_63:
@@ -3249,14 +3323,14 @@ label_63:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=981 dst=r0 src=r0 offset=0 imm=2
 #line 183 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 183 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 183 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=982 dst=r6 src=r0 offset=0 imm=0
+#line 183 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=982 dst=r6 src=r0 offset=0 imm=0
 #line 183 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=983 dst=r3 src=r6 offset=0 imm=0
@@ -3270,10 +3344,12 @@ label_63:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=986 dst=r3 src=r0 offset=1 imm=-1
 #line 184 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 184 "sample/undocked/map.c"
         goto label_64;
-        // EBPF_OP_JA pc=987 dst=r0 src=r0 offset=16 imm=0
+#line 184 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=987 dst=r0 src=r0 offset=16 imm=0
 #line 184 "sample/undocked/map.c"
     goto label_65;
 label_64:
@@ -3306,14 +3382,14 @@ label_64:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=998 dst=r0 src=r0 offset=0 imm=2
 #line 189 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 189 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 189 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
+#line 189 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
 #line 189 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1000 dst=r3 src=r6 offset=0 imm=0
@@ -3327,9 +3403,11 @@ label_64:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1003 dst=r3 src=r0 offset=32 imm=-1
 #line 190 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 190 "sample/undocked/map.c"
         goto label_66;
+#line 190 "sample/undocked/map.c"
+    }
 label_65:
     // EBPF_OP_LDDW pc=1004 dst=r1 src=r0 offset=0 imm=1684369010
 #line 190 "sample/undocked/map.c"
@@ -3366,14 +3444,14 @@ label_65:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=1019 dst=r0 src=r0 offset=0 imm=13
 #line 190 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 190 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 190 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1020 dst=r1 src=r0 offset=0 imm=100
+#line 190 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1020 dst=r1 src=r0 offset=0 imm=100
 #line 190 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1021 dst=r10 src=r1 offset=-28 imm=0
@@ -3439,14 +3517,14 @@ label_66:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1046 dst=r0 src=r0 offset=0 imm=2
 #line 129 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 129 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 129 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 129 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1047 dst=r6 src=r0 offset=0 imm=0
+#line 129 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1047 dst=r6 src=r0 offset=0 imm=0
 #line 129 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1048 dst=r3 src=r6 offset=0 imm=0
@@ -3460,10 +3538,12 @@ label_66:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1051 dst=r3 src=r0 offset=1 imm=-1
 #line 130 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 130 "sample/undocked/map.c"
         goto label_67;
-        // EBPF_OP_JA pc=1052 dst=r0 src=r0 offset=159 imm=0
+#line 130 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1052 dst=r0 src=r0 offset=159 imm=0
 #line 130 "sample/undocked/map.c"
     goto label_77;
 label_67:
@@ -3490,14 +3570,14 @@ label_67:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1061 dst=r0 src=r0 offset=0 imm=2
 #line 135 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1062 dst=r6 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1062 dst=r6 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1063 dst=r3 src=r6 offset=0 imm=0
@@ -3511,10 +3591,12 @@ label_67:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1066 dst=r3 src=r0 offset=1 imm=-1
 #line 136 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 136 "sample/undocked/map.c"
         goto label_68;
-        // EBPF_OP_JA pc=1067 dst=r0 src=r0 offset=144 imm=0
+#line 136 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1067 dst=r0 src=r0 offset=144 imm=0
 #line 136 "sample/undocked/map.c"
     goto label_77;
 label_68:
@@ -3544,14 +3626,14 @@ label_68:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1077 dst=r0 src=r0 offset=0 imm=2
 #line 141 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1078 dst=r6 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1078 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1079 dst=r3 src=r6 offset=0 imm=0
@@ -3565,10 +3647,12 @@ label_68:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1082 dst=r3 src=r0 offset=1 imm=-1
 #line 142 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 142 "sample/undocked/map.c"
         goto label_69;
-        // EBPF_OP_JA pc=1083 dst=r0 src=r0 offset=128 imm=0
+#line 142 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1083 dst=r0 src=r0 offset=128 imm=0
 #line 142 "sample/undocked/map.c"
     goto label_77;
 label_69:
@@ -3598,14 +3682,14 @@ label_69:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1093 dst=r0 src=r0 offset=0 imm=2
 #line 147 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1094 dst=r6 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1094 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1095 dst=r3 src=r6 offset=0 imm=0
@@ -3619,10 +3703,12 @@ label_69:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1098 dst=r3 src=r0 offset=1 imm=-1
 #line 148 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 148 "sample/undocked/map.c"
         goto label_70;
-        // EBPF_OP_JA pc=1099 dst=r0 src=r0 offset=112 imm=0
+#line 148 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1099 dst=r0 src=r0 offset=112 imm=0
 #line 148 "sample/undocked/map.c"
     goto label_77;
 label_70:
@@ -3652,14 +3738,14 @@ label_70:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1109 dst=r0 src=r0 offset=0 imm=2
 #line 153 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1110 dst=r6 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1110 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1111 dst=r3 src=r6 offset=0 imm=0
@@ -3673,10 +3759,12 @@ label_70:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1114 dst=r3 src=r0 offset=1 imm=-1
 #line 154 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 154 "sample/undocked/map.c"
         goto label_71;
-        // EBPF_OP_JA pc=1115 dst=r0 src=r0 offset=96 imm=0
+#line 154 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1115 dst=r0 src=r0 offset=96 imm=0
 #line 154 "sample/undocked/map.c"
     goto label_77;
 label_71:
@@ -3706,14 +3794,14 @@ label_71:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1125 dst=r0 src=r0 offset=0 imm=2
 #line 159 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1126 dst=r6 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1126 dst=r6 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1127 dst=r3 src=r6 offset=0 imm=0
@@ -3727,10 +3815,12 @@ label_71:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1130 dst=r3 src=r0 offset=1 imm=-1
 #line 160 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 160 "sample/undocked/map.c"
         goto label_72;
-        // EBPF_OP_JA pc=1131 dst=r0 src=r0 offset=80 imm=0
+#line 160 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1131 dst=r0 src=r0 offset=80 imm=0
 #line 160 "sample/undocked/map.c"
     goto label_77;
 label_72:
@@ -3760,14 +3850,14 @@ label_72:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1141 dst=r0 src=r0 offset=0 imm=2
 #line 165 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1142 dst=r6 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1142 dst=r6 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1143 dst=r3 src=r6 offset=0 imm=0
@@ -3781,10 +3871,12 @@ label_72:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1146 dst=r3 src=r0 offset=1 imm=-1
 #line 166 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 166 "sample/undocked/map.c"
         goto label_73;
-        // EBPF_OP_JA pc=1147 dst=r0 src=r0 offset=64 imm=0
+#line 166 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1147 dst=r0 src=r0 offset=64 imm=0
 #line 166 "sample/undocked/map.c"
     goto label_77;
 label_73:
@@ -3814,14 +3906,14 @@ label_73:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1157 dst=r0 src=r0 offset=0 imm=2
 #line 171 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 171 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 171 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 171 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1158 dst=r6 src=r0 offset=0 imm=0
+#line 171 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1158 dst=r6 src=r0 offset=0 imm=0
 #line 171 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1159 dst=r3 src=r6 offset=0 imm=0
@@ -3835,10 +3927,12 @@ label_73:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1162 dst=r3 src=r0 offset=1 imm=-1
 #line 172 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 172 "sample/undocked/map.c"
         goto label_74;
-        // EBPF_OP_JA pc=1163 dst=r0 src=r0 offset=48 imm=0
+#line 172 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1163 dst=r0 src=r0 offset=48 imm=0
 #line 172 "sample/undocked/map.c"
     goto label_77;
 label_74:
@@ -3868,14 +3962,14 @@ label_74:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1173 dst=r0 src=r0 offset=0 imm=2
 #line 177 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 177 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 177 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1174 dst=r6 src=r0 offset=0 imm=0
+#line 177 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1174 dst=r6 src=r0 offset=0 imm=0
 #line 177 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1175 dst=r3 src=r6 offset=0 imm=0
@@ -3889,10 +3983,12 @@ label_74:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1178 dst=r3 src=r0 offset=1 imm=-1
 #line 178 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 178 "sample/undocked/map.c"
         goto label_75;
-        // EBPF_OP_JA pc=1179 dst=r0 src=r0 offset=32 imm=0
+#line 178 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1179 dst=r0 src=r0 offset=32 imm=0
 #line 178 "sample/undocked/map.c"
     goto label_77;
 label_75:
@@ -3922,14 +4018,14 @@ label_75:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1189 dst=r0 src=r0 offset=0 imm=2
 #line 183 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 183 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 183 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1190 dst=r6 src=r0 offset=0 imm=0
+#line 183 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1190 dst=r6 src=r0 offset=0 imm=0
 #line 183 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1191 dst=r3 src=r6 offset=0 imm=0
@@ -3943,10 +4039,12 @@ label_75:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1194 dst=r3 src=r0 offset=1 imm=-1
 #line 184 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 184 "sample/undocked/map.c"
         goto label_76;
-        // EBPF_OP_JA pc=1195 dst=r0 src=r0 offset=16 imm=0
+#line 184 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1195 dst=r0 src=r0 offset=16 imm=0
 #line 184 "sample/undocked/map.c"
     goto label_77;
 label_76:
@@ -3979,14 +4077,14 @@ label_76:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1206 dst=r0 src=r0 offset=0 imm=2
 #line 189 "sample/undocked/map.c"
-    r0 = test_maps_helpers[0].address
+    r0 = test_maps_helpers[0].address(r1, r2, r3, r4, r5);
 #line 189 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/undocked/map.c"
-    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0)) {
 #line 189 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1207 dst=r6 src=r0 offset=0 imm=0
+#line 189 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1207 dst=r6 src=r0 offset=0 imm=0
 #line 189 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1208 dst=r3 src=r6 offset=0 imm=0
@@ -4000,9 +4098,11 @@ label_76:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1211 dst=r3 src=r0 offset=35 imm=-1
 #line 190 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 190 "sample/undocked/map.c"
         goto label_78;
+#line 190 "sample/undocked/map.c"
+    }
 label_77:
     // EBPF_OP_LDDW pc=1212 dst=r1 src=r0 offset=0 imm=1684369010
 #line 190 "sample/undocked/map.c"
@@ -4039,14 +4139,14 @@ label_77:
     r2 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=1227 dst=r0 src=r0 offset=0 imm=13
 #line 190 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 190 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 190 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1228 dst=r1 src=r0 offset=0 imm=0
+#line 190 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1228 dst=r1 src=r0 offset=0 imm=0
 #line 190 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1229 dst=r10 src=r1 offset=-20 imm=0
@@ -4103,14 +4203,14 @@ label_78:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1252 dst=r0 src=r0 offset=0 imm=18
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1253 dst=r6 src=r0 offset=0 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1253 dst=r6 src=r0 offset=0 imm=0
 #line 240 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1254 dst=r4 src=r6 offset=0 imm=0
@@ -4130,9 +4230,11 @@ label_78:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1260 dst=r1 src=r2 offset=27 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 240 "sample/undocked/map.c"
         goto label_81;
+#line 240 "sample/undocked/map.c"
+    }
 label_79:
     // EBPF_OP_MOV64_IMM pc=1261 dst=r1 src=r0 offset=0 imm=100
 #line 240 "sample/undocked/map.c"
@@ -4194,14 +4296,14 @@ label_80:
     r3 = IMMEDIATE(-7);
     // EBPF_OP_CALL pc=1286 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1287 dst=r0 src=r0 offset=26 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1287 dst=r0 src=r0 offset=26 imm=0
 #line 240 "sample/undocked/map.c"
     goto label_85;
 label_81:
@@ -4210,9 +4312,11 @@ label_81:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1289 dst=r3 src=r0 offset=90 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 240 "sample/undocked/map.c"
         goto label_90;
+#line 240 "sample/undocked/map.c"
+    }
 label_82:
     // EBPF_OP_LDDW pc=1290 dst=r1 src=r0 offset=0 imm=1852404835
 #line 240 "sample/undocked/map.c"
@@ -4266,14 +4370,14 @@ label_83:
 label_84:
     // EBPF_OP_CALL pc=1311 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=1312 dst=r6 src=r0 offset=0 imm=-1
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1312 dst=r6 src=r0 offset=0 imm=-1
 #line 240 "sample/undocked/map.c"
     r6 = (uint64_t)4294967295;
 label_85:
@@ -4288,10 +4392,12 @@ label_85:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1317 dst=r3 src=r0 offset=1 imm=-1
 #line 303 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 303 "sample/undocked/map.c"
         goto label_86;
-        // EBPF_OP_JA pc=1318 dst=r0 src=r0 offset=42 imm=0
+#line 303 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1318 dst=r0 src=r0 offset=42 imm=0
 #line 303 "sample/undocked/map.c"
     goto label_89;
 label_86:
@@ -4312,14 +4418,14 @@ label_86:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=1325 dst=r0 src=r0 offset=0 imm=18
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1326 dst=r7 src=r0 offset=0 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1326 dst=r7 src=r0 offset=0 imm=0
 #line 240 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1327 dst=r4 src=r7 offset=0 imm=0
@@ -4339,9 +4445,11 @@ label_86:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1333 dst=r1 src=r2 offset=865 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 240 "sample/undocked/map.c"
         goto label_137;
+#line 240 "sample/undocked/map.c"
+    }
 label_87:
     // EBPF_OP_MOV64_IMM pc=1334 dst=r1 src=r0 offset=0 imm=100
 #line 240 "sample/undocked/map.c"
@@ -4403,14 +4511,14 @@ label_88:
     r3 = IMMEDIATE(-7);
     // EBPF_OP_CALL pc=1359 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1360 dst=r0 src=r0 offset=864 imm=0
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1360 dst=r0 src=r0 offset=864 imm=0
 #line 240 "sample/undocked/map.c"
     goto label_141;
 label_89:
@@ -4474,14 +4582,14 @@ label_90:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1386 dst=r0 src=r0 offset=0 imm=17
 #line 241 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 241 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 241 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 241 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1387 dst=r6 src=r0 offset=0 imm=0
+#line 241 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1387 dst=r6 src=r0 offset=0 imm=0
 #line 241 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1388 dst=r4 src=r6 offset=0 imm=0
@@ -4501,9 +4609,11 @@ label_90:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=1394 dst=r1 src=r2 offset=24 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 241 "sample/undocked/map.c"
         goto label_92;
+#line 241 "sample/undocked/map.c"
+    }
 label_91:
     // EBPF_OP_STXB pc=1395 dst=r10 src=r7 offset=-16 imm=0
 #line 241 "sample/undocked/map.c"
@@ -4565,9 +4675,11 @@ label_92:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1420 dst=r3 src=r0 offset=19 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 241 "sample/undocked/map.c"
         goto label_94;
+#line 241 "sample/undocked/map.c"
+    }
 label_93:
     // EBPF_OP_LDDW pc=1421 dst=r1 src=r0 offset=0 imm=1735289204
 #line 241 "sample/undocked/map.c"
@@ -4632,14 +4744,14 @@ label_94:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1447 dst=r0 src=r0 offset=0 imm=16
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1448 dst=r6 src=r0 offset=0 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1448 dst=r6 src=r0 offset=0 imm=0
 #line 249 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1449 dst=r5 src=r6 offset=0 imm=0
@@ -4656,9 +4768,11 @@ label_94:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1453 dst=r1 src=r0 offset=31 imm=0
 #line 249 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 249 "sample/undocked/map.c"
         goto label_98;
+#line 249 "sample/undocked/map.c"
+    }
 label_95:
     // EBPF_OP_MOV64_IMM pc=1454 dst=r1 src=r0 offset=0 imm=25637
 #line 249 "sample/undocked/map.c"
@@ -4733,14 +4847,14 @@ label_96:
 label_97:
     // EBPF_OP_CALL pc=1483 dst=r0 src=r0 offset=0 imm=15
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[10].address
+    r0 = test_maps_helpers[10].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[10].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[10].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1484 dst=r0 src=r0 offset=-171 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1484 dst=r0 src=r0 offset=-171 imm=0
 #line 249 "sample/undocked/map.c"
     goto label_85;
 label_98:
@@ -4767,14 +4881,14 @@ label_98:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1493 dst=r0 src=r0 offset=0 imm=16
 #line 250 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 250 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 250 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 250 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1494 dst=r6 src=r0 offset=0 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1494 dst=r6 src=r0 offset=0 imm=0
 #line 250 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1495 dst=r5 src=r6 offset=0 imm=0
@@ -4791,10 +4905,12 @@ label_98:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1499 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 250 "sample/undocked/map.c"
         goto label_99;
-        // EBPF_OP_JA pc=1500 dst=r0 src=r0 offset=-47 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1500 dst=r0 src=r0 offset=-47 imm=0
 #line 250 "sample/undocked/map.c"
     goto label_95;
 label_99:
@@ -4821,14 +4937,14 @@ label_99:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1509 dst=r0 src=r0 offset=0 imm=16
 #line 251 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 251 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 251 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 251 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1510 dst=r6 src=r0 offset=0 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1510 dst=r6 src=r0 offset=0 imm=0
 #line 251 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1511 dst=r5 src=r6 offset=0 imm=0
@@ -4845,10 +4961,12 @@ label_99:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1515 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 251 "sample/undocked/map.c"
         goto label_100;
-        // EBPF_OP_JA pc=1516 dst=r0 src=r0 offset=-63 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1516 dst=r0 src=r0 offset=-63 imm=0
 #line 251 "sample/undocked/map.c"
     goto label_95;
 label_100:
@@ -4875,14 +4993,14 @@ label_100:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1525 dst=r0 src=r0 offset=0 imm=16
 #line 252 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 252 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 252 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 252 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1526 dst=r6 src=r0 offset=0 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1526 dst=r6 src=r0 offset=0 imm=0
 #line 252 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1527 dst=r5 src=r6 offset=0 imm=0
@@ -4899,10 +5017,12 @@ label_100:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1531 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 252 "sample/undocked/map.c"
         goto label_101;
-        // EBPF_OP_JA pc=1532 dst=r0 src=r0 offset=-79 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1532 dst=r0 src=r0 offset=-79 imm=0
 #line 252 "sample/undocked/map.c"
     goto label_95;
 label_101:
@@ -4929,14 +5049,14 @@ label_101:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1541 dst=r0 src=r0 offset=0 imm=16
 #line 253 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 253 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 253 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 253 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1542 dst=r6 src=r0 offset=0 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1542 dst=r6 src=r0 offset=0 imm=0
 #line 253 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1543 dst=r5 src=r6 offset=0 imm=0
@@ -4953,10 +5073,12 @@ label_101:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1547 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 253 "sample/undocked/map.c"
         goto label_102;
-        // EBPF_OP_JA pc=1548 dst=r0 src=r0 offset=-95 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1548 dst=r0 src=r0 offset=-95 imm=0
 #line 253 "sample/undocked/map.c"
     goto label_95;
 label_102:
@@ -4983,14 +5105,14 @@ label_102:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1557 dst=r0 src=r0 offset=0 imm=16
 #line 254 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 254 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 254 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 254 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1558 dst=r6 src=r0 offset=0 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1558 dst=r6 src=r0 offset=0 imm=0
 #line 254 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1559 dst=r5 src=r6 offset=0 imm=0
@@ -5007,10 +5129,12 @@ label_102:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1563 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 254 "sample/undocked/map.c"
         goto label_103;
-        // EBPF_OP_JA pc=1564 dst=r0 src=r0 offset=-111 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1564 dst=r0 src=r0 offset=-111 imm=0
 #line 254 "sample/undocked/map.c"
     goto label_95;
 label_103:
@@ -5037,14 +5161,14 @@ label_103:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1573 dst=r0 src=r0 offset=0 imm=16
 #line 255 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 255 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 255 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 255 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1574 dst=r6 src=r0 offset=0 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1574 dst=r6 src=r0 offset=0 imm=0
 #line 255 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1575 dst=r5 src=r6 offset=0 imm=0
@@ -5061,10 +5185,12 @@ label_103:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1579 dst=r1 src=r0 offset=1 imm=0
 #line 255 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 255 "sample/undocked/map.c"
         goto label_104;
-        // EBPF_OP_JA pc=1580 dst=r0 src=r0 offset=-127 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1580 dst=r0 src=r0 offset=-127 imm=0
 #line 255 "sample/undocked/map.c"
     goto label_95;
 label_104:
@@ -5091,14 +5217,14 @@ label_104:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1589 dst=r0 src=r0 offset=0 imm=16
 #line 256 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 256 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 256 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 256 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1590 dst=r6 src=r0 offset=0 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1590 dst=r6 src=r0 offset=0 imm=0
 #line 256 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1591 dst=r5 src=r6 offset=0 imm=0
@@ -5115,10 +5241,12 @@ label_104:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1595 dst=r1 src=r0 offset=1 imm=0
 #line 256 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 256 "sample/undocked/map.c"
         goto label_105;
-        // EBPF_OP_JA pc=1596 dst=r0 src=r0 offset=-143 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1596 dst=r0 src=r0 offset=-143 imm=0
 #line 256 "sample/undocked/map.c"
     goto label_95;
 label_105:
@@ -5145,14 +5273,14 @@ label_105:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1605 dst=r0 src=r0 offset=0 imm=16
 #line 257 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 257 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 257 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 257 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1606 dst=r6 src=r0 offset=0 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1606 dst=r6 src=r0 offset=0 imm=0
 #line 257 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1607 dst=r5 src=r6 offset=0 imm=0
@@ -5169,10 +5297,12 @@ label_105:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1611 dst=r1 src=r0 offset=1 imm=0
 #line 257 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 257 "sample/undocked/map.c"
         goto label_106;
-        // EBPF_OP_JA pc=1612 dst=r0 src=r0 offset=-159 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1612 dst=r0 src=r0 offset=-159 imm=0
 #line 257 "sample/undocked/map.c"
     goto label_95;
 label_106:
@@ -5199,14 +5329,14 @@ label_106:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1621 dst=r0 src=r0 offset=0 imm=16
 #line 258 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 258 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 258 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 258 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1622 dst=r6 src=r0 offset=0 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1622 dst=r6 src=r0 offset=0 imm=0
 #line 258 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1623 dst=r5 src=r6 offset=0 imm=0
@@ -5223,10 +5353,12 @@ label_106:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1627 dst=r1 src=r0 offset=1 imm=0
 #line 258 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 258 "sample/undocked/map.c"
         goto label_107;
-        // EBPF_OP_JA pc=1628 dst=r0 src=r0 offset=-175 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1628 dst=r0 src=r0 offset=-175 imm=0
 #line 258 "sample/undocked/map.c"
     goto label_95;
 label_107:
@@ -5253,14 +5385,14 @@ label_107:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1637 dst=r0 src=r0 offset=0 imm=16
 #line 261 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 261 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 261 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 261 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1638 dst=r6 src=r0 offset=0 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1638 dst=r6 src=r0 offset=0 imm=0
 #line 261 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1639 dst=r5 src=r6 offset=0 imm=0
@@ -5280,10 +5412,12 @@ label_107:
     r2 = (uint64_t)4294967267;
     // EBPF_OP_JEQ_REG pc=1645 dst=r1 src=r2 offset=30 imm=0
 #line 261 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 261 "sample/undocked/map.c"
         goto label_108;
-        // EBPF_OP_STXB pc=1646 dst=r10 src=r8 offset=-10 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_STXB pc=1646 dst=r10 src=r8 offset=-10 imm=0
 #line 261 "sample/undocked/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1647 dst=r1 src=r0 offset=0 imm=25637
@@ -5373,14 +5507,14 @@ label_108:
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=1682 dst=r0 src=r0 offset=0 imm=16
 #line 262 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 262 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 262 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 262 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1683 dst=r6 src=r0 offset=0 imm=0
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1683 dst=r6 src=r0 offset=0 imm=0
 #line 262 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1684 dst=r5 src=r6 offset=0 imm=0
@@ -5397,10 +5531,12 @@ label_108:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1688 dst=r1 src=r0 offset=25 imm=0
 #line 262 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 262 "sample/undocked/map.c"
         goto label_109;
-        // EBPF_OP_MOV64_IMM pc=1689 dst=r1 src=r0 offset=0 imm=25637
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1689 dst=r1 src=r0 offset=0 imm=25637
 #line 262 "sample/undocked/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1690 dst=r10 src=r1 offset=-12 imm=0
@@ -5475,14 +5611,14 @@ label_109:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1720 dst=r0 src=r0 offset=0 imm=18
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1721 dst=r6 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1721 dst=r6 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1722 dst=r4 src=r6 offset=0 imm=0
@@ -5499,10 +5635,12 @@ label_109:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1726 dst=r1 src=r0 offset=27 imm=0
 #line 264 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 264 "sample/undocked/map.c"
         goto label_111;
-        // EBPF_OP_MOV64_IMM pc=1727 dst=r1 src=r0 offset=0 imm=100
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1727 dst=r1 src=r0 offset=0 imm=100
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1728 dst=r10 src=r1 offset=-16 imm=0
@@ -5562,14 +5700,14 @@ label_110:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=1752 dst=r0 src=r0 offset=0 imm=14
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=1753 dst=r0 src=r0 offset=-440 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1753 dst=r0 src=r0 offset=-440 imm=0
 #line 264 "sample/undocked/map.c"
     goto label_85;
 label_111:
@@ -5578,10 +5716,12 @@ label_111:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1755 dst=r3 src=r0 offset=22 imm=1
 #line 264 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 264 "sample/undocked/map.c"
         goto label_112;
-        // EBPF_OP_MOV64_IMM pc=1756 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1756 dst=r1 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1757 dst=r10 src=r1 offset=-24 imm=0
@@ -5650,14 +5790,14 @@ label_112:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1784 dst=r0 src=r0 offset=0 imm=17
 #line 272 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 272 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 272 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 272 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1785 dst=r6 src=r0 offset=0 imm=0
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1785 dst=r6 src=r0 offset=0 imm=0
 #line 272 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1786 dst=r4 src=r6 offset=0 imm=0
@@ -5674,9 +5814,11 @@ label_112:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1790 dst=r1 src=r0 offset=24 imm=0
 #line 272 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 272 "sample/undocked/map.c"
         goto label_114;
+#line 272 "sample/undocked/map.c"
+    }
 label_113:
     // EBPF_OP_LDDW pc=1791 dst=r1 src=r0 offset=0 imm=1701737077
 #line 272 "sample/undocked/map.c"
@@ -5738,10 +5880,12 @@ label_114:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1816 dst=r3 src=r0 offset=20 imm=1
 #line 272 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 272 "sample/undocked/map.c"
         goto label_115;
-        // EBPF_OP_LDDW pc=1817 dst=r1 src=r0 offset=0 imm=1735289204
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1817 dst=r1 src=r0 offset=0 imm=1735289204
 #line 272 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1819 dst=r10 src=r1 offset=-32 imm=0
@@ -5804,14 +5948,14 @@ label_115:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1843 dst=r0 src=r0 offset=0 imm=17
 #line 273 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 273 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 273 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 273 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1844 dst=r6 src=r0 offset=0 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1844 dst=r6 src=r0 offset=0 imm=0
 #line 273 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1845 dst=r4 src=r6 offset=0 imm=0
@@ -5828,10 +5972,12 @@ label_115:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1849 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 273 "sample/undocked/map.c"
         goto label_116;
-        // EBPF_OP_JA pc=1850 dst=r0 src=r0 offset=-60 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1850 dst=r0 src=r0 offset=-60 imm=0
 #line 273 "sample/undocked/map.c"
     goto label_113;
 label_116:
@@ -5840,10 +5986,12 @@ label_116:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1852 dst=r3 src=r0 offset=20 imm=2
 #line 273 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(2))
+    if (r3 == IMMEDIATE(2)) {
 #line 273 "sample/undocked/map.c"
         goto label_117;
-        // EBPF_OP_LDDW pc=1853 dst=r1 src=r0 offset=0 imm=1735289204
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1853 dst=r1 src=r0 offset=0 imm=1735289204
 #line 273 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1855 dst=r10 src=r1 offset=-32 imm=0
@@ -5906,14 +6054,14 @@ label_117:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1879 dst=r0 src=r0 offset=0 imm=17
 #line 274 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 274 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 274 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 274 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1880 dst=r6 src=r0 offset=0 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1880 dst=r6 src=r0 offset=0 imm=0
 #line 274 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1881 dst=r4 src=r6 offset=0 imm=0
@@ -5930,10 +6078,12 @@ label_117:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1885 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 274 "sample/undocked/map.c"
         goto label_118;
-        // EBPF_OP_JA pc=1886 dst=r0 src=r0 offset=-96 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1886 dst=r0 src=r0 offset=-96 imm=0
 #line 274 "sample/undocked/map.c"
     goto label_113;
 label_118:
@@ -5942,10 +6092,12 @@ label_118:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1888 dst=r3 src=r0 offset=20 imm=3
 #line 274 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(3))
+    if (r3 == IMMEDIATE(3)) {
 #line 274 "sample/undocked/map.c"
         goto label_119;
-        // EBPF_OP_LDDW pc=1889 dst=r1 src=r0 offset=0 imm=1735289204
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1889 dst=r1 src=r0 offset=0 imm=1735289204
 #line 274 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1891 dst=r10 src=r1 offset=-32 imm=0
@@ -6008,14 +6160,14 @@ label_119:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1915 dst=r0 src=r0 offset=0 imm=17
 #line 275 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 275 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 275 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 275 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1916 dst=r6 src=r0 offset=0 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1916 dst=r6 src=r0 offset=0 imm=0
 #line 275 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1917 dst=r4 src=r6 offset=0 imm=0
@@ -6032,10 +6184,12 @@ label_119:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1921 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 275 "sample/undocked/map.c"
         goto label_120;
-        // EBPF_OP_JA pc=1922 dst=r0 src=r0 offset=-132 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1922 dst=r0 src=r0 offset=-132 imm=0
 #line 275 "sample/undocked/map.c"
     goto label_113;
 label_120:
@@ -6044,10 +6198,12 @@ label_120:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1924 dst=r3 src=r0 offset=20 imm=4
 #line 275 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(4))
+    if (r3 == IMMEDIATE(4)) {
 #line 275 "sample/undocked/map.c"
         goto label_121;
-        // EBPF_OP_LDDW pc=1925 dst=r1 src=r0 offset=0 imm=1735289204
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1925 dst=r1 src=r0 offset=0 imm=1735289204
 #line 275 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1927 dst=r10 src=r1 offset=-32 imm=0
@@ -6110,14 +6266,14 @@ label_121:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1951 dst=r0 src=r0 offset=0 imm=17
 #line 276 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 276 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 276 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 276 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1952 dst=r6 src=r0 offset=0 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1952 dst=r6 src=r0 offset=0 imm=0
 #line 276 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1953 dst=r4 src=r6 offset=0 imm=0
@@ -6134,10 +6290,12 @@ label_121:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1957 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 276 "sample/undocked/map.c"
         goto label_122;
-        // EBPF_OP_JA pc=1958 dst=r0 src=r0 offset=-168 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1958 dst=r0 src=r0 offset=-168 imm=0
 #line 276 "sample/undocked/map.c"
     goto label_113;
 label_122:
@@ -6146,10 +6304,12 @@ label_122:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1960 dst=r3 src=r0 offset=20 imm=5
 #line 276 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(5))
+    if (r3 == IMMEDIATE(5)) {
 #line 276 "sample/undocked/map.c"
         goto label_123;
-        // EBPF_OP_LDDW pc=1961 dst=r1 src=r0 offset=0 imm=1735289204
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1961 dst=r1 src=r0 offset=0 imm=1735289204
 #line 276 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1963 dst=r10 src=r1 offset=-32 imm=0
@@ -6212,14 +6372,14 @@ label_123:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=1987 dst=r0 src=r0 offset=0 imm=17
 #line 277 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 277 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 277 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 277 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1988 dst=r6 src=r0 offset=0 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=1988 dst=r6 src=r0 offset=0 imm=0
 #line 277 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1989 dst=r4 src=r6 offset=0 imm=0
@@ -6236,10 +6396,12 @@ label_123:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1993 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 277 "sample/undocked/map.c"
         goto label_124;
-        // EBPF_OP_JA pc=1994 dst=r0 src=r0 offset=-204 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=1994 dst=r0 src=r0 offset=-204 imm=0
 #line 277 "sample/undocked/map.c"
     goto label_113;
 label_124:
@@ -6248,10 +6410,12 @@ label_124:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=1996 dst=r3 src=r0 offset=20 imm=6
 #line 277 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(6))
+    if (r3 == IMMEDIATE(6)) {
 #line 277 "sample/undocked/map.c"
         goto label_125;
-        // EBPF_OP_LDDW pc=1997 dst=r1 src=r0 offset=0 imm=1735289204
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=1997 dst=r1 src=r0 offset=0 imm=1735289204
 #line 277 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=1999 dst=r10 src=r1 offset=-32 imm=0
@@ -6314,14 +6478,14 @@ label_125:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2023 dst=r0 src=r0 offset=0 imm=17
 #line 278 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 278 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 278 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 278 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2024 dst=r6 src=r0 offset=0 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2024 dst=r6 src=r0 offset=0 imm=0
 #line 278 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2025 dst=r4 src=r6 offset=0 imm=0
@@ -6338,10 +6502,12 @@ label_125:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2029 dst=r1 src=r0 offset=1 imm=0
 #line 278 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 278 "sample/undocked/map.c"
         goto label_126;
-        // EBPF_OP_JA pc=2030 dst=r0 src=r0 offset=-240 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2030 dst=r0 src=r0 offset=-240 imm=0
 #line 278 "sample/undocked/map.c"
     goto label_113;
 label_126:
@@ -6350,10 +6516,12 @@ label_126:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2032 dst=r3 src=r0 offset=20 imm=7
 #line 278 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(7))
+    if (r3 == IMMEDIATE(7)) {
 #line 278 "sample/undocked/map.c"
         goto label_127;
-        // EBPF_OP_LDDW pc=2033 dst=r1 src=r0 offset=0 imm=1735289204
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2033 dst=r1 src=r0 offset=0 imm=1735289204
 #line 278 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2035 dst=r10 src=r1 offset=-32 imm=0
@@ -6416,14 +6584,14 @@ label_127:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2059 dst=r0 src=r0 offset=0 imm=17
 #line 279 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 279 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 279 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 279 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2060 dst=r6 src=r0 offset=0 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2060 dst=r6 src=r0 offset=0 imm=0
 #line 279 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2061 dst=r4 src=r6 offset=0 imm=0
@@ -6440,10 +6608,12 @@ label_127:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2065 dst=r1 src=r0 offset=1 imm=0
 #line 279 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 279 "sample/undocked/map.c"
         goto label_128;
-        // EBPF_OP_JA pc=2066 dst=r0 src=r0 offset=-276 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2066 dst=r0 src=r0 offset=-276 imm=0
 #line 279 "sample/undocked/map.c"
     goto label_113;
 label_128:
@@ -6452,10 +6622,12 @@ label_128:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2068 dst=r3 src=r0 offset=20 imm=8
 #line 279 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(8))
+    if (r3 == IMMEDIATE(8)) {
 #line 279 "sample/undocked/map.c"
         goto label_129;
-        // EBPF_OP_LDDW pc=2069 dst=r1 src=r0 offset=0 imm=1735289204
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2069 dst=r1 src=r0 offset=0 imm=1735289204
 #line 279 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2071 dst=r10 src=r1 offset=-32 imm=0
@@ -6518,14 +6690,14 @@ label_129:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2095 dst=r0 src=r0 offset=0 imm=17
 #line 280 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 280 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 280 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 280 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2096 dst=r6 src=r0 offset=0 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2096 dst=r6 src=r0 offset=0 imm=0
 #line 280 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2097 dst=r4 src=r6 offset=0 imm=0
@@ -6542,10 +6714,12 @@ label_129:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2101 dst=r1 src=r0 offset=1 imm=0
 #line 280 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 280 "sample/undocked/map.c"
         goto label_130;
-        // EBPF_OP_JA pc=2102 dst=r0 src=r0 offset=-312 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2102 dst=r0 src=r0 offset=-312 imm=0
 #line 280 "sample/undocked/map.c"
     goto label_113;
 label_130:
@@ -6554,10 +6728,12 @@ label_130:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2104 dst=r3 src=r0 offset=20 imm=9
 #line 280 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(9))
+    if (r3 == IMMEDIATE(9)) {
 #line 280 "sample/undocked/map.c"
         goto label_131;
-        // EBPF_OP_LDDW pc=2105 dst=r1 src=r0 offset=0 imm=1735289204
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2105 dst=r1 src=r0 offset=0 imm=1735289204
 #line 280 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2107 dst=r10 src=r1 offset=-32 imm=0
@@ -6620,14 +6796,14 @@ label_131:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2131 dst=r0 src=r0 offset=0 imm=17
 #line 281 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 281 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 281 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 281 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2132 dst=r6 src=r0 offset=0 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2132 dst=r6 src=r0 offset=0 imm=0
 #line 281 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2133 dst=r4 src=r6 offset=0 imm=0
@@ -6644,10 +6820,12 @@ label_131:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2137 dst=r1 src=r0 offset=1 imm=0
 #line 281 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 281 "sample/undocked/map.c"
         goto label_132;
-        // EBPF_OP_JA pc=2138 dst=r0 src=r0 offset=-348 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2138 dst=r0 src=r0 offset=-348 imm=0
 #line 281 "sample/undocked/map.c"
     goto label_113;
 label_132:
@@ -6656,10 +6834,12 @@ label_132:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2140 dst=r3 src=r0 offset=20 imm=10
 #line 281 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 281 "sample/undocked/map.c"
         goto label_133;
-        // EBPF_OP_LDDW pc=2141 dst=r1 src=r0 offset=0 imm=1735289204
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2141 dst=r1 src=r0 offset=0 imm=1735289204
 #line 281 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2143 dst=r10 src=r1 offset=-32 imm=0
@@ -6722,14 +6902,14 @@ label_133:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2167 dst=r0 src=r0 offset=0 imm=18
 #line 284 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 284 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 284 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 284 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2168 dst=r6 src=r0 offset=0 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2168 dst=r6 src=r0 offset=0 imm=0
 #line 284 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2169 dst=r4 src=r6 offset=0 imm=0
@@ -6749,10 +6929,12 @@ label_133:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2175 dst=r1 src=r2 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 284 "sample/undocked/map.c"
         goto label_134;
-        // EBPF_OP_JA pc=2176 dst=r0 src=r0 offset=-916 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2176 dst=r0 src=r0 offset=-916 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_79;
 label_134:
@@ -6761,10 +6943,12 @@ label_134:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2178 dst=r3 src=r0 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 284 "sample/undocked/map.c"
         goto label_135;
-        // EBPF_OP_JA pc=2179 dst=r0 src=r0 offset=-890 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2179 dst=r0 src=r0 offset=-890 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_82;
 label_135:
@@ -6785,14 +6969,14 @@ label_135:
     r1 = POINTER(_maps[6].address);
     // EBPF_OP_CALL pc=2186 dst=r0 src=r0 offset=0 imm=17
 #line 285 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 285 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 285 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 285 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2187 dst=r6 src=r0 offset=0 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2187 dst=r6 src=r0 offset=0 imm=0
 #line 285 "sample/undocked/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=2188 dst=r4 src=r6 offset=0 imm=0
@@ -6812,10 +6996,12 @@ label_135:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2194 dst=r1 src=r2 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 285 "sample/undocked/map.c"
         goto label_136;
-        // EBPF_OP_JA pc=2195 dst=r0 src=r0 offset=-801 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2195 dst=r0 src=r0 offset=-801 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_91;
 label_136:
@@ -6824,10 +7010,12 @@ label_136:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2197 dst=r3 src=r0 offset=-879 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 285 "sample/undocked/map.c"
         goto label_86;
-        // EBPF_OP_JA pc=2198 dst=r0 src=r0 offset=-778 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2198 dst=r0 src=r0 offset=-778 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_93;
 label_137:
@@ -6836,9 +7024,11 @@ label_137:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2200 dst=r3 src=r0 offset=50 imm=0
 #line 240 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 240 "sample/undocked/map.c"
         goto label_142;
+#line 240 "sample/undocked/map.c"
+    }
 label_138:
     // EBPF_OP_LDDW pc=2201 dst=r1 src=r0 offset=0 imm=1852404835
 #line 240 "sample/undocked/map.c"
@@ -6892,14 +7082,14 @@ label_139:
 label_140:
     // EBPF_OP_CALL pc=2222 dst=r0 src=r0 offset=0 imm=14
 #line 240 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 240 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 240 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 240 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_LDDW pc=2223 dst=r7 src=r0 offset=0 imm=-1
+#line 240 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2223 dst=r7 src=r0 offset=0 imm=-1
 #line 240 "sample/undocked/map.c"
     r7 = (uint64_t)4294967295;
 label_141:
@@ -6917,10 +7107,12 @@ label_141:
     r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=2229 dst=r3 src=r0 offset=-2128 imm=-1
 #line 304 "sample/undocked/map.c"
-    if ((int64_t)r3 > IMMEDIATE(-1))
+    if ((int64_t)r3 > IMMEDIATE(-1)) {
 #line 304 "sample/undocked/map.c"
         goto label_9;
-        // EBPF_OP_LDDW pc=2230 dst=r1 src=r0 offset=0 imm=1684369010
+#line 304 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2230 dst=r1 src=r0 offset=0 imm=1684369010
 #line 304 "sample/undocked/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=2232 dst=r10 src=r1 offset=-32 imm=0
@@ -6961,14 +7153,14 @@ label_141:
     r2 = IMMEDIATE(40);
     // EBPF_OP_CALL pc=2248 dst=r0 src=r0 offset=0 imm=13
 #line 304 "sample/undocked/map.c"
-    r0 = test_maps_helpers[4].address
+    r0 = test_maps_helpers[4].address(r1, r2, r3, r4, r5);
 #line 304 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 304 "sample/undocked/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0)) {
 #line 304 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2249 dst=r6 src=r7 offset=0 imm=0
+#line 304 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2249 dst=r6 src=r7 offset=0 imm=0
 #line 304 "sample/undocked/map.c"
     r6 = r7;
     // EBPF_OP_JA pc=2250 dst=r0 src=r0 offset=-2149 imm=0
@@ -6992,14 +7184,14 @@ label_142:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2257 dst=r0 src=r0 offset=0 imm=17
 #line 241 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 241 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 241 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 241 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2258 dst=r7 src=r0 offset=0 imm=0
+#line 241 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2258 dst=r7 src=r0 offset=0 imm=0
 #line 241 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2259 dst=r4 src=r7 offset=0 imm=0
@@ -7019,9 +7211,11 @@ label_142:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=2265 dst=r1 src=r2 offset=24 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 241 "sample/undocked/map.c"
         goto label_144;
+#line 241 "sample/undocked/map.c"
+    }
 label_143:
     // EBPF_OP_STXB pc=2266 dst=r10 src=r6 offset=-16 imm=0
 #line 241 "sample/undocked/map.c"
@@ -7083,9 +7277,11 @@ label_144:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2291 dst=r3 src=r0 offset=19 imm=0
 #line 241 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 241 "sample/undocked/map.c"
         goto label_146;
+#line 241 "sample/undocked/map.c"
+    }
 label_145:
     // EBPF_OP_LDDW pc=2292 dst=r1 src=r0 offset=0 imm=1735289204
 #line 241 "sample/undocked/map.c"
@@ -7150,14 +7346,14 @@ label_146:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2318 dst=r0 src=r0 offset=0 imm=16
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2319 dst=r7 src=r0 offset=0 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2319 dst=r7 src=r0 offset=0 imm=0
 #line 249 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2320 dst=r5 src=r7 offset=0 imm=0
@@ -7174,9 +7370,11 @@ label_146:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2324 dst=r1 src=r0 offset=31 imm=0
 #line 249 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 249 "sample/undocked/map.c"
         goto label_150;
+#line 249 "sample/undocked/map.c"
+    }
 label_147:
     // EBPF_OP_MOV64_IMM pc=2325 dst=r1 src=r0 offset=0 imm=25637
 #line 249 "sample/undocked/map.c"
@@ -7251,14 +7449,14 @@ label_148:
 label_149:
     // EBPF_OP_CALL pc=2354 dst=r0 src=r0 offset=0 imm=15
 #line 249 "sample/undocked/map.c"
-    r0 = test_maps_helpers[10].address
+    r0 = test_maps_helpers[10].address(r1, r2, r3, r4, r5);
 #line 249 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 249 "sample/undocked/map.c"
-    if ((test_maps_helpers[10].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[10].tail_call) && (r0 == 0)) {
 #line 249 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=2355 dst=r0 src=r0 offset=-131 imm=0
+#line 249 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2355 dst=r0 src=r0 offset=-131 imm=0
 #line 249 "sample/undocked/map.c"
     goto label_141;
 label_150:
@@ -7285,14 +7483,14 @@ label_150:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2364 dst=r0 src=r0 offset=0 imm=16
 #line 250 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 250 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 250 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 250 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2365 dst=r7 src=r0 offset=0 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2365 dst=r7 src=r0 offset=0 imm=0
 #line 250 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2366 dst=r5 src=r7 offset=0 imm=0
@@ -7309,10 +7507,12 @@ label_150:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2370 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 250 "sample/undocked/map.c"
         goto label_151;
-        // EBPF_OP_JA pc=2371 dst=r0 src=r0 offset=-47 imm=0
+#line 250 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2371 dst=r0 src=r0 offset=-47 imm=0
 #line 250 "sample/undocked/map.c"
     goto label_147;
 label_151:
@@ -7339,14 +7539,14 @@ label_151:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2380 dst=r0 src=r0 offset=0 imm=16
 #line 251 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 251 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 251 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 251 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2381 dst=r7 src=r0 offset=0 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2381 dst=r7 src=r0 offset=0 imm=0
 #line 251 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2382 dst=r5 src=r7 offset=0 imm=0
@@ -7363,10 +7563,12 @@ label_151:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2386 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 251 "sample/undocked/map.c"
         goto label_152;
-        // EBPF_OP_JA pc=2387 dst=r0 src=r0 offset=-63 imm=0
+#line 251 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2387 dst=r0 src=r0 offset=-63 imm=0
 #line 251 "sample/undocked/map.c"
     goto label_147;
 label_152:
@@ -7393,14 +7595,14 @@ label_152:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2396 dst=r0 src=r0 offset=0 imm=16
 #line 252 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 252 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 252 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 252 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2397 dst=r7 src=r0 offset=0 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2397 dst=r7 src=r0 offset=0 imm=0
 #line 252 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2398 dst=r5 src=r7 offset=0 imm=0
@@ -7417,10 +7619,12 @@ label_152:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2402 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 252 "sample/undocked/map.c"
         goto label_153;
-        // EBPF_OP_JA pc=2403 dst=r0 src=r0 offset=-79 imm=0
+#line 252 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2403 dst=r0 src=r0 offset=-79 imm=0
 #line 252 "sample/undocked/map.c"
     goto label_147;
 label_153:
@@ -7447,14 +7651,14 @@ label_153:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2412 dst=r0 src=r0 offset=0 imm=16
 #line 253 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 253 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 253 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 253 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2413 dst=r7 src=r0 offset=0 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2413 dst=r7 src=r0 offset=0 imm=0
 #line 253 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2414 dst=r5 src=r7 offset=0 imm=0
@@ -7471,10 +7675,12 @@ label_153:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2418 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 253 "sample/undocked/map.c"
         goto label_154;
-        // EBPF_OP_JA pc=2419 dst=r0 src=r0 offset=-95 imm=0
+#line 253 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2419 dst=r0 src=r0 offset=-95 imm=0
 #line 253 "sample/undocked/map.c"
     goto label_147;
 label_154:
@@ -7501,14 +7707,14 @@ label_154:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2428 dst=r0 src=r0 offset=0 imm=16
 #line 254 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 254 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 254 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 254 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2429 dst=r7 src=r0 offset=0 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2429 dst=r7 src=r0 offset=0 imm=0
 #line 254 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2430 dst=r5 src=r7 offset=0 imm=0
@@ -7525,10 +7731,12 @@ label_154:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2434 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 254 "sample/undocked/map.c"
         goto label_155;
-        // EBPF_OP_JA pc=2435 dst=r0 src=r0 offset=-111 imm=0
+#line 254 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2435 dst=r0 src=r0 offset=-111 imm=0
 #line 254 "sample/undocked/map.c"
     goto label_147;
 label_155:
@@ -7555,14 +7763,14 @@ label_155:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2444 dst=r0 src=r0 offset=0 imm=16
 #line 255 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 255 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 255 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 255 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2445 dst=r7 src=r0 offset=0 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2445 dst=r7 src=r0 offset=0 imm=0
 #line 255 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2446 dst=r5 src=r7 offset=0 imm=0
@@ -7579,10 +7787,12 @@ label_155:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2450 dst=r1 src=r0 offset=1 imm=0
 #line 255 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 255 "sample/undocked/map.c"
         goto label_156;
-        // EBPF_OP_JA pc=2451 dst=r0 src=r0 offset=-127 imm=0
+#line 255 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2451 dst=r0 src=r0 offset=-127 imm=0
 #line 255 "sample/undocked/map.c"
     goto label_147;
 label_156:
@@ -7609,14 +7819,14 @@ label_156:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2460 dst=r0 src=r0 offset=0 imm=16
 #line 256 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 256 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 256 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 256 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2461 dst=r7 src=r0 offset=0 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2461 dst=r7 src=r0 offset=0 imm=0
 #line 256 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2462 dst=r5 src=r7 offset=0 imm=0
@@ -7633,10 +7843,12 @@ label_156:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2466 dst=r1 src=r0 offset=1 imm=0
 #line 256 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 256 "sample/undocked/map.c"
         goto label_157;
-        // EBPF_OP_JA pc=2467 dst=r0 src=r0 offset=-143 imm=0
+#line 256 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2467 dst=r0 src=r0 offset=-143 imm=0
 #line 256 "sample/undocked/map.c"
     goto label_147;
 label_157:
@@ -7663,14 +7875,14 @@ label_157:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2476 dst=r0 src=r0 offset=0 imm=16
 #line 257 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 257 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 257 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 257 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2477 dst=r7 src=r0 offset=0 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2477 dst=r7 src=r0 offset=0 imm=0
 #line 257 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2478 dst=r5 src=r7 offset=0 imm=0
@@ -7687,10 +7899,12 @@ label_157:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2482 dst=r1 src=r0 offset=1 imm=0
 #line 257 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 257 "sample/undocked/map.c"
         goto label_158;
-        // EBPF_OP_JA pc=2483 dst=r0 src=r0 offset=-159 imm=0
+#line 257 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2483 dst=r0 src=r0 offset=-159 imm=0
 #line 257 "sample/undocked/map.c"
     goto label_147;
 label_158:
@@ -7717,14 +7931,14 @@ label_158:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2492 dst=r0 src=r0 offset=0 imm=16
 #line 258 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 258 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 258 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 258 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2493 dst=r7 src=r0 offset=0 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2493 dst=r7 src=r0 offset=0 imm=0
 #line 258 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2494 dst=r5 src=r7 offset=0 imm=0
@@ -7741,10 +7955,12 @@ label_158:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2498 dst=r1 src=r0 offset=1 imm=0
 #line 258 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 258 "sample/undocked/map.c"
         goto label_159;
-        // EBPF_OP_JA pc=2499 dst=r0 src=r0 offset=-175 imm=0
+#line 258 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2499 dst=r0 src=r0 offset=-175 imm=0
 #line 258 "sample/undocked/map.c"
     goto label_147;
 label_159:
@@ -7771,14 +7987,14 @@ label_159:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2508 dst=r0 src=r0 offset=0 imm=16
 #line 261 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 261 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 261 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 261 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2509 dst=r7 src=r0 offset=0 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2509 dst=r7 src=r0 offset=0 imm=0
 #line 261 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2510 dst=r5 src=r7 offset=0 imm=0
@@ -7798,10 +8014,12 @@ label_159:
     r2 = (uint64_t)4294967267;
     // EBPF_OP_JEQ_REG pc=2516 dst=r1 src=r2 offset=30 imm=0
 #line 261 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 261 "sample/undocked/map.c"
         goto label_160;
-        // EBPF_OP_STXB pc=2517 dst=r10 src=r8 offset=-10 imm=0
+#line 261 "sample/undocked/map.c"
+    }
+    // EBPF_OP_STXB pc=2517 dst=r10 src=r8 offset=-10 imm=0
 #line 261 "sample/undocked/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=2518 dst=r1 src=r0 offset=0 imm=25637
@@ -7891,14 +8109,14 @@ label_160:
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=2553 dst=r0 src=r0 offset=0 imm=16
 #line 262 "sample/undocked/map.c"
-    r0 = test_maps_helpers[9].address
+    r0 = test_maps_helpers[9].address(r1, r2, r3, r4, r5);
 #line 262 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 262 "sample/undocked/map.c"
-    if ((test_maps_helpers[9].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[9].tail_call) && (r0 == 0)) {
 #line 262 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2554 dst=r7 src=r0 offset=0 imm=0
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2554 dst=r7 src=r0 offset=0 imm=0
 #line 262 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2555 dst=r5 src=r7 offset=0 imm=0
@@ -7915,10 +8133,12 @@ label_160:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2559 dst=r1 src=r0 offset=25 imm=0
 #line 262 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 262 "sample/undocked/map.c"
         goto label_161;
-        // EBPF_OP_MOV64_IMM pc=2560 dst=r1 src=r0 offset=0 imm=25637
+#line 262 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2560 dst=r1 src=r0 offset=0 imm=25637
 #line 262 "sample/undocked/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=2561 dst=r10 src=r1 offset=-12 imm=0
@@ -7993,14 +8213,14 @@ label_161:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2591 dst=r0 src=r0 offset=0 imm=18
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2592 dst=r7 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2592 dst=r7 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2593 dst=r4 src=r7 offset=0 imm=0
@@ -8017,10 +8237,12 @@ label_161:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2597 dst=r1 src=r0 offset=27 imm=0
 #line 264 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 264 "sample/undocked/map.c"
         goto label_163;
-        // EBPF_OP_MOV64_IMM pc=2598 dst=r1 src=r0 offset=0 imm=100
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2598 dst=r1 src=r0 offset=0 imm=100
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=2599 dst=r10 src=r1 offset=-16 imm=0
@@ -8080,14 +8302,14 @@ label_162:
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=2623 dst=r0 src=r0 offset=0 imm=14
 #line 264 "sample/undocked/map.c"
-    r0 = test_maps_helpers[7].address
+    r0 = test_maps_helpers[7].address(r1, r2, r3, r4, r5);
 #line 264 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 264 "sample/undocked/map.c"
-    if ((test_maps_helpers[7].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[7].tail_call) && (r0 == 0)) {
 #line 264 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_JA pc=2624 dst=r0 src=r0 offset=-400 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2624 dst=r0 src=r0 offset=-400 imm=0
 #line 264 "sample/undocked/map.c"
     goto label_141;
 label_163:
@@ -8096,10 +8318,12 @@ label_163:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2626 dst=r3 src=r0 offset=22 imm=10
 #line 264 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 264 "sample/undocked/map.c"
         goto label_164;
-        // EBPF_OP_MOV64_IMM pc=2627 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=2627 dst=r1 src=r0 offset=0 imm=0
 #line 264 "sample/undocked/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=2628 dst=r10 src=r1 offset=-24 imm=0
@@ -8168,14 +8392,14 @@ label_164:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2655 dst=r0 src=r0 offset=0 imm=17
 #line 272 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 272 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 272 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 272 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2656 dst=r7 src=r0 offset=0 imm=0
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2656 dst=r7 src=r0 offset=0 imm=0
 #line 272 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2657 dst=r4 src=r7 offset=0 imm=0
@@ -8192,9 +8416,11 @@ label_164:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2661 dst=r1 src=r0 offset=24 imm=0
 #line 272 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 272 "sample/undocked/map.c"
         goto label_166;
+#line 272 "sample/undocked/map.c"
+    }
 label_165:
     // EBPF_OP_LDDW pc=2662 dst=r1 src=r0 offset=0 imm=1701737077
 #line 272 "sample/undocked/map.c"
@@ -8256,10 +8482,12 @@ label_166:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2687 dst=r3 src=r0 offset=20 imm=10
 #line 272 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(10))
+    if (r3 == IMMEDIATE(10)) {
 #line 272 "sample/undocked/map.c"
         goto label_167;
-        // EBPF_OP_LDDW pc=2688 dst=r1 src=r0 offset=0 imm=1735289204
+#line 272 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2688 dst=r1 src=r0 offset=0 imm=1735289204
 #line 272 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2690 dst=r10 src=r1 offset=-32 imm=0
@@ -8322,14 +8550,14 @@ label_167:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2714 dst=r0 src=r0 offset=0 imm=17
 #line 273 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 273 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 273 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 273 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2715 dst=r7 src=r0 offset=0 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2715 dst=r7 src=r0 offset=0 imm=0
 #line 273 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2716 dst=r4 src=r7 offset=0 imm=0
@@ -8346,10 +8574,12 @@ label_167:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2720 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 273 "sample/undocked/map.c"
         goto label_168;
-        // EBPF_OP_JA pc=2721 dst=r0 src=r0 offset=-60 imm=0
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2721 dst=r0 src=r0 offset=-60 imm=0
 #line 273 "sample/undocked/map.c"
     goto label_165;
 label_168:
@@ -8358,10 +8588,12 @@ label_168:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2723 dst=r3 src=r0 offset=20 imm=9
 #line 273 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(9))
+    if (r3 == IMMEDIATE(9)) {
 #line 273 "sample/undocked/map.c"
         goto label_169;
-        // EBPF_OP_LDDW pc=2724 dst=r1 src=r0 offset=0 imm=1735289204
+#line 273 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2724 dst=r1 src=r0 offset=0 imm=1735289204
 #line 273 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2726 dst=r10 src=r1 offset=-32 imm=0
@@ -8424,14 +8656,14 @@ label_169:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2750 dst=r0 src=r0 offset=0 imm=17
 #line 274 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 274 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 274 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 274 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2751 dst=r7 src=r0 offset=0 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2751 dst=r7 src=r0 offset=0 imm=0
 #line 274 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2752 dst=r4 src=r7 offset=0 imm=0
@@ -8448,10 +8680,12 @@ label_169:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2756 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 274 "sample/undocked/map.c"
         goto label_170;
-        // EBPF_OP_JA pc=2757 dst=r0 src=r0 offset=-96 imm=0
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2757 dst=r0 src=r0 offset=-96 imm=0
 #line 274 "sample/undocked/map.c"
     goto label_165;
 label_170:
@@ -8460,10 +8694,12 @@ label_170:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2759 dst=r3 src=r0 offset=20 imm=8
 #line 274 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(8))
+    if (r3 == IMMEDIATE(8)) {
 #line 274 "sample/undocked/map.c"
         goto label_171;
-        // EBPF_OP_LDDW pc=2760 dst=r1 src=r0 offset=0 imm=1735289204
+#line 274 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2760 dst=r1 src=r0 offset=0 imm=1735289204
 #line 274 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2762 dst=r10 src=r1 offset=-32 imm=0
@@ -8526,14 +8762,14 @@ label_171:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2786 dst=r0 src=r0 offset=0 imm=17
 #line 275 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 275 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 275 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 275 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2787 dst=r7 src=r0 offset=0 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2787 dst=r7 src=r0 offset=0 imm=0
 #line 275 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2788 dst=r4 src=r7 offset=0 imm=0
@@ -8550,10 +8786,12 @@ label_171:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2792 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 275 "sample/undocked/map.c"
         goto label_172;
-        // EBPF_OP_JA pc=2793 dst=r0 src=r0 offset=-132 imm=0
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2793 dst=r0 src=r0 offset=-132 imm=0
 #line 275 "sample/undocked/map.c"
     goto label_165;
 label_172:
@@ -8562,10 +8800,12 @@ label_172:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2795 dst=r3 src=r0 offset=20 imm=7
 #line 275 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(7))
+    if (r3 == IMMEDIATE(7)) {
 #line 275 "sample/undocked/map.c"
         goto label_173;
-        // EBPF_OP_LDDW pc=2796 dst=r1 src=r0 offset=0 imm=1735289204
+#line 275 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2796 dst=r1 src=r0 offset=0 imm=1735289204
 #line 275 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2798 dst=r10 src=r1 offset=-32 imm=0
@@ -8628,14 +8868,14 @@ label_173:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2822 dst=r0 src=r0 offset=0 imm=17
 #line 276 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 276 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 276 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 276 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2823 dst=r7 src=r0 offset=0 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2823 dst=r7 src=r0 offset=0 imm=0
 #line 276 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2824 dst=r4 src=r7 offset=0 imm=0
@@ -8652,10 +8892,12 @@ label_173:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2828 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 276 "sample/undocked/map.c"
         goto label_174;
-        // EBPF_OP_JA pc=2829 dst=r0 src=r0 offset=-168 imm=0
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2829 dst=r0 src=r0 offset=-168 imm=0
 #line 276 "sample/undocked/map.c"
     goto label_165;
 label_174:
@@ -8664,10 +8906,12 @@ label_174:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2831 dst=r3 src=r0 offset=20 imm=6
 #line 276 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(6))
+    if (r3 == IMMEDIATE(6)) {
 #line 276 "sample/undocked/map.c"
         goto label_175;
-        // EBPF_OP_LDDW pc=2832 dst=r1 src=r0 offset=0 imm=1735289204
+#line 276 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2832 dst=r1 src=r0 offset=0 imm=1735289204
 #line 276 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2834 dst=r10 src=r1 offset=-32 imm=0
@@ -8730,14 +8974,14 @@ label_175:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2858 dst=r0 src=r0 offset=0 imm=17
 #line 277 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 277 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 277 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 277 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2859 dst=r7 src=r0 offset=0 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2859 dst=r7 src=r0 offset=0 imm=0
 #line 277 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2860 dst=r4 src=r7 offset=0 imm=0
@@ -8754,10 +8998,12 @@ label_175:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2864 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 277 "sample/undocked/map.c"
         goto label_176;
-        // EBPF_OP_JA pc=2865 dst=r0 src=r0 offset=-204 imm=0
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2865 dst=r0 src=r0 offset=-204 imm=0
 #line 277 "sample/undocked/map.c"
     goto label_165;
 label_176:
@@ -8766,10 +9012,12 @@ label_176:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2867 dst=r3 src=r0 offset=20 imm=5
 #line 277 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(5))
+    if (r3 == IMMEDIATE(5)) {
 #line 277 "sample/undocked/map.c"
         goto label_177;
-        // EBPF_OP_LDDW pc=2868 dst=r1 src=r0 offset=0 imm=1735289204
+#line 277 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2868 dst=r1 src=r0 offset=0 imm=1735289204
 #line 277 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2870 dst=r10 src=r1 offset=-32 imm=0
@@ -8832,14 +9080,14 @@ label_177:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2894 dst=r0 src=r0 offset=0 imm=17
 #line 278 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 278 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 278 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 278 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2895 dst=r7 src=r0 offset=0 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2895 dst=r7 src=r0 offset=0 imm=0
 #line 278 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2896 dst=r4 src=r7 offset=0 imm=0
@@ -8856,10 +9104,12 @@ label_177:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2900 dst=r1 src=r0 offset=1 imm=0
 #line 278 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 278 "sample/undocked/map.c"
         goto label_178;
-        // EBPF_OP_JA pc=2901 dst=r0 src=r0 offset=-240 imm=0
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2901 dst=r0 src=r0 offset=-240 imm=0
 #line 278 "sample/undocked/map.c"
     goto label_165;
 label_178:
@@ -8868,10 +9118,12 @@ label_178:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2903 dst=r3 src=r0 offset=20 imm=4
 #line 278 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(4))
+    if (r3 == IMMEDIATE(4)) {
 #line 278 "sample/undocked/map.c"
         goto label_179;
-        // EBPF_OP_LDDW pc=2904 dst=r1 src=r0 offset=0 imm=1735289204
+#line 278 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2904 dst=r1 src=r0 offset=0 imm=1735289204
 #line 278 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2906 dst=r10 src=r1 offset=-32 imm=0
@@ -8934,14 +9186,14 @@ label_179:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2930 dst=r0 src=r0 offset=0 imm=17
 #line 279 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 279 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 279 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 279 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2931 dst=r7 src=r0 offset=0 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2931 dst=r7 src=r0 offset=0 imm=0
 #line 279 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2932 dst=r4 src=r7 offset=0 imm=0
@@ -8958,10 +9210,12 @@ label_179:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2936 dst=r1 src=r0 offset=1 imm=0
 #line 279 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 279 "sample/undocked/map.c"
         goto label_180;
-        // EBPF_OP_JA pc=2937 dst=r0 src=r0 offset=-276 imm=0
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2937 dst=r0 src=r0 offset=-276 imm=0
 #line 279 "sample/undocked/map.c"
     goto label_165;
 label_180:
@@ -8970,10 +9224,12 @@ label_180:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2939 dst=r3 src=r0 offset=20 imm=3
 #line 279 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(3))
+    if (r3 == IMMEDIATE(3)) {
 #line 279 "sample/undocked/map.c"
         goto label_181;
-        // EBPF_OP_LDDW pc=2940 dst=r1 src=r0 offset=0 imm=1735289204
+#line 279 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2940 dst=r1 src=r0 offset=0 imm=1735289204
 #line 279 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2942 dst=r10 src=r1 offset=-32 imm=0
@@ -9036,14 +9292,14 @@ label_181:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=2966 dst=r0 src=r0 offset=0 imm=17
 #line 280 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 280 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 280 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 280 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=2967 dst=r7 src=r0 offset=0 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=2967 dst=r7 src=r0 offset=0 imm=0
 #line 280 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2968 dst=r4 src=r7 offset=0 imm=0
@@ -9060,10 +9316,12 @@ label_181:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2972 dst=r1 src=r0 offset=1 imm=0
 #line 280 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 280 "sample/undocked/map.c"
         goto label_182;
-        // EBPF_OP_JA pc=2973 dst=r0 src=r0 offset=-312 imm=0
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=2973 dst=r0 src=r0 offset=-312 imm=0
 #line 280 "sample/undocked/map.c"
     goto label_165;
 label_182:
@@ -9072,10 +9330,12 @@ label_182:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=2975 dst=r3 src=r0 offset=20 imm=2
 #line 280 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(2))
+    if (r3 == IMMEDIATE(2)) {
 #line 280 "sample/undocked/map.c"
         goto label_183;
-        // EBPF_OP_LDDW pc=2976 dst=r1 src=r0 offset=0 imm=1735289204
+#line 280 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=2976 dst=r1 src=r0 offset=0 imm=1735289204
 #line 280 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=2978 dst=r10 src=r1 offset=-32 imm=0
@@ -9138,14 +9398,14 @@ label_183:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3002 dst=r0 src=r0 offset=0 imm=17
 #line 281 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 281 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 281 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 281 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3003 dst=r7 src=r0 offset=0 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3003 dst=r7 src=r0 offset=0 imm=0
 #line 281 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3004 dst=r4 src=r7 offset=0 imm=0
@@ -9162,10 +9422,12 @@ label_183:
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=3008 dst=r1 src=r0 offset=1 imm=0
 #line 281 "sample/undocked/map.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 281 "sample/undocked/map.c"
         goto label_184;
-        // EBPF_OP_JA pc=3009 dst=r0 src=r0 offset=-348 imm=0
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3009 dst=r0 src=r0 offset=-348 imm=0
 #line 281 "sample/undocked/map.c"
     goto label_165;
 label_184:
@@ -9174,10 +9436,12 @@ label_184:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3011 dst=r3 src=r0 offset=20 imm=1
 #line 281 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(1))
+    if (r3 == IMMEDIATE(1)) {
 #line 281 "sample/undocked/map.c"
         goto label_185;
-        // EBPF_OP_LDDW pc=3012 dst=r1 src=r0 offset=0 imm=1735289204
+#line 281 "sample/undocked/map.c"
+    }
+    // EBPF_OP_LDDW pc=3012 dst=r1 src=r0 offset=0 imm=1735289204
 #line 281 "sample/undocked/map.c"
     r1 = (uint64_t)28188318775535988;
     // EBPF_OP_STXDW pc=3014 dst=r10 src=r1 offset=-32 imm=0
@@ -9240,14 +9504,14 @@ label_185:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3038 dst=r0 src=r0 offset=0 imm=18
 #line 284 "sample/undocked/map.c"
-    r0 = test_maps_helpers[6].address
+    r0 = test_maps_helpers[6].address(r1, r2, r3, r4, r5);
 #line 284 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 284 "sample/undocked/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0)) {
 #line 284 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3039 dst=r7 src=r0 offset=0 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3039 dst=r7 src=r0 offset=0 imm=0
 #line 284 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3040 dst=r4 src=r7 offset=0 imm=0
@@ -9267,10 +9531,12 @@ label_185:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=3046 dst=r1 src=r2 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 284 "sample/undocked/map.c"
         goto label_186;
-        // EBPF_OP_JA pc=3047 dst=r0 src=r0 offset=-1714 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3047 dst=r0 src=r0 offset=-1714 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_87;
 label_186:
@@ -9279,10 +9545,12 @@ label_186:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3049 dst=r3 src=r0 offset=1 imm=0
 #line 284 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 284 "sample/undocked/map.c"
         goto label_187;
-        // EBPF_OP_JA pc=3050 dst=r0 src=r0 offset=-850 imm=0
+#line 284 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3050 dst=r0 src=r0 offset=-850 imm=0
 #line 284 "sample/undocked/map.c"
     goto label_138;
 label_187:
@@ -9303,14 +9571,14 @@ label_187:
     r1 = POINTER(_maps[7].address);
     // EBPF_OP_CALL pc=3057 dst=r0 src=r0 offset=0 imm=17
 #line 285 "sample/undocked/map.c"
-    r0 = test_maps_helpers[8].address
+    r0 = test_maps_helpers[8].address(r1, r2, r3, r4, r5);
 #line 285 "sample/undocked/map.c"
-         (r1, r2, r3, r4, r5);
-#line 285 "sample/undocked/map.c"
-    if ((test_maps_helpers[8].tail_call) && (r0 == 0))
+    if ((test_maps_helpers[8].tail_call) && (r0 == 0)) {
 #line 285 "sample/undocked/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=3058 dst=r7 src=r0 offset=0 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=3058 dst=r7 src=r0 offset=0 imm=0
 #line 285 "sample/undocked/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=3059 dst=r4 src=r7 offset=0 imm=0
@@ -9330,10 +9598,12 @@ label_187:
     r2 = (uint64_t)4294967289;
     // EBPF_OP_JEQ_REG pc=3065 dst=r1 src=r2 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r1 == r2)
+    if (r1 == r2) {
 #line 285 "sample/undocked/map.c"
         goto label_188;
-        // EBPF_OP_JA pc=3066 dst=r0 src=r0 offset=-801 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3066 dst=r0 src=r0 offset=-801 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_143;
 label_188:
@@ -9342,10 +9612,12 @@ label_188:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_JEQ_IMM pc=3068 dst=r3 src=r0 offset=1 imm=0
 #line 285 "sample/undocked/map.c"
-    if (r3 == IMMEDIATE(0))
+    if (r3 == IMMEDIATE(0)) {
 #line 285 "sample/undocked/map.c"
         goto label_189;
-        // EBPF_OP_JA pc=3069 dst=r0 src=r0 offset=-778 imm=0
+#line 285 "sample/undocked/map.c"
+    }
+    // EBPF_OP_JA pc=3069 dst=r0 src=r0 offset=-778 imm=0
 #line 285 "sample/undocked/map.c"
     goto label_145;
 label_189:

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -115,27 +115,31 @@ func(void* context)
     r2 = IMMEDIATE(16);
     // EBPF_OP_JGT_REG pc=3 dst=r2 src=r1 offset=18 imm=0
 #line 46 "sample/pidtgid.c"
-    if (r2 > r1)
+    if (r2 > r1) {
 #line 46 "sample/pidtgid.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
+#line 46 "sample/pidtgid.c"
+    }
+    // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
 #line 46 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
 #line 46 "sample/pidtgid.c"
-    if (r1 != IMMEDIATE(15295))
+    if (r1 != IMMEDIATE(15295)) {
 #line 46 "sample/pidtgid.c"
         goto label_1;
-        // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
+#line 46 "sample/pidtgid.c"
+    }
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
 #line 47 "sample/pidtgid.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 47 "sample/pidtgid.c"
-         (r1, r2, r3, r4, r5);
-#line 47 "sample/pidtgid.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 47 "sample/pidtgid.c"
         return 0;
-        // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
+#line 47 "sample/pidtgid.c"
+    }
+    // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
 #line 49 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
@@ -176,13 +180,13 @@ func(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=21 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/pidtgid.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/pidtgid.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/pidtgid.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/pidtgid.c"
         return 0;
+#line 51 "sample/pidtgid.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=0
 #line 54 "sample/pidtgid.c"

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -89,27 +89,31 @@ func(void* context)
     r2 = IMMEDIATE(16);
     // EBPF_OP_JGT_REG pc=3 dst=r2 src=r1 offset=18 imm=0
 #line 46 "sample/pidtgid.c"
-    if (r2 > r1)
+    if (r2 > r1) {
 #line 46 "sample/pidtgid.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
+#line 46 "sample/pidtgid.c"
+    }
+    // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
 #line 46 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
 #line 46 "sample/pidtgid.c"
-    if (r1 != IMMEDIATE(15295))
+    if (r1 != IMMEDIATE(15295)) {
 #line 46 "sample/pidtgid.c"
         goto label_1;
-        // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
+#line 46 "sample/pidtgid.c"
+    }
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
 #line 47 "sample/pidtgid.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 47 "sample/pidtgid.c"
-         (r1, r2, r3, r4, r5);
-#line 47 "sample/pidtgid.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 47 "sample/pidtgid.c"
         return 0;
-        // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
+#line 47 "sample/pidtgid.c"
+    }
+    // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
 #line 49 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
@@ -150,13 +154,13 @@ func(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=21 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/pidtgid.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/pidtgid.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/pidtgid.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/pidtgid.c"
         return 0;
+#line 51 "sample/pidtgid.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=0
 #line 54 "sample/pidtgid.c"

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -250,27 +250,31 @@ func(void* context)
     r2 = IMMEDIATE(16);
     // EBPF_OP_JGT_REG pc=3 dst=r2 src=r1 offset=18 imm=0
 #line 46 "sample/pidtgid.c"
-    if (r2 > r1)
+    if (r2 > r1) {
 #line 46 "sample/pidtgid.c"
         goto label_1;
-        // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
+#line 46 "sample/pidtgid.c"
+    }
+    // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
 #line 46 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
 #line 46 "sample/pidtgid.c"
-    if (r1 != IMMEDIATE(15295))
+    if (r1 != IMMEDIATE(15295)) {
 #line 46 "sample/pidtgid.c"
         goto label_1;
-        // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
+#line 46 "sample/pidtgid.c"
+    }
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
 #line 47 "sample/pidtgid.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 47 "sample/pidtgid.c"
-         (r1, r2, r3, r4, r5);
-#line 47 "sample/pidtgid.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 47 "sample/pidtgid.c"
         return 0;
-        // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
+#line 47 "sample/pidtgid.c"
+    }
+    // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
 #line 49 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
@@ -311,13 +315,13 @@ func(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=21 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/pidtgid.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 51 "sample/pidtgid.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/pidtgid.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/pidtgid.c"
         return 0;
+#line 51 "sample/pidtgid.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=0
 #line 54 "sample/pidtgid.c"

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -124,14 +124,14 @@ func(void* context)
     r2 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=12
 #line 23 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 23 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 23 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 23 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
+#line 23 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r9 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -157,26 +157,26 @@ func(void* context)
     r2 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 24 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 24 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 24 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 24 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+#line 24 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=19
 #line 27 "sample/printk.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 27 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 27 "sample/printk.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 27 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
+#line 27 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=1852404597
@@ -220,14 +220,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=13
 #line 28 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 28 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 28 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 28 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
+#line 28 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
 #line 28 "sample/printk.c"
     r1 = IMMEDIATE(7695397);
     // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-16 imm=0
@@ -262,14 +262,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=53 dst=r0 src=r0 offset=0 imm=13
 #line 29 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 29 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 29 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
+#line 29 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
 #line 29 "sample/printk.c"
     r1 = IMMEDIATE(1819026725);
     // EBPF_OP_STXW pc=55 dst=r10 src=r1 offset=-16 imm=0
@@ -307,14 +307,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=13
 #line 30 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 30 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 30 "sample/printk.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
+#line 30 "sample/printk.c"
+    }
+    // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
 #line 30 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_STXH pc=70 dst=r10 src=r9 offset=-16 imm=0
@@ -349,14 +349,14 @@ func(void* context)
     r2 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=14
 #line 31 "sample/printk.c"
-    r0 = func_helpers[3].address
+    r0 = func_helpers[3].address(r1, r2, r3, r4, r5);
 #line 31 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/printk.c"
-    if ((func_helpers[3].tail_call) && (r0 == 0))
+    if ((func_helpers[3].tail_call) && (r0 == 0)) {
 #line 31 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
+#line 31 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(117);
     // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-4 imm=0
@@ -403,14 +403,14 @@ func(void* context)
     r2 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=99 dst=r0 src=r0 offset=0 imm=15
 #line 33 "sample/printk.c"
-    r0 = func_helpers[4].address
+    r0 = func_helpers[4].address(r1, r2, r3, r4, r5);
 #line 33 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/printk.c"
-    if ((func_helpers[4].tail_call) && (r0 == 0))
+    if ((func_helpers[4].tail_call) && (r0 == 0)) {
 #line 33 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
+#line 33 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-28 imm=0
@@ -442,14 +442,14 @@ func(void* context)
     r2 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=110 dst=r0 src=r0 offset=0 imm=12
 #line 37 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 37 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 37 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
+#line 37 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
 #line 37 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-32 imm=0
@@ -475,14 +475,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=120 dst=r0 src=r0 offset=0 imm=12
 #line 38 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 38 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 38 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
+#line 38 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
 #line 38 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-32 imm=0
@@ -508,14 +508,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=130 dst=r0 src=r0 offset=0 imm=13
 #line 39 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 39 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 39 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
+#line 39 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
 #line 39 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=133 dst=r10 src=r1 offset=-32 imm=0
@@ -538,14 +538,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=139 dst=r0 src=r0 offset=0 imm=13
 #line 40 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 40 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 40 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 40 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
+#line 40 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
 #line 40 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=141 dst=r10 src=r1 offset=-32 imm=0
@@ -571,14 +571,14 @@ func(void* context)
     r2 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=148 dst=r0 src=r0 offset=0 imm=13
 #line 44 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 44 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 44 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
+#line 44 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
 #line 44 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=151 dst=r10 src=r1 offset=-32 imm=0
@@ -598,14 +598,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=156 dst=r0 src=r0 offset=0 imm=12
 #line 45 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 45 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 45 "sample/printk.c"
         return 0;
-        // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
+#line 45 "sample/printk.c"
+    }
+    // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
 #line 48 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=158 dst=r1 src=r0 offset=0 imm=25966
@@ -634,14 +634,14 @@ func(void* context)
     r2 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=167 dst=r0 src=r0 offset=0 imm=12
 #line 48 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/printk.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
+#line 48 "sample/printk.c"
+    }
+    // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
 #line 48 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=169 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -123,14 +123,14 @@ func(void* context)
     r2 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=12
 #line 31 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 31 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 31 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+#line 31 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 31 "sample/printk_legacy.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -156,14 +156,14 @@ func(void* context)
     r2 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 32 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 32 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 32 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 32 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+#line 32 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 32 "sample/printk_legacy.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -189,14 +189,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=13
 #line 35 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 35 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 35 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 35 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+#line 35 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 35 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -234,14 +234,14 @@ func(void* context)
     r2 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=14
 #line 36 "sample/printk_legacy.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 36 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/printk_legacy.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 36 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+#line 36 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 38 "sample/printk_legacy.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -288,14 +288,14 @@ func(void* context)
     r2 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=15
 #line 38 "sample/printk_legacy.c"
-    r0 = func_helpers[3].address
+    r0 = func_helpers[3].address(r1, r2, r3, r4, r5);
 #line 38 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/printk_legacy.c"
-    if ((func_helpers[3].tail_call) && (r0 == 0))
+    if ((func_helpers[3].tail_call) && (r0 == 0)) {
 #line 38 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+#line 38 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 38 "sample/printk_legacy.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -327,14 +327,14 @@ func(void* context)
     r2 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=74 dst=r0 src=r0 offset=0 imm=12
 #line 42 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+#line 42 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 42 "sample/printk_legacy.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -360,14 +360,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=12
 #line 43 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+#line 43 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 43 "sample/printk_legacy.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -393,14 +393,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=13
 #line 44 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 44 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 44 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+#line 44 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 44 "sample/printk_legacy.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -423,14 +423,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=13
 #line 45 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+#line 45 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 45 "sample/printk_legacy.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -456,14 +456,14 @@ func(void* context)
     r2 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=112 dst=r0 src=r0 offset=0 imm=13
 #line 49 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 49 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 49 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 49 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+#line 49 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 49 "sample/printk_legacy.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -483,14 +483,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=120 dst=r0 src=r0 offset=0 imm=12
 #line 50 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 50 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 50 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 50 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+#line 50 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 53 "sample/printk_legacy.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -519,14 +519,14 @@ func(void* context)
     r2 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=131 dst=r0 src=r0 offset=0 imm=12
 #line 53 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+#line 53 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -97,14 +97,14 @@ func(void* context)
     r2 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=12
 #line 31 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 31 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 31 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+#line 31 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 31 "sample/printk_legacy.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -130,14 +130,14 @@ func(void* context)
     r2 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 32 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 32 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 32 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 32 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+#line 32 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 32 "sample/printk_legacy.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -163,14 +163,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=13
 #line 35 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 35 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 35 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 35 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+#line 35 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 35 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -208,14 +208,14 @@ func(void* context)
     r2 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=14
 #line 36 "sample/printk_legacy.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 36 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/printk_legacy.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 36 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+#line 36 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 38 "sample/printk_legacy.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -262,14 +262,14 @@ func(void* context)
     r2 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=15
 #line 38 "sample/printk_legacy.c"
-    r0 = func_helpers[3].address
+    r0 = func_helpers[3].address(r1, r2, r3, r4, r5);
 #line 38 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/printk_legacy.c"
-    if ((func_helpers[3].tail_call) && (r0 == 0))
+    if ((func_helpers[3].tail_call) && (r0 == 0)) {
 #line 38 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+#line 38 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 38 "sample/printk_legacy.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -301,14 +301,14 @@ func(void* context)
     r2 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=74 dst=r0 src=r0 offset=0 imm=12
 #line 42 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+#line 42 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 42 "sample/printk_legacy.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -334,14 +334,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=12
 #line 43 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+#line 43 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 43 "sample/printk_legacy.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -367,14 +367,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=13
 #line 44 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 44 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 44 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+#line 44 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 44 "sample/printk_legacy.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -397,14 +397,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=13
 #line 45 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+#line 45 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 45 "sample/printk_legacy.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -430,14 +430,14 @@ func(void* context)
     r2 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=112 dst=r0 src=r0 offset=0 imm=13
 #line 49 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 49 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 49 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 49 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+#line 49 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 49 "sample/printk_legacy.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -457,14 +457,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=120 dst=r0 src=r0 offset=0 imm=12
 #line 50 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 50 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 50 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 50 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+#line 50 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 53 "sample/printk_legacy.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -493,14 +493,14 @@ func(void* context)
     r2 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=131 dst=r0 src=r0 offset=0 imm=12
 #line 53 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+#line 53 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -258,14 +258,14 @@ func(void* context)
     r2 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=12
 #line 31 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 31 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 31 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+#line 31 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 31 "sample/printk_legacy.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -291,14 +291,14 @@ func(void* context)
     r2 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 32 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 32 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 32 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 32 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+#line 32 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 32 "sample/printk_legacy.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -324,14 +324,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=13
 #line 35 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 35 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 35 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 35 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+#line 35 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 35 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -369,14 +369,14 @@ func(void* context)
     r2 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=14
 #line 36 "sample/printk_legacy.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 36 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/printk_legacy.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 36 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+#line 36 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 38 "sample/printk_legacy.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -423,14 +423,14 @@ func(void* context)
     r2 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=15
 #line 38 "sample/printk_legacy.c"
-    r0 = func_helpers[3].address
+    r0 = func_helpers[3].address(r1, r2, r3, r4, r5);
 #line 38 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/printk_legacy.c"
-    if ((func_helpers[3].tail_call) && (r0 == 0))
+    if ((func_helpers[3].tail_call) && (r0 == 0)) {
 #line 38 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+#line 38 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 38 "sample/printk_legacy.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -462,14 +462,14 @@ func(void* context)
     r2 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=74 dst=r0 src=r0 offset=0 imm=12
 #line 42 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 42 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 42 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+#line 42 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 42 "sample/printk_legacy.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -495,14 +495,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=12
 #line 43 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+#line 43 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 43 "sample/printk_legacy.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -528,14 +528,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=13
 #line 44 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 44 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 44 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+#line 44 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 44 "sample/printk_legacy.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -558,14 +558,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=13
 #line 45 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+#line 45 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 45 "sample/printk_legacy.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -591,14 +591,14 @@ func(void* context)
     r2 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=112 dst=r0 src=r0 offset=0 imm=13
 #line 49 "sample/printk_legacy.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 49 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 49 "sample/printk_legacy.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 49 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+#line 49 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 49 "sample/printk_legacy.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -618,14 +618,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=120 dst=r0 src=r0 offset=0 imm=12
 #line 50 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 50 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 50 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 50 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+#line 50 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 53 "sample/printk_legacy.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -654,14 +654,14 @@ func(void* context)
     r2 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=131 dst=r0 src=r0 offset=0 imm=12
 #line 53 "sample/printk_legacy.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 53 "sample/printk_legacy.c"
-         (r1, r2, r3, r4, r5);
-#line 53 "sample/printk_legacy.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 53 "sample/printk_legacy.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+#line 53 "sample/printk_legacy.c"
+    }
+    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -98,14 +98,14 @@ func(void* context)
     r2 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=12
 #line 23 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 23 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 23 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 23 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
+#line 23 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r9 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -131,26 +131,26 @@ func(void* context)
     r2 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 24 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 24 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 24 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 24 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+#line 24 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=19
 #line 27 "sample/printk.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 27 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 27 "sample/printk.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 27 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
+#line 27 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=1852404597
@@ -194,14 +194,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=13
 #line 28 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 28 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 28 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 28 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
+#line 28 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
 #line 28 "sample/printk.c"
     r1 = IMMEDIATE(7695397);
     // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-16 imm=0
@@ -236,14 +236,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=53 dst=r0 src=r0 offset=0 imm=13
 #line 29 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 29 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 29 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
+#line 29 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
 #line 29 "sample/printk.c"
     r1 = IMMEDIATE(1819026725);
     // EBPF_OP_STXW pc=55 dst=r10 src=r1 offset=-16 imm=0
@@ -281,14 +281,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=13
 #line 30 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 30 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 30 "sample/printk.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
+#line 30 "sample/printk.c"
+    }
+    // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
 #line 30 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_STXH pc=70 dst=r10 src=r9 offset=-16 imm=0
@@ -323,14 +323,14 @@ func(void* context)
     r2 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=14
 #line 31 "sample/printk.c"
-    r0 = func_helpers[3].address
+    r0 = func_helpers[3].address(r1, r2, r3, r4, r5);
 #line 31 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/printk.c"
-    if ((func_helpers[3].tail_call) && (r0 == 0))
+    if ((func_helpers[3].tail_call) && (r0 == 0)) {
 #line 31 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
+#line 31 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(117);
     // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-4 imm=0
@@ -377,14 +377,14 @@ func(void* context)
     r2 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=99 dst=r0 src=r0 offset=0 imm=15
 #line 33 "sample/printk.c"
-    r0 = func_helpers[4].address
+    r0 = func_helpers[4].address(r1, r2, r3, r4, r5);
 #line 33 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/printk.c"
-    if ((func_helpers[4].tail_call) && (r0 == 0))
+    if ((func_helpers[4].tail_call) && (r0 == 0)) {
 #line 33 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
+#line 33 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-28 imm=0
@@ -416,14 +416,14 @@ func(void* context)
     r2 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=110 dst=r0 src=r0 offset=0 imm=12
 #line 37 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 37 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 37 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
+#line 37 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
 #line 37 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-32 imm=0
@@ -449,14 +449,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=120 dst=r0 src=r0 offset=0 imm=12
 #line 38 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 38 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 38 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
+#line 38 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
 #line 38 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-32 imm=0
@@ -482,14 +482,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=130 dst=r0 src=r0 offset=0 imm=13
 #line 39 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 39 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 39 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
+#line 39 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
 #line 39 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=133 dst=r10 src=r1 offset=-32 imm=0
@@ -512,14 +512,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=139 dst=r0 src=r0 offset=0 imm=13
 #line 40 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 40 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 40 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 40 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
+#line 40 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
 #line 40 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=141 dst=r10 src=r1 offset=-32 imm=0
@@ -545,14 +545,14 @@ func(void* context)
     r2 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=148 dst=r0 src=r0 offset=0 imm=13
 #line 44 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 44 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 44 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
+#line 44 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
 #line 44 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=151 dst=r10 src=r1 offset=-32 imm=0
@@ -572,14 +572,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=156 dst=r0 src=r0 offset=0 imm=12
 #line 45 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 45 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 45 "sample/printk.c"
         return 0;
-        // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
+#line 45 "sample/printk.c"
+    }
+    // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
 #line 48 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=158 dst=r1 src=r0 offset=0 imm=25966
@@ -608,14 +608,14 @@ func(void* context)
     r2 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=167 dst=r0 src=r0 offset=0 imm=12
 #line 48 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/printk.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
+#line 48 "sample/printk.c"
+    }
+    // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
 #line 48 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=169 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -259,14 +259,14 @@ func(void* context)
     r2 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=12
 #line 23 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 23 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 23 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 23 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
+#line 23 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r9 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -292,26 +292,26 @@ func(void* context)
     r2 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 24 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 24 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 24 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 24 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+#line 24 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=19
 #line 27 "sample/printk.c"
-    r0 = func_helpers[1].address
+    r0 = func_helpers[1].address(r1, r2, r3, r4, r5);
 #line 27 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 27 "sample/printk.c"
-    if ((func_helpers[1].tail_call) && (r0 == 0))
+    if ((func_helpers[1].tail_call) && (r0 == 0)) {
 #line 27 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
+#line 27 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=1852404597
@@ -355,14 +355,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=13
 #line 28 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 28 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 28 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 28 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
+#line 28 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
 #line 28 "sample/printk.c"
     r1 = IMMEDIATE(7695397);
     // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-16 imm=0
@@ -397,14 +397,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=53 dst=r0 src=r0 offset=0 imm=13
 #line 29 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 29 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 29 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 29 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
+#line 29 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
 #line 29 "sample/printk.c"
     r1 = IMMEDIATE(1819026725);
     // EBPF_OP_STXW pc=55 dst=r10 src=r1 offset=-16 imm=0
@@ -442,14 +442,14 @@ func(void* context)
     r3 = r8;
     // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=13
 #line 30 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 30 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 30 "sample/printk.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
+#line 30 "sample/printk.c"
+    }
+    // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
 #line 30 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_STXH pc=70 dst=r10 src=r9 offset=-16 imm=0
@@ -484,14 +484,14 @@ func(void* context)
     r2 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=14
 #line 31 "sample/printk.c"
-    r0 = func_helpers[3].address
+    r0 = func_helpers[3].address(r1, r2, r3, r4, r5);
 #line 31 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/printk.c"
-    if ((func_helpers[3].tail_call) && (r0 == 0))
+    if ((func_helpers[3].tail_call) && (r0 == 0)) {
 #line 31 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
+#line 31 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(117);
     // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-4 imm=0
@@ -538,14 +538,14 @@ func(void* context)
     r2 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=99 dst=r0 src=r0 offset=0 imm=15
 #line 33 "sample/printk.c"
-    r0 = func_helpers[4].address
+    r0 = func_helpers[4].address(r1, r2, r3, r4, r5);
 #line 33 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/printk.c"
-    if ((func_helpers[4].tail_call) && (r0 == 0))
+    if ((func_helpers[4].tail_call) && (r0 == 0)) {
 #line 33 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
+#line 33 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-28 imm=0
@@ -577,14 +577,14 @@ func(void* context)
     r2 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=110 dst=r0 src=r0 offset=0 imm=12
 #line 37 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 37 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 37 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
+#line 37 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
 #line 37 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-32 imm=0
@@ -610,14 +610,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=120 dst=r0 src=r0 offset=0 imm=12
 #line 38 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 38 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 38 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
+#line 38 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
 #line 38 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-32 imm=0
@@ -643,14 +643,14 @@ func(void* context)
     r2 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=130 dst=r0 src=r0 offset=0 imm=13
 #line 39 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 39 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 39 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
+#line 39 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
 #line 39 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=133 dst=r10 src=r1 offset=-32 imm=0
@@ -673,14 +673,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=139 dst=r0 src=r0 offset=0 imm=13
 #line 40 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 40 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 40 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 40 "sample/printk.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
+#line 40 "sample/printk.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
 #line 40 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=141 dst=r10 src=r1 offset=-32 imm=0
@@ -706,14 +706,14 @@ func(void* context)
     r2 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=148 dst=r0 src=r0 offset=0 imm=13
 #line 44 "sample/printk.c"
-    r0 = func_helpers[2].address
+    r0 = func_helpers[2].address(r1, r2, r3, r4, r5);
 #line 44 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 44 "sample/printk.c"
-    if ((func_helpers[2].tail_call) && (r0 == 0))
+    if ((func_helpers[2].tail_call) && (r0 == 0)) {
 #line 44 "sample/printk.c"
         return 0;
-        // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
+#line 44 "sample/printk.c"
+    }
+    // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
 #line 44 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=151 dst=r10 src=r1 offset=-32 imm=0
@@ -733,14 +733,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=156 dst=r0 src=r0 offset=0 imm=12
 #line 45 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 45 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 45 "sample/printk.c"
         return 0;
-        // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
+#line 45 "sample/printk.c"
+    }
+    // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
 #line 48 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=158 dst=r1 src=r0 offset=0 imm=25966
@@ -769,14 +769,14 @@ func(void* context)
     r2 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=167 dst=r0 src=r0 offset=0 imm=12
 #line 48 "sample/printk.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 48 "sample/printk.c"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/printk.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 48 "sample/printk.c"
         return 0;
-        // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
+#line 48 "sample/printk.c"
+    }
+    // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
 #line 48 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=169 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_dll.c
@@ -100,14 +100,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=13
 #line 22 "sample/unsafe/printk_unsafe.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 22 "sample/unsafe/printk_unsafe.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/unsafe/printk_unsafe.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 22 "sample/unsafe/printk_unsafe.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/unsafe/printk_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
 #line 23 "sample/unsafe/printk_unsafe.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=9 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_unsafe_raw.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_raw.c
@@ -74,14 +74,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=13
 #line 22 "sample/unsafe/printk_unsafe.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 22 "sample/unsafe/printk_unsafe.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/unsafe/printk_unsafe.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 22 "sample/unsafe/printk_unsafe.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/unsafe/printk_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
 #line 23 "sample/unsafe/printk_unsafe.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=9 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_sys.c
@@ -235,14 +235,14 @@ func(void* context)
     r2 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=13
 #line 22 "sample/unsafe/printk_unsafe.c"
-    r0 = func_helpers[0].address
+    r0 = func_helpers[0].address(r1, r2, r3, r4, r5);
 #line 22 "sample/unsafe/printk_unsafe.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/unsafe/printk_unsafe.c"
-    if ((func_helpers[0].tail_call) && (r0 == 0))
+    if ((func_helpers[0].tail_call) && (r0 == 0)) {
 #line 22 "sample/unsafe/printk_unsafe.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/unsafe/printk_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
 #line 23 "sample/unsafe/printk_unsafe.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=9 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -95,23 +95,29 @@ reflect_packet(void* context)
     r2 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=5 dst=r2 src=r3 offset=211 imm=0
 #line 29 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+#line 29 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=60 imm=56710
 #line 34 "sample/reflect_packet.c"
-    if (r4 == IMMEDIATE(56710))
+    if (r4 == IMMEDIATE(56710)) {
 #line 34 "sample/reflect_packet.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=208 imm=8
 #line 34 "sample/reflect_packet.c"
-    if (r4 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=208 imm=8
+#line 34 "sample/reflect_packet.c"
+    if (r4 != IMMEDIATE(8)) {
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+#line 34 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 35 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -119,18 +125,22 @@ reflect_packet(void* context)
     r4 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=11 dst=r4 src=r3 offset=205 imm=0
 #line 35 "sample/reflect_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 35 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+#line 35 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=203 imm=17
 #line 41 "sample/reflect_packet.c"
-    if (r4 != IMMEDIATE(17))
+    if (r4 != IMMEDIATE(17)) {
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+#line 41 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
@@ -150,18 +160,22 @@ reflect_packet(void* context)
     r4 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=20 dst=r4 src=r3 offset=196 imm=0
 #line 41 "sample/reflect_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=21 dst=r3 src=r2 offset=2 imm=0
+#line 41 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=21 dst=r3 src=r2 offset=2 imm=0
 #line 47 "sample/reflect_packet.c"
     r3 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r3 src=r0 offset=194 imm=7459
 #line 47 "sample/reflect_packet.c"
-    if (r3 != IMMEDIATE(7459))
+    if (r3 != IMMEDIATE(7459)) {
 #line 47 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=23 dst=r3 src=r1 offset=5 imm=0
+#line 47 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=23 dst=r3 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r3 src=r0 offset=0 imm=8
@@ -305,10 +319,12 @@ label_1:
     r2 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=70 dst=r2 src=r3 offset=146 imm=0
 #line 56 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 56 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=71 dst=r2 src=r1 offset=0 imm=0
+#line 56 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=71 dst=r2 src=r1 offset=0 imm=0
 #line 56 "sample/reflect_packet.c"
     r2 = r1;
     // EBPF_OP_ADD64_IMM pc=72 dst=r2 src=r0 offset=0 imm=62
@@ -316,26 +332,32 @@ label_1:
     r2 += IMMEDIATE(62);
     // EBPF_OP_JGT_REG pc=73 dst=r2 src=r3 offset=143 imm=0
 #line 62 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=20 imm=0
+#line 62 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=20 imm=0
 #line 62 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=75 dst=r2 src=r0 offset=141 imm=17
 #line 62 "sample/reflect_packet.c"
-    if (r2 != IMMEDIATE(17))
+    if (r2 != IMMEDIATE(17)) {
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=76 dst=r2 src=r1 offset=56 imm=0
+#line 62 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=76 dst=r2 src=r1 offset=56 imm=0
 #line 68 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=77 dst=r2 src=r0 offset=139 imm=7459
 #line 68 "sample/reflect_packet.c"
-    if (r2 != IMMEDIATE(7459))
+    if (r2 != IMMEDIATE(7459)) {
 #line 68 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=78 dst=r2 src=r1 offset=5 imm=0
+#line 68 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=78 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -69,23 +69,29 @@ reflect_packet(void* context)
     r2 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=5 dst=r2 src=r3 offset=211 imm=0
 #line 29 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+#line 29 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=60 imm=56710
 #line 34 "sample/reflect_packet.c"
-    if (r4 == IMMEDIATE(56710))
+    if (r4 == IMMEDIATE(56710)) {
 #line 34 "sample/reflect_packet.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=208 imm=8
 #line 34 "sample/reflect_packet.c"
-    if (r4 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=208 imm=8
+#line 34 "sample/reflect_packet.c"
+    if (r4 != IMMEDIATE(8)) {
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+#line 34 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 35 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -93,18 +99,22 @@ reflect_packet(void* context)
     r4 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=11 dst=r4 src=r3 offset=205 imm=0
 #line 35 "sample/reflect_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 35 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+#line 35 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=203 imm=17
 #line 41 "sample/reflect_packet.c"
-    if (r4 != IMMEDIATE(17))
+    if (r4 != IMMEDIATE(17)) {
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+#line 41 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
@@ -124,18 +134,22 @@ reflect_packet(void* context)
     r4 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=20 dst=r4 src=r3 offset=196 imm=0
 #line 41 "sample/reflect_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=21 dst=r3 src=r2 offset=2 imm=0
+#line 41 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=21 dst=r3 src=r2 offset=2 imm=0
 #line 47 "sample/reflect_packet.c"
     r3 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r3 src=r0 offset=194 imm=7459
 #line 47 "sample/reflect_packet.c"
-    if (r3 != IMMEDIATE(7459))
+    if (r3 != IMMEDIATE(7459)) {
 #line 47 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=23 dst=r3 src=r1 offset=5 imm=0
+#line 47 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=23 dst=r3 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r3 src=r0 offset=0 imm=8
@@ -279,10 +293,12 @@ label_1:
     r2 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=70 dst=r2 src=r3 offset=146 imm=0
 #line 56 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 56 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=71 dst=r2 src=r1 offset=0 imm=0
+#line 56 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=71 dst=r2 src=r1 offset=0 imm=0
 #line 56 "sample/reflect_packet.c"
     r2 = r1;
     // EBPF_OP_ADD64_IMM pc=72 dst=r2 src=r0 offset=0 imm=62
@@ -290,26 +306,32 @@ label_1:
     r2 += IMMEDIATE(62);
     // EBPF_OP_JGT_REG pc=73 dst=r2 src=r3 offset=143 imm=0
 #line 62 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=20 imm=0
+#line 62 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=20 imm=0
 #line 62 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=75 dst=r2 src=r0 offset=141 imm=17
 #line 62 "sample/reflect_packet.c"
-    if (r2 != IMMEDIATE(17))
+    if (r2 != IMMEDIATE(17)) {
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=76 dst=r2 src=r1 offset=56 imm=0
+#line 62 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=76 dst=r2 src=r1 offset=56 imm=0
 #line 68 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=77 dst=r2 src=r0 offset=139 imm=7459
 #line 68 "sample/reflect_packet.c"
-    if (r2 != IMMEDIATE(7459))
+    if (r2 != IMMEDIATE(7459)) {
 #line 68 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=78 dst=r2 src=r1 offset=5 imm=0
+#line 68 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=78 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -230,23 +230,29 @@ reflect_packet(void* context)
     r2 += IMMEDIATE(14);
     // EBPF_OP_JGT_REG pc=5 dst=r2 src=r3 offset=211 imm=0
 #line 29 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+#line 29 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=60 imm=56710
 #line 34 "sample/reflect_packet.c"
-    if (r4 == IMMEDIATE(56710))
+    if (r4 == IMMEDIATE(56710)) {
 #line 34 "sample/reflect_packet.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=208 imm=8
 #line 34 "sample/reflect_packet.c"
-    if (r4 != IMMEDIATE(8))
+    }
+    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=208 imm=8
+#line 34 "sample/reflect_packet.c"
+    if (r4 != IMMEDIATE(8)) {
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+#line 34 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 35 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -254,18 +260,22 @@ reflect_packet(void* context)
     r4 += IMMEDIATE(34);
     // EBPF_OP_JGT_REG pc=11 dst=r4 src=r3 offset=205 imm=0
 #line 35 "sample/reflect_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 35 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+#line 35 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=203 imm=17
 #line 41 "sample/reflect_packet.c"
-    if (r4 != IMMEDIATE(17))
+    if (r4 != IMMEDIATE(17)) {
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+#line 41 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
@@ -285,18 +295,22 @@ reflect_packet(void* context)
     r4 += IMMEDIATE(8);
     // EBPF_OP_JGT_REG pc=20 dst=r4 src=r3 offset=196 imm=0
 #line 41 "sample/reflect_packet.c"
-    if (r4 > r3)
+    if (r4 > r3) {
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=21 dst=r3 src=r2 offset=2 imm=0
+#line 41 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=21 dst=r3 src=r2 offset=2 imm=0
 #line 47 "sample/reflect_packet.c"
     r3 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r3 src=r0 offset=194 imm=7459
 #line 47 "sample/reflect_packet.c"
-    if (r3 != IMMEDIATE(7459))
+    if (r3 != IMMEDIATE(7459)) {
 #line 47 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=23 dst=r3 src=r1 offset=5 imm=0
+#line 47 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=23 dst=r3 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r3 src=r0 offset=0 imm=8
@@ -440,10 +454,12 @@ label_1:
     r2 += IMMEDIATE(54);
     // EBPF_OP_JGT_REG pc=70 dst=r2 src=r3 offset=146 imm=0
 #line 56 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 56 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=71 dst=r2 src=r1 offset=0 imm=0
+#line 56 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_MOV64_REG pc=71 dst=r2 src=r1 offset=0 imm=0
 #line 56 "sample/reflect_packet.c"
     r2 = r1;
     // EBPF_OP_ADD64_IMM pc=72 dst=r2 src=r0 offset=0 imm=62
@@ -451,26 +467,32 @@ label_1:
     r2 += IMMEDIATE(62);
     // EBPF_OP_JGT_REG pc=73 dst=r2 src=r3 offset=143 imm=0
 #line 62 "sample/reflect_packet.c"
-    if (r2 > r3)
+    if (r2 > r3) {
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=20 imm=0
+#line 62 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=20 imm=0
 #line 62 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=75 dst=r2 src=r0 offset=141 imm=17
 #line 62 "sample/reflect_packet.c"
-    if (r2 != IMMEDIATE(17))
+    if (r2 != IMMEDIATE(17)) {
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXH pc=76 dst=r2 src=r1 offset=56 imm=0
+#line 62 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXH pc=76 dst=r2 src=r1 offset=56 imm=0
 #line 68 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=77 dst=r2 src=r0 offset=139 imm=7459
 #line 68 "sample/reflect_packet.c"
-    if (r2 != IMMEDIATE(7459))
+    if (r2 != IMMEDIATE(7459)) {
 #line 68 "sample/reflect_packet.c"
         goto label_3;
-        // EBPF_OP_LDXB pc=78 dst=r2 src=r1 offset=5 imm=0
+#line 68 "sample/reflect_packet.c"
+    }
+    // EBPF_OP_LDXB pc=78 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -132,23 +132,29 @@ connection_monitor(void* context)
     r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=3 dst=r4 src=r0 offset=8 imm=0
 #line 77 "sample/sockops.c"
-    if (r4 == IMMEDIATE(0))
+    if (r4 == IMMEDIATE(0)) {
 #line 77 "sample/sockops.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
 #line 77 "sample/sockops.c"
-    if (r4 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(2)) {
 #line 77 "sample/sockops.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
+#line 77 "sample/sockops.c"
+    }
+    // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
 #line 77 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r4 src=r0 offset=162 imm=1
 #line 77 "sample/sockops.c"
-    if (r4 != IMMEDIATE(1))
+    if (r4 != IMMEDIATE(1)) {
 #line 77 "sample/sockops.c"
         goto label_5;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
 #line 77 "sample/sockops.c"
     r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -167,10 +173,12 @@ label_2:
     r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=33 imm=2
 #line 94 "sample/sockops.c"
-    if (r4 != IMMEDIATE(2))
+    if (r4 != IMMEDIATE(2)) {
 #line 94 "sample/sockops.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
+#line 94 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
 #line 94 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=15 dst=r10 src=r4 offset=-8 imm=0
@@ -250,14 +258,14 @@ label_2:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
     // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
@@ -265,10 +273,12 @@ label_2:
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=124 imm=0
 #line 26 "sample/sockops.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
-        // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
 #line 26 "sample/sockops.c"
     goto label_4;
 label_3:
@@ -604,14 +614,14 @@ label_3:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
     // EBPF_OP_LDDW pc=160 dst=r0 src=r0 offset=0 imm=-1
@@ -619,9 +629,11 @@ label_3:
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=162 dst=r1 src=r0 offset=7 imm=0
 #line 26 "sample/sockops.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
+#line 26 "sample/sockops.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=163 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/sockops.c"
@@ -640,13 +652,13 @@ label_4:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=169 dst=r0 src=r0 offset=0 imm=11
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
+#line 26 "sample/sockops.c"
+    }
 label_5:
     // EBPF_OP_EXIT pc=170 dst=r0 src=r0 offset=0 imm=0
 #line 97 "sample/sockops.c"

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -106,23 +106,29 @@ connection_monitor(void* context)
     r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=3 dst=r4 src=r0 offset=8 imm=0
 #line 77 "sample/sockops.c"
-    if (r4 == IMMEDIATE(0))
+    if (r4 == IMMEDIATE(0)) {
 #line 77 "sample/sockops.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
 #line 77 "sample/sockops.c"
-    if (r4 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(2)) {
 #line 77 "sample/sockops.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
+#line 77 "sample/sockops.c"
+    }
+    // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
 #line 77 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r4 src=r0 offset=162 imm=1
 #line 77 "sample/sockops.c"
-    if (r4 != IMMEDIATE(1))
+    if (r4 != IMMEDIATE(1)) {
 #line 77 "sample/sockops.c"
         goto label_5;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
 #line 77 "sample/sockops.c"
     r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -141,10 +147,12 @@ label_2:
     r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=33 imm=2
 #line 94 "sample/sockops.c"
-    if (r4 != IMMEDIATE(2))
+    if (r4 != IMMEDIATE(2)) {
 #line 94 "sample/sockops.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
+#line 94 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
 #line 94 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=15 dst=r10 src=r4 offset=-8 imm=0
@@ -224,14 +232,14 @@ label_2:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
     // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
@@ -239,10 +247,12 @@ label_2:
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=124 imm=0
 #line 26 "sample/sockops.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
-        // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
 #line 26 "sample/sockops.c"
     goto label_4;
 label_3:
@@ -578,14 +588,14 @@ label_3:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
     // EBPF_OP_LDDW pc=160 dst=r0 src=r0 offset=0 imm=-1
@@ -593,9 +603,11 @@ label_3:
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=162 dst=r1 src=r0 offset=7 imm=0
 #line 26 "sample/sockops.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
+#line 26 "sample/sockops.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=163 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/sockops.c"
@@ -614,13 +626,13 @@ label_4:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=169 dst=r0 src=r0 offset=0 imm=11
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
+#line 26 "sample/sockops.c"
+    }
 label_5:
     // EBPF_OP_EXIT pc=170 dst=r0 src=r0 offset=0 imm=0
 #line 97 "sample/sockops.c"

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -267,23 +267,29 @@ connection_monitor(void* context)
     r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=3 dst=r4 src=r0 offset=8 imm=0
 #line 77 "sample/sockops.c"
-    if (r4 == IMMEDIATE(0))
+    if (r4 == IMMEDIATE(0)) {
 #line 77 "sample/sockops.c"
         goto label_2;
-        // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
 #line 77 "sample/sockops.c"
-    if (r4 == IMMEDIATE(2))
+    }
+    // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(2)) {
 #line 77 "sample/sockops.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
+#line 77 "sample/sockops.c"
+    }
+    // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
 #line 77 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r4 src=r0 offset=162 imm=1
 #line 77 "sample/sockops.c"
-    if (r4 != IMMEDIATE(1))
+    if (r4 != IMMEDIATE(1)) {
 #line 77 "sample/sockops.c"
         goto label_5;
-        // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
 #line 77 "sample/sockops.c"
     r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -302,10 +308,12 @@ label_2:
     r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=33 imm=2
 #line 94 "sample/sockops.c"
-    if (r4 != IMMEDIATE(2))
+    if (r4 != IMMEDIATE(2)) {
 #line 94 "sample/sockops.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
+#line 94 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
 #line 94 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=15 dst=r10 src=r4 offset=-8 imm=0
@@ -385,14 +393,14 @@ label_2:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
     // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
@@ -400,10 +408,12 @@ label_2:
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=124 imm=0
 #line 26 "sample/sockops.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
-        // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
 #line 26 "sample/sockops.c"
     goto label_4;
 label_3:
@@ -739,14 +749,14 @@ label_3:
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
     // EBPF_OP_LDDW pc=160 dst=r0 src=r0 offset=0 imm=-1
@@ -754,9 +764,11 @@ label_3:
     r0 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=162 dst=r1 src=r0 offset=7 imm=0
 #line 26 "sample/sockops.c"
-    if (r1 == IMMEDIATE(0))
+    if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
+#line 26 "sample/sockops.c"
+    }
 label_4:
     // EBPF_OP_MOV64_REG pc=163 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/sockops.c"
@@ -775,13 +787,13 @@ label_4:
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=169 dst=r0 src=r0 offset=0 imm=11
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5);
 #line 26 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
+#line 26 "sample/sockops.c"
+    }
 label_5:
     // EBPF_OP_EXIT pc=170 dst=r0 src=r0 offset=0 imm=0
 #line 97 "sample/sockops.c"

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -131,14 +131,14 @@ caller(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
 #line 39 "sample/undocked/tail_call_bad.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/tail_call_bad.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/tail_call_bad.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/tail_call_bad.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
+#line 39 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
 #line 39 "sample/undocked/tail_call_bad.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=7 dst=r2 src=r10 offset=0 imm=0
@@ -152,19 +152,21 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=1
 #line 41 "sample/undocked/tail_call_bad.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call_bad.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call_bad.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call_bad.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
+#line 41 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
 #line 42 "sample/undocked/tail_call_bad.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/tail_call_bad.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
+#line 42 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/tail_call_bad.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=14 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -105,14 +105,14 @@ caller(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
 #line 39 "sample/undocked/tail_call_bad.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/tail_call_bad.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/tail_call_bad.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/tail_call_bad.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
+#line 39 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
 #line 39 "sample/undocked/tail_call_bad.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=7 dst=r2 src=r10 offset=0 imm=0
@@ -126,19 +126,21 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=1
 #line 41 "sample/undocked/tail_call_bad.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call_bad.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call_bad.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call_bad.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
+#line 41 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
 #line 42 "sample/undocked/tail_call_bad.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/tail_call_bad.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
+#line 42 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/tail_call_bad.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=14 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -266,14 +266,14 @@ caller(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
 #line 39 "sample/undocked/tail_call_bad.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/tail_call_bad.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/tail_call_bad.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/tail_call_bad.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
+#line 39 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
 #line 39 "sample/undocked/tail_call_bad.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=7 dst=r2 src=r10 offset=0 imm=0
@@ -287,19 +287,21 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=1
 #line 41 "sample/undocked/tail_call_bad.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call_bad.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call_bad.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call_bad.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
+#line 41 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
 #line 42 "sample/undocked/tail_call_bad.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/tail_call_bad.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
+#line 42 "sample/undocked/tail_call_bad.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/tail_call_bad.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=14 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -129,14 +129,14 @@ caller(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
 #line 38 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 38 "sample/undocked/tail_call.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/undocked/tail_call.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 38 "sample/undocked/tail_call.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
+#line 38 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
 #line 38 "sample/undocked/tail_call.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
@@ -147,19 +147,21 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 41 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
+#line 41 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
 #line 42 "sample/undocked/tail_call.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/tail_call.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
+#line 42 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/tail_call.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -136,14 +136,14 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 43 "sample/undocked/tail_call_map.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/undocked/tail_call_map.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/undocked/tail_call_map.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/undocked/tail_call_map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
+#line 43 "sample/undocked/tail_call_map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/undocked/tail_call_map.c"
     r1 = r6;
     // EBPF_OP_MOV64_REG pc=9 dst=r2 src=r0 offset=0 imm=0
@@ -154,14 +154,14 @@ caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=5
 #line 45 "sample/undocked/tail_call_map.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/undocked/tail_call_map.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/undocked/tail_call_map.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/undocked/tail_call_map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
+#line 45 "sample/undocked/tail_call_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
 #line 48 "sample/undocked/tail_call_map.c"
     r0 = IMMEDIATE(6);
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
@@ -255,13 +255,17 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _inner_map_initial_string_table[] = {
     "callee",
 };
+// clang-format on
 
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -110,14 +110,14 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 43 "sample/undocked/tail_call_map.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/undocked/tail_call_map.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/undocked/tail_call_map.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/undocked/tail_call_map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
+#line 43 "sample/undocked/tail_call_map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/undocked/tail_call_map.c"
     r1 = r6;
     // EBPF_OP_MOV64_REG pc=9 dst=r2 src=r0 offset=0 imm=0
@@ -128,14 +128,14 @@ caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=5
 #line 45 "sample/undocked/tail_call_map.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/undocked/tail_call_map.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/undocked/tail_call_map.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/undocked/tail_call_map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
+#line 45 "sample/undocked/tail_call_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
 #line 48 "sample/undocked/tail_call_map.c"
     r0 = IMMEDIATE(6);
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
@@ -229,13 +229,17 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _inner_map_initial_string_table[] = {
     "callee",
 };
+// clang-format on
 
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -271,14 +271,14 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 43 "sample/undocked/tail_call_map.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/undocked/tail_call_map.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/undocked/tail_call_map.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/undocked/tail_call_map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
+#line 43 "sample/undocked/tail_call_map.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/undocked/tail_call_map.c"
     r1 = r6;
     // EBPF_OP_MOV64_REG pc=9 dst=r2 src=r0 offset=0 imm=0
@@ -289,14 +289,14 @@ caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=5
 #line 45 "sample/undocked/tail_call_map.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/undocked/tail_call_map.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/undocked/tail_call_map.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/undocked/tail_call_map.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
+#line 45 "sample/undocked/tail_call_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
 #line 48 "sample/undocked/tail_call_map.c"
     r0 = IMMEDIATE(6);
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
@@ -390,13 +390,17 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _inner_map_initial_string_table[] = {
     "callee",
 };
+// clang-format on
 
+// clang-format off
 static const char* _outer_map_initial_string_table[] = {
     "inner_map",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -159,14 +159,14 @@ bind_test_caller(void* context)
     r2 = IMMEDIATE(38);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 126 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[0].address
+    r0 = bind_test_caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 126 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 126 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 126 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r7 src=r0 offset=0 imm=0
+#line 126 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r7 src=r0 offset=0 imm=0
 #line 126 "sample/tail_call_max_exceed.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
@@ -180,19 +180,21 @@ bind_test_caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=5
 #line 127 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[1].address
+    r0 = bind_test_caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 127 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 127 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 127 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=27 dst=r0 src=r0 offset=17 imm=-1
 #line 127 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=27 dst=r0 src=r0 offset=17 imm=-1
+#line 127 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 127 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=2660
+#line 127 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=2660
 #line 127 "sample/tail_call_max_exceed.c"
     r1 = IMMEDIATE(2660);
     // EBPF_OP_STXH pc=29 dst=r10 src=r1 offset=-16 imm=0
@@ -233,13 +235,13 @@ bind_test_caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=44 dst=r0 src=r0 offset=0 imm=13
 #line 128 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[2].address
+    r0 = bind_test_caller_helpers[2].address(r1, r2, r3, r4, r5);
 #line 128 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 128 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[2].tail_call) && (r0 == 0)) {
 #line 128 "sample/tail_call_max_exceed.c"
         return 0;
+#line 128 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=45 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/tail_call_max_exceed.c"
@@ -361,14 +363,14 @@ bind_test_callee0(void* context)
     r4 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[0].address
+    r0 = bind_test_callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 85 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 85 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -379,19 +381,21 @@ bind_test_callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[1].address
+    r0 = bind_test_callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 85 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 85 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 85 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 85 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 85 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -432,13 +436,13 @@ bind_test_callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[2].address
+    r0 = bind_test_callee0_helpers[2].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[2].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
+#line 85 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 85 "sample/tail_call_max_exceed.c"
@@ -560,14 +564,14 @@ bind_test_callee1(void* context)
     r4 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[0].address
+    r0 = bind_test_callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 86 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 86 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -578,19 +582,21 @@ bind_test_callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[1].address
+    r0 = bind_test_callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 86 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 86 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 86 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 86 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 86 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -631,13 +637,13 @@ bind_test_callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[2].address
+    r0 = bind_test_callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
+#line 86 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 86 "sample/tail_call_max_exceed.c"
@@ -759,14 +765,14 @@ bind_test_callee10(void* context)
     r4 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[0].address
+    r0 = bind_test_callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 95 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 95 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -777,19 +783,21 @@ bind_test_callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[1].address
+    r0 = bind_test_callee10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[1].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 95 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 95 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 95 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 95 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 95 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -830,13 +838,13 @@ bind_test_callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[2].address
+    r0 = bind_test_callee10_helpers[2].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[2].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
+#line 95 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 95 "sample/tail_call_max_exceed.c"
@@ -958,14 +966,14 @@ bind_test_callee11(void* context)
     r4 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[0].address
+    r0 = bind_test_callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 96 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 96 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -976,19 +984,21 @@ bind_test_callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[1].address
+    r0 = bind_test_callee11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[1].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 96 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 96 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 96 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 96 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 96 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1029,13 +1039,13 @@ bind_test_callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[2].address
+    r0 = bind_test_callee11_helpers[2].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[2].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
+#line 96 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 96 "sample/tail_call_max_exceed.c"
@@ -1157,14 +1167,14 @@ bind_test_callee12(void* context)
     r4 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[0].address
+    r0 = bind_test_callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 97 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 97 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1175,19 +1185,21 @@ bind_test_callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[1].address
+    r0 = bind_test_callee12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[1].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 97 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 97 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 97 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 97 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 97 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1228,13 +1240,13 @@ bind_test_callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[2].address
+    r0 = bind_test_callee12_helpers[2].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[2].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
+#line 97 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 97 "sample/tail_call_max_exceed.c"
@@ -1356,14 +1368,14 @@ bind_test_callee13(void* context)
     r4 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[0].address
+    r0 = bind_test_callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 98 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 98 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1374,19 +1386,21 @@ bind_test_callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[1].address
+    r0 = bind_test_callee13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[1].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 98 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 98 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 98 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 98 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 98 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1427,13 +1441,13 @@ bind_test_callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[2].address
+    r0 = bind_test_callee13_helpers[2].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[2].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
+#line 98 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 98 "sample/tail_call_max_exceed.c"
@@ -1555,14 +1569,14 @@ bind_test_callee14(void* context)
     r4 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[0].address
+    r0 = bind_test_callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 99 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 99 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1573,19 +1587,21 @@ bind_test_callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[1].address
+    r0 = bind_test_callee14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[1].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 99 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 99 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 99 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 99 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 99 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1626,13 +1642,13 @@ bind_test_callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[2].address
+    r0 = bind_test_callee14_helpers[2].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[2].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
+#line 99 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 99 "sample/tail_call_max_exceed.c"
@@ -1754,14 +1770,14 @@ bind_test_callee15(void* context)
     r4 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[0].address
+    r0 = bind_test_callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 100 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 100 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1772,19 +1788,21 @@ bind_test_callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[1].address
+    r0 = bind_test_callee15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[1].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 100 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 100 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 100 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 100 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 100 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1825,13 +1843,13 @@ bind_test_callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[2].address
+    r0 = bind_test_callee15_helpers[2].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[2].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
+#line 100 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 100 "sample/tail_call_max_exceed.c"
@@ -1953,14 +1971,14 @@ bind_test_callee16(void* context)
     r4 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[0].address
+    r0 = bind_test_callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 101 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1971,19 +1989,21 @@ bind_test_callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[1].address
+    r0 = bind_test_callee16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[1].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 101 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 101 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 101 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 101 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 101 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2024,13 +2044,13 @@ bind_test_callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[2].address
+    r0 = bind_test_callee16_helpers[2].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[2].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
+#line 101 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 101 "sample/tail_call_max_exceed.c"
@@ -2152,14 +2172,14 @@ bind_test_callee17(void* context)
     r4 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[0].address
+    r0 = bind_test_callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 102 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2170,19 +2190,21 @@ bind_test_callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[1].address
+    r0 = bind_test_callee17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[1].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 102 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 102 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 102 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 102 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 102 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2223,13 +2245,13 @@ bind_test_callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[2].address
+    r0 = bind_test_callee17_helpers[2].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[2].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
+#line 102 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 102 "sample/tail_call_max_exceed.c"
@@ -2351,14 +2373,14 @@ bind_test_callee18(void* context)
     r4 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[0].address
+    r0 = bind_test_callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 103 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 103 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2369,19 +2391,21 @@ bind_test_callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[1].address
+    r0 = bind_test_callee18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[1].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 103 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 103 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 103 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 103 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 103 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2422,13 +2446,13 @@ bind_test_callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[2].address
+    r0 = bind_test_callee18_helpers[2].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[2].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
+#line 103 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 103 "sample/tail_call_max_exceed.c"
@@ -2550,14 +2574,14 @@ bind_test_callee19(void* context)
     r4 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[0].address
+    r0 = bind_test_callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 104 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 104 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2568,19 +2592,21 @@ bind_test_callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[1].address
+    r0 = bind_test_callee19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[1].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 104 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 104 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 104 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 104 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 104 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2621,13 +2647,13 @@ bind_test_callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[2].address
+    r0 = bind_test_callee19_helpers[2].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[2].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
+#line 104 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 104 "sample/tail_call_max_exceed.c"
@@ -2749,14 +2775,14 @@ bind_test_callee2(void* context)
     r4 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[0].address
+    r0 = bind_test_callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 87 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2767,19 +2793,21 @@ bind_test_callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[1].address
+    r0 = bind_test_callee2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[1].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 87 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 87 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 87 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 87 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 87 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2820,13 +2848,13 @@ bind_test_callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[2].address
+    r0 = bind_test_callee2_helpers[2].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[2].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
+#line 87 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 87 "sample/tail_call_max_exceed.c"
@@ -2948,14 +2976,14 @@ bind_test_callee20(void* context)
     r4 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[0].address
+    r0 = bind_test_callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 105 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 105 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2966,19 +2994,21 @@ bind_test_callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[1].address
+    r0 = bind_test_callee20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[1].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 105 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 105 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 105 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 105 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 105 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3019,13 +3049,13 @@ bind_test_callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[2].address
+    r0 = bind_test_callee20_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
+#line 105 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 105 "sample/tail_call_max_exceed.c"
@@ -3147,14 +3177,14 @@ bind_test_callee21(void* context)
     r4 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[0].address
+    r0 = bind_test_callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 106 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 106 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3165,19 +3195,21 @@ bind_test_callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[1].address
+    r0 = bind_test_callee21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[1].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 106 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 106 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 106 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 106 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 106 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3218,13 +3250,13 @@ bind_test_callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[2].address
+    r0 = bind_test_callee21_helpers[2].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[2].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
+#line 106 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 106 "sample/tail_call_max_exceed.c"
@@ -3346,14 +3378,14 @@ bind_test_callee22(void* context)
     r4 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[0].address
+    r0 = bind_test_callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 107 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 107 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3364,19 +3396,21 @@ bind_test_callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[1].address
+    r0 = bind_test_callee22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[1].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 107 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 107 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 107 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 107 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 107 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3417,13 +3451,13 @@ bind_test_callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[2].address
+    r0 = bind_test_callee22_helpers[2].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[2].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
+#line 107 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 107 "sample/tail_call_max_exceed.c"
@@ -3545,14 +3579,14 @@ bind_test_callee23(void* context)
     r4 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[0].address
+    r0 = bind_test_callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3563,19 +3597,21 @@ bind_test_callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[1].address
+    r0 = bind_test_callee23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[1].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 108 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 108 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 108 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 108 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 108 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3616,13 +3652,13 @@ bind_test_callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[2].address
+    r0 = bind_test_callee23_helpers[2].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[2].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
+#line 108 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 108 "sample/tail_call_max_exceed.c"
@@ -3744,14 +3780,14 @@ bind_test_callee24(void* context)
     r4 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[0].address
+    r0 = bind_test_callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 109 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 109 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3762,19 +3798,21 @@ bind_test_callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[1].address
+    r0 = bind_test_callee24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[1].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 109 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 109 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 109 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 109 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 109 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3815,13 +3853,13 @@ bind_test_callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[2].address
+    r0 = bind_test_callee24_helpers[2].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[2].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
+#line 109 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 109 "sample/tail_call_max_exceed.c"
@@ -3943,14 +3981,14 @@ bind_test_callee25(void* context)
     r4 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[0].address
+    r0 = bind_test_callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 110 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 110 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3961,19 +3999,21 @@ bind_test_callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[1].address
+    r0 = bind_test_callee25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[1].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 110 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 110 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 110 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 110 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 110 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4014,13 +4054,13 @@ bind_test_callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[2].address
+    r0 = bind_test_callee25_helpers[2].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[2].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
+#line 110 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 110 "sample/tail_call_max_exceed.c"
@@ -4142,14 +4182,14 @@ bind_test_callee26(void* context)
     r4 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[0].address
+    r0 = bind_test_callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 111 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 111 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4160,19 +4200,21 @@ bind_test_callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[1].address
+    r0 = bind_test_callee26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[1].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 111 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 111 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 111 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 111 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 111 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4213,13 +4255,13 @@ bind_test_callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[2].address
+    r0 = bind_test_callee26_helpers[2].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[2].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
+#line 111 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 111 "sample/tail_call_max_exceed.c"
@@ -4341,14 +4383,14 @@ bind_test_callee27(void* context)
     r4 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[0].address
+    r0 = bind_test_callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 112 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 112 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4359,19 +4401,21 @@ bind_test_callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[1].address
+    r0 = bind_test_callee27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[1].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 112 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 112 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 112 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 112 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 112 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4412,13 +4456,13 @@ bind_test_callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[2].address
+    r0 = bind_test_callee27_helpers[2].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[2].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
+#line 112 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 112 "sample/tail_call_max_exceed.c"
@@ -4540,14 +4584,14 @@ bind_test_callee28(void* context)
     r4 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[0].address
+    r0 = bind_test_callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 113 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 113 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4558,19 +4602,21 @@ bind_test_callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[1].address
+    r0 = bind_test_callee28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[1].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 113 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 113 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 113 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 113 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 113 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4611,13 +4657,13 @@ bind_test_callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[2].address
+    r0 = bind_test_callee28_helpers[2].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[2].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
+#line 113 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 113 "sample/tail_call_max_exceed.c"
@@ -4739,14 +4785,14 @@ bind_test_callee29(void* context)
     r4 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[0].address
+    r0 = bind_test_callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 114 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 114 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4757,19 +4803,21 @@ bind_test_callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[1].address
+    r0 = bind_test_callee29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[1].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 114 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 114 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 114 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 114 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 114 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4810,13 +4858,13 @@ bind_test_callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[2].address
+    r0 = bind_test_callee29_helpers[2].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[2].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
+#line 114 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 114 "sample/tail_call_max_exceed.c"
@@ -4938,14 +4986,14 @@ bind_test_callee3(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[0].address
+    r0 = bind_test_callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 88 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 88 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4956,19 +5004,21 @@ bind_test_callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[1].address
+    r0 = bind_test_callee3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[1].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 88 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 88 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 88 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 88 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 88 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5009,13 +5059,13 @@ bind_test_callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[2].address
+    r0 = bind_test_callee3_helpers[2].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[2].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
+#line 88 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 88 "sample/tail_call_max_exceed.c"
@@ -5137,14 +5187,14 @@ bind_test_callee30(void* context)
     r4 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[0].address
+    r0 = bind_test_callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 115 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 115 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5155,19 +5205,21 @@ bind_test_callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[1].address
+    r0 = bind_test_callee30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[1].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 115 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 115 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 115 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 115 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 115 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5208,13 +5260,13 @@ bind_test_callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[2].address
+    r0 = bind_test_callee30_helpers[2].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[2].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
+#line 115 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 115 "sample/tail_call_max_exceed.c"
@@ -5336,14 +5388,14 @@ bind_test_callee31(void* context)
     r4 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[0].address
+    r0 = bind_test_callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 116 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 116 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5354,19 +5406,21 @@ bind_test_callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[1].address
+    r0 = bind_test_callee31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[1].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 116 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 116 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 116 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 116 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 116 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5407,13 +5461,13 @@ bind_test_callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[2].address
+    r0 = bind_test_callee31_helpers[2].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[2].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
+#line 116 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 116 "sample/tail_call_max_exceed.c"
@@ -5535,14 +5589,14 @@ bind_test_callee32(void* context)
     r4 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[0].address
+    r0 = bind_test_callee32_helpers[0].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[0].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 117 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 117 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5553,19 +5607,21 @@ bind_test_callee32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[1].address
+    r0 = bind_test_callee32_helpers[1].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[1].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 117 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 117 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 117 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 117 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 117 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5606,13 +5662,13 @@ bind_test_callee32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[2].address
+    r0 = bind_test_callee32_helpers[2].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[2].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
+#line 117 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 117 "sample/tail_call_max_exceed.c"
@@ -5734,14 +5790,14 @@ bind_test_callee33(void* context)
     r4 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[0].address
+    r0 = bind_test_callee33_helpers[0].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[0].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 118 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 118 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5752,19 +5808,21 @@ bind_test_callee33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[1].address
+    r0 = bind_test_callee33_helpers[1].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[1].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 118 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 118 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 118 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 118 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 118 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5805,13 +5863,13 @@ bind_test_callee33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[2].address
+    r0 = bind_test_callee33_helpers[2].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[2].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
+#line 118 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 118 "sample/tail_call_max_exceed.c"
@@ -5908,14 +5966,14 @@ bind_test_callee34(void* context)
     r2 = IMMEDIATE(42);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 138 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee34_helpers[0].address
+    r0 = bind_test_callee34_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee34_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee34_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r0 src=r0 offset=0 imm=0
+#line 138 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r0 src=r0 offset=0 imm=0
 #line 141 "sample/tail_call_max_exceed.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=22 dst=r0 src=r0 offset=0 imm=0
@@ -6035,14 +6093,14 @@ bind_test_callee4(void* context)
     r4 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[0].address
+    r0 = bind_test_callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 89 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 89 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6053,19 +6111,21 @@ bind_test_callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[1].address
+    r0 = bind_test_callee4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[1].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 89 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 89 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 89 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 89 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 89 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6106,13 +6166,13 @@ bind_test_callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[2].address
+    r0 = bind_test_callee4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[2].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
+#line 89 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 89 "sample/tail_call_max_exceed.c"
@@ -6234,14 +6294,14 @@ bind_test_callee5(void* context)
     r4 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[0].address
+    r0 = bind_test_callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 90 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6252,19 +6312,21 @@ bind_test_callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[1].address
+    r0 = bind_test_callee5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[1].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 90 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 90 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 90 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 90 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 90 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6305,13 +6367,13 @@ bind_test_callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[2].address
+    r0 = bind_test_callee5_helpers[2].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[2].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
+#line 90 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 90 "sample/tail_call_max_exceed.c"
@@ -6433,14 +6495,14 @@ bind_test_callee6(void* context)
     r4 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[0].address
+    r0 = bind_test_callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 91 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 91 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6451,19 +6513,21 @@ bind_test_callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[1].address
+    r0 = bind_test_callee6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[1].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 91 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 91 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 91 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 91 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 91 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6504,13 +6568,13 @@ bind_test_callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[2].address
+    r0 = bind_test_callee6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[2].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
+#line 91 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 91 "sample/tail_call_max_exceed.c"
@@ -6632,14 +6696,14 @@ bind_test_callee7(void* context)
     r4 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[0].address
+    r0 = bind_test_callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 92 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 92 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6650,19 +6714,21 @@ bind_test_callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[1].address
+    r0 = bind_test_callee7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[1].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 92 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 92 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 92 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 92 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 92 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6703,13 +6769,13 @@ bind_test_callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[2].address
+    r0 = bind_test_callee7_helpers[2].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[2].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
+#line 92 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 92 "sample/tail_call_max_exceed.c"
@@ -6831,14 +6897,14 @@ bind_test_callee8(void* context)
     r4 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[0].address
+    r0 = bind_test_callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 93 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 93 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6849,19 +6915,21 @@ bind_test_callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[1].address
+    r0 = bind_test_callee8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[1].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 93 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 93 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 93 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 93 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 93 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6902,13 +6970,13 @@ bind_test_callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[2].address
+    r0 = bind_test_callee8_helpers[2].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[2].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
+#line 93 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 93 "sample/tail_call_max_exceed.c"
@@ -7030,14 +7098,14 @@ bind_test_callee9(void* context)
     r4 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[0].address
+    r0 = bind_test_callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 94 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 94 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -7048,19 +7116,21 @@ bind_test_callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[1].address
+    r0 = bind_test_callee9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[1].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 94 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 94 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 94 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=1680154744
+#line 94 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=1680154744
 #line 94 "sample/tail_call_max_exceed.c"
     r1 = IMMEDIATE(1680154744);
     // EBPF_OP_STXW pc=33 dst=r10 src=r1 offset=-24 imm=0
@@ -7101,13 +7171,13 @@ bind_test_callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[2].address
+    r0 = bind_test_callee9_helpers[2].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[2].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
+#line 94 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 94 "sample/tail_call_max_exceed.c"
@@ -7645,6 +7715,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _bind_tail_call_map_initial_string_table[] = {
     "bind_test_callee0",
     "bind_test_callee1",
@@ -7682,6 +7753,7 @@ static const char* _bind_tail_call_map_initial_string_table[] = {
     "bind_test_callee33",
     "bind_test_callee34",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
@@ -133,14 +133,14 @@ bind_test_caller(void* context)
     r2 = IMMEDIATE(38);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 126 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[0].address
+    r0 = bind_test_caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 126 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 126 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 126 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r7 src=r0 offset=0 imm=0
+#line 126 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r7 src=r0 offset=0 imm=0
 #line 126 "sample/tail_call_max_exceed.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
@@ -154,19 +154,21 @@ bind_test_caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=5
 #line 127 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[1].address
+    r0 = bind_test_caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 127 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 127 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 127 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=27 dst=r0 src=r0 offset=17 imm=-1
 #line 127 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=27 dst=r0 src=r0 offset=17 imm=-1
+#line 127 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 127 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=2660
+#line 127 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=2660
 #line 127 "sample/tail_call_max_exceed.c"
     r1 = IMMEDIATE(2660);
     // EBPF_OP_STXH pc=29 dst=r10 src=r1 offset=-16 imm=0
@@ -207,13 +209,13 @@ bind_test_caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=44 dst=r0 src=r0 offset=0 imm=13
 #line 128 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[2].address
+    r0 = bind_test_caller_helpers[2].address(r1, r2, r3, r4, r5);
 #line 128 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 128 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[2].tail_call) && (r0 == 0)) {
 #line 128 "sample/tail_call_max_exceed.c"
         return 0;
+#line 128 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=45 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/tail_call_max_exceed.c"
@@ -335,14 +337,14 @@ bind_test_callee0(void* context)
     r4 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[0].address
+    r0 = bind_test_callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 85 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 85 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -353,19 +355,21 @@ bind_test_callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[1].address
+    r0 = bind_test_callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 85 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 85 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 85 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 85 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 85 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -406,13 +410,13 @@ bind_test_callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[2].address
+    r0 = bind_test_callee0_helpers[2].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[2].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
+#line 85 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 85 "sample/tail_call_max_exceed.c"
@@ -534,14 +538,14 @@ bind_test_callee1(void* context)
     r4 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[0].address
+    r0 = bind_test_callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 86 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 86 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -552,19 +556,21 @@ bind_test_callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[1].address
+    r0 = bind_test_callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 86 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 86 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 86 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 86 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 86 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -605,13 +611,13 @@ bind_test_callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[2].address
+    r0 = bind_test_callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
+#line 86 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 86 "sample/tail_call_max_exceed.c"
@@ -733,14 +739,14 @@ bind_test_callee10(void* context)
     r4 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[0].address
+    r0 = bind_test_callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 95 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 95 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -751,19 +757,21 @@ bind_test_callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[1].address
+    r0 = bind_test_callee10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[1].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 95 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 95 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 95 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 95 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 95 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -804,13 +812,13 @@ bind_test_callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[2].address
+    r0 = bind_test_callee10_helpers[2].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[2].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
+#line 95 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 95 "sample/tail_call_max_exceed.c"
@@ -932,14 +940,14 @@ bind_test_callee11(void* context)
     r4 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[0].address
+    r0 = bind_test_callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 96 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 96 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -950,19 +958,21 @@ bind_test_callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[1].address
+    r0 = bind_test_callee11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[1].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 96 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 96 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 96 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 96 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 96 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1003,13 +1013,13 @@ bind_test_callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[2].address
+    r0 = bind_test_callee11_helpers[2].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[2].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
+#line 96 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 96 "sample/tail_call_max_exceed.c"
@@ -1131,14 +1141,14 @@ bind_test_callee12(void* context)
     r4 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[0].address
+    r0 = bind_test_callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 97 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 97 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1149,19 +1159,21 @@ bind_test_callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[1].address
+    r0 = bind_test_callee12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[1].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 97 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 97 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 97 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 97 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 97 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1202,13 +1214,13 @@ bind_test_callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[2].address
+    r0 = bind_test_callee12_helpers[2].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[2].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
+#line 97 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 97 "sample/tail_call_max_exceed.c"
@@ -1330,14 +1342,14 @@ bind_test_callee13(void* context)
     r4 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[0].address
+    r0 = bind_test_callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 98 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 98 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1348,19 +1360,21 @@ bind_test_callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[1].address
+    r0 = bind_test_callee13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[1].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 98 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 98 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 98 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 98 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 98 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1401,13 +1415,13 @@ bind_test_callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[2].address
+    r0 = bind_test_callee13_helpers[2].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[2].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
+#line 98 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 98 "sample/tail_call_max_exceed.c"
@@ -1529,14 +1543,14 @@ bind_test_callee14(void* context)
     r4 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[0].address
+    r0 = bind_test_callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 99 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 99 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1547,19 +1561,21 @@ bind_test_callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[1].address
+    r0 = bind_test_callee14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[1].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 99 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 99 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 99 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 99 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 99 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1600,13 +1616,13 @@ bind_test_callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[2].address
+    r0 = bind_test_callee14_helpers[2].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[2].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
+#line 99 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 99 "sample/tail_call_max_exceed.c"
@@ -1728,14 +1744,14 @@ bind_test_callee15(void* context)
     r4 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[0].address
+    r0 = bind_test_callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 100 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 100 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1746,19 +1762,21 @@ bind_test_callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[1].address
+    r0 = bind_test_callee15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[1].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 100 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 100 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 100 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 100 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 100 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1799,13 +1817,13 @@ bind_test_callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[2].address
+    r0 = bind_test_callee15_helpers[2].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[2].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
+#line 100 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 100 "sample/tail_call_max_exceed.c"
@@ -1927,14 +1945,14 @@ bind_test_callee16(void* context)
     r4 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[0].address
+    r0 = bind_test_callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 101 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1945,19 +1963,21 @@ bind_test_callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[1].address
+    r0 = bind_test_callee16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[1].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 101 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 101 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 101 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 101 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 101 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1998,13 +2018,13 @@ bind_test_callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[2].address
+    r0 = bind_test_callee16_helpers[2].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[2].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
+#line 101 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 101 "sample/tail_call_max_exceed.c"
@@ -2126,14 +2146,14 @@ bind_test_callee17(void* context)
     r4 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[0].address
+    r0 = bind_test_callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 102 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2144,19 +2164,21 @@ bind_test_callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[1].address
+    r0 = bind_test_callee17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[1].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 102 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 102 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 102 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 102 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 102 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2197,13 +2219,13 @@ bind_test_callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[2].address
+    r0 = bind_test_callee17_helpers[2].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[2].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
+#line 102 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 102 "sample/tail_call_max_exceed.c"
@@ -2325,14 +2347,14 @@ bind_test_callee18(void* context)
     r4 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[0].address
+    r0 = bind_test_callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 103 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 103 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2343,19 +2365,21 @@ bind_test_callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[1].address
+    r0 = bind_test_callee18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[1].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 103 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 103 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 103 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 103 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 103 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2396,13 +2420,13 @@ bind_test_callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[2].address
+    r0 = bind_test_callee18_helpers[2].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[2].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
+#line 103 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 103 "sample/tail_call_max_exceed.c"
@@ -2524,14 +2548,14 @@ bind_test_callee19(void* context)
     r4 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[0].address
+    r0 = bind_test_callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 104 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 104 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2542,19 +2566,21 @@ bind_test_callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[1].address
+    r0 = bind_test_callee19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[1].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 104 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 104 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 104 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 104 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 104 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2595,13 +2621,13 @@ bind_test_callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[2].address
+    r0 = bind_test_callee19_helpers[2].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[2].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
+#line 104 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 104 "sample/tail_call_max_exceed.c"
@@ -2723,14 +2749,14 @@ bind_test_callee2(void* context)
     r4 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[0].address
+    r0 = bind_test_callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 87 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2741,19 +2767,21 @@ bind_test_callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[1].address
+    r0 = bind_test_callee2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[1].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 87 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 87 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 87 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 87 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 87 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2794,13 +2822,13 @@ bind_test_callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[2].address
+    r0 = bind_test_callee2_helpers[2].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[2].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
+#line 87 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 87 "sample/tail_call_max_exceed.c"
@@ -2922,14 +2950,14 @@ bind_test_callee20(void* context)
     r4 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[0].address
+    r0 = bind_test_callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 105 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 105 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2940,19 +2968,21 @@ bind_test_callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[1].address
+    r0 = bind_test_callee20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[1].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 105 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 105 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 105 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 105 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 105 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2993,13 +3023,13 @@ bind_test_callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[2].address
+    r0 = bind_test_callee20_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
+#line 105 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 105 "sample/tail_call_max_exceed.c"
@@ -3121,14 +3151,14 @@ bind_test_callee21(void* context)
     r4 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[0].address
+    r0 = bind_test_callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 106 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 106 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3139,19 +3169,21 @@ bind_test_callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[1].address
+    r0 = bind_test_callee21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[1].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 106 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 106 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 106 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 106 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 106 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3192,13 +3224,13 @@ bind_test_callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[2].address
+    r0 = bind_test_callee21_helpers[2].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[2].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
+#line 106 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 106 "sample/tail_call_max_exceed.c"
@@ -3320,14 +3352,14 @@ bind_test_callee22(void* context)
     r4 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[0].address
+    r0 = bind_test_callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 107 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 107 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3338,19 +3370,21 @@ bind_test_callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[1].address
+    r0 = bind_test_callee22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[1].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 107 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 107 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 107 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 107 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 107 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3391,13 +3425,13 @@ bind_test_callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[2].address
+    r0 = bind_test_callee22_helpers[2].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[2].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
+#line 107 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 107 "sample/tail_call_max_exceed.c"
@@ -3519,14 +3553,14 @@ bind_test_callee23(void* context)
     r4 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[0].address
+    r0 = bind_test_callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3537,19 +3571,21 @@ bind_test_callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[1].address
+    r0 = bind_test_callee23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[1].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 108 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 108 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 108 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 108 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 108 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3590,13 +3626,13 @@ bind_test_callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[2].address
+    r0 = bind_test_callee23_helpers[2].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[2].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
+#line 108 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 108 "sample/tail_call_max_exceed.c"
@@ -3718,14 +3754,14 @@ bind_test_callee24(void* context)
     r4 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[0].address
+    r0 = bind_test_callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 109 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 109 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3736,19 +3772,21 @@ bind_test_callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[1].address
+    r0 = bind_test_callee24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[1].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 109 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 109 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 109 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 109 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 109 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3789,13 +3827,13 @@ bind_test_callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[2].address
+    r0 = bind_test_callee24_helpers[2].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[2].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
+#line 109 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 109 "sample/tail_call_max_exceed.c"
@@ -3917,14 +3955,14 @@ bind_test_callee25(void* context)
     r4 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[0].address
+    r0 = bind_test_callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 110 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 110 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3935,19 +3973,21 @@ bind_test_callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[1].address
+    r0 = bind_test_callee25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[1].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 110 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 110 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 110 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 110 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 110 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3988,13 +4028,13 @@ bind_test_callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[2].address
+    r0 = bind_test_callee25_helpers[2].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[2].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
+#line 110 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 110 "sample/tail_call_max_exceed.c"
@@ -4116,14 +4156,14 @@ bind_test_callee26(void* context)
     r4 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[0].address
+    r0 = bind_test_callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 111 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 111 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4134,19 +4174,21 @@ bind_test_callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[1].address
+    r0 = bind_test_callee26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[1].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 111 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 111 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 111 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 111 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 111 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4187,13 +4229,13 @@ bind_test_callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[2].address
+    r0 = bind_test_callee26_helpers[2].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[2].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
+#line 111 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 111 "sample/tail_call_max_exceed.c"
@@ -4315,14 +4357,14 @@ bind_test_callee27(void* context)
     r4 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[0].address
+    r0 = bind_test_callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 112 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 112 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4333,19 +4375,21 @@ bind_test_callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[1].address
+    r0 = bind_test_callee27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[1].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 112 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 112 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 112 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 112 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 112 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4386,13 +4430,13 @@ bind_test_callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[2].address
+    r0 = bind_test_callee27_helpers[2].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[2].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
+#line 112 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 112 "sample/tail_call_max_exceed.c"
@@ -4514,14 +4558,14 @@ bind_test_callee28(void* context)
     r4 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[0].address
+    r0 = bind_test_callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 113 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 113 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4532,19 +4576,21 @@ bind_test_callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[1].address
+    r0 = bind_test_callee28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[1].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 113 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 113 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 113 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 113 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 113 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4585,13 +4631,13 @@ bind_test_callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[2].address
+    r0 = bind_test_callee28_helpers[2].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[2].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
+#line 113 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 113 "sample/tail_call_max_exceed.c"
@@ -4713,14 +4759,14 @@ bind_test_callee29(void* context)
     r4 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[0].address
+    r0 = bind_test_callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 114 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 114 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4731,19 +4777,21 @@ bind_test_callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[1].address
+    r0 = bind_test_callee29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[1].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 114 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 114 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 114 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 114 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 114 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4784,13 +4832,13 @@ bind_test_callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[2].address
+    r0 = bind_test_callee29_helpers[2].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[2].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
+#line 114 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 114 "sample/tail_call_max_exceed.c"
@@ -4912,14 +4960,14 @@ bind_test_callee3(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[0].address
+    r0 = bind_test_callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 88 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 88 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4930,19 +4978,21 @@ bind_test_callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[1].address
+    r0 = bind_test_callee3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[1].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 88 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 88 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 88 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 88 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 88 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4983,13 +5033,13 @@ bind_test_callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[2].address
+    r0 = bind_test_callee3_helpers[2].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[2].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
+#line 88 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 88 "sample/tail_call_max_exceed.c"
@@ -5111,14 +5161,14 @@ bind_test_callee30(void* context)
     r4 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[0].address
+    r0 = bind_test_callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 115 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 115 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5129,19 +5179,21 @@ bind_test_callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[1].address
+    r0 = bind_test_callee30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[1].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 115 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 115 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 115 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 115 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 115 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5182,13 +5234,13 @@ bind_test_callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[2].address
+    r0 = bind_test_callee30_helpers[2].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[2].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
+#line 115 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 115 "sample/tail_call_max_exceed.c"
@@ -5310,14 +5362,14 @@ bind_test_callee31(void* context)
     r4 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[0].address
+    r0 = bind_test_callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 116 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 116 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5328,19 +5380,21 @@ bind_test_callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[1].address
+    r0 = bind_test_callee31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[1].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 116 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 116 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 116 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 116 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 116 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5381,13 +5435,13 @@ bind_test_callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[2].address
+    r0 = bind_test_callee31_helpers[2].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[2].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
+#line 116 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 116 "sample/tail_call_max_exceed.c"
@@ -5509,14 +5563,14 @@ bind_test_callee32(void* context)
     r4 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[0].address
+    r0 = bind_test_callee32_helpers[0].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[0].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 117 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 117 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5527,19 +5581,21 @@ bind_test_callee32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[1].address
+    r0 = bind_test_callee32_helpers[1].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[1].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 117 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 117 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 117 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 117 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 117 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5580,13 +5636,13 @@ bind_test_callee32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[2].address
+    r0 = bind_test_callee32_helpers[2].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[2].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
+#line 117 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 117 "sample/tail_call_max_exceed.c"
@@ -5708,14 +5764,14 @@ bind_test_callee33(void* context)
     r4 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[0].address
+    r0 = bind_test_callee33_helpers[0].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[0].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 118 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 118 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5726,19 +5782,21 @@ bind_test_callee33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[1].address
+    r0 = bind_test_callee33_helpers[1].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[1].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 118 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 118 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 118 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 118 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 118 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5779,13 +5837,13 @@ bind_test_callee33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[2].address
+    r0 = bind_test_callee33_helpers[2].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[2].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
+#line 118 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 118 "sample/tail_call_max_exceed.c"
@@ -5882,14 +5940,14 @@ bind_test_callee34(void* context)
     r2 = IMMEDIATE(42);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 138 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee34_helpers[0].address
+    r0 = bind_test_callee34_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee34_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee34_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r0 src=r0 offset=0 imm=0
+#line 138 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r0 src=r0 offset=0 imm=0
 #line 141 "sample/tail_call_max_exceed.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=22 dst=r0 src=r0 offset=0 imm=0
@@ -6009,14 +6067,14 @@ bind_test_callee4(void* context)
     r4 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[0].address
+    r0 = bind_test_callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 89 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 89 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6027,19 +6085,21 @@ bind_test_callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[1].address
+    r0 = bind_test_callee4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[1].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 89 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 89 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 89 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 89 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 89 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6080,13 +6140,13 @@ bind_test_callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[2].address
+    r0 = bind_test_callee4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[2].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
+#line 89 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 89 "sample/tail_call_max_exceed.c"
@@ -6208,14 +6268,14 @@ bind_test_callee5(void* context)
     r4 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[0].address
+    r0 = bind_test_callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 90 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6226,19 +6286,21 @@ bind_test_callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[1].address
+    r0 = bind_test_callee5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[1].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 90 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 90 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 90 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 90 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 90 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6279,13 +6341,13 @@ bind_test_callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[2].address
+    r0 = bind_test_callee5_helpers[2].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[2].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
+#line 90 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 90 "sample/tail_call_max_exceed.c"
@@ -6407,14 +6469,14 @@ bind_test_callee6(void* context)
     r4 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[0].address
+    r0 = bind_test_callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 91 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 91 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6425,19 +6487,21 @@ bind_test_callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[1].address
+    r0 = bind_test_callee6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[1].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 91 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 91 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 91 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 91 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 91 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6478,13 +6542,13 @@ bind_test_callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[2].address
+    r0 = bind_test_callee6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[2].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
+#line 91 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 91 "sample/tail_call_max_exceed.c"
@@ -6606,14 +6670,14 @@ bind_test_callee7(void* context)
     r4 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[0].address
+    r0 = bind_test_callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 92 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 92 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6624,19 +6688,21 @@ bind_test_callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[1].address
+    r0 = bind_test_callee7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[1].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 92 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 92 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 92 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 92 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 92 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6677,13 +6743,13 @@ bind_test_callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[2].address
+    r0 = bind_test_callee7_helpers[2].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[2].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
+#line 92 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 92 "sample/tail_call_max_exceed.c"
@@ -6805,14 +6871,14 @@ bind_test_callee8(void* context)
     r4 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[0].address
+    r0 = bind_test_callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 93 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 93 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6823,19 +6889,21 @@ bind_test_callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[1].address
+    r0 = bind_test_callee8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[1].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 93 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 93 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 93 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 93 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 93 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6876,13 +6944,13 @@ bind_test_callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[2].address
+    r0 = bind_test_callee8_helpers[2].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[2].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
+#line 93 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 93 "sample/tail_call_max_exceed.c"
@@ -7004,14 +7072,14 @@ bind_test_callee9(void* context)
     r4 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[0].address
+    r0 = bind_test_callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 94 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 94 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -7022,19 +7090,21 @@ bind_test_callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[1].address
+    r0 = bind_test_callee9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[1].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 94 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 94 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 94 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=1680154744
+#line 94 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=1680154744
 #line 94 "sample/tail_call_max_exceed.c"
     r1 = IMMEDIATE(1680154744);
     // EBPF_OP_STXW pc=33 dst=r10 src=r1 offset=-24 imm=0
@@ -7075,13 +7145,13 @@ bind_test_callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[2].address
+    r0 = bind_test_callee9_helpers[2].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[2].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
+#line 94 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 94 "sample/tail_call_max_exceed.c"
@@ -7619,6 +7689,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _bind_tail_call_map_initial_string_table[] = {
     "bind_test_callee0",
     "bind_test_callee1",
@@ -7656,6 +7727,7 @@ static const char* _bind_tail_call_map_initial_string_table[] = {
     "bind_test_callee33",
     "bind_test_callee34",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
@@ -294,14 +294,14 @@ bind_test_caller(void* context)
     r2 = IMMEDIATE(38);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 126 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[0].address
+    r0 = bind_test_caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 126 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 126 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 126 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r7 src=r0 offset=0 imm=0
+#line 126 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r7 src=r0 offset=0 imm=0
 #line 126 "sample/tail_call_max_exceed.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
@@ -315,19 +315,21 @@ bind_test_caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=5
 #line 127 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[1].address
+    r0 = bind_test_caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 127 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 127 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 127 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=27 dst=r0 src=r0 offset=17 imm=-1
 #line 127 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=27 dst=r0 src=r0 offset=17 imm=-1
+#line 127 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 127 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=2660
+#line 127 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=2660
 #line 127 "sample/tail_call_max_exceed.c"
     r1 = IMMEDIATE(2660);
     // EBPF_OP_STXH pc=29 dst=r10 src=r1 offset=-16 imm=0
@@ -368,13 +370,13 @@ bind_test_caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=44 dst=r0 src=r0 offset=0 imm=13
 #line 128 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_caller_helpers[2].address
+    r0 = bind_test_caller_helpers[2].address(r1, r2, r3, r4, r5);
 #line 128 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 128 "sample/tail_call_max_exceed.c"
-    if ((bind_test_caller_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_caller_helpers[2].tail_call) && (r0 == 0)) {
 #line 128 "sample/tail_call_max_exceed.c"
         return 0;
+#line 128 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=45 dst=r0 src=r0 offset=0 imm=1
 #line 131 "sample/tail_call_max_exceed.c"
@@ -496,14 +498,14 @@ bind_test_callee0(void* context)
     r4 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[0].address
+    r0 = bind_test_callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 85 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 85 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -514,19 +516,21 @@ bind_test_callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[1].address
+    r0 = bind_test_callee0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[1].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 85 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 85 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 85 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 85 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 85 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -567,13 +571,13 @@ bind_test_callee0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 85 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee0_helpers[2].address
+    r0 = bind_test_callee0_helpers[2].address(r1, r2, r3, r4, r5);
 #line 85 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee0_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee0_helpers[2].tail_call) && (r0 == 0)) {
 #line 85 "sample/tail_call_max_exceed.c"
         return 0;
+#line 85 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 85 "sample/tail_call_max_exceed.c"
@@ -695,14 +699,14 @@ bind_test_callee1(void* context)
     r4 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[0].address
+    r0 = bind_test_callee1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[0].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 86 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 86 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -713,19 +717,21 @@ bind_test_callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[1].address
+    r0 = bind_test_callee1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[1].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 86 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 86 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 86 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 86 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 86 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -766,13 +772,13 @@ bind_test_callee1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 86 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee1_helpers[2].address
+    r0 = bind_test_callee1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 86 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 86 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee1_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee1_helpers[2].tail_call) && (r0 == 0)) {
 #line 86 "sample/tail_call_max_exceed.c"
         return 0;
+#line 86 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 86 "sample/tail_call_max_exceed.c"
@@ -894,14 +900,14 @@ bind_test_callee10(void* context)
     r4 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[0].address
+    r0 = bind_test_callee10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[0].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 95 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 95 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -912,19 +918,21 @@ bind_test_callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[1].address
+    r0 = bind_test_callee10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[1].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 95 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 95 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 95 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 95 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 95 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -965,13 +973,13 @@ bind_test_callee10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 95 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee10_helpers[2].address
+    r0 = bind_test_callee10_helpers[2].address(r1, r2, r3, r4, r5);
 #line 95 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 95 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee10_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee10_helpers[2].tail_call) && (r0 == 0)) {
 #line 95 "sample/tail_call_max_exceed.c"
         return 0;
+#line 95 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 95 "sample/tail_call_max_exceed.c"
@@ -1093,14 +1101,14 @@ bind_test_callee11(void* context)
     r4 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[0].address
+    r0 = bind_test_callee11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[0].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 96 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 96 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1111,19 +1119,21 @@ bind_test_callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[1].address
+    r0 = bind_test_callee11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[1].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 96 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 96 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 96 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 96 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 96 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1164,13 +1174,13 @@ bind_test_callee11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 96 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee11_helpers[2].address
+    r0 = bind_test_callee11_helpers[2].address(r1, r2, r3, r4, r5);
 #line 96 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 96 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee11_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee11_helpers[2].tail_call) && (r0 == 0)) {
 #line 96 "sample/tail_call_max_exceed.c"
         return 0;
+#line 96 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 96 "sample/tail_call_max_exceed.c"
@@ -1292,14 +1302,14 @@ bind_test_callee12(void* context)
     r4 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[0].address
+    r0 = bind_test_callee12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[0].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 97 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 97 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1310,19 +1320,21 @@ bind_test_callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[1].address
+    r0 = bind_test_callee12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[1].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 97 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 97 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 97 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 97 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 97 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1363,13 +1375,13 @@ bind_test_callee12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 97 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee12_helpers[2].address
+    r0 = bind_test_callee12_helpers[2].address(r1, r2, r3, r4, r5);
 #line 97 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 97 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee12_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee12_helpers[2].tail_call) && (r0 == 0)) {
 #line 97 "sample/tail_call_max_exceed.c"
         return 0;
+#line 97 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 97 "sample/tail_call_max_exceed.c"
@@ -1491,14 +1503,14 @@ bind_test_callee13(void* context)
     r4 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[0].address
+    r0 = bind_test_callee13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[0].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 98 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 98 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1509,19 +1521,21 @@ bind_test_callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[1].address
+    r0 = bind_test_callee13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[1].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 98 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 98 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 98 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 98 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 98 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1562,13 +1576,13 @@ bind_test_callee13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 98 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee13_helpers[2].address
+    r0 = bind_test_callee13_helpers[2].address(r1, r2, r3, r4, r5);
 #line 98 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 98 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee13_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee13_helpers[2].tail_call) && (r0 == 0)) {
 #line 98 "sample/tail_call_max_exceed.c"
         return 0;
+#line 98 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 98 "sample/tail_call_max_exceed.c"
@@ -1690,14 +1704,14 @@ bind_test_callee14(void* context)
     r4 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[0].address
+    r0 = bind_test_callee14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[0].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 99 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 99 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1708,19 +1722,21 @@ bind_test_callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[1].address
+    r0 = bind_test_callee14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[1].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 99 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 99 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 99 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 99 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 99 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1761,13 +1777,13 @@ bind_test_callee14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 99 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee14_helpers[2].address
+    r0 = bind_test_callee14_helpers[2].address(r1, r2, r3, r4, r5);
 #line 99 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 99 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee14_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee14_helpers[2].tail_call) && (r0 == 0)) {
 #line 99 "sample/tail_call_max_exceed.c"
         return 0;
+#line 99 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 99 "sample/tail_call_max_exceed.c"
@@ -1889,14 +1905,14 @@ bind_test_callee15(void* context)
     r4 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[0].address
+    r0 = bind_test_callee15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[0].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 100 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 100 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -1907,19 +1923,21 @@ bind_test_callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[1].address
+    r0 = bind_test_callee15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[1].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 100 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 100 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 100 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 100 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 100 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -1960,13 +1978,13 @@ bind_test_callee15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 100 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee15_helpers[2].address
+    r0 = bind_test_callee15_helpers[2].address(r1, r2, r3, r4, r5);
 #line 100 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 100 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee15_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee15_helpers[2].tail_call) && (r0 == 0)) {
 #line 100 "sample/tail_call_max_exceed.c"
         return 0;
+#line 100 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 100 "sample/tail_call_max_exceed.c"
@@ -2088,14 +2106,14 @@ bind_test_callee16(void* context)
     r4 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[0].address
+    r0 = bind_test_callee16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[0].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 101 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2106,19 +2124,21 @@ bind_test_callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[1].address
+    r0 = bind_test_callee16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[1].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 101 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 101 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 101 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 101 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 101 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2159,13 +2179,13 @@ bind_test_callee16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 101 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee16_helpers[2].address
+    r0 = bind_test_callee16_helpers[2].address(r1, r2, r3, r4, r5);
 #line 101 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 101 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee16_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee16_helpers[2].tail_call) && (r0 == 0)) {
 #line 101 "sample/tail_call_max_exceed.c"
         return 0;
+#line 101 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 101 "sample/tail_call_max_exceed.c"
@@ -2287,14 +2307,14 @@ bind_test_callee17(void* context)
     r4 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[0].address
+    r0 = bind_test_callee17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[0].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 102 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2305,19 +2325,21 @@ bind_test_callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[1].address
+    r0 = bind_test_callee17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[1].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 102 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 102 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 102 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 102 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 102 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2358,13 +2380,13 @@ bind_test_callee17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 102 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee17_helpers[2].address
+    r0 = bind_test_callee17_helpers[2].address(r1, r2, r3, r4, r5);
 #line 102 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 102 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee17_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee17_helpers[2].tail_call) && (r0 == 0)) {
 #line 102 "sample/tail_call_max_exceed.c"
         return 0;
+#line 102 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 102 "sample/tail_call_max_exceed.c"
@@ -2486,14 +2508,14 @@ bind_test_callee18(void* context)
     r4 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[0].address
+    r0 = bind_test_callee18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[0].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 103 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 103 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2504,19 +2526,21 @@ bind_test_callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[1].address
+    r0 = bind_test_callee18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[1].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 103 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 103 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 103 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 103 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 103 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2557,13 +2581,13 @@ bind_test_callee18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 103 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee18_helpers[2].address
+    r0 = bind_test_callee18_helpers[2].address(r1, r2, r3, r4, r5);
 #line 103 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 103 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee18_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee18_helpers[2].tail_call) && (r0 == 0)) {
 #line 103 "sample/tail_call_max_exceed.c"
         return 0;
+#line 103 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 103 "sample/tail_call_max_exceed.c"
@@ -2685,14 +2709,14 @@ bind_test_callee19(void* context)
     r4 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[0].address
+    r0 = bind_test_callee19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[0].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 104 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 104 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2703,19 +2727,21 @@ bind_test_callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[1].address
+    r0 = bind_test_callee19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[1].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 104 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 104 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 104 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 104 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 104 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2756,13 +2782,13 @@ bind_test_callee19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 104 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee19_helpers[2].address
+    r0 = bind_test_callee19_helpers[2].address(r1, r2, r3, r4, r5);
 #line 104 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 104 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee19_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee19_helpers[2].tail_call) && (r0 == 0)) {
 #line 104 "sample/tail_call_max_exceed.c"
         return 0;
+#line 104 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 104 "sample/tail_call_max_exceed.c"
@@ -2884,14 +2910,14 @@ bind_test_callee2(void* context)
     r4 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[0].address
+    r0 = bind_test_callee2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[0].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 87 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -2902,19 +2928,21 @@ bind_test_callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[1].address
+    r0 = bind_test_callee2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[1].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 87 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 87 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 87 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 87 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 87 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -2955,13 +2983,13 @@ bind_test_callee2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 87 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee2_helpers[2].address
+    r0 = bind_test_callee2_helpers[2].address(r1, r2, r3, r4, r5);
 #line 87 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 87 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee2_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee2_helpers[2].tail_call) && (r0 == 0)) {
 #line 87 "sample/tail_call_max_exceed.c"
         return 0;
+#line 87 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 87 "sample/tail_call_max_exceed.c"
@@ -3083,14 +3111,14 @@ bind_test_callee20(void* context)
     r4 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[0].address
+    r0 = bind_test_callee20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[0].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 105 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 105 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3101,19 +3129,21 @@ bind_test_callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[1].address
+    r0 = bind_test_callee20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[1].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 105 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 105 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 105 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 105 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 105 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3154,13 +3184,13 @@ bind_test_callee20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 105 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee20_helpers[2].address
+    r0 = bind_test_callee20_helpers[2].address(r1, r2, r3, r4, r5);
 #line 105 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 105 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee20_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee20_helpers[2].tail_call) && (r0 == 0)) {
 #line 105 "sample/tail_call_max_exceed.c"
         return 0;
+#line 105 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 105 "sample/tail_call_max_exceed.c"
@@ -3282,14 +3312,14 @@ bind_test_callee21(void* context)
     r4 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[0].address
+    r0 = bind_test_callee21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[0].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 106 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 106 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3300,19 +3330,21 @@ bind_test_callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[1].address
+    r0 = bind_test_callee21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[1].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 106 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 106 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 106 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 106 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 106 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3353,13 +3385,13 @@ bind_test_callee21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 106 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee21_helpers[2].address
+    r0 = bind_test_callee21_helpers[2].address(r1, r2, r3, r4, r5);
 #line 106 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 106 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee21_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee21_helpers[2].tail_call) && (r0 == 0)) {
 #line 106 "sample/tail_call_max_exceed.c"
         return 0;
+#line 106 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 106 "sample/tail_call_max_exceed.c"
@@ -3481,14 +3513,14 @@ bind_test_callee22(void* context)
     r4 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[0].address
+    r0 = bind_test_callee22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[0].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 107 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 107 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3499,19 +3531,21 @@ bind_test_callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[1].address
+    r0 = bind_test_callee22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[1].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 107 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 107 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 107 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 107 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 107 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3552,13 +3586,13 @@ bind_test_callee22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 107 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee22_helpers[2].address
+    r0 = bind_test_callee22_helpers[2].address(r1, r2, r3, r4, r5);
 #line 107 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 107 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee22_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee22_helpers[2].tail_call) && (r0 == 0)) {
 #line 107 "sample/tail_call_max_exceed.c"
         return 0;
+#line 107 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 107 "sample/tail_call_max_exceed.c"
@@ -3680,14 +3714,14 @@ bind_test_callee23(void* context)
     r4 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[0].address
+    r0 = bind_test_callee23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[0].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3698,19 +3732,21 @@ bind_test_callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[1].address
+    r0 = bind_test_callee23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[1].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 108 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 108 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 108 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 108 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 108 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3751,13 +3787,13 @@ bind_test_callee23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 108 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee23_helpers[2].address
+    r0 = bind_test_callee23_helpers[2].address(r1, r2, r3, r4, r5);
 #line 108 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 108 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee23_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee23_helpers[2].tail_call) && (r0 == 0)) {
 #line 108 "sample/tail_call_max_exceed.c"
         return 0;
+#line 108 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 108 "sample/tail_call_max_exceed.c"
@@ -3879,14 +3915,14 @@ bind_test_callee24(void* context)
     r4 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[0].address
+    r0 = bind_test_callee24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[0].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 109 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 109 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -3897,19 +3933,21 @@ bind_test_callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[1].address
+    r0 = bind_test_callee24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[1].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 109 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 109 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 109 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 109 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 109 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -3950,13 +3988,13 @@ bind_test_callee24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 109 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee24_helpers[2].address
+    r0 = bind_test_callee24_helpers[2].address(r1, r2, r3, r4, r5);
 #line 109 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 109 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee24_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee24_helpers[2].tail_call) && (r0 == 0)) {
 #line 109 "sample/tail_call_max_exceed.c"
         return 0;
+#line 109 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 109 "sample/tail_call_max_exceed.c"
@@ -4078,14 +4116,14 @@ bind_test_callee25(void* context)
     r4 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[0].address
+    r0 = bind_test_callee25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[0].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 110 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 110 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4096,19 +4134,21 @@ bind_test_callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[1].address
+    r0 = bind_test_callee25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[1].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 110 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 110 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 110 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 110 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 110 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4149,13 +4189,13 @@ bind_test_callee25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 110 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee25_helpers[2].address
+    r0 = bind_test_callee25_helpers[2].address(r1, r2, r3, r4, r5);
 #line 110 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 110 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee25_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee25_helpers[2].tail_call) && (r0 == 0)) {
 #line 110 "sample/tail_call_max_exceed.c"
         return 0;
+#line 110 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 110 "sample/tail_call_max_exceed.c"
@@ -4277,14 +4317,14 @@ bind_test_callee26(void* context)
     r4 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[0].address
+    r0 = bind_test_callee26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[0].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 111 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 111 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4295,19 +4335,21 @@ bind_test_callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[1].address
+    r0 = bind_test_callee26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[1].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 111 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 111 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 111 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 111 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 111 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4348,13 +4390,13 @@ bind_test_callee26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 111 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee26_helpers[2].address
+    r0 = bind_test_callee26_helpers[2].address(r1, r2, r3, r4, r5);
 #line 111 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 111 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee26_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee26_helpers[2].tail_call) && (r0 == 0)) {
 #line 111 "sample/tail_call_max_exceed.c"
         return 0;
+#line 111 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 111 "sample/tail_call_max_exceed.c"
@@ -4476,14 +4518,14 @@ bind_test_callee27(void* context)
     r4 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[0].address
+    r0 = bind_test_callee27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[0].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 112 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 112 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4494,19 +4536,21 @@ bind_test_callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[1].address
+    r0 = bind_test_callee27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[1].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 112 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 112 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 112 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 112 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 112 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4547,13 +4591,13 @@ bind_test_callee27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 112 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee27_helpers[2].address
+    r0 = bind_test_callee27_helpers[2].address(r1, r2, r3, r4, r5);
 #line 112 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee27_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee27_helpers[2].tail_call) && (r0 == 0)) {
 #line 112 "sample/tail_call_max_exceed.c"
         return 0;
+#line 112 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 112 "sample/tail_call_max_exceed.c"
@@ -4675,14 +4719,14 @@ bind_test_callee28(void* context)
     r4 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[0].address
+    r0 = bind_test_callee28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[0].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 113 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 113 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4693,19 +4737,21 @@ bind_test_callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[1].address
+    r0 = bind_test_callee28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[1].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 113 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 113 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 113 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 113 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 113 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4746,13 +4792,13 @@ bind_test_callee28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 113 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee28_helpers[2].address
+    r0 = bind_test_callee28_helpers[2].address(r1, r2, r3, r4, r5);
 #line 113 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 113 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee28_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee28_helpers[2].tail_call) && (r0 == 0)) {
 #line 113 "sample/tail_call_max_exceed.c"
         return 0;
+#line 113 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 113 "sample/tail_call_max_exceed.c"
@@ -4874,14 +4920,14 @@ bind_test_callee29(void* context)
     r4 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[0].address
+    r0 = bind_test_callee29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[0].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 114 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 114 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -4892,19 +4938,21 @@ bind_test_callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[1].address
+    r0 = bind_test_callee29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[1].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 114 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 114 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 114 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 114 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 114 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -4945,13 +4993,13 @@ bind_test_callee29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 114 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee29_helpers[2].address
+    r0 = bind_test_callee29_helpers[2].address(r1, r2, r3, r4, r5);
 #line 114 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 114 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee29_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee29_helpers[2].tail_call) && (r0 == 0)) {
 #line 114 "sample/tail_call_max_exceed.c"
         return 0;
+#line 114 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 114 "sample/tail_call_max_exceed.c"
@@ -5073,14 +5121,14 @@ bind_test_callee3(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[0].address
+    r0 = bind_test_callee3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[0].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 88 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 88 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5091,19 +5139,21 @@ bind_test_callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[1].address
+    r0 = bind_test_callee3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[1].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 88 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 88 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 88 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 88 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 88 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5144,13 +5194,13 @@ bind_test_callee3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 88 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee3_helpers[2].address
+    r0 = bind_test_callee3_helpers[2].address(r1, r2, r3, r4, r5);
 #line 88 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 88 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee3_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee3_helpers[2].tail_call) && (r0 == 0)) {
 #line 88 "sample/tail_call_max_exceed.c"
         return 0;
+#line 88 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 88 "sample/tail_call_max_exceed.c"
@@ -5272,14 +5322,14 @@ bind_test_callee30(void* context)
     r4 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[0].address
+    r0 = bind_test_callee30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[0].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 115 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 115 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5290,19 +5340,21 @@ bind_test_callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[1].address
+    r0 = bind_test_callee30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[1].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 115 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 115 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 115 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 115 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 115 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5343,13 +5395,13 @@ bind_test_callee30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 115 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee30_helpers[2].address
+    r0 = bind_test_callee30_helpers[2].address(r1, r2, r3, r4, r5);
 #line 115 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 115 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee30_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee30_helpers[2].tail_call) && (r0 == 0)) {
 #line 115 "sample/tail_call_max_exceed.c"
         return 0;
+#line 115 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 115 "sample/tail_call_max_exceed.c"
@@ -5471,14 +5523,14 @@ bind_test_callee31(void* context)
     r4 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[0].address
+    r0 = bind_test_callee31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[0].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 116 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 116 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5489,19 +5541,21 @@ bind_test_callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[1].address
+    r0 = bind_test_callee31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[1].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 116 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 116 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 116 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 116 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 116 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5542,13 +5596,13 @@ bind_test_callee31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 116 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee31_helpers[2].address
+    r0 = bind_test_callee31_helpers[2].address(r1, r2, r3, r4, r5);
 #line 116 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 116 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee31_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee31_helpers[2].tail_call) && (r0 == 0)) {
 #line 116 "sample/tail_call_max_exceed.c"
         return 0;
+#line 116 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 116 "sample/tail_call_max_exceed.c"
@@ -5670,14 +5724,14 @@ bind_test_callee32(void* context)
     r4 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[0].address
+    r0 = bind_test_callee32_helpers[0].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[0].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 117 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 117 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5688,19 +5742,21 @@ bind_test_callee32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[1].address
+    r0 = bind_test_callee32_helpers[1].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[1].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 117 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 117 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 117 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 117 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 117 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5741,13 +5797,13 @@ bind_test_callee32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 117 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee32_helpers[2].address
+    r0 = bind_test_callee32_helpers[2].address(r1, r2, r3, r4, r5);
 #line 117 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 117 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee32_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee32_helpers[2].tail_call) && (r0 == 0)) {
 #line 117 "sample/tail_call_max_exceed.c"
         return 0;
+#line 117 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 117 "sample/tail_call_max_exceed.c"
@@ -5869,14 +5925,14 @@ bind_test_callee33(void* context)
     r4 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[0].address
+    r0 = bind_test_callee33_helpers[0].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[0].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 118 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 118 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -5887,19 +5943,21 @@ bind_test_callee33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[1].address
+    r0 = bind_test_callee33_helpers[1].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[1].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 118 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 118 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 118 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 118 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 118 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -5940,13 +5998,13 @@ bind_test_callee33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 118 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee33_helpers[2].address
+    r0 = bind_test_callee33_helpers[2].address(r1, r2, r3, r4, r5);
 #line 118 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 118 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee33_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee33_helpers[2].tail_call) && (r0 == 0)) {
 #line 118 "sample/tail_call_max_exceed.c"
         return 0;
+#line 118 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 118 "sample/tail_call_max_exceed.c"
@@ -6043,14 +6101,14 @@ bind_test_callee34(void* context)
     r2 = IMMEDIATE(42);
     // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=12
 #line 138 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee34_helpers[0].address
+    r0 = bind_test_callee34_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee34_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee34_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=21 dst=r0 src=r0 offset=0 imm=0
+#line 138 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=21 dst=r0 src=r0 offset=0 imm=0
 #line 141 "sample/tail_call_max_exceed.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=22 dst=r0 src=r0 offset=0 imm=0
@@ -6170,14 +6228,14 @@ bind_test_callee4(void* context)
     r4 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[0].address
+    r0 = bind_test_callee4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[0].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 89 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 89 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6188,19 +6246,21 @@ bind_test_callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[1].address
+    r0 = bind_test_callee4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[1].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 89 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 89 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 89 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 89 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 89 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6241,13 +6301,13 @@ bind_test_callee4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 89 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee4_helpers[2].address
+    r0 = bind_test_callee4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 89 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 89 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee4_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee4_helpers[2].tail_call) && (r0 == 0)) {
 #line 89 "sample/tail_call_max_exceed.c"
         return 0;
+#line 89 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 89 "sample/tail_call_max_exceed.c"
@@ -6369,14 +6429,14 @@ bind_test_callee5(void* context)
     r4 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[0].address
+    r0 = bind_test_callee5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[0].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 90 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6387,19 +6447,21 @@ bind_test_callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[1].address
+    r0 = bind_test_callee5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[1].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 90 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 90 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 90 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 90 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 90 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6440,13 +6502,13 @@ bind_test_callee5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 90 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee5_helpers[2].address
+    r0 = bind_test_callee5_helpers[2].address(r1, r2, r3, r4, r5);
 #line 90 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 90 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee5_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee5_helpers[2].tail_call) && (r0 == 0)) {
 #line 90 "sample/tail_call_max_exceed.c"
         return 0;
+#line 90 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 90 "sample/tail_call_max_exceed.c"
@@ -6568,14 +6630,14 @@ bind_test_callee6(void* context)
     r4 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[0].address
+    r0 = bind_test_callee6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[0].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 91 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 91 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6586,19 +6648,21 @@ bind_test_callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[1].address
+    r0 = bind_test_callee6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[1].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 91 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 91 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 91 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 91 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 91 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6639,13 +6703,13 @@ bind_test_callee6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 91 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee6_helpers[2].address
+    r0 = bind_test_callee6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 91 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 91 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee6_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee6_helpers[2].tail_call) && (r0 == 0)) {
 #line 91 "sample/tail_call_max_exceed.c"
         return 0;
+#line 91 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 91 "sample/tail_call_max_exceed.c"
@@ -6767,14 +6831,14 @@ bind_test_callee7(void* context)
     r4 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[0].address
+    r0 = bind_test_callee7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[0].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 92 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 92 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6785,19 +6849,21 @@ bind_test_callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[1].address
+    r0 = bind_test_callee7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[1].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 92 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 92 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 92 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 92 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 92 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -6838,13 +6904,13 @@ bind_test_callee7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 92 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee7_helpers[2].address
+    r0 = bind_test_callee7_helpers[2].address(r1, r2, r3, r4, r5);
 #line 92 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 92 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee7_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee7_helpers[2].tail_call) && (r0 == 0)) {
 #line 92 "sample/tail_call_max_exceed.c"
         return 0;
+#line 92 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 92 "sample/tail_call_max_exceed.c"
@@ -6966,14 +7032,14 @@ bind_test_callee8(void* context)
     r4 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[0].address
+    r0 = bind_test_callee8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[0].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 93 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 93 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -6984,19 +7050,21 @@ bind_test_callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[1].address
+    r0 = bind_test_callee8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[1].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 93 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 93 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 93 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
+#line 93 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_STXH pc=32 dst=r10 src=r7 offset=-20 imm=0
 #line 93 "sample/tail_call_max_exceed.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r7;
     // EBPF_OP_MOV64_IMM pc=33 dst=r1 src=r0 offset=0 imm=1680154744
@@ -7037,13 +7105,13 @@ bind_test_callee8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 93 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee8_helpers[2].address
+    r0 = bind_test_callee8_helpers[2].address(r1, r2, r3, r4, r5);
 #line 93 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 93 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee8_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee8_helpers[2].tail_call) && (r0 == 0)) {
 #line 93 "sample/tail_call_max_exceed.c"
         return 0;
+#line 93 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 93 "sample/tail_call_max_exceed.c"
@@ -7165,14 +7233,14 @@ bind_test_callee9(void* context)
     r4 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=14
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[0].address
+    r0 = bind_test_callee9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[0].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[0].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 94 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_REG pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 94 "sample/tail_call_max_exceed.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=27 dst=r2 src=r0 offset=0 imm=0
@@ -7183,19 +7251,21 @@ bind_test_callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[1].address
+    r0 = bind_test_callee9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[1].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[1].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
-        // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
 #line 94 "sample/tail_call_max_exceed.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    }
+    // EBPF_OP_JSGT_IMM pc=31 dst=r0 src=r0 offset=17 imm=-1
+#line 94 "sample/tail_call_max_exceed.c"
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 94 "sample/tail_call_max_exceed.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=1680154744
+#line 94 "sample/tail_call_max_exceed.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=1680154744
 #line 94 "sample/tail_call_max_exceed.c"
     r1 = IMMEDIATE(1680154744);
     // EBPF_OP_STXW pc=33 dst=r10 src=r1 offset=-24 imm=0
@@ -7236,13 +7306,13 @@ bind_test_callee9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=48 dst=r0 src=r0 offset=0 imm=13
 #line 94 "sample/tail_call_max_exceed.c"
-    r0 = bind_test_callee9_helpers[2].address
+    r0 = bind_test_callee9_helpers[2].address(r1, r2, r3, r4, r5);
 #line 94 "sample/tail_call_max_exceed.c"
-         (r1, r2, r3, r4, r5);
-#line 94 "sample/tail_call_max_exceed.c"
-    if ((bind_test_callee9_helpers[2].tail_call) && (r0 == 0))
+    if ((bind_test_callee9_helpers[2].tail_call) && (r0 == 0)) {
 #line 94 "sample/tail_call_max_exceed.c"
         return 0;
+#line 94 "sample/tail_call_max_exceed.c"
+    }
 label_1:
     // EBPF_OP_MOV64_IMM pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 94 "sample/tail_call_max_exceed.c"
@@ -7780,6 +7850,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _bind_tail_call_map_initial_string_table[] = {
     "bind_test_callee0",
     "bind_test_callee1",
@@ -7817,6 +7888,7 @@ static const char* _bind_tail_call_map_initial_string_table[] = {
     "bind_test_callee33",
     "bind_test_callee34",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -109,14 +109,14 @@ caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=5
 #line 30 "sample/undocked/tail_call_multiple.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 30 "sample/undocked/tail_call_multiple.c"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/undocked/tail_call_multiple.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 30 "sample/undocked/tail_call_multiple.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
+#line 30 "sample/undocked/tail_call_multiple.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
 #line 33 "sample/undocked/tail_call_multiple.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -174,14 +174,14 @@ callee0(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=5
 #line 41 "sample/undocked/tail_call_multiple.c"
-    r0 = callee0_helpers[0].address
+    r0 = callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call_multiple.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call_multiple.c"
-    if ((callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call_multiple.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
+#line 41 "sample/undocked/tail_call_multiple.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
 #line 44 "sample/undocked/tail_call_multiple.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -83,14 +83,14 @@ caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=5
 #line 30 "sample/undocked/tail_call_multiple.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 30 "sample/undocked/tail_call_multiple.c"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/undocked/tail_call_multiple.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 30 "sample/undocked/tail_call_multiple.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
+#line 30 "sample/undocked/tail_call_multiple.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
 #line 33 "sample/undocked/tail_call_multiple.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -148,14 +148,14 @@ callee0(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=5
 #line 41 "sample/undocked/tail_call_multiple.c"
-    r0 = callee0_helpers[0].address
+    r0 = callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call_multiple.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call_multiple.c"
-    if ((callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call_multiple.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
+#line 41 "sample/undocked/tail_call_multiple.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
 #line 44 "sample/undocked/tail_call_multiple.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -244,14 +244,14 @@ caller(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=5
 #line 30 "sample/undocked/tail_call_multiple.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 30 "sample/undocked/tail_call_multiple.c"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/undocked/tail_call_multiple.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 30 "sample/undocked/tail_call_multiple.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
+#line 30 "sample/undocked/tail_call_multiple.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
 #line 33 "sample/undocked/tail_call_multiple.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -309,14 +309,14 @@ callee0(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=5
 #line 41 "sample/undocked/tail_call_multiple.c"
-    r0 = callee0_helpers[0].address
+    r0 = callee0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call_multiple.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call_multiple.c"
-    if ((callee0_helpers[0].tail_call) && (r0 == 0))
+    if ((callee0_helpers[0].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call_multiple.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
+#line 41 "sample/undocked/tail_call_multiple.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
 #line 44 "sample/undocked/tail_call_multiple.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -103,14 +103,14 @@ caller(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
 #line 38 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 38 "sample/undocked/tail_call.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/undocked/tail_call.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 38 "sample/undocked/tail_call.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
+#line 38 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
 #line 38 "sample/undocked/tail_call.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
@@ -121,19 +121,21 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 41 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
+#line 41 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
 #line 42 "sample/undocked/tail_call.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/tail_call.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
+#line 42 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/tail_call.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -142,22 +142,24 @@ recurse(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 51 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[0].address
+    r0 = recurse_helpers[0].address(r1, r2, r3, r4, r5);
 #line 51 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[0].tail_call) && (r0 == 0))
+    if ((recurse_helpers[0].tail_call) && (r0 == 0)) {
 #line 51 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 51 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 51 "sample/undocked/tail_call_recursive.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=22 imm=0
 #line 52 "sample/undocked/tail_call_recursive.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 52 "sample/undocked/tail_call_recursive.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r1 src=r0 offset=0 imm=680997
+#line 52 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r1 src=r0 offset=0 imm=680997
 #line 52 "sample/undocked/tail_call_recursive.c"
     r1 = IMMEDIATE(680997);
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-8 imm=0
@@ -189,14 +191,14 @@ recurse(void* context)
     r2 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[1].address
+    r0 = recurse_helpers[1].address(r1, r2, r3, r4, r5);
 #line 56 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[1].tail_call) && (r0 == 0))
+    if ((recurse_helpers[1].tail_call) && (r0 == 0)) {
 #line 56 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_LDXW pc=23 dst=r1 src=r7 offset=0 imm=0
+#line 56 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_LDXW pc=23 dst=r1 src=r7 offset=0 imm=0
 #line 59 "sample/undocked/tail_call_recursive.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=1
@@ -216,14 +218,14 @@ recurse(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 62 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[2].address
+    r0 = recurse_helpers[2].address(r1, r2, r3, r4, r5);
 #line 62 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[2].tail_call) && (r0 == 0))
+    if ((recurse_helpers[2].tail_call) && (r0 == 0)) {
 #line 62 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=31 dst=r8 src=r0 offset=0 imm=0
+#line 62 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_REG pc=31 dst=r8 src=r0 offset=0 imm=0
 #line 62 "sample/undocked/tail_call_recursive.c"
     r8 = r0;
 label_1:
@@ -273,11 +275,13 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _map_initial_string_table[] = {
     NULL,
     "recurse",
     NULL,
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
@@ -116,22 +116,24 @@ recurse(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 51 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[0].address
+    r0 = recurse_helpers[0].address(r1, r2, r3, r4, r5);
 #line 51 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[0].tail_call) && (r0 == 0))
+    if ((recurse_helpers[0].tail_call) && (r0 == 0)) {
 #line 51 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 51 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 51 "sample/undocked/tail_call_recursive.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=22 imm=0
 #line 52 "sample/undocked/tail_call_recursive.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 52 "sample/undocked/tail_call_recursive.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r1 src=r0 offset=0 imm=680997
+#line 52 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r1 src=r0 offset=0 imm=680997
 #line 52 "sample/undocked/tail_call_recursive.c"
     r1 = IMMEDIATE(680997);
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-8 imm=0
@@ -163,14 +165,14 @@ recurse(void* context)
     r2 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[1].address
+    r0 = recurse_helpers[1].address(r1, r2, r3, r4, r5);
 #line 56 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[1].tail_call) && (r0 == 0))
+    if ((recurse_helpers[1].tail_call) && (r0 == 0)) {
 #line 56 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_LDXW pc=23 dst=r1 src=r7 offset=0 imm=0
+#line 56 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_LDXW pc=23 dst=r1 src=r7 offset=0 imm=0
 #line 59 "sample/undocked/tail_call_recursive.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=1
@@ -190,14 +192,14 @@ recurse(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 62 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[2].address
+    r0 = recurse_helpers[2].address(r1, r2, r3, r4, r5);
 #line 62 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[2].tail_call) && (r0 == 0))
+    if ((recurse_helpers[2].tail_call) && (r0 == 0)) {
 #line 62 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=31 dst=r8 src=r0 offset=0 imm=0
+#line 62 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_REG pc=31 dst=r8 src=r0 offset=0 imm=0
 #line 62 "sample/undocked/tail_call_recursive.c"
     r8 = r0;
 label_1:
@@ -247,11 +249,13 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _map_initial_string_table[] = {
     NULL,
     "recurse",
     NULL,
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
@@ -277,22 +277,24 @@ recurse(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 51 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[0].address
+    r0 = recurse_helpers[0].address(r1, r2, r3, r4, r5);
 #line 51 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[0].tail_call) && (r0 == 0))
+    if ((recurse_helpers[0].tail_call) && (r0 == 0)) {
 #line 51 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+#line 51 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 51 "sample/undocked/tail_call_recursive.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=22 imm=0
 #line 52 "sample/undocked/tail_call_recursive.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 52 "sample/undocked/tail_call_recursive.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=10 dst=r1 src=r0 offset=0 imm=680997
+#line 52 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=10 dst=r1 src=r0 offset=0 imm=680997
 #line 52 "sample/undocked/tail_call_recursive.c"
     r1 = IMMEDIATE(680997);
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-8 imm=0
@@ -324,14 +326,14 @@ recurse(void* context)
     r2 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=13
 #line 56 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[1].address
+    r0 = recurse_helpers[1].address(r1, r2, r3, r4, r5);
 #line 56 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 56 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[1].tail_call) && (r0 == 0))
+    if ((recurse_helpers[1].tail_call) && (r0 == 0)) {
 #line 56 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_LDXW pc=23 dst=r1 src=r7 offset=0 imm=0
+#line 56 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_LDXW pc=23 dst=r1 src=r7 offset=0 imm=0
 #line 59 "sample/undocked/tail_call_recursive.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=1
@@ -351,14 +353,14 @@ recurse(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=5
 #line 62 "sample/undocked/tail_call_recursive.c"
-    r0 = recurse_helpers[2].address
+    r0 = recurse_helpers[2].address(r1, r2, r3, r4, r5);
 #line 62 "sample/undocked/tail_call_recursive.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/undocked/tail_call_recursive.c"
-    if ((recurse_helpers[2].tail_call) && (r0 == 0))
+    if ((recurse_helpers[2].tail_call) && (r0 == 0)) {
 #line 62 "sample/undocked/tail_call_recursive.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=31 dst=r8 src=r0 offset=0 imm=0
+#line 62 "sample/undocked/tail_call_recursive.c"
+    }
+    // EBPF_OP_MOV64_REG pc=31 dst=r8 src=r0 offset=0 imm=0
 #line 62 "sample/undocked/tail_call_recursive.c"
     r8 = r0;
 label_1:
@@ -408,11 +410,13 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _map_initial_string_table[] = {
     NULL,
     "recurse",
     NULL,
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -144,14 +144,14 @@ sequential0(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[0].address
+    r0 = sequential0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[0].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -159,10 +159,12 @@ sequential0(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -194,22 +196,24 @@ sequential0(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[1].address
+    r0 = sequential0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[1].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=1
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=1
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -226,14 +230,14 @@ sequential0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[2].address
+    r0 = sequential0_helpers[2].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[2].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -318,14 +322,14 @@ sequential1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[0].address
+    r0 = sequential1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[0].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -333,10 +337,12 @@ sequential1(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -368,22 +374,24 @@ sequential1(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[1].address
+    r0 = sequential1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[1].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=1
 #line 134 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(1))
+    if (r1 != IMMEDIATE(1)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -400,14 +408,14 @@ sequential1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[2].address
+    r0 = sequential1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[2].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -494,14 +502,14 @@ sequential10(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[0].address
+    r0 = sequential10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[0].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -509,10 +517,12 @@ sequential10(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -547,22 +557,24 @@ sequential10(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[1].address
+    r0 = sequential10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[1].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=10
 #line 143 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(10))
+    if (r1 != IMMEDIATE(10)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=11
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=11
 #line 143 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(11);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -579,14 +591,14 @@ sequential10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[2].address
+    r0 = sequential10_helpers[2].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[2].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -673,14 +685,14 @@ sequential11(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[0].address
+    r0 = sequential11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[0].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -688,10 +700,12 @@ sequential11(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -726,22 +740,24 @@ sequential11(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[1].address
+    r0 = sequential11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[1].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=11
 #line 144 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(11))
+    if (r1 != IMMEDIATE(11)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=12
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=12
 #line 144 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(12);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -758,14 +774,14 @@ sequential11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[2].address
+    r0 = sequential11_helpers[2].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[2].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -852,14 +868,14 @@ sequential12(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[0].address
+    r0 = sequential12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[0].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -867,10 +883,12 @@ sequential12(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -905,22 +923,24 @@ sequential12(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[1].address
+    r0 = sequential12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[1].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=12
 #line 145 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(12))
+    if (r1 != IMMEDIATE(12)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=13
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=13
 #line 145 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(13);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -937,14 +957,14 @@ sequential12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[2].address
+    r0 = sequential12_helpers[2].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[2].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1031,14 +1051,14 @@ sequential13(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[0].address
+    r0 = sequential13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[0].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1046,10 +1066,12 @@ sequential13(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1084,22 +1106,24 @@ sequential13(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[1].address
+    r0 = sequential13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[1].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=13
 #line 146 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(13))
+    if (r1 != IMMEDIATE(13)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=14
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=14
 #line 146 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(14);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1116,14 +1140,14 @@ sequential13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[2].address
+    r0 = sequential13_helpers[2].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[2].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1210,14 +1234,14 @@ sequential14(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[0].address
+    r0 = sequential14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1225,10 +1249,12 @@ sequential14(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1263,22 +1289,24 @@ sequential14(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[1].address
+    r0 = sequential14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[1].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=14
 #line 147 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(14))
+    if (r1 != IMMEDIATE(14)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=15
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=15
 #line 147 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(15);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1295,14 +1323,14 @@ sequential14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[2].address
+    r0 = sequential14_helpers[2].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[2].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1389,14 +1417,14 @@ sequential15(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[0].address
+    r0 = sequential15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[0].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1404,10 +1432,12 @@ sequential15(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1442,22 +1472,24 @@ sequential15(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[1].address
+    r0 = sequential15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[1].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=15
 #line 148 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(15))
+    if (r1 != IMMEDIATE(15)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=16
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=16
 #line 148 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(16);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1474,14 +1506,14 @@ sequential15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[2].address
+    r0 = sequential15_helpers[2].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[2].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1568,14 +1600,14 @@ sequential16(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[0].address
+    r0 = sequential16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[0].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1583,10 +1615,12 @@ sequential16(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1621,22 +1655,24 @@ sequential16(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[1].address
+    r0 = sequential16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[1].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=16
 #line 149 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(16))
+    if (r1 != IMMEDIATE(16)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=17
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=17
 #line 149 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(17);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1653,14 +1689,14 @@ sequential16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[2].address
+    r0 = sequential16_helpers[2].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[2].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1747,14 +1783,14 @@ sequential17(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[0].address
+    r0 = sequential17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[0].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1762,10 +1798,12 @@ sequential17(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1800,22 +1838,24 @@ sequential17(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[1].address
+    r0 = sequential17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[1].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=17
 #line 150 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(17))
+    if (r1 != IMMEDIATE(17)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=18
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=18
 #line 150 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(18);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1832,14 +1872,14 @@ sequential17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[2].address
+    r0 = sequential17_helpers[2].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[2].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1926,14 +1966,14 @@ sequential18(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[0].address
+    r0 = sequential18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[0].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1941,10 +1981,12 @@ sequential18(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1979,22 +2021,24 @@ sequential18(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[1].address
+    r0 = sequential18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[1].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=18
 #line 151 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(18))
+    if (r1 != IMMEDIATE(18)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=19
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=19
 #line 151 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(19);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2011,14 +2055,14 @@ sequential18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[2].address
+    r0 = sequential18_helpers[2].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[2].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2105,14 +2149,14 @@ sequential19(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[0].address
+    r0 = sequential19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[0].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2120,10 +2164,12 @@ sequential19(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2158,22 +2204,24 @@ sequential19(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[1].address
+    r0 = sequential19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[1].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=19
 #line 152 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(19))
+    if (r1 != IMMEDIATE(19)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=20
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=20
 #line 152 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(20);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2190,14 +2238,14 @@ sequential19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[2].address
+    r0 = sequential19_helpers[2].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[2].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2282,14 +2330,14 @@ sequential2(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[0].address
+    r0 = sequential2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2297,10 +2345,12 @@ sequential2(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -2332,22 +2382,24 @@ sequential2(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[1].address
+    r0 = sequential2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[1].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=2
 #line 135 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(2))
+    if (r1 != IMMEDIATE(2)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=3
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=3
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -2364,14 +2416,14 @@ sequential2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[2].address
+    r0 = sequential2_helpers[2].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[2].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2458,14 +2510,14 @@ sequential20(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[0].address
+    r0 = sequential20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2473,10 +2525,12 @@ sequential20(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2511,22 +2565,24 @@ sequential20(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[1].address
+    r0 = sequential20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[1].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=20
 #line 153 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(20))
+    if (r1 != IMMEDIATE(20)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=21
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=21
 #line 153 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(21);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2543,14 +2599,14 @@ sequential20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[2].address
+    r0 = sequential20_helpers[2].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[2].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2637,14 +2693,14 @@ sequential21(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[0].address
+    r0 = sequential21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[0].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2652,10 +2708,12 @@ sequential21(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2690,22 +2748,24 @@ sequential21(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[1].address
+    r0 = sequential21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[1].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=21
 #line 154 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(21))
+    if (r1 != IMMEDIATE(21)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=22
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=22
 #line 154 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(22);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2722,14 +2782,14 @@ sequential21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[2].address
+    r0 = sequential21_helpers[2].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[2].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2816,14 +2876,14 @@ sequential22(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[0].address
+    r0 = sequential22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[0].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2831,10 +2891,12 @@ sequential22(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2869,22 +2931,24 @@ sequential22(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[1].address
+    r0 = sequential22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[1].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=22
 #line 155 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(22))
+    if (r1 != IMMEDIATE(22)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=23
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=23
 #line 155 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(23);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2901,14 +2965,14 @@ sequential22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[2].address
+    r0 = sequential22_helpers[2].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[2].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2995,14 +3059,14 @@ sequential23(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[0].address
+    r0 = sequential23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[0].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3010,10 +3074,12 @@ sequential23(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3048,22 +3114,24 @@ sequential23(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[1].address
+    r0 = sequential23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[1].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=23
 #line 156 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(23))
+    if (r1 != IMMEDIATE(23)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=24
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=24
 #line 156 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3080,14 +3148,14 @@ sequential23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[2].address
+    r0 = sequential23_helpers[2].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[2].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3174,14 +3242,14 @@ sequential24(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[0].address
+    r0 = sequential24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[0].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3189,10 +3257,12 @@ sequential24(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3230,22 +3300,24 @@ sequential24(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=13
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[1].address
+    r0 = sequential24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[1].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=27 dst=r1 src=r8 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=27 dst=r1 src=r8 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=28 dst=r1 src=r0 offset=7 imm=24
 #line 157 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(24))
+    if (r1 != IMMEDIATE(24)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXW pc=29 dst=r8 src=r9 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXW pc=29 dst=r8 src=r9 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     *(uint32_t*)(uintptr_t)(r8 + OFFSET(0)) = (uint32_t)r9;
     // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
@@ -3259,14 +3331,14 @@ sequential24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[2].address
+    r0 = sequential24_helpers[2].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[2].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3353,14 +3425,14 @@ sequential25(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[0].address
+    r0 = sequential25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[0].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3368,10 +3440,12 @@ sequential25(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3406,22 +3480,24 @@ sequential25(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[1].address
+    r0 = sequential25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[1].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=25
 #line 158 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(25))
+    if (r1 != IMMEDIATE(25)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=26
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=26
 #line 158 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(26);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3438,14 +3514,14 @@ sequential25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[2].address
+    r0 = sequential25_helpers[2].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[2].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3532,14 +3608,14 @@ sequential26(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[0].address
+    r0 = sequential26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3547,10 +3623,12 @@ sequential26(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3585,22 +3663,24 @@ sequential26(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[1].address
+    r0 = sequential26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[1].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=26
 #line 159 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(26))
+    if (r1 != IMMEDIATE(26)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=27
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=27
 #line 159 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(27);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3617,14 +3697,14 @@ sequential26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[2].address
+    r0 = sequential26_helpers[2].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[2].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3711,14 +3791,14 @@ sequential27(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[0].address
+    r0 = sequential27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[0].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3726,10 +3806,12 @@ sequential27(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3764,22 +3846,24 @@ sequential27(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[1].address
+    r0 = sequential27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[1].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=27
 #line 160 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(27))
+    if (r1 != IMMEDIATE(27)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=28
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=28
 #line 160 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(28);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3796,14 +3880,14 @@ sequential27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[2].address
+    r0 = sequential27_helpers[2].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[2].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3890,14 +3974,14 @@ sequential28(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[0].address
+    r0 = sequential28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[0].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3905,10 +3989,12 @@ sequential28(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3943,22 +4029,24 @@ sequential28(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[1].address
+    r0 = sequential28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[1].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=28
 #line 161 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(28))
+    if (r1 != IMMEDIATE(28)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=29
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=29
 #line 161 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(29);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3975,14 +4063,14 @@ sequential28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[2].address
+    r0 = sequential28_helpers[2].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[2].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4069,14 +4157,14 @@ sequential29(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[0].address
+    r0 = sequential29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[0].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4084,10 +4172,12 @@ sequential29(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4122,22 +4212,24 @@ sequential29(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[1].address
+    r0 = sequential29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[1].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=29
 #line 162 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(29))
+    if (r1 != IMMEDIATE(29)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=30
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=30
 #line 162 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(30);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4154,14 +4246,14 @@ sequential29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[2].address
+    r0 = sequential29_helpers[2].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[2].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4246,14 +4338,14 @@ sequential3(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[0].address
+    r0 = sequential3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[0].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4261,10 +4353,12 @@ sequential3(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -4296,22 +4390,24 @@ sequential3(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[1].address
+    r0 = sequential3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[1].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=3
 #line 136 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(3))
+    if (r1 != IMMEDIATE(3)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=4
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=4
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -4328,14 +4424,14 @@ sequential3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[2].address
+    r0 = sequential3_helpers[2].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[2].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4422,14 +4518,14 @@ sequential30(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[0].address
+    r0 = sequential30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[0].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4437,10 +4533,12 @@ sequential30(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4475,22 +4573,24 @@ sequential30(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[1].address
+    r0 = sequential30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[1].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=30
 #line 163 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(30))
+    if (r1 != IMMEDIATE(30)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=31
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=31
 #line 163 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(31);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4507,14 +4607,14 @@ sequential30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[2].address
+    r0 = sequential30_helpers[2].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[2].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4601,14 +4701,14 @@ sequential31(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[0].address
+    r0 = sequential31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[0].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4616,10 +4716,12 @@ sequential31(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4654,22 +4756,24 @@ sequential31(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[1].address
+    r0 = sequential31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[1].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=31
 #line 164 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(31))
+    if (r1 != IMMEDIATE(31)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=32
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=32
 #line 164 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(32);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4686,14 +4790,14 @@ sequential31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[2].address
+    r0 = sequential31_helpers[2].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[2].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4780,14 +4884,14 @@ sequential32(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[0].address
+    r0 = sequential32_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4795,10 +4899,12 @@ sequential32(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4833,22 +4939,24 @@ sequential32(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[1].address
+    r0 = sequential32_helpers[1].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[1].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=32
 #line 165 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(32))
+    if (r1 != IMMEDIATE(32)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=33
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=33
 #line 165 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(33);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4865,14 +4973,14 @@ sequential32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[2].address
+    r0 = sequential32_helpers[2].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[2].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4959,14 +5067,14 @@ sequential33(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[0].address
+    r0 = sequential33_helpers[0].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[0].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4974,10 +5082,12 @@ sequential33(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -5012,22 +5122,24 @@ sequential33(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[1].address
+    r0 = sequential33_helpers[1].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[1].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=33
 #line 166 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(33))
+    if (r1 != IMMEDIATE(33)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=34
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=34
 #line 166 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(34);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5044,14 +5156,14 @@ sequential33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[2].address
+    r0 = sequential33_helpers[2].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[2].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5138,14 +5250,14 @@ sequential34(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[0].address
+    r0 = sequential34_helpers[0].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[0].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5153,10 +5265,12 @@ sequential34(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -5191,22 +5305,24 @@ sequential34(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[1].address
+    r0 = sequential34_helpers[1].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[1].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=34
 #line 167 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(34))
+    if (r1 != IMMEDIATE(34)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=35
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=35
 #line 167 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(35);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5223,14 +5339,14 @@ sequential34(void* context)
     r3 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[2].address
+    r0 = sequential34_helpers[2].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[2].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5315,14 +5431,14 @@ sequential4(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[0].address
+    r0 = sequential4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[0].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5330,10 +5446,12 @@ sequential4(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5365,22 +5483,24 @@ sequential4(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[1].address
+    r0 = sequential4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[1].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=4
 #line 137 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(4))
+    if (r1 != IMMEDIATE(4)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=5
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=5
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5397,14 +5517,14 @@ sequential4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[2].address
+    r0 = sequential4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[2].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5489,14 +5609,14 @@ sequential5(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[0].address
+    r0 = sequential5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5504,10 +5624,12 @@ sequential5(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5539,22 +5661,24 @@ sequential5(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[1].address
+    r0 = sequential5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[1].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=5
 #line 138 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(5))
+    if (r1 != IMMEDIATE(5)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=6
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=6
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5571,14 +5695,14 @@ sequential5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[2].address
+    r0 = sequential5_helpers[2].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[2].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5663,14 +5787,14 @@ sequential6(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[0].address
+    r0 = sequential6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[0].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5678,10 +5802,12 @@ sequential6(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5713,22 +5839,24 @@ sequential6(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[1].address
+    r0 = sequential6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[1].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=6
 #line 139 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(6))
+    if (r1 != IMMEDIATE(6)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=7
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=7
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5745,14 +5873,14 @@ sequential6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[2].address
+    r0 = sequential6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[2].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5837,14 +5965,14 @@ sequential7(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[0].address
+    r0 = sequential7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[0].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5852,10 +5980,12 @@ sequential7(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5887,22 +6017,24 @@ sequential7(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[1].address
+    r0 = sequential7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[1].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=7
 #line 140 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(7))
+    if (r1 != IMMEDIATE(7)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=8
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=8
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5919,14 +6051,14 @@ sequential7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[2].address
+    r0 = sequential7_helpers[2].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[2].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6011,14 +6143,14 @@ sequential8(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[0].address
+    r0 = sequential8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -6026,10 +6158,12 @@ sequential8(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6061,22 +6195,24 @@ sequential8(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[1].address
+    r0 = sequential8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[1].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=8
 #line 141 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(8))
+    if (r1 != IMMEDIATE(8)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=9
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6093,14 +6229,14 @@ sequential8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[2].address
+    r0 = sequential8_helpers[2].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[2].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6185,14 +6321,14 @@ sequential9(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[0].address
+    r0 = sequential9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[0].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -6200,10 +6336,12 @@ sequential9(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6235,22 +6373,24 @@ sequential9(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[1].address
+    r0 = sequential9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[1].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=9
 #line 142 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(9))
+    if (r1 != IMMEDIATE(9)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=10
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=10
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6267,14 +6407,14 @@ sequential9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[2].address
+    r0 = sequential9_helpers[2].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[2].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6800,6 +6940,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _map_initial_string_table[] = {
     "sequential0",
     "sequential1",
@@ -6837,6 +6978,7 @@ static const char* _map_initial_string_table[] = {
     "sequential33",
     "sequential34",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
@@ -118,14 +118,14 @@ sequential0(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[0].address
+    r0 = sequential0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[0].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -133,10 +133,12 @@ sequential0(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -168,22 +170,24 @@ sequential0(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[1].address
+    r0 = sequential0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[1].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=1
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=1
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -200,14 +204,14 @@ sequential0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[2].address
+    r0 = sequential0_helpers[2].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[2].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -292,14 +296,14 @@ sequential1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[0].address
+    r0 = sequential1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[0].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -307,10 +311,12 @@ sequential1(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -342,22 +348,24 @@ sequential1(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[1].address
+    r0 = sequential1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[1].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=1
 #line 134 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(1))
+    if (r1 != IMMEDIATE(1)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -374,14 +382,14 @@ sequential1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[2].address
+    r0 = sequential1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[2].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -468,14 +476,14 @@ sequential10(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[0].address
+    r0 = sequential10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[0].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -483,10 +491,12 @@ sequential10(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -521,22 +531,24 @@ sequential10(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[1].address
+    r0 = sequential10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[1].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=10
 #line 143 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(10))
+    if (r1 != IMMEDIATE(10)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=11
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=11
 #line 143 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(11);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -553,14 +565,14 @@ sequential10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[2].address
+    r0 = sequential10_helpers[2].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[2].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -647,14 +659,14 @@ sequential11(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[0].address
+    r0 = sequential11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[0].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -662,10 +674,12 @@ sequential11(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -700,22 +714,24 @@ sequential11(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[1].address
+    r0 = sequential11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[1].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=11
 #line 144 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(11))
+    if (r1 != IMMEDIATE(11)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=12
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=12
 #line 144 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(12);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -732,14 +748,14 @@ sequential11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[2].address
+    r0 = sequential11_helpers[2].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[2].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -826,14 +842,14 @@ sequential12(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[0].address
+    r0 = sequential12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[0].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -841,10 +857,12 @@ sequential12(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -879,22 +897,24 @@ sequential12(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[1].address
+    r0 = sequential12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[1].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=12
 #line 145 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(12))
+    if (r1 != IMMEDIATE(12)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=13
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=13
 #line 145 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(13);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -911,14 +931,14 @@ sequential12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[2].address
+    r0 = sequential12_helpers[2].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[2].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1005,14 +1025,14 @@ sequential13(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[0].address
+    r0 = sequential13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[0].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1020,10 +1040,12 @@ sequential13(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1058,22 +1080,24 @@ sequential13(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[1].address
+    r0 = sequential13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[1].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=13
 #line 146 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(13))
+    if (r1 != IMMEDIATE(13)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=14
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=14
 #line 146 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(14);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1090,14 +1114,14 @@ sequential13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[2].address
+    r0 = sequential13_helpers[2].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[2].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1184,14 +1208,14 @@ sequential14(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[0].address
+    r0 = sequential14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1199,10 +1223,12 @@ sequential14(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1237,22 +1263,24 @@ sequential14(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[1].address
+    r0 = sequential14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[1].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=14
 #line 147 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(14))
+    if (r1 != IMMEDIATE(14)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=15
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=15
 #line 147 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(15);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1269,14 +1297,14 @@ sequential14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[2].address
+    r0 = sequential14_helpers[2].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[2].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1363,14 +1391,14 @@ sequential15(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[0].address
+    r0 = sequential15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[0].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1378,10 +1406,12 @@ sequential15(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1416,22 +1446,24 @@ sequential15(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[1].address
+    r0 = sequential15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[1].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=15
 #line 148 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(15))
+    if (r1 != IMMEDIATE(15)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=16
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=16
 #line 148 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(16);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1448,14 +1480,14 @@ sequential15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[2].address
+    r0 = sequential15_helpers[2].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[2].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1542,14 +1574,14 @@ sequential16(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[0].address
+    r0 = sequential16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[0].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1557,10 +1589,12 @@ sequential16(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1595,22 +1629,24 @@ sequential16(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[1].address
+    r0 = sequential16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[1].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=16
 #line 149 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(16))
+    if (r1 != IMMEDIATE(16)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=17
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=17
 #line 149 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(17);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1627,14 +1663,14 @@ sequential16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[2].address
+    r0 = sequential16_helpers[2].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[2].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1721,14 +1757,14 @@ sequential17(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[0].address
+    r0 = sequential17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[0].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1736,10 +1772,12 @@ sequential17(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1774,22 +1812,24 @@ sequential17(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[1].address
+    r0 = sequential17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[1].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=17
 #line 150 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(17))
+    if (r1 != IMMEDIATE(17)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=18
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=18
 #line 150 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(18);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1806,14 +1846,14 @@ sequential17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[2].address
+    r0 = sequential17_helpers[2].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[2].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1900,14 +1940,14 @@ sequential18(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[0].address
+    r0 = sequential18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[0].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1915,10 +1955,12 @@ sequential18(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1953,22 +1995,24 @@ sequential18(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[1].address
+    r0 = sequential18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[1].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=18
 #line 151 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(18))
+    if (r1 != IMMEDIATE(18)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=19
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=19
 #line 151 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(19);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1985,14 +2029,14 @@ sequential18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[2].address
+    r0 = sequential18_helpers[2].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[2].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2079,14 +2123,14 @@ sequential19(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[0].address
+    r0 = sequential19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[0].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2094,10 +2138,12 @@ sequential19(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2132,22 +2178,24 @@ sequential19(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[1].address
+    r0 = sequential19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[1].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=19
 #line 152 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(19))
+    if (r1 != IMMEDIATE(19)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=20
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=20
 #line 152 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(20);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2164,14 +2212,14 @@ sequential19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[2].address
+    r0 = sequential19_helpers[2].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[2].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2256,14 +2304,14 @@ sequential2(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[0].address
+    r0 = sequential2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2271,10 +2319,12 @@ sequential2(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -2306,22 +2356,24 @@ sequential2(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[1].address
+    r0 = sequential2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[1].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=2
 #line 135 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(2))
+    if (r1 != IMMEDIATE(2)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=3
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=3
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -2338,14 +2390,14 @@ sequential2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[2].address
+    r0 = sequential2_helpers[2].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[2].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2432,14 +2484,14 @@ sequential20(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[0].address
+    r0 = sequential20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2447,10 +2499,12 @@ sequential20(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2485,22 +2539,24 @@ sequential20(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[1].address
+    r0 = sequential20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[1].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=20
 #line 153 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(20))
+    if (r1 != IMMEDIATE(20)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=21
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=21
 #line 153 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(21);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2517,14 +2573,14 @@ sequential20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[2].address
+    r0 = sequential20_helpers[2].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[2].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2611,14 +2667,14 @@ sequential21(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[0].address
+    r0 = sequential21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[0].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2626,10 +2682,12 @@ sequential21(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2664,22 +2722,24 @@ sequential21(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[1].address
+    r0 = sequential21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[1].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=21
 #line 154 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(21))
+    if (r1 != IMMEDIATE(21)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=22
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=22
 #line 154 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(22);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2696,14 +2756,14 @@ sequential21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[2].address
+    r0 = sequential21_helpers[2].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[2].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2790,14 +2850,14 @@ sequential22(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[0].address
+    r0 = sequential22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[0].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2805,10 +2865,12 @@ sequential22(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2843,22 +2905,24 @@ sequential22(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[1].address
+    r0 = sequential22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[1].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=22
 #line 155 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(22))
+    if (r1 != IMMEDIATE(22)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=23
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=23
 #line 155 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(23);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2875,14 +2939,14 @@ sequential22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[2].address
+    r0 = sequential22_helpers[2].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[2].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2969,14 +3033,14 @@ sequential23(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[0].address
+    r0 = sequential23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[0].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2984,10 +3048,12 @@ sequential23(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3022,22 +3088,24 @@ sequential23(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[1].address
+    r0 = sequential23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[1].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=23
 #line 156 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(23))
+    if (r1 != IMMEDIATE(23)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=24
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=24
 #line 156 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3054,14 +3122,14 @@ sequential23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[2].address
+    r0 = sequential23_helpers[2].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[2].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3148,14 +3216,14 @@ sequential24(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[0].address
+    r0 = sequential24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[0].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3163,10 +3231,12 @@ sequential24(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3204,22 +3274,24 @@ sequential24(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=13
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[1].address
+    r0 = sequential24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[1].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=27 dst=r1 src=r8 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=27 dst=r1 src=r8 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=28 dst=r1 src=r0 offset=7 imm=24
 #line 157 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(24))
+    if (r1 != IMMEDIATE(24)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXW pc=29 dst=r8 src=r9 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXW pc=29 dst=r8 src=r9 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     *(uint32_t*)(uintptr_t)(r8 + OFFSET(0)) = (uint32_t)r9;
     // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
@@ -3233,14 +3305,14 @@ sequential24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[2].address
+    r0 = sequential24_helpers[2].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[2].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3327,14 +3399,14 @@ sequential25(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[0].address
+    r0 = sequential25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[0].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3342,10 +3414,12 @@ sequential25(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3380,22 +3454,24 @@ sequential25(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[1].address
+    r0 = sequential25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[1].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=25
 #line 158 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(25))
+    if (r1 != IMMEDIATE(25)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=26
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=26
 #line 158 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(26);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3412,14 +3488,14 @@ sequential25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[2].address
+    r0 = sequential25_helpers[2].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[2].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3506,14 +3582,14 @@ sequential26(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[0].address
+    r0 = sequential26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3521,10 +3597,12 @@ sequential26(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3559,22 +3637,24 @@ sequential26(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[1].address
+    r0 = sequential26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[1].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=26
 #line 159 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(26))
+    if (r1 != IMMEDIATE(26)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=27
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=27
 #line 159 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(27);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3591,14 +3671,14 @@ sequential26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[2].address
+    r0 = sequential26_helpers[2].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[2].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3685,14 +3765,14 @@ sequential27(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[0].address
+    r0 = sequential27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[0].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3700,10 +3780,12 @@ sequential27(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3738,22 +3820,24 @@ sequential27(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[1].address
+    r0 = sequential27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[1].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=27
 #line 160 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(27))
+    if (r1 != IMMEDIATE(27)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=28
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=28
 #line 160 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(28);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3770,14 +3854,14 @@ sequential27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[2].address
+    r0 = sequential27_helpers[2].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[2].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3864,14 +3948,14 @@ sequential28(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[0].address
+    r0 = sequential28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[0].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3879,10 +3963,12 @@ sequential28(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3917,22 +4003,24 @@ sequential28(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[1].address
+    r0 = sequential28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[1].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=28
 #line 161 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(28))
+    if (r1 != IMMEDIATE(28)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=29
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=29
 #line 161 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(29);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3949,14 +4037,14 @@ sequential28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[2].address
+    r0 = sequential28_helpers[2].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[2].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4043,14 +4131,14 @@ sequential29(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[0].address
+    r0 = sequential29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[0].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4058,10 +4146,12 @@ sequential29(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4096,22 +4186,24 @@ sequential29(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[1].address
+    r0 = sequential29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[1].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=29
 #line 162 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(29))
+    if (r1 != IMMEDIATE(29)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=30
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=30
 #line 162 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(30);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4128,14 +4220,14 @@ sequential29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[2].address
+    r0 = sequential29_helpers[2].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[2].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4220,14 +4312,14 @@ sequential3(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[0].address
+    r0 = sequential3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[0].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4235,10 +4327,12 @@ sequential3(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -4270,22 +4364,24 @@ sequential3(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[1].address
+    r0 = sequential3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[1].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=3
 #line 136 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(3))
+    if (r1 != IMMEDIATE(3)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=4
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=4
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -4302,14 +4398,14 @@ sequential3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[2].address
+    r0 = sequential3_helpers[2].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[2].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4396,14 +4492,14 @@ sequential30(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[0].address
+    r0 = sequential30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[0].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4411,10 +4507,12 @@ sequential30(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4449,22 +4547,24 @@ sequential30(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[1].address
+    r0 = sequential30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[1].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=30
 #line 163 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(30))
+    if (r1 != IMMEDIATE(30)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=31
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=31
 #line 163 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(31);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4481,14 +4581,14 @@ sequential30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[2].address
+    r0 = sequential30_helpers[2].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[2].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4575,14 +4675,14 @@ sequential31(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[0].address
+    r0 = sequential31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[0].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4590,10 +4690,12 @@ sequential31(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4628,22 +4730,24 @@ sequential31(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[1].address
+    r0 = sequential31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[1].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=31
 #line 164 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(31))
+    if (r1 != IMMEDIATE(31)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=32
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=32
 #line 164 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(32);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4660,14 +4764,14 @@ sequential31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[2].address
+    r0 = sequential31_helpers[2].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[2].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4754,14 +4858,14 @@ sequential32(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[0].address
+    r0 = sequential32_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4769,10 +4873,12 @@ sequential32(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4807,22 +4913,24 @@ sequential32(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[1].address
+    r0 = sequential32_helpers[1].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[1].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=32
 #line 165 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(32))
+    if (r1 != IMMEDIATE(32)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=33
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=33
 #line 165 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(33);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4839,14 +4947,14 @@ sequential32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[2].address
+    r0 = sequential32_helpers[2].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[2].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4933,14 +5041,14 @@ sequential33(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[0].address
+    r0 = sequential33_helpers[0].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[0].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4948,10 +5056,12 @@ sequential33(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4986,22 +5096,24 @@ sequential33(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[1].address
+    r0 = sequential33_helpers[1].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[1].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=33
 #line 166 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(33))
+    if (r1 != IMMEDIATE(33)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=34
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=34
 #line 166 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(34);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5018,14 +5130,14 @@ sequential33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[2].address
+    r0 = sequential33_helpers[2].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[2].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5112,14 +5224,14 @@ sequential34(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[0].address
+    r0 = sequential34_helpers[0].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[0].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5127,10 +5239,12 @@ sequential34(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -5165,22 +5279,24 @@ sequential34(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[1].address
+    r0 = sequential34_helpers[1].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[1].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=34
 #line 167 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(34))
+    if (r1 != IMMEDIATE(34)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=35
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=35
 #line 167 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(35);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5197,14 +5313,14 @@ sequential34(void* context)
     r3 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[2].address
+    r0 = sequential34_helpers[2].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[2].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5289,14 +5405,14 @@ sequential4(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[0].address
+    r0 = sequential4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[0].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5304,10 +5420,12 @@ sequential4(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5339,22 +5457,24 @@ sequential4(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[1].address
+    r0 = sequential4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[1].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=4
 #line 137 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(4))
+    if (r1 != IMMEDIATE(4)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=5
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=5
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5371,14 +5491,14 @@ sequential4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[2].address
+    r0 = sequential4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[2].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5463,14 +5583,14 @@ sequential5(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[0].address
+    r0 = sequential5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5478,10 +5598,12 @@ sequential5(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5513,22 +5635,24 @@ sequential5(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[1].address
+    r0 = sequential5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[1].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=5
 #line 138 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(5))
+    if (r1 != IMMEDIATE(5)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=6
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=6
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5545,14 +5669,14 @@ sequential5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[2].address
+    r0 = sequential5_helpers[2].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[2].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5637,14 +5761,14 @@ sequential6(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[0].address
+    r0 = sequential6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[0].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5652,10 +5776,12 @@ sequential6(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5687,22 +5813,24 @@ sequential6(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[1].address
+    r0 = sequential6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[1].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=6
 #line 139 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(6))
+    if (r1 != IMMEDIATE(6)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=7
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=7
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5719,14 +5847,14 @@ sequential6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[2].address
+    r0 = sequential6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[2].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5811,14 +5939,14 @@ sequential7(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[0].address
+    r0 = sequential7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[0].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5826,10 +5954,12 @@ sequential7(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5861,22 +5991,24 @@ sequential7(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[1].address
+    r0 = sequential7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[1].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=7
 #line 140 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(7))
+    if (r1 != IMMEDIATE(7)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=8
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=8
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5893,14 +6025,14 @@ sequential7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[2].address
+    r0 = sequential7_helpers[2].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[2].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5985,14 +6117,14 @@ sequential8(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[0].address
+    r0 = sequential8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -6000,10 +6132,12 @@ sequential8(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6035,22 +6169,24 @@ sequential8(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[1].address
+    r0 = sequential8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[1].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=8
 #line 141 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(8))
+    if (r1 != IMMEDIATE(8)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=9
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6067,14 +6203,14 @@ sequential8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[2].address
+    r0 = sequential8_helpers[2].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[2].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6159,14 +6295,14 @@ sequential9(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[0].address
+    r0 = sequential9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[0].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -6174,10 +6310,12 @@ sequential9(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6209,22 +6347,24 @@ sequential9(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[1].address
+    r0 = sequential9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[1].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=9
 #line 142 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(9))
+    if (r1 != IMMEDIATE(9)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=10
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=10
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6241,14 +6381,14 @@ sequential9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[2].address
+    r0 = sequential9_helpers[2].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[2].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6774,6 +6914,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _map_initial_string_table[] = {
     "sequential0",
     "sequential1",
@@ -6811,6 +6952,7 @@ static const char* _map_initial_string_table[] = {
     "sequential33",
     "sequential34",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
@@ -279,14 +279,14 @@ sequential0(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[0].address
+    r0 = sequential0_helpers[0].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[0].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -294,10 +294,12 @@ sequential0(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -329,22 +331,24 @@ sequential0(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[1].address
+    r0 = sequential0_helpers[1].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[1].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(0))
+    if (r1 != IMMEDIATE(0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=1
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=1
 #line 133 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -361,14 +365,14 @@ sequential0(void* context)
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 133 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential0_helpers[2].address
+    r0 = sequential0_helpers[2].address(r1, r2, r3, r4, r5);
 #line 133 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 133 "sample/undocked/tail_call_sequential.c"
-    if ((sequential0_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential0_helpers[2].tail_call) && (r0 == 0)) {
 #line 133 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 133 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 133 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -453,14 +457,14 @@ sequential1(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[0].address
+    r0 = sequential1_helpers[0].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[0].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -468,10 +472,12 @@ sequential1(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -503,22 +509,24 @@ sequential1(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[1].address
+    r0 = sequential1_helpers[1].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[1].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=1
 #line 134 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(1))
+    if (r1 != IMMEDIATE(1)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
 #line 134 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -535,14 +543,14 @@ sequential1(void* context)
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 134 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential1_helpers[2].address
+    r0 = sequential1_helpers[2].address(r1, r2, r3, r4, r5);
 #line 134 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 134 "sample/undocked/tail_call_sequential.c"
-    if ((sequential1_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential1_helpers[2].tail_call) && (r0 == 0)) {
 #line 134 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 134 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 134 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -629,14 +637,14 @@ sequential10(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[0].address
+    r0 = sequential10_helpers[0].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[0].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -644,10 +652,12 @@ sequential10(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -682,22 +692,24 @@ sequential10(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[1].address
+    r0 = sequential10_helpers[1].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[1].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=10
 #line 143 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(10))
+    if (r1 != IMMEDIATE(10)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=11
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=11
 #line 143 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(11);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -714,14 +726,14 @@ sequential10(void* context)
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 143 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential10_helpers[2].address
+    r0 = sequential10_helpers[2].address(r1, r2, r3, r4, r5);
 #line 143 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 143 "sample/undocked/tail_call_sequential.c"
-    if ((sequential10_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential10_helpers[2].tail_call) && (r0 == 0)) {
 #line 143 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 143 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 143 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -808,14 +820,14 @@ sequential11(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[0].address
+    r0 = sequential11_helpers[0].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[0].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -823,10 +835,12 @@ sequential11(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -861,22 +875,24 @@ sequential11(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[1].address
+    r0 = sequential11_helpers[1].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[1].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=11
 #line 144 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(11))
+    if (r1 != IMMEDIATE(11)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=12
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=12
 #line 144 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(12);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -893,14 +909,14 @@ sequential11(void* context)
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 144 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential11_helpers[2].address
+    r0 = sequential11_helpers[2].address(r1, r2, r3, r4, r5);
 #line 144 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 144 "sample/undocked/tail_call_sequential.c"
-    if ((sequential11_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential11_helpers[2].tail_call) && (r0 == 0)) {
 #line 144 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 144 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 144 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -987,14 +1003,14 @@ sequential12(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[0].address
+    r0 = sequential12_helpers[0].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[0].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1002,10 +1018,12 @@ sequential12(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1040,22 +1058,24 @@ sequential12(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[1].address
+    r0 = sequential12_helpers[1].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[1].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=12
 #line 145 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(12))
+    if (r1 != IMMEDIATE(12)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=13
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=13
 #line 145 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(13);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1072,14 +1092,14 @@ sequential12(void* context)
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 145 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential12_helpers[2].address
+    r0 = sequential12_helpers[2].address(r1, r2, r3, r4, r5);
 #line 145 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 145 "sample/undocked/tail_call_sequential.c"
-    if ((sequential12_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential12_helpers[2].tail_call) && (r0 == 0)) {
 #line 145 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 145 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 145 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1166,14 +1186,14 @@ sequential13(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[0].address
+    r0 = sequential13_helpers[0].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[0].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1181,10 +1201,12 @@ sequential13(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1219,22 +1241,24 @@ sequential13(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[1].address
+    r0 = sequential13_helpers[1].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[1].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=13
 #line 146 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(13))
+    if (r1 != IMMEDIATE(13)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=14
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=14
 #line 146 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(14);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1251,14 +1275,14 @@ sequential13(void* context)
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 146 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential13_helpers[2].address
+    r0 = sequential13_helpers[2].address(r1, r2, r3, r4, r5);
 #line 146 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 146 "sample/undocked/tail_call_sequential.c"
-    if ((sequential13_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential13_helpers[2].tail_call) && (r0 == 0)) {
 #line 146 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 146 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 146 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1345,14 +1369,14 @@ sequential14(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[0].address
+    r0 = sequential14_helpers[0].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[0].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1360,10 +1384,12 @@ sequential14(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1398,22 +1424,24 @@ sequential14(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[1].address
+    r0 = sequential14_helpers[1].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[1].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=14
 #line 147 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(14))
+    if (r1 != IMMEDIATE(14)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=15
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=15
 #line 147 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(15);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1430,14 +1458,14 @@ sequential14(void* context)
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 147 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential14_helpers[2].address
+    r0 = sequential14_helpers[2].address(r1, r2, r3, r4, r5);
 #line 147 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 147 "sample/undocked/tail_call_sequential.c"
-    if ((sequential14_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential14_helpers[2].tail_call) && (r0 == 0)) {
 #line 147 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 147 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 147 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1524,14 +1552,14 @@ sequential15(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[0].address
+    r0 = sequential15_helpers[0].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[0].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1539,10 +1567,12 @@ sequential15(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1577,22 +1607,24 @@ sequential15(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[1].address
+    r0 = sequential15_helpers[1].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[1].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=15
 #line 148 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(15))
+    if (r1 != IMMEDIATE(15)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=16
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=16
 #line 148 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(16);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1609,14 +1641,14 @@ sequential15(void* context)
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 148 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential15_helpers[2].address
+    r0 = sequential15_helpers[2].address(r1, r2, r3, r4, r5);
 #line 148 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 148 "sample/undocked/tail_call_sequential.c"
-    if ((sequential15_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential15_helpers[2].tail_call) && (r0 == 0)) {
 #line 148 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 148 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 148 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1703,14 +1735,14 @@ sequential16(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[0].address
+    r0 = sequential16_helpers[0].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[0].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1718,10 +1750,12 @@ sequential16(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1756,22 +1790,24 @@ sequential16(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[1].address
+    r0 = sequential16_helpers[1].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[1].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=16
 #line 149 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(16))
+    if (r1 != IMMEDIATE(16)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=17
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=17
 #line 149 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(17);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1788,14 +1824,14 @@ sequential16(void* context)
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 149 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential16_helpers[2].address
+    r0 = sequential16_helpers[2].address(r1, r2, r3, r4, r5);
 #line 149 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 149 "sample/undocked/tail_call_sequential.c"
-    if ((sequential16_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential16_helpers[2].tail_call) && (r0 == 0)) {
 #line 149 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 149 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 149 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -1882,14 +1918,14 @@ sequential17(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[0].address
+    r0 = sequential17_helpers[0].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[0].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -1897,10 +1933,12 @@ sequential17(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -1935,22 +1973,24 @@ sequential17(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[1].address
+    r0 = sequential17_helpers[1].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[1].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=17
 #line 150 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(17))
+    if (r1 != IMMEDIATE(17)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=18
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=18
 #line 150 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(18);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -1967,14 +2007,14 @@ sequential17(void* context)
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 150 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential17_helpers[2].address
+    r0 = sequential17_helpers[2].address(r1, r2, r3, r4, r5);
 #line 150 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 150 "sample/undocked/tail_call_sequential.c"
-    if ((sequential17_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential17_helpers[2].tail_call) && (r0 == 0)) {
 #line 150 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 150 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2061,14 +2101,14 @@ sequential18(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[0].address
+    r0 = sequential18_helpers[0].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[0].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2076,10 +2116,12 @@ sequential18(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2114,22 +2156,24 @@ sequential18(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[1].address
+    r0 = sequential18_helpers[1].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[1].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=18
 #line 151 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(18))
+    if (r1 != IMMEDIATE(18)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=19
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=19
 #line 151 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(19);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2146,14 +2190,14 @@ sequential18(void* context)
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 151 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential18_helpers[2].address
+    r0 = sequential18_helpers[2].address(r1, r2, r3, r4, r5);
 #line 151 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 151 "sample/undocked/tail_call_sequential.c"
-    if ((sequential18_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential18_helpers[2].tail_call) && (r0 == 0)) {
 #line 151 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 151 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 151 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2240,14 +2284,14 @@ sequential19(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[0].address
+    r0 = sequential19_helpers[0].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[0].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2255,10 +2299,12 @@ sequential19(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2293,22 +2339,24 @@ sequential19(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[1].address
+    r0 = sequential19_helpers[1].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[1].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=19
 #line 152 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(19))
+    if (r1 != IMMEDIATE(19)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=20
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=20
 #line 152 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(20);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2325,14 +2373,14 @@ sequential19(void* context)
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 152 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential19_helpers[2].address
+    r0 = sequential19_helpers[2].address(r1, r2, r3, r4, r5);
 #line 152 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 152 "sample/undocked/tail_call_sequential.c"
-    if ((sequential19_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential19_helpers[2].tail_call) && (r0 == 0)) {
 #line 152 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 152 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 152 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2417,14 +2465,14 @@ sequential2(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[0].address
+    r0 = sequential2_helpers[0].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[0].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2432,10 +2480,12 @@ sequential2(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -2467,22 +2517,24 @@ sequential2(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[1].address
+    r0 = sequential2_helpers[1].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[1].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=2
 #line 135 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(2))
+    if (r1 != IMMEDIATE(2)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=3
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=3
 #line 135 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -2499,14 +2551,14 @@ sequential2(void* context)
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 135 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential2_helpers[2].address
+    r0 = sequential2_helpers[2].address(r1, r2, r3, r4, r5);
 #line 135 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 135 "sample/undocked/tail_call_sequential.c"
-    if ((sequential2_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential2_helpers[2].tail_call) && (r0 == 0)) {
 #line 135 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 135 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 135 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2593,14 +2645,14 @@ sequential20(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[0].address
+    r0 = sequential20_helpers[0].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[0].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2608,10 +2660,12 @@ sequential20(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2646,22 +2700,24 @@ sequential20(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[1].address
+    r0 = sequential20_helpers[1].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[1].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=20
 #line 153 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(20))
+    if (r1 != IMMEDIATE(20)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=21
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=21
 #line 153 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(21);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2678,14 +2734,14 @@ sequential20(void* context)
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 153 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential20_helpers[2].address
+    r0 = sequential20_helpers[2].address(r1, r2, r3, r4, r5);
 #line 153 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 153 "sample/undocked/tail_call_sequential.c"
-    if ((sequential20_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential20_helpers[2].tail_call) && (r0 == 0)) {
 #line 153 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 153 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 153 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2772,14 +2828,14 @@ sequential21(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[0].address
+    r0 = sequential21_helpers[0].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[0].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2787,10 +2843,12 @@ sequential21(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -2825,22 +2883,24 @@ sequential21(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[1].address
+    r0 = sequential21_helpers[1].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[1].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=21
 #line 154 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(21))
+    if (r1 != IMMEDIATE(21)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=22
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=22
 #line 154 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(22);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -2857,14 +2917,14 @@ sequential21(void* context)
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 154 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential21_helpers[2].address
+    r0 = sequential21_helpers[2].address(r1, r2, r3, r4, r5);
 #line 154 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 154 "sample/undocked/tail_call_sequential.c"
-    if ((sequential21_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential21_helpers[2].tail_call) && (r0 == 0)) {
 #line 154 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 154 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 154 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -2951,14 +3011,14 @@ sequential22(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[0].address
+    r0 = sequential22_helpers[0].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[0].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -2966,10 +3026,12 @@ sequential22(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3004,22 +3066,24 @@ sequential22(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[1].address
+    r0 = sequential22_helpers[1].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[1].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=22
 #line 155 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(22))
+    if (r1 != IMMEDIATE(22)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=23
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=23
 #line 155 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(23);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3036,14 +3100,14 @@ sequential22(void* context)
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 155 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential22_helpers[2].address
+    r0 = sequential22_helpers[2].address(r1, r2, r3, r4, r5);
 #line 155 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 155 "sample/undocked/tail_call_sequential.c"
-    if ((sequential22_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential22_helpers[2].tail_call) && (r0 == 0)) {
 #line 155 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 155 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 155 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3130,14 +3194,14 @@ sequential23(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[0].address
+    r0 = sequential23_helpers[0].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[0].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3145,10 +3209,12 @@ sequential23(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3183,22 +3249,24 @@ sequential23(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[1].address
+    r0 = sequential23_helpers[1].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[1].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=23
 #line 156 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(23))
+    if (r1 != IMMEDIATE(23)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=24
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=24
 #line 156 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3215,14 +3283,14 @@ sequential23(void* context)
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 156 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential23_helpers[2].address
+    r0 = sequential23_helpers[2].address(r1, r2, r3, r4, r5);
 #line 156 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 156 "sample/undocked/tail_call_sequential.c"
-    if ((sequential23_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential23_helpers[2].tail_call) && (r0 == 0)) {
 #line 156 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 156 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 156 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3309,14 +3377,14 @@ sequential24(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[0].address
+    r0 = sequential24_helpers[0].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[0].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3324,10 +3392,12 @@ sequential24(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3365,22 +3435,24 @@ sequential24(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=13
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[1].address
+    r0 = sequential24_helpers[1].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[1].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=27 dst=r1 src=r8 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=27 dst=r1 src=r8 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=28 dst=r1 src=r0 offset=7 imm=24
 #line 157 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(24))
+    if (r1 != IMMEDIATE(24)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXW pc=29 dst=r8 src=r9 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXW pc=29 dst=r8 src=r9 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     *(uint32_t*)(uintptr_t)(r8 + OFFSET(0)) = (uint32_t)r9;
     // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
@@ -3394,14 +3466,14 @@ sequential24(void* context)
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 157 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential24_helpers[2].address
+    r0 = sequential24_helpers[2].address(r1, r2, r3, r4, r5);
 #line 157 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 157 "sample/undocked/tail_call_sequential.c"
-    if ((sequential24_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential24_helpers[2].tail_call) && (r0 == 0)) {
 #line 157 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 157 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 157 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3488,14 +3560,14 @@ sequential25(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[0].address
+    r0 = sequential25_helpers[0].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[0].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3503,10 +3575,12 @@ sequential25(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3541,22 +3615,24 @@ sequential25(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[1].address
+    r0 = sequential25_helpers[1].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[1].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=25
 #line 158 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(25))
+    if (r1 != IMMEDIATE(25)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=26
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=26
 #line 158 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(26);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3573,14 +3649,14 @@ sequential25(void* context)
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 158 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential25_helpers[2].address
+    r0 = sequential25_helpers[2].address(r1, r2, r3, r4, r5);
 #line 158 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 158 "sample/undocked/tail_call_sequential.c"
-    if ((sequential25_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential25_helpers[2].tail_call) && (r0 == 0)) {
 #line 158 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 158 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 158 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3667,14 +3743,14 @@ sequential26(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[0].address
+    r0 = sequential26_helpers[0].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[0].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3682,10 +3758,12 @@ sequential26(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3720,22 +3798,24 @@ sequential26(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[1].address
+    r0 = sequential26_helpers[1].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[1].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=26
 #line 159 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(26))
+    if (r1 != IMMEDIATE(26)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=27
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=27
 #line 159 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(27);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3752,14 +3832,14 @@ sequential26(void* context)
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 159 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential26_helpers[2].address
+    r0 = sequential26_helpers[2].address(r1, r2, r3, r4, r5);
 #line 159 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 159 "sample/undocked/tail_call_sequential.c"
-    if ((sequential26_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential26_helpers[2].tail_call) && (r0 == 0)) {
 #line 159 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 159 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 159 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -3846,14 +3926,14 @@ sequential27(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[0].address
+    r0 = sequential27_helpers[0].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[0].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -3861,10 +3941,12 @@ sequential27(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -3899,22 +3981,24 @@ sequential27(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[1].address
+    r0 = sequential27_helpers[1].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[1].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=27
 #line 160 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(27))
+    if (r1 != IMMEDIATE(27)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=28
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=28
 #line 160 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(28);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -3931,14 +4015,14 @@ sequential27(void* context)
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 160 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential27_helpers[2].address
+    r0 = sequential27_helpers[2].address(r1, r2, r3, r4, r5);
 #line 160 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 160 "sample/undocked/tail_call_sequential.c"
-    if ((sequential27_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential27_helpers[2].tail_call) && (r0 == 0)) {
 #line 160 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 160 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 160 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4025,14 +4109,14 @@ sequential28(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[0].address
+    r0 = sequential28_helpers[0].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[0].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4040,10 +4124,12 @@ sequential28(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4078,22 +4164,24 @@ sequential28(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[1].address
+    r0 = sequential28_helpers[1].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[1].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=28
 #line 161 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(28))
+    if (r1 != IMMEDIATE(28)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=29
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=29
 #line 161 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(29);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4110,14 +4198,14 @@ sequential28(void* context)
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 161 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential28_helpers[2].address
+    r0 = sequential28_helpers[2].address(r1, r2, r3, r4, r5);
 #line 161 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 161 "sample/undocked/tail_call_sequential.c"
-    if ((sequential28_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential28_helpers[2].tail_call) && (r0 == 0)) {
 #line 161 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 161 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 161 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4204,14 +4292,14 @@ sequential29(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[0].address
+    r0 = sequential29_helpers[0].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[0].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4219,10 +4307,12 @@ sequential29(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4257,22 +4347,24 @@ sequential29(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[1].address
+    r0 = sequential29_helpers[1].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[1].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=29
 #line 162 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(29))
+    if (r1 != IMMEDIATE(29)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=30
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=30
 #line 162 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(30);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4289,14 +4381,14 @@ sequential29(void* context)
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 162 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential29_helpers[2].address
+    r0 = sequential29_helpers[2].address(r1, r2, r3, r4, r5);
 #line 162 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 162 "sample/undocked/tail_call_sequential.c"
-    if ((sequential29_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential29_helpers[2].tail_call) && (r0 == 0)) {
 #line 162 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 162 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 162 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4381,14 +4473,14 @@ sequential3(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[0].address
+    r0 = sequential3_helpers[0].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[0].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4396,10 +4488,12 @@ sequential3(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -4431,22 +4525,24 @@ sequential3(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[1].address
+    r0 = sequential3_helpers[1].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[1].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=3
 #line 136 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(3))
+    if (r1 != IMMEDIATE(3)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=4
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=4
 #line 136 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -4463,14 +4559,14 @@ sequential3(void* context)
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 136 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential3_helpers[2].address
+    r0 = sequential3_helpers[2].address(r1, r2, r3, r4, r5);
 #line 136 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 136 "sample/undocked/tail_call_sequential.c"
-    if ((sequential3_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential3_helpers[2].tail_call) && (r0 == 0)) {
 #line 136 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 136 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 136 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4557,14 +4653,14 @@ sequential30(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[0].address
+    r0 = sequential30_helpers[0].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[0].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4572,10 +4668,12 @@ sequential30(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4610,22 +4708,24 @@ sequential30(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[1].address
+    r0 = sequential30_helpers[1].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[1].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=30
 #line 163 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(30))
+    if (r1 != IMMEDIATE(30)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=31
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=31
 #line 163 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(31);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4642,14 +4742,14 @@ sequential30(void* context)
     r3 = IMMEDIATE(31);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 163 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential30_helpers[2].address
+    r0 = sequential30_helpers[2].address(r1, r2, r3, r4, r5);
 #line 163 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 163 "sample/undocked/tail_call_sequential.c"
-    if ((sequential30_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential30_helpers[2].tail_call) && (r0 == 0)) {
 #line 163 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 163 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 163 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4736,14 +4836,14 @@ sequential31(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[0].address
+    r0 = sequential31_helpers[0].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[0].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4751,10 +4851,12 @@ sequential31(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4789,22 +4891,24 @@ sequential31(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[1].address
+    r0 = sequential31_helpers[1].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[1].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=31
 #line 164 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(31))
+    if (r1 != IMMEDIATE(31)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=32
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=32
 #line 164 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(32);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -4821,14 +4925,14 @@ sequential31(void* context)
     r3 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 164 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential31_helpers[2].address
+    r0 = sequential31_helpers[2].address(r1, r2, r3, r4, r5);
 #line 164 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 164 "sample/undocked/tail_call_sequential.c"
-    if ((sequential31_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential31_helpers[2].tail_call) && (r0 == 0)) {
 #line 164 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 164 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -4915,14 +5019,14 @@ sequential32(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[0].address
+    r0 = sequential32_helpers[0].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[0].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -4930,10 +5034,12 @@ sequential32(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -4968,22 +5074,24 @@ sequential32(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[1].address
+    r0 = sequential32_helpers[1].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[1].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=32
 #line 165 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(32))
+    if (r1 != IMMEDIATE(32)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=33
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=33
 #line 165 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(33);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5000,14 +5108,14 @@ sequential32(void* context)
     r3 = IMMEDIATE(33);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 165 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential32_helpers[2].address
+    r0 = sequential32_helpers[2].address(r1, r2, r3, r4, r5);
 #line 165 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 165 "sample/undocked/tail_call_sequential.c"
-    if ((sequential32_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential32_helpers[2].tail_call) && (r0 == 0)) {
 #line 165 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 165 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 165 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5094,14 +5202,14 @@ sequential33(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[0].address
+    r0 = sequential33_helpers[0].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[0].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5109,10 +5217,12 @@ sequential33(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -5147,22 +5257,24 @@ sequential33(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[1].address
+    r0 = sequential33_helpers[1].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[1].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=33
 #line 166 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(33))
+    if (r1 != IMMEDIATE(33)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=34
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=34
 #line 166 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(34);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5179,14 +5291,14 @@ sequential33(void* context)
     r3 = IMMEDIATE(34);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 166 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential33_helpers[2].address
+    r0 = sequential33_helpers[2].address(r1, r2, r3, r4, r5);
 #line 166 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 166 "sample/undocked/tail_call_sequential.c"
-    if ((sequential33_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential33_helpers[2].tail_call) && (r0 == 0)) {
 #line 166 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 166 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 166 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5273,14 +5385,14 @@ sequential34(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[0].address
+    r0 = sequential34_helpers[0].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[0].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5288,10 +5400,12 @@ sequential34(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=25 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_STXB pc=11 dst=r10 src=r9 offset=-8 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r9;
     // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1702194273
@@ -5326,22 +5440,24 @@ sequential34(void* context)
     r2 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=13
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[1].address
+    r0 = sequential34_helpers[1].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[1].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r8 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=8 imm=34
 #line 167 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(34))
+    if (r1 != IMMEDIATE(34)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=35
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=28 dst=r1 src=r0 offset=0 imm=35
 #line 167 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(35);
     // EBPF_OP_STXW pc=29 dst=r8 src=r1 offset=0 imm=0
@@ -5358,14 +5474,14 @@ sequential34(void* context)
     r3 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=34 dst=r0 src=r0 offset=0 imm=5
 #line 167 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential34_helpers[2].address
+    r0 = sequential34_helpers[2].address(r1, r2, r3, r4, r5);
 #line 167 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 167 "sample/undocked/tail_call_sequential.c"
-    if ((sequential34_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential34_helpers[2].tail_call) && (r0 == 0)) {
 #line 167 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 167 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 167 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5450,14 +5566,14 @@ sequential4(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[0].address
+    r0 = sequential4_helpers[0].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[0].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5465,10 +5581,12 @@ sequential4(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5500,22 +5618,24 @@ sequential4(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[1].address
+    r0 = sequential4_helpers[1].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[1].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=4
 #line 137 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(4))
+    if (r1 != IMMEDIATE(4)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=5
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=5
 #line 137 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5532,14 +5652,14 @@ sequential4(void* context)
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 137 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential4_helpers[2].address
+    r0 = sequential4_helpers[2].address(r1, r2, r3, r4, r5);
 #line 137 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 137 "sample/undocked/tail_call_sequential.c"
-    if ((sequential4_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential4_helpers[2].tail_call) && (r0 == 0)) {
 #line 137 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 137 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 137 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5624,14 +5744,14 @@ sequential5(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[0].address
+    r0 = sequential5_helpers[0].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[0].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5639,10 +5759,12 @@ sequential5(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5674,22 +5796,24 @@ sequential5(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[1].address
+    r0 = sequential5_helpers[1].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[1].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=5
 #line 138 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(5))
+    if (r1 != IMMEDIATE(5)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=6
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=6
 #line 138 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5706,14 +5830,14 @@ sequential5(void* context)
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 138 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential5_helpers[2].address
+    r0 = sequential5_helpers[2].address(r1, r2, r3, r4, r5);
 #line 138 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 138 "sample/undocked/tail_call_sequential.c"
-    if ((sequential5_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential5_helpers[2].tail_call) && (r0 == 0)) {
 #line 138 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 138 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 138 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5798,14 +5922,14 @@ sequential6(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[0].address
+    r0 = sequential6_helpers[0].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[0].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5813,10 +5937,12 @@ sequential6(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -5848,22 +5974,24 @@ sequential6(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[1].address
+    r0 = sequential6_helpers[1].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[1].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=6
 #line 139 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(6))
+    if (r1 != IMMEDIATE(6)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=7
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=7
 #line 139 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -5880,14 +6008,14 @@ sequential6(void* context)
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 139 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential6_helpers[2].address
+    r0 = sequential6_helpers[2].address(r1, r2, r3, r4, r5);
 #line 139 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 139 "sample/undocked/tail_call_sequential.c"
-    if ((sequential6_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential6_helpers[2].tail_call) && (r0 == 0)) {
 #line 139 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 139 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 139 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -5972,14 +6100,14 @@ sequential7(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[0].address
+    r0 = sequential7_helpers[0].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[0].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -5987,10 +6115,12 @@ sequential7(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6022,22 +6152,24 @@ sequential7(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[1].address
+    r0 = sequential7_helpers[1].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[1].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=7
 #line 140 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(7))
+    if (r1 != IMMEDIATE(7)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=8
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=8
 #line 140 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6054,14 +6186,14 @@ sequential7(void* context)
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 140 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential7_helpers[2].address
+    r0 = sequential7_helpers[2].address(r1, r2, r3, r4, r5);
 #line 140 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 140 "sample/undocked/tail_call_sequential.c"
-    if ((sequential7_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential7_helpers[2].tail_call) && (r0 == 0)) {
 #line 140 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 140 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 140 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6146,14 +6278,14 @@ sequential8(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[0].address
+    r0 = sequential8_helpers[0].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[0].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -6161,10 +6293,12 @@ sequential8(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6196,22 +6330,24 @@ sequential8(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[1].address
+    r0 = sequential8_helpers[1].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[1].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=8
 #line 141 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(8))
+    if (r1 != IMMEDIATE(8)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=9
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6228,14 +6364,14 @@ sequential8(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 141 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential8_helpers[2].address
+    r0 = sequential8_helpers[2].address(r1, r2, r3, r4, r5);
 #line 141 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 141 "sample/undocked/tail_call_sequential.c"
-    if ((sequential8_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential8_helpers[2].tail_call) && (r0 == 0)) {
 #line 141 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 141 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6320,14 +6456,14 @@ sequential9(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[0].address
+    r0 = sequential9_helpers[0].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[0].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[0].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=8 dst=r8 src=r0 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=9 dst=r7 src=r0 offset=0 imm=1
@@ -6335,10 +6471,12 @@ sequential9(void* context)
     r7 = IMMEDIATE(1);
     // EBPF_OP_JEQ_IMM pc=10 dst=r8 src=r0 offset=24 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1030059372
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = (uint64_t)2924860873733484;
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-16 imm=0
@@ -6370,22 +6508,24 @@ sequential9(void* context)
     r2 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=13
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[1].address
+    r0 = sequential9_helpers[1].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[1].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[1].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_LDXW pc=25 dst=r1 src=r8 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=26 dst=r1 src=r0 offset=8 imm=9
 #line 142 "sample/undocked/tail_call_sequential.c"
-    if (r1 != IMMEDIATE(9))
+    if (r1 != IMMEDIATE(9)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=10
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=10
 #line 142 "sample/undocked/tail_call_sequential.c"
     r1 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=28 dst=r8 src=r1 offset=0 imm=0
@@ -6402,14 +6542,14 @@ sequential9(void* context)
     r3 = IMMEDIATE(10);
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=5
 #line 142 "sample/undocked/tail_call_sequential.c"
-    r0 = sequential9_helpers[2].address
+    r0 = sequential9_helpers[2].address(r1, r2, r3, r4, r5);
 #line 142 "sample/undocked/tail_call_sequential.c"
-         (r1, r2, r3, r4, r5);
-#line 142 "sample/undocked/tail_call_sequential.c"
-    if ((sequential9_helpers[2].tail_call) && (r0 == 0))
+    if ((sequential9_helpers[2].tail_call) && (r0 == 0)) {
 #line 142 "sample/undocked/tail_call_sequential.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 142 "sample/undocked/tail_call_sequential.c"
+    }
+    // EBPF_OP_MOV64_REG pc=34 dst=r7 src=r0 offset=0 imm=0
 #line 142 "sample/undocked/tail_call_sequential.c"
     r7 = r0;
 label_1:
@@ -6935,6 +7075,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 }
 
 #pragma data_seg(push, "map_initial_values")
+// clang-format off
 static const char* _map_initial_string_table[] = {
     "sequential0",
     "sequential1",
@@ -6972,6 +7113,7 @@ static const char* _map_initial_string_table[] = {
     "sequential33",
     "sequential34",
 };
+// clang-format on
 
 static map_initial_values_t _map_initial_values_array[] = {
     {

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -264,14 +264,14 @@ caller(void* context)
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
 #line 38 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[0].address
+    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
 #line 38 "sample/undocked/tail_call.c"
-         (r1, r2, r3, r4, r5);
-#line 38 "sample/undocked/tail_call.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0))
+    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
 #line 38 "sample/undocked/tail_call.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
+#line 38 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
 #line 38 "sample/undocked/tail_call.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
@@ -282,19 +282,21 @@ caller(void* context)
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 41 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[1].address
+    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
 #line 41 "sample/undocked/tail_call.c"
-         (r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0))
+    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
 #line 41 "sample/undocked/tail_call.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
+#line 41 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
 #line 42 "sample/undocked/tail_call.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/tail_call.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
+#line 42 "sample/undocked/tail_call.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
 #line 42 "sample/undocked/tail_call.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -132,14 +132,14 @@ test_program_entry(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[0].address
+    r0 = test_program_entry_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
+#line 39 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
 #line 39 "sample/undocked/test_sample_ebpf.c"
     r8 = r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
@@ -153,22 +153,24 @@ test_program_entry(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 40 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[0].address
+    r0 = test_program_entry_helpers[0].address(r1, r2, r3, r4, r5);
 #line 40 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 40 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0)) {
 #line 40 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/test_sample_ebpf.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
@@ -176,10 +178,12 @@ test_program_entry(void* context)
     r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 42 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
+#line 42 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 47 "sample/undocked/test_sample_ebpf.c"
     r2 -= r1;
     // EBPF_OP_MOV64_REG pc=21 dst=r3 src=r8 offset=0 imm=0
@@ -190,19 +194,21 @@ test_program_entry(void* context)
     r4 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=23 dst=r0 src=r0 offset=0 imm=65537
 #line 46 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[1].address
+    r0 = test_program_entry_helpers[1].address(r1, r2, r3, r4, r5);
 #line 46 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[1].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[1].tail_call) && (r0 == 0)) {
 #line 46 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
+#line 46 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
 #line 48 "sample/undocked/test_sample_ebpf.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 48 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
+#line 48 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
 #line 50 "sample/undocked/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=26 dst=r2 src=r6 offset=8 imm=0
@@ -222,43 +228,47 @@ test_program_entry(void* context)
     r5 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=65538
 #line 49 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[2].address
+    r0 = test_program_entry_helpers[2].address(r1, r2, r3, r4, r5);
 #line 49 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 49 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[2].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[2].tail_call) && (r0 == 0)) {
 #line 49 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
+#line 49 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
 #line 49 "sample/undocked/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r1 src=r0 offset=5 imm=0
 #line 51 "sample/undocked/test_sample_ebpf.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 51 "sample/undocked/test_sample_ebpf.c"
         goto label_2;
+#line 51 "sample/undocked/test_sample_ebpf.c"
+    }
 label_1:
     // EBPF_OP_MOV64_REG pc=34 dst=r1 src=r6 offset=0 imm=0
 #line 58 "sample/undocked/test_sample_ebpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=65536
 #line 58 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[3].address
+    r0 = test_program_entry_helpers[3].address(r1, r2, r3, r4, r5);
 #line 58 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[3].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[3].tail_call) && (r0 == 0)) {
 #line 58 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
+#line 58 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
 #line 58 "sample/undocked/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 59 "sample/undocked/test_sample_ebpf.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 59 "sample/undocked/test_sample_ebpf.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
+#line 59 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
 #line 59 "sample/undocked/test_sample_ebpf.c"
     r0 = IMMEDIATE(42);
 label_2:

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -106,14 +106,14 @@ test_program_entry(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[0].address
+    r0 = test_program_entry_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
+#line 39 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
 #line 39 "sample/undocked/test_sample_ebpf.c"
     r8 = r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
@@ -127,22 +127,24 @@ test_program_entry(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 40 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[0].address
+    r0 = test_program_entry_helpers[0].address(r1, r2, r3, r4, r5);
 #line 40 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 40 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0)) {
 #line 40 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/test_sample_ebpf.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
@@ -150,10 +152,12 @@ test_program_entry(void* context)
     r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 42 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
+#line 42 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 47 "sample/undocked/test_sample_ebpf.c"
     r2 -= r1;
     // EBPF_OP_MOV64_REG pc=21 dst=r3 src=r8 offset=0 imm=0
@@ -164,19 +168,21 @@ test_program_entry(void* context)
     r4 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=23 dst=r0 src=r0 offset=0 imm=65537
 #line 46 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[1].address
+    r0 = test_program_entry_helpers[1].address(r1, r2, r3, r4, r5);
 #line 46 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[1].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[1].tail_call) && (r0 == 0)) {
 #line 46 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
+#line 46 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
 #line 48 "sample/undocked/test_sample_ebpf.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 48 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
+#line 48 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
 #line 50 "sample/undocked/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=26 dst=r2 src=r6 offset=8 imm=0
@@ -196,43 +202,47 @@ test_program_entry(void* context)
     r5 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=65538
 #line 49 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[2].address
+    r0 = test_program_entry_helpers[2].address(r1, r2, r3, r4, r5);
 #line 49 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 49 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[2].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[2].tail_call) && (r0 == 0)) {
 #line 49 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
+#line 49 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
 #line 49 "sample/undocked/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r1 src=r0 offset=5 imm=0
 #line 51 "sample/undocked/test_sample_ebpf.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 51 "sample/undocked/test_sample_ebpf.c"
         goto label_2;
+#line 51 "sample/undocked/test_sample_ebpf.c"
+    }
 label_1:
     // EBPF_OP_MOV64_REG pc=34 dst=r1 src=r6 offset=0 imm=0
 #line 58 "sample/undocked/test_sample_ebpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=65536
 #line 58 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[3].address
+    r0 = test_program_entry_helpers[3].address(r1, r2, r3, r4, r5);
 #line 58 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[3].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[3].tail_call) && (r0 == 0)) {
 #line 58 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
+#line 58 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
 #line 58 "sample/undocked/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 59 "sample/undocked/test_sample_ebpf.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 59 "sample/undocked/test_sample_ebpf.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
+#line 59 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
 #line 59 "sample/undocked/test_sample_ebpf.c"
     r0 = IMMEDIATE(42);
 label_2:

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -267,14 +267,14 @@ test_program_entry(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=1
 #line 39 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[0].address
+    r0 = test_program_entry_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
+#line 39 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
 #line 39 "sample/undocked/test_sample_ebpf.c"
     r8 = r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
@@ -288,22 +288,24 @@ test_program_entry(void* context)
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=1
 #line 40 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[0].address
+    r0 = test_program_entry_helpers[0].address(r1, r2, r3, r4, r5);
 #line 40 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 40 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[0].tail_call) && (r0 == 0)) {
 #line 40 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 40 "sample/undocked/test_sample_ebpf.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
-    if (r8 == IMMEDIATE(0))
+    if (r8 == IMMEDIATE(0)) {
 #line 42 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
@@ -311,10 +313,12 @@ test_program_entry(void* context)
     r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
 #line 42 "sample/undocked/test_sample_ebpf.c"
-    if (r1 >= r2)
+    if (r1 >= r2) {
 #line 42 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
+#line 42 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 47 "sample/undocked/test_sample_ebpf.c"
     r2 -= r1;
     // EBPF_OP_MOV64_REG pc=21 dst=r3 src=r8 offset=0 imm=0
@@ -325,19 +329,21 @@ test_program_entry(void* context)
     r4 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=23 dst=r0 src=r0 offset=0 imm=65537
 #line 46 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[1].address
+    r0 = test_program_entry_helpers[1].address(r1, r2, r3, r4, r5);
 #line 46 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 46 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[1].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[1].tail_call) && (r0 == 0)) {
 #line 46 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
+#line 46 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
 #line 48 "sample/undocked/test_sample_ebpf.c"
-    if (r7 == IMMEDIATE(0))
+    if (r7 == IMMEDIATE(0)) {
 #line 48 "sample/undocked/test_sample_ebpf.c"
         goto label_1;
-        // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
+#line 48 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
 #line 50 "sample/undocked/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=26 dst=r2 src=r6 offset=8 imm=0
@@ -357,43 +363,47 @@ test_program_entry(void* context)
     r5 = IMMEDIATE(32);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=65538
 #line 49 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[2].address
+    r0 = test_program_entry_helpers[2].address(r1, r2, r3, r4, r5);
 #line 49 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 49 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[2].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[2].tail_call) && (r0 == 0)) {
 #line 49 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
+#line 49 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
 #line 49 "sample/undocked/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r1 src=r0 offset=5 imm=0
 #line 51 "sample/undocked/test_sample_ebpf.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 51 "sample/undocked/test_sample_ebpf.c"
         goto label_2;
+#line 51 "sample/undocked/test_sample_ebpf.c"
+    }
 label_1:
     // EBPF_OP_MOV64_REG pc=34 dst=r1 src=r6 offset=0 imm=0
 #line 58 "sample/undocked/test_sample_ebpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=65536
 #line 58 "sample/undocked/test_sample_ebpf.c"
-    r0 = test_program_entry_helpers[3].address
+    r0 = test_program_entry_helpers[3].address(r1, r2, r3, r4, r5);
 #line 58 "sample/undocked/test_sample_ebpf.c"
-         (r1, r2, r3, r4, r5);
-#line 58 "sample/undocked/test_sample_ebpf.c"
-    if ((test_program_entry_helpers[3].tail_call) && (r0 == 0))
+    if ((test_program_entry_helpers[3].tail_call) && (r0 == 0)) {
 #line 58 "sample/undocked/test_sample_ebpf.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
+#line 58 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
 #line 58 "sample/undocked/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=37 dst=r1 src=r0 offset=1 imm=0
 #line 59 "sample/undocked/test_sample_ebpf.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 59 "sample/undocked/test_sample_ebpf.c"
         goto label_2;
-        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
+#line 59 "sample/undocked/test_sample_ebpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
 #line 59 "sample/undocked/test_sample_ebpf.c"
     r0 = IMMEDIATE(42);
 label_2:

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -133,62 +133,62 @@ test_utility_helpers(void* context)
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=6
 #line 16 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5);
 #line 16 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 16 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
+#line 16 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
 #line 24 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5);
 #line 24 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 24 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
+#line 24 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=9
 #line 27 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5);
 #line 27 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 27 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
+#line 27 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
 #line 30 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[3].address
+    r0 = test_utility_helpers_helpers[3].address(r1, r2, r3, r4, r5);
 #line 30 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0)) {
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
+#line 30 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=16 dst=r0 src=r0 offset=0 imm=19
 #line 33 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5);
 #line 33 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
+#line 33 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
 #line 33 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
@@ -214,59 +214,59 @@ test_utility_helpers(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=2
 #line 36 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5);
 #line 36 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
+#line 36 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
 #line 39 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=9
 #line 42 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5);
 #line 42 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=7
 #line 45 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
+#line 45 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
 #line 45 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=19
 #line 48 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5);
 #line 48 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
 #line 48 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
+#line 48 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
@@ -286,14 +286,14 @@ test_utility_helpers(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5);
 #line 51 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
 #line 51 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
+#line 51 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=43 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -107,62 +107,62 @@ test_utility_helpers(void* context)
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=6
 #line 16 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5);
 #line 16 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 16 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
+#line 16 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
 #line 24 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5);
 #line 24 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 24 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
+#line 24 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=9
 #line 27 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5);
 #line 27 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 27 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
+#line 27 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
 #line 30 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[3].address
+    r0 = test_utility_helpers_helpers[3].address(r1, r2, r3, r4, r5);
 #line 30 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0)) {
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
+#line 30 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=16 dst=r0 src=r0 offset=0 imm=19
 #line 33 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5);
 #line 33 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
+#line 33 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
 #line 33 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
@@ -188,59 +188,59 @@ test_utility_helpers(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=2
 #line 36 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5);
 #line 36 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
+#line 36 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
 #line 39 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=9
 #line 42 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5);
 #line 42 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=7
 #line 45 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
+#line 45 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
 #line 45 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=19
 #line 48 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5);
 #line 48 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
 #line 48 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
+#line 48 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
@@ -260,14 +260,14 @@ test_utility_helpers(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5);
 #line 51 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
 #line 51 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
+#line 51 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=43 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -268,62 +268,62 @@ test_utility_helpers(void* context)
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=6
 #line 16 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5);
 #line 16 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 16 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
+#line 16 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
 #line 24 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5);
 #line 24 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 24 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
+#line 24 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=9
 #line 27 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5);
 #line 27 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 27 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
+#line 27 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
 #line 30 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[3].address
+    r0 = test_utility_helpers_helpers[3].address(r1, r2, r3, r4, r5);
 #line 30 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 30 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0)) {
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
+#line 30 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=16 dst=r0 src=r0 offset=0 imm=19
 #line 33 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5);
 #line 33 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 33 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
+#line 33 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
 #line 33 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
@@ -349,59 +349,59 @@ test_utility_helpers(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=2
 #line 36 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5);
 #line 36 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 36 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
+#line 36 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
 #line 39 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5);
 #line 39 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 39 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=9
 #line 42 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5);
 #line 42 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 42 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=7
 #line 45 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5);
 #line 45 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
+#line 45 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
 #line 45 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=19
 #line 48 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5);
 #line 48 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 48 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
 #line 48 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
+#line 48 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
@@ -421,14 +421,14 @@ test_utility_helpers(void* context)
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5);
 #line 51 "sample/./sample_common_routines.h"
-         (r1, r2, r3, r4, r5);
-#line 51 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0))
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
 #line 51 "sample/./sample_common_routines.h"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
+#line 51 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=43 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -140,14 +140,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=23
 #line 31 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 31 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 31 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r6 src=r0 offset=0 imm=1
+#line 31 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=19 dst=r6 src=r0 offset=0 imm=1
 #line 31 "sample/utility.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_LSH64_IMM pc=20 dst=r0 src=r0 offset=0 imm=32
@@ -158,10 +158,12 @@ UtilityTest(void* context)
     r0 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=22 dst=r0 src=r0 offset=83 imm=0
 #line 31 "sample/utility.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 31 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=84
+#line 31 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=84
 #line 31 "sample/utility.c"
     r1 = IMMEDIATE(84);
     // EBPF_OP_STXB pc=24 dst=r10 src=r1 offset=-8 imm=0
@@ -187,14 +189,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=23
 #line 37 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 37 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 37 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r6 src=r0 offset=0 imm=2
+#line 37 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r6 src=r0 offset=0 imm=2
 #line 37 "sample/utility.c"
     r6 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
@@ -205,10 +207,12 @@ UtilityTest(void* context)
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=35 dst=r0 src=r0 offset=70 imm=-1
 #line 37 "sample/utility.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 37 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=36 dst=r1 src=r10 offset=0 imm=0
+#line 37 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=36 dst=r1 src=r10 offset=0 imm=0
 #line 37 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=37 dst=r1 src=r0 offset=0 imm=-8
@@ -231,14 +235,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=23
 #line 43 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/utility.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
+#line 43 "sample/utility.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
 #line 43 "sample/utility.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
@@ -246,10 +250,12 @@ UtilityTest(void* context)
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=46 dst=r0 src=r0 offset=59 imm=-1
 #line 43 "sample/utility.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 43 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=1414743380
+#line 43 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=1414743380
 #line 43 "sample/utility.c"
     r1 = IMMEDIATE(1414743380);
     // EBPF_OP_STXW pc=48 dst=r10 src=r1 offset=-8 imm=0
@@ -275,14 +281,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=22
 #line 54 "sample/utility.c"
-    r0 = UtilityTest_helpers[1].address
+    r0 = UtilityTest_helpers[1].address(r1, r2, r3, r4, r5);
 #line 54 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/utility.c"
-    if ((UtilityTest_helpers[1].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[1].tail_call) && (r0 == 0)) {
 #line 54 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
+#line 54 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
 #line 54 "sample/utility.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=57 dst=r6 src=r0 offset=0 imm=4
@@ -290,10 +296,12 @@ UtilityTest(void* context)
     r6 = IMMEDIATE(4);
     // EBPF_OP_JSGT_REG pc=58 dst=r1 src=r0 offset=47 imm=0
 #line 54 "sample/utility.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 54 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=59 dst=r6 src=r0 offset=0 imm=5
+#line 54 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=59 dst=r6 src=r0 offset=0 imm=5
 #line 54 "sample/utility.c"
     r6 = IMMEDIATE(5);
     // EBPF_OP_LDXB pc=60 dst=r1 src=r10 offset=-8 imm=0
@@ -301,34 +309,42 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8));
     // EBPF_OP_JNE_IMM pc=61 dst=r1 src=r0 offset=44 imm=116
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(116))
+    if (r1 != IMMEDIATE(116)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=62 dst=r1 src=r10 offset=-7 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=62 dst=r1 src=r10 offset=-7 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-7));
     // EBPF_OP_JNE_IMM pc=63 dst=r1 src=r0 offset=42 imm=101
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(101))
+    if (r1 != IMMEDIATE(101)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=64 dst=r1 src=r10 offset=-6 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=64 dst=r1 src=r10 offset=-6 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-6));
     // EBPF_OP_JNE_IMM pc=65 dst=r1 src=r0 offset=40 imm=115
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(115))
+    if (r1 != IMMEDIATE(115)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=66 dst=r1 src=r10 offset=-5 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=66 dst=r1 src=r10 offset=-5 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-5));
     // EBPF_OP_JNE_IMM pc=67 dst=r1 src=r0 offset=38 imm=116
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(116))
+    if (r1 != IMMEDIATE(116)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r10 offset=0 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r10 offset=0 imm=0
 #line 59 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=69 dst=r1 src=r0 offset=0 imm=-8
@@ -342,22 +358,24 @@ UtilityTest(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=24
 #line 64 "sample/utility.c"
-    r0 = UtilityTest_helpers[2].address
+    r0 = UtilityTest_helpers[2].address(r1, r2, r3, r4, r5);
 #line 64 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/utility.c"
-    if ((UtilityTest_helpers[2].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[2].tail_call) && (r0 == 0)) {
 #line 64 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=73 dst=r6 src=r0 offset=0 imm=6
+#line 64 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=73 dst=r6 src=r0 offset=0 imm=6
 #line 64 "sample/utility.c"
     r6 = IMMEDIATE(6);
     // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=31 imm=0
 #line 64 "sample/utility.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 64 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=75 dst=r1 src=r10 offset=-8 imm=0
+#line 64 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=75 dst=r1 src=r10 offset=-8 imm=0
 #line 69 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8));
     // EBPF_OP_LDXB pc=76 dst=r2 src=r10 offset=-7 imm=0
@@ -386,10 +404,12 @@ UtilityTest(void* context)
     r2 &= IMMEDIATE(255);
     // EBPF_OP_JNE_IMM pc=84 dst=r2 src=r0 offset=21 imm=0
 #line 69 "sample/utility.c"
-    if (r2 != IMMEDIATE(0))
+    if (r2 != IMMEDIATE(0)) {
 #line 69 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r10 offset=0 imm=0
+#line 69 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r10 offset=0 imm=0
 #line 74 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=-30
@@ -409,14 +429,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=91 dst=r0 src=r0 offset=0 imm=25
 #line 74 "sample/utility.c"
-    r0 = UtilityTest_helpers[3].address
+    r0 = UtilityTest_helpers[3].address(r1, r2, r3, r4, r5);
 #line 74 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/utility.c"
-    if ((UtilityTest_helpers[3].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[3].tail_call) && (r0 == 0)) {
 #line 74 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=92 dst=r6 src=r0 offset=0 imm=8
+#line 74 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=92 dst=r6 src=r0 offset=0 imm=8
 #line 74 "sample/utility.c"
     r6 = IMMEDIATE(8);
     // EBPF_OP_MOV64_IMM pc=93 dst=r1 src=r0 offset=0 imm=0
@@ -424,10 +444,12 @@ UtilityTest(void* context)
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=94 dst=r1 src=r0 offset=11 imm=0
 #line 74 "sample/utility.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 74 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=95 dst=r6 src=r0 offset=0 imm=9
+#line 74 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=95 dst=r6 src=r0 offset=0 imm=9
 #line 74 "sample/utility.c"
     r6 = IMMEDIATE(9);
     // EBPF_OP_LDXB pc=96 dst=r1 src=r10 offset=-30 imm=0
@@ -435,26 +457,32 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-30));
     // EBPF_OP_JNE_IMM pc=97 dst=r1 src=r0 offset=8 imm=49
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(49))
+    if (r1 != IMMEDIATE(49)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=98 dst=r1 src=r10 offset=-29 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=98 dst=r1 src=r10 offset=-29 imm=0
 #line 79 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-29));
     // EBPF_OP_JNE_IMM pc=99 dst=r1 src=r0 offset=6 imm=50
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(50))
+    if (r1 != IMMEDIATE(50)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=100 dst=r1 src=r10 offset=-28 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=100 dst=r1 src=r10 offset=-28 imm=0
 #line 79 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-28));
     // EBPF_OP_JNE_IMM pc=101 dst=r1 src=r0 offset=4 imm=51
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(51))
+    if (r1 != IMMEDIATE(51)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=102 dst=r6 src=r0 offset=0 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=102 dst=r6 src=r0 offset=0 imm=0
 #line 79 "sample/utility.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_LDXB pc=103 dst=r1 src=r10 offset=-27 imm=0
@@ -462,10 +490,12 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-27));
     // EBPF_OP_JEQ_IMM pc=104 dst=r1 src=r0 offset=1 imm=52
 #line 79 "sample/utility.c"
-    if (r1 == IMMEDIATE(52))
+    if (r1 == IMMEDIATE(52)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=105 dst=r6 src=r0 offset=0 imm=9
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=105 dst=r6 src=r0 offset=0 imm=9
 #line 79 "sample/utility.c"
     r6 = IMMEDIATE(9);
 label_1:

--- a/tests/bpf2c_tests/expected/utility_raw.c
+++ b/tests/bpf2c_tests/expected/utility_raw.c
@@ -114,14 +114,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=23
 #line 31 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 31 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 31 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r6 src=r0 offset=0 imm=1
+#line 31 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=19 dst=r6 src=r0 offset=0 imm=1
 #line 31 "sample/utility.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_LSH64_IMM pc=20 dst=r0 src=r0 offset=0 imm=32
@@ -132,10 +132,12 @@ UtilityTest(void* context)
     r0 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=22 dst=r0 src=r0 offset=83 imm=0
 #line 31 "sample/utility.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 31 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=84
+#line 31 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=84
 #line 31 "sample/utility.c"
     r1 = IMMEDIATE(84);
     // EBPF_OP_STXB pc=24 dst=r10 src=r1 offset=-8 imm=0
@@ -161,14 +163,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=23
 #line 37 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 37 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 37 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r6 src=r0 offset=0 imm=2
+#line 37 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r6 src=r0 offset=0 imm=2
 #line 37 "sample/utility.c"
     r6 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
@@ -179,10 +181,12 @@ UtilityTest(void* context)
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=35 dst=r0 src=r0 offset=70 imm=-1
 #line 37 "sample/utility.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 37 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=36 dst=r1 src=r10 offset=0 imm=0
+#line 37 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=36 dst=r1 src=r10 offset=0 imm=0
 #line 37 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=37 dst=r1 src=r0 offset=0 imm=-8
@@ -205,14 +209,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=23
 #line 43 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/utility.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
+#line 43 "sample/utility.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
 #line 43 "sample/utility.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
@@ -220,10 +224,12 @@ UtilityTest(void* context)
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=46 dst=r0 src=r0 offset=59 imm=-1
 #line 43 "sample/utility.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 43 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=1414743380
+#line 43 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=1414743380
 #line 43 "sample/utility.c"
     r1 = IMMEDIATE(1414743380);
     // EBPF_OP_STXW pc=48 dst=r10 src=r1 offset=-8 imm=0
@@ -249,14 +255,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=22
 #line 54 "sample/utility.c"
-    r0 = UtilityTest_helpers[1].address
+    r0 = UtilityTest_helpers[1].address(r1, r2, r3, r4, r5);
 #line 54 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/utility.c"
-    if ((UtilityTest_helpers[1].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[1].tail_call) && (r0 == 0)) {
 #line 54 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
+#line 54 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
 #line 54 "sample/utility.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=57 dst=r6 src=r0 offset=0 imm=4
@@ -264,10 +270,12 @@ UtilityTest(void* context)
     r6 = IMMEDIATE(4);
     // EBPF_OP_JSGT_REG pc=58 dst=r1 src=r0 offset=47 imm=0
 #line 54 "sample/utility.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 54 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=59 dst=r6 src=r0 offset=0 imm=5
+#line 54 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=59 dst=r6 src=r0 offset=0 imm=5
 #line 54 "sample/utility.c"
     r6 = IMMEDIATE(5);
     // EBPF_OP_LDXB pc=60 dst=r1 src=r10 offset=-8 imm=0
@@ -275,34 +283,42 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8));
     // EBPF_OP_JNE_IMM pc=61 dst=r1 src=r0 offset=44 imm=116
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(116))
+    if (r1 != IMMEDIATE(116)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=62 dst=r1 src=r10 offset=-7 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=62 dst=r1 src=r10 offset=-7 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-7));
     // EBPF_OP_JNE_IMM pc=63 dst=r1 src=r0 offset=42 imm=101
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(101))
+    if (r1 != IMMEDIATE(101)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=64 dst=r1 src=r10 offset=-6 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=64 dst=r1 src=r10 offset=-6 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-6));
     // EBPF_OP_JNE_IMM pc=65 dst=r1 src=r0 offset=40 imm=115
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(115))
+    if (r1 != IMMEDIATE(115)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=66 dst=r1 src=r10 offset=-5 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=66 dst=r1 src=r10 offset=-5 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-5));
     // EBPF_OP_JNE_IMM pc=67 dst=r1 src=r0 offset=38 imm=116
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(116))
+    if (r1 != IMMEDIATE(116)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r10 offset=0 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r10 offset=0 imm=0
 #line 59 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=69 dst=r1 src=r0 offset=0 imm=-8
@@ -316,22 +332,24 @@ UtilityTest(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=24
 #line 64 "sample/utility.c"
-    r0 = UtilityTest_helpers[2].address
+    r0 = UtilityTest_helpers[2].address(r1, r2, r3, r4, r5);
 #line 64 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/utility.c"
-    if ((UtilityTest_helpers[2].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[2].tail_call) && (r0 == 0)) {
 #line 64 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=73 dst=r6 src=r0 offset=0 imm=6
+#line 64 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=73 dst=r6 src=r0 offset=0 imm=6
 #line 64 "sample/utility.c"
     r6 = IMMEDIATE(6);
     // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=31 imm=0
 #line 64 "sample/utility.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 64 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=75 dst=r1 src=r10 offset=-8 imm=0
+#line 64 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=75 dst=r1 src=r10 offset=-8 imm=0
 #line 69 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8));
     // EBPF_OP_LDXB pc=76 dst=r2 src=r10 offset=-7 imm=0
@@ -360,10 +378,12 @@ UtilityTest(void* context)
     r2 &= IMMEDIATE(255);
     // EBPF_OP_JNE_IMM pc=84 dst=r2 src=r0 offset=21 imm=0
 #line 69 "sample/utility.c"
-    if (r2 != IMMEDIATE(0))
+    if (r2 != IMMEDIATE(0)) {
 #line 69 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r10 offset=0 imm=0
+#line 69 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r10 offset=0 imm=0
 #line 74 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=-30
@@ -383,14 +403,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=91 dst=r0 src=r0 offset=0 imm=25
 #line 74 "sample/utility.c"
-    r0 = UtilityTest_helpers[3].address
+    r0 = UtilityTest_helpers[3].address(r1, r2, r3, r4, r5);
 #line 74 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/utility.c"
-    if ((UtilityTest_helpers[3].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[3].tail_call) && (r0 == 0)) {
 #line 74 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=92 dst=r6 src=r0 offset=0 imm=8
+#line 74 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=92 dst=r6 src=r0 offset=0 imm=8
 #line 74 "sample/utility.c"
     r6 = IMMEDIATE(8);
     // EBPF_OP_MOV64_IMM pc=93 dst=r1 src=r0 offset=0 imm=0
@@ -398,10 +418,12 @@ UtilityTest(void* context)
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=94 dst=r1 src=r0 offset=11 imm=0
 #line 74 "sample/utility.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 74 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=95 dst=r6 src=r0 offset=0 imm=9
+#line 74 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=95 dst=r6 src=r0 offset=0 imm=9
 #line 74 "sample/utility.c"
     r6 = IMMEDIATE(9);
     // EBPF_OP_LDXB pc=96 dst=r1 src=r10 offset=-30 imm=0
@@ -409,26 +431,32 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-30));
     // EBPF_OP_JNE_IMM pc=97 dst=r1 src=r0 offset=8 imm=49
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(49))
+    if (r1 != IMMEDIATE(49)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=98 dst=r1 src=r10 offset=-29 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=98 dst=r1 src=r10 offset=-29 imm=0
 #line 79 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-29));
     // EBPF_OP_JNE_IMM pc=99 dst=r1 src=r0 offset=6 imm=50
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(50))
+    if (r1 != IMMEDIATE(50)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=100 dst=r1 src=r10 offset=-28 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=100 dst=r1 src=r10 offset=-28 imm=0
 #line 79 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-28));
     // EBPF_OP_JNE_IMM pc=101 dst=r1 src=r0 offset=4 imm=51
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(51))
+    if (r1 != IMMEDIATE(51)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=102 dst=r6 src=r0 offset=0 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=102 dst=r6 src=r0 offset=0 imm=0
 #line 79 "sample/utility.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_LDXB pc=103 dst=r1 src=r10 offset=-27 imm=0
@@ -436,10 +464,12 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-27));
     // EBPF_OP_JEQ_IMM pc=104 dst=r1 src=r0 offset=1 imm=52
 #line 79 "sample/utility.c"
-    if (r1 == IMMEDIATE(52))
+    if (r1 == IMMEDIATE(52)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=105 dst=r6 src=r0 offset=0 imm=9
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=105 dst=r6 src=r0 offset=0 imm=9
 #line 79 "sample/utility.c"
     r6 = IMMEDIATE(9);
 label_1:

--- a/tests/bpf2c_tests/expected/utility_sys.c
+++ b/tests/bpf2c_tests/expected/utility_sys.c
@@ -275,14 +275,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=23
 #line 31 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 31 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 31 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 31 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r6 src=r0 offset=0 imm=1
+#line 31 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=19 dst=r6 src=r0 offset=0 imm=1
 #line 31 "sample/utility.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_LSH64_IMM pc=20 dst=r0 src=r0 offset=0 imm=32
@@ -293,10 +293,12 @@ UtilityTest(void* context)
     r0 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=22 dst=r0 src=r0 offset=83 imm=0
 #line 31 "sample/utility.c"
-    if (r0 != IMMEDIATE(0))
+    if (r0 != IMMEDIATE(0)) {
 #line 31 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=84
+#line 31 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=84
 #line 31 "sample/utility.c"
     r1 = IMMEDIATE(84);
     // EBPF_OP_STXB pc=24 dst=r10 src=r1 offset=-8 imm=0
@@ -322,14 +324,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=23
 #line 37 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 37 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 37 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=32 dst=r6 src=r0 offset=0 imm=2
+#line 37 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=32 dst=r6 src=r0 offset=0 imm=2
 #line 37 "sample/utility.c"
     r6 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
@@ -340,10 +342,12 @@ UtilityTest(void* context)
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=35 dst=r0 src=r0 offset=70 imm=-1
 #line 37 "sample/utility.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 37 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=36 dst=r1 src=r10 offset=0 imm=0
+#line 37 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=36 dst=r1 src=r10 offset=0 imm=0
 #line 37 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=37 dst=r1 src=r0 offset=0 imm=-8
@@ -366,14 +370,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=23
 #line 43 "sample/utility.c"
-    r0 = UtilityTest_helpers[0].address
+    r0 = UtilityTest_helpers[0].address(r1, r2, r3, r4, r5);
 #line 43 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 43 "sample/utility.c"
-    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[0].tail_call) && (r0 == 0)) {
 #line 43 "sample/utility.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
+#line 43 "sample/utility.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
 #line 43 "sample/utility.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
@@ -381,10 +385,12 @@ UtilityTest(void* context)
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=46 dst=r0 src=r0 offset=59 imm=-1
 #line 43 "sample/utility.c"
-    if ((int64_t)r0 > IMMEDIATE(-1))
+    if ((int64_t)r0 > IMMEDIATE(-1)) {
 #line 43 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=1414743380
+#line 43 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=1414743380
 #line 43 "sample/utility.c"
     r1 = IMMEDIATE(1414743380);
     // EBPF_OP_STXW pc=48 dst=r10 src=r1 offset=-8 imm=0
@@ -410,14 +416,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=22
 #line 54 "sample/utility.c"
-    r0 = UtilityTest_helpers[1].address
+    r0 = UtilityTest_helpers[1].address(r1, r2, r3, r4, r5);
 #line 54 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 54 "sample/utility.c"
-    if ((UtilityTest_helpers[1].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[1].tail_call) && (r0 == 0)) {
 #line 54 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
+#line 54 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
 #line 54 "sample/utility.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=57 dst=r6 src=r0 offset=0 imm=4
@@ -425,10 +431,12 @@ UtilityTest(void* context)
     r6 = IMMEDIATE(4);
     // EBPF_OP_JSGT_REG pc=58 dst=r1 src=r0 offset=47 imm=0
 #line 54 "sample/utility.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 54 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=59 dst=r6 src=r0 offset=0 imm=5
+#line 54 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=59 dst=r6 src=r0 offset=0 imm=5
 #line 54 "sample/utility.c"
     r6 = IMMEDIATE(5);
     // EBPF_OP_LDXB pc=60 dst=r1 src=r10 offset=-8 imm=0
@@ -436,34 +444,42 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8));
     // EBPF_OP_JNE_IMM pc=61 dst=r1 src=r0 offset=44 imm=116
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(116))
+    if (r1 != IMMEDIATE(116)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=62 dst=r1 src=r10 offset=-7 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=62 dst=r1 src=r10 offset=-7 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-7));
     // EBPF_OP_JNE_IMM pc=63 dst=r1 src=r0 offset=42 imm=101
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(101))
+    if (r1 != IMMEDIATE(101)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=64 dst=r1 src=r10 offset=-6 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=64 dst=r1 src=r10 offset=-6 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-6));
     // EBPF_OP_JNE_IMM pc=65 dst=r1 src=r0 offset=40 imm=115
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(115))
+    if (r1 != IMMEDIATE(115)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=66 dst=r1 src=r10 offset=-5 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=66 dst=r1 src=r10 offset=-5 imm=0
 #line 59 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-5));
     // EBPF_OP_JNE_IMM pc=67 dst=r1 src=r0 offset=38 imm=116
 #line 59 "sample/utility.c"
-    if (r1 != IMMEDIATE(116))
+    if (r1 != IMMEDIATE(116)) {
 #line 59 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r10 offset=0 imm=0
+#line 59 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r10 offset=0 imm=0
 #line 59 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=69 dst=r1 src=r0 offset=0 imm=-8
@@ -477,22 +493,24 @@ UtilityTest(void* context)
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=24
 #line 64 "sample/utility.c"
-    r0 = UtilityTest_helpers[2].address
+    r0 = UtilityTest_helpers[2].address(r1, r2, r3, r4, r5);
 #line 64 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 64 "sample/utility.c"
-    if ((UtilityTest_helpers[2].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[2].tail_call) && (r0 == 0)) {
 #line 64 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=73 dst=r6 src=r0 offset=0 imm=6
+#line 64 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=73 dst=r6 src=r0 offset=0 imm=6
 #line 64 "sample/utility.c"
     r6 = IMMEDIATE(6);
     // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=31 imm=0
 #line 64 "sample/utility.c"
-    if (r0 == IMMEDIATE(0))
+    if (r0 == IMMEDIATE(0)) {
 #line 64 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=75 dst=r1 src=r10 offset=-8 imm=0
+#line 64 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=75 dst=r1 src=r10 offset=-8 imm=0
 #line 69 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8));
     // EBPF_OP_LDXB pc=76 dst=r2 src=r10 offset=-7 imm=0
@@ -521,10 +539,12 @@ UtilityTest(void* context)
     r2 &= IMMEDIATE(255);
     // EBPF_OP_JNE_IMM pc=84 dst=r2 src=r0 offset=21 imm=0
 #line 69 "sample/utility.c"
-    if (r2 != IMMEDIATE(0))
+    if (r2 != IMMEDIATE(0)) {
 #line 69 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r10 offset=0 imm=0
+#line 69 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r10 offset=0 imm=0
 #line 74 "sample/utility.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=86 dst=r1 src=r0 offset=0 imm=-30
@@ -544,14 +564,14 @@ UtilityTest(void* context)
     r4 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=91 dst=r0 src=r0 offset=0 imm=25
 #line 74 "sample/utility.c"
-    r0 = UtilityTest_helpers[3].address
+    r0 = UtilityTest_helpers[3].address(r1, r2, r3, r4, r5);
 #line 74 "sample/utility.c"
-         (r1, r2, r3, r4, r5);
-#line 74 "sample/utility.c"
-    if ((UtilityTest_helpers[3].tail_call) && (r0 == 0))
+    if ((UtilityTest_helpers[3].tail_call) && (r0 == 0)) {
 #line 74 "sample/utility.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=92 dst=r6 src=r0 offset=0 imm=8
+#line 74 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=92 dst=r6 src=r0 offset=0 imm=8
 #line 74 "sample/utility.c"
     r6 = IMMEDIATE(8);
     // EBPF_OP_MOV64_IMM pc=93 dst=r1 src=r0 offset=0 imm=0
@@ -559,10 +579,12 @@ UtilityTest(void* context)
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=94 dst=r1 src=r0 offset=11 imm=0
 #line 74 "sample/utility.c"
-    if ((int64_t)r1 > (int64_t)r0)
+    if ((int64_t)r1 > (int64_t)r0) {
 #line 74 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=95 dst=r6 src=r0 offset=0 imm=9
+#line 74 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=95 dst=r6 src=r0 offset=0 imm=9
 #line 74 "sample/utility.c"
     r6 = IMMEDIATE(9);
     // EBPF_OP_LDXB pc=96 dst=r1 src=r10 offset=-30 imm=0
@@ -570,26 +592,32 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-30));
     // EBPF_OP_JNE_IMM pc=97 dst=r1 src=r0 offset=8 imm=49
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(49))
+    if (r1 != IMMEDIATE(49)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=98 dst=r1 src=r10 offset=-29 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=98 dst=r1 src=r10 offset=-29 imm=0
 #line 79 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-29));
     // EBPF_OP_JNE_IMM pc=99 dst=r1 src=r0 offset=6 imm=50
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(50))
+    if (r1 != IMMEDIATE(50)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_LDXB pc=100 dst=r1 src=r10 offset=-28 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_LDXB pc=100 dst=r1 src=r10 offset=-28 imm=0
 #line 79 "sample/utility.c"
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-28));
     // EBPF_OP_JNE_IMM pc=101 dst=r1 src=r0 offset=4 imm=51
 #line 79 "sample/utility.c"
-    if (r1 != IMMEDIATE(51))
+    if (r1 != IMMEDIATE(51)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=102 dst=r6 src=r0 offset=0 imm=0
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=102 dst=r6 src=r0 offset=0 imm=0
 #line 79 "sample/utility.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_LDXB pc=103 dst=r1 src=r10 offset=-27 imm=0
@@ -597,10 +625,12 @@ UtilityTest(void* context)
     r1 = *(uint8_t*)(uintptr_t)(r10 + OFFSET(-27));
     // EBPF_OP_JEQ_IMM pc=104 dst=r1 src=r0 offset=1 imm=52
 #line 79 "sample/utility.c"
-    if (r1 == IMMEDIATE(52))
+    if (r1 == IMMEDIATE(52)) {
 #line 79 "sample/utility.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=105 dst=r6 src=r0 offset=0 imm=9
+#line 79 "sample/utility.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=105 dst=r6 src=r0 offset=0 imm=9
 #line 79 "sample/utility.c"
     r6 = IMMEDIATE(9);
 label_1:

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
@@ -85,14 +85,14 @@ xdp_invalid_socket_cookie(void* context)
 
     // EBPF_OP_CALL pc=0 dst=r0 src=r0 offset=0 imm=26
 #line 20 "sample/xdp_invalid_socket_cookie.c"
-    r0 = xdp_invalid_socket_cookie_helpers[0].address
+    r0 = xdp_invalid_socket_cookie_helpers[0].address(r1, r2, r3, r4, r5);
 #line 20 "sample/xdp_invalid_socket_cookie.c"
-         (r1, r2, r3, r4, r5);
-#line 20 "sample/xdp_invalid_socket_cookie.c"
-    if ((xdp_invalid_socket_cookie_helpers[0].tail_call) && (r0 == 0))
+    if ((xdp_invalid_socket_cookie_helpers[0].tail_call) && (r0 == 0)) {
 #line 20 "sample/xdp_invalid_socket_cookie.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
+#line 20 "sample/xdp_invalid_socket_cookie.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
 #line 20 "sample/xdp_invalid_socket_cookie.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=2 dst=r10 src=r1 offset=-4 imm=0
@@ -130,14 +130,14 @@ xdp_invalid_socket_cookie(void* context)
     r3 = r0;
     // EBPF_OP_CALL pc=15 dst=r0 src=r0 offset=0 imm=13
 #line 22 "sample/xdp_invalid_socket_cookie.c"
-    r0 = xdp_invalid_socket_cookie_helpers[1].address
+    r0 = xdp_invalid_socket_cookie_helpers[1].address(r1, r2, r3, r4, r5);
 #line 22 "sample/xdp_invalid_socket_cookie.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/xdp_invalid_socket_cookie.c"
-    if ((xdp_invalid_socket_cookie_helpers[1].tail_call) && (r0 == 0))
+    if ((xdp_invalid_socket_cookie_helpers[1].tail_call) && (r0 == 0)) {
 #line 22 "sample/xdp_invalid_socket_cookie.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/xdp_invalid_socket_cookie.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=1
 #line 25 "sample/xdp_invalid_socket_cookie.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
@@ -178,7 +178,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 15;
+    version->minor = 16;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_raw.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_raw.c
@@ -59,14 +59,14 @@ xdp_invalid_socket_cookie(void* context)
 
     // EBPF_OP_CALL pc=0 dst=r0 src=r0 offset=0 imm=26
 #line 20 "sample/xdp_invalid_socket_cookie.c"
-    r0 = xdp_invalid_socket_cookie_helpers[0].address
+    r0 = xdp_invalid_socket_cookie_helpers[0].address(r1, r2, r3, r4, r5);
 #line 20 "sample/xdp_invalid_socket_cookie.c"
-         (r1, r2, r3, r4, r5);
-#line 20 "sample/xdp_invalid_socket_cookie.c"
-    if ((xdp_invalid_socket_cookie_helpers[0].tail_call) && (r0 == 0))
+    if ((xdp_invalid_socket_cookie_helpers[0].tail_call) && (r0 == 0)) {
 #line 20 "sample/xdp_invalid_socket_cookie.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
+#line 20 "sample/xdp_invalid_socket_cookie.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
 #line 20 "sample/xdp_invalid_socket_cookie.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=2 dst=r10 src=r1 offset=-4 imm=0
@@ -104,14 +104,14 @@ xdp_invalid_socket_cookie(void* context)
     r3 = r0;
     // EBPF_OP_CALL pc=15 dst=r0 src=r0 offset=0 imm=13
 #line 22 "sample/xdp_invalid_socket_cookie.c"
-    r0 = xdp_invalid_socket_cookie_helpers[1].address
+    r0 = xdp_invalid_socket_cookie_helpers[1].address(r1, r2, r3, r4, r5);
 #line 22 "sample/xdp_invalid_socket_cookie.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/xdp_invalid_socket_cookie.c"
-    if ((xdp_invalid_socket_cookie_helpers[1].tail_call) && (r0 == 0))
+    if ((xdp_invalid_socket_cookie_helpers[1].tail_call) && (r0 == 0)) {
 #line 22 "sample/xdp_invalid_socket_cookie.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/xdp_invalid_socket_cookie.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=1
 #line 25 "sample/xdp_invalid_socket_cookie.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
@@ -152,7 +152,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 15;
+    version->minor = 16;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_sys.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_sys.c
@@ -220,14 +220,14 @@ xdp_invalid_socket_cookie(void* context)
 
     // EBPF_OP_CALL pc=0 dst=r0 src=r0 offset=0 imm=26
 #line 20 "sample/xdp_invalid_socket_cookie.c"
-    r0 = xdp_invalid_socket_cookie_helpers[0].address
+    r0 = xdp_invalid_socket_cookie_helpers[0].address(r1, r2, r3, r4, r5);
 #line 20 "sample/xdp_invalid_socket_cookie.c"
-         (r1, r2, r3, r4, r5);
-#line 20 "sample/xdp_invalid_socket_cookie.c"
-    if ((xdp_invalid_socket_cookie_helpers[0].tail_call) && (r0 == 0))
+    if ((xdp_invalid_socket_cookie_helpers[0].tail_call) && (r0 == 0)) {
 #line 20 "sample/xdp_invalid_socket_cookie.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
+#line 20 "sample/xdp_invalid_socket_cookie.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
 #line 20 "sample/xdp_invalid_socket_cookie.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=2 dst=r10 src=r1 offset=-4 imm=0
@@ -265,14 +265,14 @@ xdp_invalid_socket_cookie(void* context)
     r3 = r0;
     // EBPF_OP_CALL pc=15 dst=r0 src=r0 offset=0 imm=13
 #line 22 "sample/xdp_invalid_socket_cookie.c"
-    r0 = xdp_invalid_socket_cookie_helpers[1].address
+    r0 = xdp_invalid_socket_cookie_helpers[1].address(r1, r2, r3, r4, r5);
 #line 22 "sample/xdp_invalid_socket_cookie.c"
-         (r1, r2, r3, r4, r5);
-#line 22 "sample/xdp_invalid_socket_cookie.c"
-    if ((xdp_invalid_socket_cookie_helpers[1].tail_call) && (r0 == 0))
+    if ((xdp_invalid_socket_cookie_helpers[1].tail_call) && (r0 == 0)) {
 #line 22 "sample/xdp_invalid_socket_cookie.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/xdp_invalid_socket_cookie.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=1
 #line 25 "sample/xdp_invalid_socket_cookie.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
@@ -313,7 +313,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 15;
+    version->minor = 16;
     version->revision = 0;
 }
 


### PR DESCRIPTION
## Description

Update bpf2c to generate code that passes the clang format check.
With this PR, the expected output can be regenerated as normal and will not require any reformatting by format-code or use of --no-verify.

Fixes #3509

## Testing

Tested using existing bpf2c tests.

## Documentation

No impact.

## Installation

No impact.
