### PR TITLE
Cleanup batch APIs and remove unused parameter

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -350,7 +350,6 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
 /**
  * @brief Prepare the eBPF program for batch invocation.
  *
- * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
  * @param[in] state_size The size of the state to be allocated, which should be greater than or equal to
  * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
@@ -360,7 +359,7 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
  */
 typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
-    _In_ const void* extension_client_binding_context, size_t state_size, _Out_writes_(state_size) void* state);
+    size_t state_size, _Out_writes_(state_size) void* state);
 
 /**
  * @brief Invoke the eBPF program in batch mode.
@@ -381,13 +380,12 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
 /**
  * @brief Clean up the eBPF program after batch invocation.
  *
- * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
  * @param[in,out] state The state to be used for batch invocation.
  *
  * @retval EBPF_SUCCESS.
  */
 typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
-    _In_ const void* extension_client_binding_context, _Inout_ void* state);
+    _Inout_ void* state);
 ```
 
 The function pointer can be obtained from the client dispatch table as follows:

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -33,8 +33,6 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
 /**
  * @brief Prepare the eBPF program for batch invocation.
  *
- * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
- * created.
  * @param[in] state_size The size of the state to be allocated, which should be greater than or equal to
  * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
@@ -44,7 +42,7 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  * @retval EBPF_EXTENSION_FAILED_TO_LOAD The required extension is not loaded.
  */
 typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
-    _In_ const void* extension_client_binding_context, size_t state_size, _Out_writes_(state_size) void* state);
+    size_t state_size, _Out_writes_(state_size) void* state);
 
 /**
  * @brief Invoke the eBPF program in batch mode.
@@ -66,14 +64,11 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
 /**
  * @brief Clean up the eBPF program after batch invocation.
  *
- * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
- * created.
  * @param[in,out] state The state to be used for batch invocation.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
-    _In_ const void* extension_client_binding_context, _Inout_ void* state);
+typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(_Inout_ void* state);
 
 typedef struct _ebpf_extension_program_dispatch_table
 {

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -229,14 +229,10 @@ typedef class _single_instance_hook : public _hook_helper
             return EBPF_EXTENSION_FAILED_TO_LOAD;
         }
 
-        ebpf_result (*batch_begin_function)(
-            _In_ const void* extension_client_binding_context,
-            size_t state_size,
-            _In_reads_bytes_(state_size) void* state);
-
+        ebpf_program_batch_begin_invoke_function_t batch_begin_function;
         batch_begin_function = reinterpret_cast<decltype(batch_begin_function)>(client_dispatch_table->function[1]);
 
-        return batch_begin_function(client_binding_context, state_size, state);
+        return batch_begin_function(state_size, state);
     }
 
     _Must_inspect_result_ ebpf_result_t
@@ -246,25 +242,21 @@ typedef class _single_instance_hook : public _hook_helper
             return EBPF_EXTENSION_FAILED_TO_LOAD;
         }
 
-        ebpf_result_t (*batch_invoke_function)(
-            _In_ const void* extension_client_binding_context,
-            _Inout_ void* program_context,
-            _Out_ uint32_t* result,
-            _In_ const void* state);
+        ebpf_program_batch_invoke_function_t batch_invoke_function;
         batch_invoke_function = reinterpret_cast<decltype(batch_invoke_function)>(client_dispatch_table->function[2]);
         return batch_invoke_function(client_binding_context, program_context, result, state);
     }
 
     _Must_inspect_result_ ebpf_result_t
-    batch_end(_In_ const void* state)
+    batch_end(_In_ void* state)
     {
         if (client_binding_context == nullptr) {
             return EBPF_EXTENSION_FAILED_TO_LOAD;
         }
 
-        ebpf_result_t (*batch_end_function)(_In_ const void* extension_client_binding_context, _In_ const void* state);
+        ebpf_program_batch_end_invoke_function_t batch_end_function;
         batch_end_function = reinterpret_cast<decltype(batch_end_function)>(client_dispatch_table->function[3]);
-        return batch_end_function(client_binding_context, state);
+        return batch_end_function(state);
     }
 
   private:

--- a/undocked/tests/sample/ext/drv/sample_ext.c
+++ b/undocked/tests/sample/ext/drv/sample_ext.c
@@ -529,9 +529,7 @@ sample_ebpf_extension_invoke_batch_begin_program(_Inout_ ebpf_execution_context_
         goto Exit;
     }
     ebpf_program_batch_begin_invoke_function_t batch_begin_function = hook_client->begin_batch_program_invoke;
-    const void* client_binding_context = hook_client->client_binding_context;
-
-    return_value = batch_begin_function(client_binding_context, sizeof(ebpf_execution_context_state_t), state);
+    return_value = batch_begin_function(sizeof(ebpf_execution_context_state_t), state);
 
 Exit:
     return return_value;
@@ -574,9 +572,7 @@ sample_ebpf_extension_invoke_batch_end_program(_Inout_ ebpf_execution_context_st
         goto Exit;
     }
     ebpf_program_batch_end_invoke_function_t batch_end_function = hook_client->end_batch_program_invoke;
-    const void* client_binding_context = hook_client->client_binding_context;
-
-    return_value = batch_end_function(client_binding_context, state);
+    return_value = batch_end_function(state);
 
 Exit:
     return return_value;


### PR DESCRIPTION
## Description

This pull request primarily focuses on simplifying the function signatures for batch invocation in the eBPF program. The changes remove the `extension_client_binding_context` parameter from various functions across multiple files, making the functions easier to use since they now require fewer arguments. 

Here are the key changes:

Removal of `extension_client_binding_context` parameter:

* [`docs/eBpfExtensions.md`](diffhunk://#diff-b183ad62c09db1f1cb4109ad107cba4e40c085d2e4a4635b5e7723fbce474310L353): The `extension_client_binding_context` parameter was removed from the `ebpf_program_batch_begin_invoke_function_t`, `ebpf_program_batch_end_invoke_function_t` functions. [[1]](diffhunk://#diff-b183ad62c09db1f1cb4109ad107cba4e40c085d2e4a4635b5e7723fbce474310L353) [[2]](diffhunk://#diff-b183ad62c09db1f1cb4109ad107cba4e40c085d2e4a4635b5e7723fbce474310L363-R362) [[3]](diffhunk://#diff-b183ad62c09db1f1cb4109ad107cba4e40c085d2e4a4635b5e7723fbce474310L384-R388)
* [`include/ebpf_extension.h`](diffhunk://#diff-109fb2b1c7e8562c572738a90786c028f5b95ad108d3f401545379352f0560d7L36-L37): The `extension_client_binding_context` parameter was removed from the `ebpf_program_batch_begin_invoke_function_t`, `ebpf_program_batch_end_invoke_function_t` functions. [[1]](diffhunk://#diff-109fb2b1c7e8562c572738a90786c028f5b95ad108d3f401545379352f0560d7L36-L37) [[2]](diffhunk://#diff-109fb2b1c7e8562c572738a90786c028f5b95ad108d3f401545379352f0560d7L47-R45) [[3]](diffhunk://#diff-109fb2b1c7e8562c572738a90786c028f5b95ad108d3f401545379352f0560d7L69-R71)
* [`libs/execution_context/ebpf_link.c`](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L79-R79): The `extension_client_binding_context` parameter was removed from the `_ebpf_link_instance_invoke_batch_begin`, `_ebpf_link_instance_invoke_batch_end` functions and their usages. [[1]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L79-R79) [[2]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L90-R89) [[3]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L470-L488) [[4]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L517-L519)
* [`tests/end_to_end/helpers.h`](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL232-R235): The `extension_client_binding_context` parameter was removed from the `batch_begin_function`, `batch_invoke_function`, `batch_end_function` functions. [[1]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL232-R235) [[2]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL249-R259)
* [`undocked/tests/sample/ext/drv/sample_ext.c`](diffhunk://#diff-fd0783b4820e9ded19ea2fc61d04b72e408df8b5dc39e2056d29acec52b887dcL532-R532): The `extension_client_binding_context` parameter was removed from the `sample_ebpf_extension_invoke_batch_begin_program`, `sample_ebpf_extension_invoke_batch_end_program` functions. [[1]](diffhunk://#diff-fd0783b4820e9ded19ea2fc61d04b72e408df8b5dc39e2056d29acec52b887dcL532-R532) [[2]](diffhunk://#diff-fd0783b4820e9ded19ea2fc61d04b72e408df8b5dc39e2056d29acec52b887dcL577-R575)

## Testing

CI/CD

## Documentation

Yes.

## Installation

No.
