### PR TITLE
UM API to write into a ring buffer map.

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -133,3 +133,4 @@ EXPORTS
     libbpf_strerror
     ring_buffer__new
     ring_buffer__free
+    ebpf_ring_buffer_map_write

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -449,6 +449,20 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options) EBPF_NO_EXCEPT;
 
+    /**
+     * @brief Write data into the ring buffer map.
+     *
+     * @param ring_buffer_map_fd ring buffer map file descriptor.
+     * @param data Pointer to data to be written.
+     * @param data_length Length of data to be written.
+     * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
+     * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
+     * @retval EBPF_NO_MEMORY Out of memory.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_ring_buffer_map_write(
+        fd_t ring_buffer_map_fd, _In_reads_bytes_(data_length) const void* data, size_t data_length) EBPF_NO_EXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4435,6 +4435,43 @@ ebpf_ring_buffer_map_subscribe(
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
+_Must_inspect_result_ ebpf_result_t
+ebpf_ring_buffer_map_write(fd_t ring_buffer_map_fd, _In_reads_bytes_(data_length) const void* data, size_t data_length)
+    NO_EXCEPT_TRY
+{
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_handle_t ring_buffer_map_handle = ebpf_handle_invalid;
+    ebpf_protocol_buffer_t request_buffer;
+    ebpf_operation_ring_buffer_map_write_data_request_t* request;
+
+    if (!data || !data_length) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    try {
+        ring_buffer_map_handle = _get_handle_from_file_descriptor(ring_buffer_map_fd);
+        if (ring_buffer_map_handle == ebpf_handle_invalid) {
+            result = EBPF_INVALID_FD;
+            EBPF_RETURN_RESULT(result);
+        }
+
+        request_buffer.resize(EBPF_OFFSET_OF(ebpf_operation_ring_buffer_map_write_data_request_t, data) + data_length);
+        request = reinterpret_cast<_ebpf_operation_ring_buffer_map_write_data_request*>(request_buffer.data());
+        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        request->header.id = ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_WRITE_DATA;
+        request->map_handle = (uint64_t)ring_buffer_map_handle;
+        request->data_length = data_length;
+        std::copy((uint8_t*)data, (uint8_t*)data + data_length, request->data);
+
+        result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer));
+    } catch (const std::bad_alloc&) {
+        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
+    }
+    EBPF_RETURN_RESULT(result);
+}
+CATCH_NO_MEMORY_EBPF_RESULT
+
 bool
 ebpf_ring_buffer_map_unsubscribe(_In_ _Post_invalid_ ring_buffer_subscription_t* subscription) NO_EXCEPT_TRY
 {

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2089,6 +2089,25 @@ Exit:
     return result;
 }
 
+static ebpf_result_t
+_ebpf_core_protocol_ring_buffer_map_write_data(_In_ const ebpf_operation_ring_buffer_map_write_data_request_t* request)
+{
+    ebpf_map_t* map = NULL;
+    ebpf_result_t result =
+        EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    if (ebpf_map_get_definition(map)->type != BPF_MAP_TYPE_RINGBUF) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+    result = ebpf_ring_buffer_map_output(map, (uint8_t*)request->data, request->data_length);
+Exit:
+    EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
+    EBPF_RETURN_RESULT(result);
+}
+
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
@@ -2624,6 +2643,7 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(bind_map, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(ring_buffer_map_query_buffer, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY_ASYNC(ring_buffer_map_async_query, PROTOCOL_ALL_MODES),
+    DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_NO_REPLY(ring_buffer_map_write_data, data, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_FIXED_REPLY(load_native_module, data, PROTOCOL_NATIVE_MODE),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_VARIABLE_REPLY(load_native_programs, data, PROTOCOL_NATIVE_MODE),
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY_ASYNC(program_test_run, data, data, PROTOCOL_ALL_MODES),

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -39,6 +39,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_BIND_MAP,
     EBPF_OPERATION_RING_BUFFER_MAP_QUERY_BUFFER,
     EBPF_OPERATION_RING_BUFFER_MAP_ASYNC_QUERY,
+    EBPF_OPERATION_RING_BUFFER_MAP_WRITE_DATA,
     EBPF_OPERATION_LOAD_NATIVE_MODULE,
     EBPF_OPERATION_LOAD_NATIVE_PROGRAMS,
     EBPF_OPERATION_PROGRAM_TEST_RUN,
@@ -389,6 +390,14 @@ typedef struct _ebpf_operation_ring_buffer_map_async_query_reply
     struct _ebpf_operation_header header;
     ebpf_ring_buffer_map_async_query_result_t async_query_result;
 } ebpf_operation_ring_buffer_map_async_query_reply_t;
+
+typedef struct _ebpf_operation_ring_buffer_map_write_data_request
+{
+    struct _ebpf_operation_header header;
+    ebpf_handle_t map_handle;
+    size_t data_length;
+    uint8_t data[1];
+} ebpf_operation_ring_buffer_map_write_data_request_t;
 
 typedef struct _ebpf_operation_load_native_module_request
 {

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -189,16 +189,29 @@ void
 ring_buffer_api_test_helper(
     fd_t ring_buffer_map, std::vector<std::vector<char>>& expected_records, std::function<void(int)> generate_event)
 {
+    std::vector<std::vector<char>> records = expected_records;
+
+    // Add a couple of interleaved messages to the records vector.
+    std::string message = "Interleaved message #1";
+    std::vector<char> record(message.begin(), message.end());
+    record.push_back('\0');
+    records.push_back(record);
+    record[record.size() - 2] = '2';
+    records.push_back(record);
+
     // Ring buffer event callback context.
     std::unique_ptr<ring_buffer_test_event_context_t> context = std::make_unique<ring_buffer_test_event_context_t>();
-    context->test_event_count = RING_BUFFER_TEST_EVENT_COUNT;
+    context->test_event_count = RING_BUFFER_TEST_EVENT_COUNT + 2;
 
-    context->records = &expected_records;
+    context->records = &records;
 
     // Generate events prior to subscribing for ring buffer events.
     for (int i = 0; i < RING_BUFFER_TEST_EVENT_COUNT / 2; i++) {
         generate_event(i);
     }
+
+    // Write an interleaved message to the ring buffer map.
+    REQUIRE(ebpf_ring_buffer_map_write(ring_buffer_map, message.c_str(), message.length() + 1) == EBPF_SUCCESS);
 
     // Get the std::future from the promise field in ring buffer event context, which should be in ready state
     // once notifications for all events are received.
@@ -215,10 +228,14 @@ ring_buffer_api_test_helper(
         generate_event(i);
     }
 
+    // Write another interleaved message to the ring buffer map.
+    message[message.length() - 1] = '2';
+    REQUIRE(ebpf_ring_buffer_map_write(ring_buffer_map, message.c_str(), message.length() + 1) == EBPF_SUCCESS);
+
     // Wait for event handler getting notifications for all RING_BUFFER_TEST_EVENT_COUNT events.
     REQUIRE(ring_buffer_event_callback.wait_for(1s) == std::future_status::ready);
 
-    REQUIRE(context->matched_entry_count == RING_BUFFER_TEST_EVENT_COUNT);
+    REQUIRE(context->matched_entry_count == context->test_event_count);
 
     // Mark the event context as canceled, such that the event callback stops processing events.
     context->canceled = true;


### PR DESCRIPTION
## Description

Addressess #3572.

Add a new API in eBPF API.dll to write into a ring buffer map from user mode. This API issues an IOCTL which calls `bpf_ring_buffer_output` function to write user specified data into the ring buffer.

## Testing
Updated unit and api tests to write messages into ring buffer interleaved with events that invoke eBPF programs (which in turn write into the same ring buffer).

## Documentation

No documentation impact.

## Installation

No installation impact.
