### PR TITLE
Implement libbpf autoload APIs

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -77,6 +77,7 @@ EXPORTS
     bpf_prog_test_run_opts
     bpf_program__attach
     bpf_program__attach_xdp
+    bpf_program__autoload
     bpf_program__fd
     bpf_program__get_expected_attach_type
     bpf_program__get_type=bpf_program__type
@@ -87,6 +88,7 @@ EXPORTS
     bpf_program__pin
     bpf_program__prev
     bpf_program__section_name
+    bpf_program__set_autoload
     bpf_program__set_expected_attach_type
     bpf_program__set_type
     bpf_program__type

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -515,6 +515,35 @@ struct bpf_link*
 bpf_program__attach_xdp(struct bpf_program* prog, int ifindex);
 
 /**
+ * @brief Get whether an eBPF program will be loaded when the object is loaded.
+ *
+ * @param[in] prog The program to check.
+ *
+ * @returns True if the program will be loaded, false if not.
+ *
+ * @sa bpf_object__load
+ * @sa bpf_object__load_xattr
+ * @sa bpf_program__set_autoload
+ */
+bool
+bpf_program__autoload(const struct bpf_program* prog);
+
+/**
+ * @brief Set whether an eBPF program will be loaded when the object is loaded.
+ *
+ * @param[in] prog The program to update.
+ *
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
+ *
+ * @sa bpf_object__load
+ * @sa bpf_object__load_xattr
+ * @sa bpf_program__autoload
+ */
+int
+bpf_program__set_autoload(struct bpf_program* prog, bool autoload);
+
+/**
  * @brief Attach an eBPF program to an attach point.
  *
  * @param[in] prog_fd File descriptor of the program to attach.

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -330,9 +330,7 @@ load_byte_code(
 
             program->handle = ebpf_handle_invalid;
             program->program_type = *(const GUID*)raw_program.info.type.platform_specific_data;
-
-            // Only autoload programs with a defined program type.
-            program->autoload = memcmp(&program->program_type, &empty_program_type, sizeof(empty_program_type)) != 0;
+            program->autoload = true;
 
             program->section_name = cxplat_duplicate_string(raw_program.section_name.c_str());
             program->program_name = cxplat_duplicate_string(raw_program.function_name.c_str());

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3548,7 +3548,6 @@ _load_native_programs(
     request.header.id = ebpf_operation_id_t::EBPF_OPERATION_LOAD_NATIVE_PROGRAMS;
     request.header.length = sizeof(ebpf_operation_load_native_programs_request_t);
     request.module_id = *module_id;
-    request.program_type = GUID_NULL;
 
     error = invoke_ioctl(request, reply_buffer);
     if (error != ERROR_SUCCESS) {

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2096,7 +2096,7 @@ CATCH_NO_MEMORY_EBPF_RESULT
 static ebpf_result_t
 _initialize_ebpf_programs_native(
     size_t count_of_programs,
-    _In_reads_(count_of_programs) ebpf_handle_t* program_handles,
+    _Inout_updates_(count_of_programs) ebpf_handle_t* program_handles,
     _Inout_ std::vector<ebpf_program_t*>& programs) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
@@ -2109,6 +2109,7 @@ _initialize_ebpf_programs_native(
 #pragma warning(suppress : 6001) // The SAL annotation checks that program_handles[i] is ok.
             if (program_handles[i] != ebpf_handle_invalid) {
                 Platform::CloseHandle(program_handles[i]);
+                program_handles[i] = ebpf_handle_invalid;
             }
             continue;
         }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2106,6 +2106,7 @@ _initialize_ebpf_programs_native(
     for (int i = 0; i < count_of_programs; i++) {
         ebpf_program_t* program = programs[i];
         if (!program->autoload) {
+#pragma warning(suppress : 6001) // The SAL annotation checks that program_handles[i] is ok.
             if (program_handles[i] != ebpf_handle_invalid) {
                 Platform::CloseHandle(program_handles[i]);
             }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3330,20 +3330,7 @@ ebpf_object_load(_Inout_ struct bpf_object* object) NO_EXCEPT_TRY
 
     if (Platform::_is_native_program(object->file_name)) {
         result = _ebpf_program_load_native(object->file_name, object->execution_type, object);
-        if (result != EBPF_SUCCESS) {
-            EBPF_RETURN_RESULT(result);
-        }
-        for (auto& program : object->programs) {
-            if (program->autoload) {
-                continue;
-            }
-            if (program->fd > 0) {
-                Platform::_close(program->fd);
-                program->fd = ebpf_fd_invalid;
-                program->handle = ebpf_handle_invalid;
-            }
-        }
-        EBPF_RETURN_RESULT(EBPF_SUCCESS);
+        EBPF_RETURN_RESULT(result);
     }
 
     try {
@@ -3520,7 +3507,7 @@ _load_native_programs(
     // Map count can be 0 (a program without any maps is a valid use case).
     ebpf_assert(count_of_maps == 0 || map_handles);
 
-    // Program count can be 0 (a map without any prorams is a valid use case).
+    // Program count can be 0 (a map without any programs is a valid use case).
     ebpf_assert(count_of_programs == 0 || program_handles);
 
     ebpf_result_t result = EBPF_SUCCESS;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2227,9 +2227,7 @@ _initialize_ebpf_object_from_native_file(
         program->program_type = info->program_type;
         program->attach_type = info->expected_attach_type;
         program->fd = ebpf_fd_invalid;
-
-        // Only autoload programs with a defined program type.
-        program->autoload = memcmp(&program->program_type, &empty_program_type, sizeof(empty_program_type)) != 0;
+        program->autoload = true;
 
         program->section_name = cxplat_duplicate_string(info->section_name);
         if (program->section_name == nullptr) {

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -505,9 +505,13 @@ bpf_program__set_type(struct bpf_program* program, enum bpf_prog_type type)
     if (program->object->loaded) {
         return libbpf_err(-EBUSY);
     }
+    if (program->object->execution_type == EBPF_EXECUTION_NATIVE) {
+        // Native BPF programs have already passed verification and so cannot
+        // have their program type changed.
+        return libbpf_err(-EINVAL);
+    }
     const ebpf_program_type_t* program_type = ebpf_get_ebpf_program_type(type);
     program->program_type = (program_type != nullptr) ? *program_type : EBPF_PROGRAM_TYPE_UNSPECIFIED;
-    program->autoload = true; // TODO(issue #3555): remove this once bpf_program__set_autoload is supported.
     return 0;
 }
 

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -161,6 +161,23 @@ bpf_program__section_name(const struct bpf_program* program)
     return program->section_name;
 }
 
+bool
+bpf_program__autoload(const struct bpf_program* program)
+{
+    return program->autoload;
+}
+
+int
+bpf_program__set_autoload(struct bpf_program* program, bool autoload)
+{
+    if (program->object->loaded) {
+        return libbpf_err(-EINVAL);
+    }
+
+    program->autoload = autoload;
+    return 0;
+}
+
 size_t
 bpf_program__size(const struct bpf_program* program)
 {

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1233,7 +1233,10 @@ _ebpf_native_load_programs(_Inout_ ebpf_native_module_t* module)
 
     // Get the programs.
     module->table.programs(&programs, &program_count);
-    if (program_count == 0 || programs == NULL) {
+    if (program_count == 0) {
+        EBPF_RETURN_RESULT(EBPF_SUCCESS);
+    }
+    if (programs == NULL) {
         return EBPF_INVALID_OBJECT;
     }
 
@@ -1491,11 +1494,13 @@ _ebpf_native_initialize_handle_cleanup_context(
     }
     cleanup_context->handle_information->count_of_map_handles = map_handle_count;
 
-    cleanup_context->handle_information->program_handles =
-        (ebpf_handle_t*)ebpf_allocate(sizeof(ebpf_handle_t) * program_handle_count);
-    if (cleanup_context->handle_information->program_handles == NULL) {
-        result = EBPF_NO_MEMORY;
-        goto Done;
+    if (program_handle_count > 0) {
+        cleanup_context->handle_information->program_handles =
+            (ebpf_handle_t*)ebpf_allocate(sizeof(ebpf_handle_t) * program_handle_count);
+        if (cleanup_context->handle_information->program_handles == NULL) {
+            result = EBPF_NO_MEMORY;
+            goto Done;
+        }
     }
     cleanup_context->handle_information->count_of_program_handles = program_handle_count;
 

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -409,7 +409,6 @@ typedef struct _ebpf_operation_load_native_module_reply
 typedef struct _ebpf_operation_load_native_programs_request
 {
     struct _ebpf_operation_header header;
-    ebpf_program_type_t program_type;
     GUID module_id;
 } ebpf_operation_load_native_programs_request_t;
 

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -16,7 +16,7 @@ static const uint32_t _ebpf_object_marker = 'eobj';
 static ebpf_lock_t _ebpf_object_tracking_list_lock = {0};
 
 /**
- * @brief Objects are allocated an entry in the the ID
+ * @brief Objects are allocated an entry in the ID
  * table when they are initialized.  Along with a pointer to the
  * object, each id table entry maintains its own ref-count that
  * starts off at 1 when it is assigned to a new object. The

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1087,6 +1087,26 @@ DECLARE_REGRESSION_TEST_CASE("0.11.0")
 // only for Debug build.
 #ifdef _DEBUG
 
+// Load a native module that has 0 programs.
+// TODO(#3597): The empty file should pass bpf2c so should be enabled for Release as well.
+TEST_CASE("load_native_program_empty", "[native_tests]")
+{
+    bpf_object* object = bpf_object__open("empty.sys");
+    REQUIRE(object != nullptr);
+
+    REQUIRE(bpf_object__load(object) == 0);
+
+    // Verify that no programs exist but at least one map exists.
+    uint32_t next_id;
+    REQUIRE(bpf_prog_get_next_id(0, &next_id) == -ENOENT);
+    REQUIRE(bpf_map_get_next_id(0, &next_id) == 0);
+
+    bpf_object__close(object);
+
+    // Verify no maps exist.
+    REQUIRE(bpf_map_get_next_id(0, &next_id) == -ENOENT);
+}
+
 static void
 _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execution_type, int expected_result)
 {
@@ -1117,10 +1137,6 @@ TEST_CASE("load_native_program_invalid2", "[native][negative]")
 TEST_CASE("load_native_program_invalid3", "[native][negative]")
 {
     _load_invalid_program("invalid_helpers.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
-}
-TEST_CASE("load_native_program_empty", "[native][negative]")
-{
-    _load_invalid_program("empty.sys", EBPF_EXECUTION_NATIVE, 0);
 }
 TEST_CASE("load_native_program_invalid5", "[native][negative]")
 {

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1118,7 +1118,7 @@ TEST_CASE("load_native_program_invalid3", "[native][negative]")
 {
     _load_invalid_program("invalid_helpers.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
 }
-TEST_CASE("load_native_program_invalid4", "[native][negative]")
+TEST_CASE("load_native_program_empty", "[native][negative]")
 {
     _load_invalid_program("empty.sys", EBPF_EXECUTION_NATIVE, 0);
 }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -80,7 +80,7 @@ static _Success_(return == 0) int _program_load_helper(
     *object = nullptr;
     struct bpf_object* new_object = bpf_object__open(file_name);
     if (new_object == nullptr) {
-        return EBPF_FAILED;
+        return -EINVAL;
     }
 
     REQUIRE(ebpf_object_set_execution_type(new_object, execution_type) == EBPF_SUCCESS);
@@ -101,7 +101,7 @@ static _Success_(return == 0) int _program_load_helper(
         *program_fd = bpf_program__fd(program);
     }
     *object = new_object;
-    return EBPF_SUCCESS;
+    return 0;
 }
 
 static void

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1108,7 +1108,7 @@ _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execut
 
 TEST_CASE("load_native_program_invalid1", "[native][negative]")
 {
-    _load_invalid_program("invalid_maps1.sys", EBPF_EXECUTION_NATIVE, 0);
+    _load_invalid_program("invalid_maps1.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
 }
 TEST_CASE("load_native_program_invalid2", "[native][negative]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2703,7 +2703,6 @@ TEST_CASE("load_native_program_empty", "[end-to-end]")
     std::wstring service_path(SERVICE_PATH_PREFIX);
     size_t count_of_maps = 0;
     size_t count_of_programs = 0;
-    std::wstring file_path(L"test_sample_ebpf_um.dll");
     ebpf_handle_t map_handles;
     ebpf_handle_t program_handles;
     _test_handle_helper module_handle;
@@ -2768,10 +2767,6 @@ TEST_CASE("load_native_program_invalid2", "[end-to-end]")
 TEST_CASE("load_native_program_invalid3", "[end-to-end]")
 {
     _test_load_invalid_program("invalid_helpers_um.dll", EBPF_EXECUTION_NATIVE, -EINVAL);
-}
-TEST_CASE("load_native_program_invalid4", "[end-to-end]")
-{
-    _test_load_invalid_program("empty_um.dll", EBPF_EXECUTION_NATIVE, 0);
 }
 TEST_CASE("load_native_program_invalid5", "[end-to-end]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2556,8 +2556,7 @@ TEST_CASE("load_native_program_negative3", "[end-to-end]")
 
     // Try to load the programs from the same module again. It should fail.
     REQUIRE(
-        test_ioctl_load_native_programs(
-            &provider_module_id, nullptr, MAP_COUNT, map_handles, PROGRAM_COUNT, program_handles) ==
+        test_ioctl_load_native_programs(&provider_module_id, MAP_COUNT, map_handles, PROGRAM_COUNT, program_handles) ==
         ERROR_OBJECT_ALREADY_EXISTS);
 
     bpf_object__close(unique_object.release());
@@ -2565,8 +2564,8 @@ TEST_CASE("load_native_program_negative3", "[end-to-end]")
     // Now that we have closed the object, try to load programs from the same module again. This should
     // fail as the module should now be marked as "unloading".
     REQUIRE(
-        test_ioctl_load_native_programs(
-            &provider_module_id, nullptr, MAP_COUNT, map_handles, PROGRAM_COUNT, program_handles) != ERROR_SUCCESS);
+        test_ioctl_load_native_programs(&provider_module_id, MAP_COUNT, map_handles, PROGRAM_COUNT, program_handles) !=
+        ERROR_SUCCESS);
 }
 
 // Load native module and then try to load programs with incorrect params.
@@ -2589,7 +2588,7 @@ TEST_CASE("load_native_program_negative4", "[end-to-end]")
 
     // First try to load native program without loading the native module.
     REQUIRE(
-        test_ioctl_load_native_programs(&provider_module_id, nullptr, 0, nullptr, PROGRAM_COUNT, program_handles) ==
+        test_ioctl_load_native_programs(&provider_module_id, 0, nullptr, PROGRAM_COUNT, program_handles) ==
         ERROR_PATH_NOT_FOUND);
 
     // Creating valid service with valid driver.
@@ -2608,7 +2607,7 @@ TEST_CASE("load_native_program_negative4", "[end-to-end]")
 
     // Try to load the programs by passing wrong map and program handles size. This should fail.
     REQUIRE(
-        test_ioctl_load_native_programs(&provider_module_id, nullptr, 0, nullptr, PROGRAM_COUNT, program_handles) ==
+        test_ioctl_load_native_programs(&provider_module_id, 0, nullptr, PROGRAM_COUNT, program_handles) ==
         ERROR_INVALID_PARAMETER);
 
     // Delete the created service.
@@ -2724,8 +2723,7 @@ TEST_CASE("load_native_program_empty", "[end-to-end]")
 
     // Try to load the programs from the module with 0 programs.
     REQUIRE(
-        test_ioctl_load_native_programs(&provider_module_id, nullptr, 1, &map_handles, 0, &program_handles) ==
-        ERROR_SUCCESS);
+        test_ioctl_load_native_programs(&provider_module_id, 1, &map_handles, 0, &program_handles) == ERROR_SUCCESS);
 
     // Delete the created service.
     Platform::_delete_service(service_handle);

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2693,7 +2693,7 @@ TEST_CASE("load_native_program_negative6", "[end-to-end]")
 #ifdef _DEBUG
 
 // Load programs from a native module which has 0 programs.
-TEST_CASE("load_native_program_negative8", "[end-to-end]")
+TEST_CASE("load_native_program_empty", "[end-to-end]")
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
@@ -2725,8 +2725,8 @@ TEST_CASE("load_native_program_negative8", "[end-to-end]")
 
     // Try to load the programs from the module with 0 programs.
     REQUIRE(
-        test_ioctl_load_native_programs(&provider_module_id, nullptr, 1, &map_handles, 1, &program_handles) ==
-        ERROR_INVALID_PARAMETER);
+        test_ioctl_load_native_programs(&provider_module_id, nullptr, 1, &map_handles, 0, &program_handles) ==
+        ERROR_SUCCESS);
 
     // Delete the created service.
     Platform::_delete_service(service_handle);
@@ -2759,7 +2759,7 @@ _test_load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t e
 
 TEST_CASE("load_native_program_invalid1", "[end-to-end]")
 {
-    _test_load_invalid_program("invalid_maps1_um.dll", EBPF_EXECUTION_NATIVE, 0);
+    _test_load_invalid_program("invalid_maps1_um.dll", EBPF_EXECUTION_NATIVE, -EINVAL);
 }
 TEST_CASE("load_native_program_invalid2", "[end-to-end]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2738,6 +2738,7 @@ _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execut
     int result;
     bpf_object_ptr unique_object;
     fd_t program_fd;
+    uint32_t next_id;
 
     program_info_provider_t bind_program_info;
     REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
@@ -2745,6 +2746,12 @@ _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execut
     result = ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, execution_type, &unique_object, &program_fd, nullptr);
     REQUIRE(result == expected_result);
     REQUIRE(program_fd == ebpf_fd_invalid);
+
+    if (result != 0) {
+        // If load failed, no programs or maps should be loaded.
+        REQUIRE(bpf_map_get_next_id(0, &next_id) == -ENOENT);
+        REQUIRE(bpf_prog_get_next_id(0, &next_id) == -ENOENT);
+    }
 }
 
 static void

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2691,7 +2691,8 @@ TEST_CASE("load_native_program_negative6", "[end-to-end]")
 // only for Debug build.
 #ifdef _DEBUG
 
-// Load programs from a native module which has 0 programs.
+// Load a native module that has 0 programs.
+// TODO(#3597): The empty file should pass bpf2c so should be enabled for Release as well.
 TEST_CASE("load_native_program_empty", "[end-to-end]")
 {
     _test_helper_end_to_end test_helper;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -385,7 +385,7 @@ ebpf_program_load(
         return error;
     }
 
-    if (program) {
+    if (program != nullptr) {
         *program_fd = bpf_program__fd(program);
     }
     unique_object->reset(new_object);
@@ -2746,6 +2746,7 @@ _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execut
 
     result = ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, execution_type, &unique_object, &program_fd, nullptr);
     REQUIRE(result == expected_result);
+    REQUIRE(program_fd == ebpf_fd_invalid);
 }
 
 static void
@@ -2758,7 +2759,7 @@ _test_load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t e
 
 TEST_CASE("load_native_program_invalid1", "[end-to-end]")
 {
-    _test_load_invalid_program("invalid_maps1_um.dll", EBPF_EXECUTION_NATIVE, -EINVAL);
+    _test_load_invalid_program("invalid_maps1_um.dll", EBPF_EXECUTION_NATIVE, 0);
 }
 TEST_CASE("load_native_program_invalid2", "[end-to-end]")
 {
@@ -2770,7 +2771,7 @@ TEST_CASE("load_native_program_invalid3", "[end-to-end]")
 }
 TEST_CASE("load_native_program_invalid4", "[end-to-end]")
 {
-    _test_load_invalid_program("empty_um.dll", EBPF_EXECUTION_NATIVE, -EINVAL);
+    _test_load_invalid_program("empty_um.dll", EBPF_EXECUTION_NATIVE, 0);
 }
 TEST_CASE("load_native_program_invalid5", "[end-to-end]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -351,7 +351,7 @@ ebpf_program_load(
     bpf_prog_type prog_type,
     ebpf_execution_type_t execution_type,
     _Out_ bpf_object_ptr* unique_object,
-    _Out_ fd_t* program_fd,
+    _Out_ fd_t* program_fd, // File descriptor of first program in the object.
     _Outptr_opt_result_maybenull_z_ const char** log_buffer)
 {
     *program_fd = ebpf_fd_invalid;
@@ -385,7 +385,9 @@ ebpf_program_load(
         return error;
     }
 
-    *program_fd = bpf_program__fd(program);
+    if (program) {
+        *program_fd = bpf_program__fd(program);
+    }
     unique_object->reset(new_object);
     return 0;
 }

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2702,8 +2702,8 @@ TEST_CASE("load_native_program_empty", "[end-to-end]")
     std::wstring service_path(SERVICE_PATH_PREFIX);
     size_t count_of_maps = 0;
     size_t count_of_programs = 0;
-    ebpf_handle_t map_handles;
-    ebpf_handle_t program_handles;
+    ebpf_handle_t map_handles = ebpf_handle_invalid;
+    ebpf_handle_t program_handles = ebpf_handle_invalid;
     _test_handle_helper module_handle;
 
     REQUIRE(UuidCreate(&provider_module_id) == RPC_S_OK);
@@ -2724,6 +2724,7 @@ TEST_CASE("load_native_program_empty", "[end-to-end]")
     // Try to load the programs from the module with 0 programs.
     REQUIRE(
         test_ioctl_load_native_programs(&provider_module_id, 1, &map_handles, 0, &program_handles) == ERROR_SUCCESS);
+    REQUIRE(map_handles != ebpf_handle_invalid);
 
     // Delete the created service.
     Platform::_delete_service(service_handle);

--- a/tests/libs/util/ioctl_helper.cpp
+++ b/tests/libs/util/ioctl_helper.cpp
@@ -61,7 +61,6 @@ Done:
 uint32_t
 test_ioctl_load_native_programs(
     _In_ const GUID* module_id,
-    _In_opt_ const ebpf_program_type_t* program_type,
     size_t count_of_maps,
     _Out_writes_(count_of_maps) ebpf_handle_t* map_handles,
     size_t count_of_programs,
@@ -82,7 +81,6 @@ test_ioctl_load_native_programs(
     request.header.id = EBPF_OPERATION_LOAD_NATIVE_PROGRAMS;
     request.header.length = sizeof(ebpf_operation_load_native_programs_request_t);
     request.module_id = *module_id;
-    request.program_type = program_type ? *program_type : GUID_NULL;
 
     error = invoke_ioctl(request, reply_buffer);
     if (error != ERROR_SUCCESS) {

--- a/tests/libs/util/ioctl_helper.h
+++ b/tests/libs/util/ioctl_helper.h
@@ -14,7 +14,6 @@ test_ioctl_load_native_module(
 uint32_t
 test_ioctl_load_native_programs(
     _In_ const GUID* module_id,
-    _In_opt_ const ebpf_program_type_t* program_type,
     size_t count_of_maps,
     _Out_writes_(count_of_maps) ebpf_handle_t* map_handles,
     size_t count_of_programs,


### PR DESCRIPTION
## Description

This PR does the following:

* Implement libbpf autoload APIs
* Make `bpf_program__set_type()` fail for native programs, since verification is done at compile time so the prog type cannot be changed after that.
* Add a test for the case of a file with maps but 0 programs.  Per the libbpf API contract, the load should succeed and create the maps.
* Remove `program_type` from the load native programs ioctl, since it was unused and since a file loaded can contain programs of multiple types.
* Update `_load_invalid_program` in unit_tests to match the same function in api_test

Fixes #3555

## Testing

Updated tests.

## Documentation

Updated docs.

## Installation

No impact.
