### PR TITLE
Fix for breaking change P2905R2 in STL

### DIFF
--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -1304,17 +1304,15 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             } else if (inst.opcode == INST_OP_CALL) {
                 std::string function_name;
                 if (output.relocation.empty()) {
-                    function_name = std::vformat(
-                        helper_array_prefix,
-                        make_format_args(std::to_string(
-                            current_section->helper_functions["helper_id_" + std::to_string(output.instruction.imm)]
-                                .index)));
+                    auto str = std::to_string(
+                        current_section->helper_functions["helper_id_" + std::to_string(output.instruction.imm)].index);
+
+                    function_name = std::vformat(helper_array_prefix, make_format_args(str));
                 } else {
                     auto helper_function = current_section->helper_functions.find(output.relocation);
                     assert(helper_function != current_section->helper_functions.end());
-                    function_name = std::vformat(
-                        helper_array_prefix,
-                        make_format_args(std::to_string(current_section->helper_functions[output.relocation].index)));
+                    auto str = std::to_string(current_section->helper_functions[output.relocation].index);
+                    function_name = std::vformat(helper_array_prefix, make_format_args(str));
                 }
                 output.lines.push_back(
                     get_register_name(0) + " = " + function_name + ".address(" + get_register_name(1) + ", " +


### PR DESCRIPTION
Resolves: #3579

## Description

The proposal [P2905R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2905r2.html) makes a breaking change to make_format_args to reject temporary values as arguments. Workaround is to create place holder variables to hold temporary and extend there lifetime.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
