### PR TITLE
Add documentation to eBpfExtensions.md to clarify use of hash

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -239,7 +239,7 @@ as well. Existing eBPF extensions would need to be re-compiled to work with the 
 #### 2.2.1 Hashing of data structures to validate verification of native images
 When native images are generated, bpf2c uses the verifier to ensure that the program is safe to execute and then
 computes a hash over the invariants used to validate the program. These invariants include the properties of the
-program information provider and the signature of helper functions. The following fields are included in the hash:
+program information provider and the signature of any helper functions used. The following fields are included in the hash:
 1. ebpf_program_type_descriptor_t::name
 2. ebpf_program_type_descriptor_t::context_descriptor
 3. ebpf_program_type_descriptor_t::program_type
@@ -259,7 +259,6 @@ be included. This ensures that hashes computed over older versions of the struct
 is not being used. If a new feature or functionality is being used, the hash value MUST change to ensure that the
 verification constraints are honored. All new fields that affect verification MUST be included with a non-default value
 and all fields that do not affect verification MUST NOT be included.
-
 
 ### 2.3 Program Information NPI Client Attach and Detach Callbacks
 The eBPF Execution Context registers a Program Information NPI client module with the NMR for every eBPF program that

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -250,8 +250,8 @@ program information provider and the signature of any helper functions used. The
     1. ebpf_helper_function_prototype_t::helper_id
     2. ebpf_helper_function_prototype_t::name
     3. ebpf_helper_function_prototype_t::return_type
-    4. Each ebpf_helper_function_prototype_t::arguments
-    5. ebpf_helper_function_prototype_t::flags - only if non-default value.
+    4. Each element of the ebpf_helper_function_prototype_t::arguments array
+    5. ebpf_helper_function_prototype_t::flags - only if non-default value
 
 Any new fields MUST be added to the end of the hash and the hash MUST include all fields up to and including the last
 field containing a non-default value. Fields containing default values after the last non-default value MUST NOT


### PR DESCRIPTION
## Description

Resolves: #3429 

Add to documentation clarify the purpose and scheme of the program information hash.

## Testing

N/A

## Documentation

Yes.

## Installation

No.
