### PR TITLE
Move `ebpf_link_dispatch_table_version_t` to `ebpf_extension.h`

### DIFF
--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -70,6 +70,17 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
  */
 typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(_Inout_ void* state);
 
+typedef enum _ebpf_link_dispatch_table_version
+{
+    EBPF_LINK_DISPATCH_TABLE_VERSION_1 = 1, ///< Initial version of the dispatch table.
+    EBPF_LINK_DISPATCH_TABLE_VERSION_CURRENT =
+        EBPF_LINK_DISPATCH_TABLE_VERSION_1, ///< Current version of the dispatch table.
+} ebpf_link_dispatch_table_version_t;
+
+#define EBPF_LINK_DISPATCH_TABLE_FUNCTION_COUNT_1 4
+#define EBPF_LINK_DISPATCH_TABLE_FUNCTION_COUNT_CURRENT \
+    EBPF_LINK_DISPATCH_TABLE_FUNCTION_COUNT_1 ///< Current number of functions in the dispatch table.
+
 typedef struct _ebpf_extension_program_dispatch_table
 {
     uint16_t version; ///< Version of the dispatch table.

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -88,16 +88,10 @@ _ebpf_link_instance_invoke_batch(
 static ebpf_result_t
 _ebpf_link_instance_invoke_batch_end(_Inout_ void* state);
 
-typedef enum _ebpf_link_dispatch_table_version
-{
-    EBPF_LINK_DISPATCH_TABLE_CURRENT_VERSION = 1, ///< Initial version of the dispatch table.
-    EBPF_LINK_DISPATCH_TABLE_VERSION =
-        EBPF_LINK_DISPATCH_TABLE_CURRENT_VERSION, ///< Current version of the dispatch table.
-} ebpf_link_dispatch_table_version_t;
-
 static const ebpf_extension_program_dispatch_table_t _ebpf_link_dispatch_table = {
-    EBPF_LINK_DISPATCH_TABLE_VERSION,
-    4, // Count of functions. This should be updated when new functions are added.
+    EBPF_LINK_DISPATCH_TABLE_VERSION_CURRENT,
+    EBPF_LINK_DISPATCH_TABLE_FUNCTION_COUNT_CURRENT, // Count of functions. This should be updated when new functions
+                                                     // are added.
     _ebpf_link_instance_invoke,
     _ebpf_link_instance_invoke_batch_begin,
     _ebpf_link_instance_invoke_batch,


### PR DESCRIPTION
## Description

This PR moves `ebpf_link_dispatch_table_version_t` enum to `ebpf_extension.h`, so that extensions can also access the enum in case they want to work with an older version of ebpfcore.

## Testing

Existing CICD

## Documentation

NA

## Installation

No
