### PR TITLE
Cache choco packages to work around connectivity issues

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -114,14 +114,14 @@ jobs:
     - name: Check for .github/workflows/reusable-test.yml
       # Check for test logs even if the workflow failed.
       uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6
-      if: always() && (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
+      if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
       id: check_reusable_test_locally
       with:
         files: .github/workflows/reusable-test.yml
 
     # Check out just this file if code hasn't been checked out yet.
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
-      if: (steps.check_reusable_test_locally.outputs.files_exists != 'true') && (steps.skip_check.outputs.should_skip != 'true')
+      if: (inputs.gather_dumps == true)  (steps.check_reusable_test_locally.outputs.files_exists != 'true') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         sparse-checkout: |
           .github/workflows/reusable-test.yml
@@ -129,7 +129,7 @@ jobs:
 
     - name: Setup choco cache folder
       # Set the choco cache to a local folder so that it can be cached.
-      if: (steps.skip_check.outputs.should_skip != 'true')
+      if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
       id: choco-cache
       run: |
         mkdir ${{github.workspace}}\choco_cache
@@ -138,7 +138,7 @@ jobs:
     - name: Cache choco packages
       # Add cache entry for any choco packages that are installed.
       # The cache key is based on the hash of this file so if any choco packages are added or removed, the cache will be invalidated.
-      if: steps.skip_check.outputs.should_skip != 'true'
+      if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
       env:
         cache-name: cache-choco-packages

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -121,7 +121,7 @@ jobs:
 
     # Check out just this file if code hasn't been checked out yet.
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
-      if: (inputs.gather_dumps == true)  (steps.check_reusable_test_locally.outputs.files_exists != 'true') && (steps.skip_check.outputs.should_skip != 'true')
+      if: (steps.check_reusable_test_locally.outputs.files_exists != 'true') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         sparse-checkout: |
           .github/workflows/reusable-test.yml

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -103,15 +103,33 @@ jobs:
         submodules: 'recursive'
         ref: ${{ github.event.workflow_run.head_branch }}
 
+
     # Perform shallow checkout for self-hosted runner.
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       if: (inputs.environment == 'ebpf_cicd_tests_ws2019' || inputs.environment == 'ebpf_cicd_tests_ws2022' || inputs.environment == 'ebpf_cicd_perf_ws2022') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
 
+    # Check if .github/workflows/reusable-test.yml exists locally
+    - name: Check for .github/workflows/reusable-test.yml
+      # Check for test logs even if the workflow failed.
+      uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6
+      if: always() && (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
+      id: check_reusable_test_locally
+      with:
+        files: .github/workflows/reusable-test.yml
+
+    # Check out just this file if code hasn't been checked out yet.
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      if: (steps.check_reusable_test_locally.outputs.files_exists != 'true') && (steps.skip_check.outputs.should_skip != 'true')
+      with:
+        sparse-checkout: |
+          .github/workflows/reusable-test.yml
+        sparse-checkout-cone-mode: false
+
     - name: Setup choco cache folder
       # Set the choco cache to a local folder so that it can be cached.
-      if: steps.skip_check.outputs.should_skip != 'true'
+      if: (steps.skip_check.outputs.should_skip != 'true')
       id: choco-cache
       run: |
         mkdir ${{github.workspace}}\choco_cache

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -109,6 +109,25 @@ jobs:
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
 
+    - name: Setup choco cache folder
+      # Set the choco cache to a local folder so that it can be cached.
+      if: steps.skip_check.outputs.should_skip != 'true'
+      id: choco-cache
+      run: |
+        mkdir ${{github.workspace}}\choco_cache
+        choco config set --name cacheLocation --value ${{github.workspace}}\choco_cache
+
+    - name: Cache choco packages
+      # Add cache entry for any choco packages that are installed.
+      # The cache key is based on the hash of this file so if any choco packages are added or removed, the cache will be invalidated.
+      if: steps.skip_check.outputs.should_skip != 'true'
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      env:
+        cache-name: cache-choco-packages
+      with:
+        path: ${{github.workspace}}\choco_cache
+        key: ${{ hashFiles('.github/workflows/reusable-test.yml') }}
+
     - name: Install ProcDump
       id: install_procdump
       if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -103,14 +103,13 @@ jobs:
         submodules: 'recursive'
         ref: ${{ github.event.workflow_run.head_branch }}
 
-
     # Perform shallow checkout for self-hosted runner.
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       if: (inputs.environment == 'ebpf_cicd_tests_ws2019' || inputs.environment == 'ebpf_cicd_tests_ws2022' || inputs.environment == 'ebpf_cicd_perf_ws2022') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
 
-    # Check if .github/workflows/reusable-test.yml exists locally
+    # Check if .github/workflows/reusable-test.yml exists locally.
     - name: Check for .github/workflows/reusable-test.yml
       # Check for test logs even if the workflow failed.
       uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6
@@ -127,7 +126,7 @@ jobs:
           .github/workflows/reusable-test.yml
         sparse-checkout-cone-mode: false
 
-    - name: Setup choco cache folder
+    - name: Set up choco cache folder
       # Set the choco cache to a local folder so that it can be cached.
       if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
       id: choco-cache


### PR DESCRIPTION
## Description

This pull request includes changes to the `.github/workflows/reusable-test.yml` file, specifically in the `jobs:` section. The changes involve setting up a local cache for Chocolatey (choco) packages and adding a cache entry for any installed choco packages. The cache key is based on the hash of the workflow file, so any changes to the choco packages in the file will invalidate the cache.

Key changes:

* [`.github/workflows/reusable-test.yml`](diffhunk://#diff-e386584fe70c301924ab6a8d4656b54ef92ed1961e6eb6f77c155be3475615f6R112-R130): Added a new step to create a local folder for caching Chocolatey packages. The cache location is set using the `choco config set` command. This step is skipped if the `should_skip` output of the `skip_check` step is 'true'.
* [`.github/workflows/reusable-test.yml`](diffhunk://#diff-e386584fe70c301924ab6a8d4656b54ef92ed1961e6eb6f77c155be3475615f6R112-R130): Added another step to cache the Chocolatey packages. The cache uses the `actions/cache` action with a specific commit hash. The cache key is generated using the `hashFiles` function with the workflow file as input. This step is also skipped if the `should_skip` output of the `skip_check` step is 'true'.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
