### PR TITLE
Multiple MSVC related fixes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,7 +80,7 @@ jobs:
       name: unit_tests
       pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
+      test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: true
@@ -98,7 +98,7 @@ jobs:
       name: unit_tests
       pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
+      test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: true
@@ -115,7 +115,7 @@ jobs:
       name: unit_tests
       pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
+      test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64-native-only
       environment: windows-2022
       code_coverage: true
@@ -438,7 +438,7 @@ jobs:
     with:
       name: unit_tests
       # Exclude [processes] test that ASAN can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
+      test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64-Sanitize
       environment: windows-2022
       code_coverage: false

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,7 +80,7 @@ jobs:
       name: unit_tests
       pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
+      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: true
@@ -98,7 +98,7 @@ jobs:
       name: unit_tests
       pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
+      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: true
@@ -115,7 +115,7 @@ jobs:
       name: unit_tests
       pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
+      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
       build_artifact: Build-x64-native-only
       environment: windows-2022
       code_coverage: true
@@ -438,7 +438,7 @@ jobs:
     with:
       name: unit_tests
       # Exclude [processes] test that ASAN can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
+      test_command: .\unit_tests.exe -d yes ~[processes] ~["show sections tail_call_multiple_um.dll"]
       build_artifact: Build-x64-Sanitize
       environment: windows-2022
       code_coverage: false

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -20,14 +20,6 @@ SPDX-License-Identifier: MIT
 			<RegistrySearch Id="FindInstallLocation" Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[WIX_UPGRADE_DETECTED]" Name="InstallLocation" Type="raw" Win64="yes" />
 		</Property>
 
-		<!-- Install preconditions -->
-		<Property Id="VC_REDIST_INSTALLED" Secure="yes">
-			<RegistrySearch Id="VC_REDIST_RegKey" Type="raw" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64" Name="Version"/>
-		</Property>
-		<Condition Message="This setup requires the 'VC++ Redistributable' v14.x to be installed. Please install it the from: https://aka.ms/vs/17/release/vc_redist.x64.exe">
-			Installed OR VC_REDIST_INSTALLED
-		</Condition>
-
 		<!-- Define the Product features and installation steps -->
 		<Feature Id="ProductFeature" Title="eBPF for Windows Installer" ConfigurableDirectory="INSTALLFOLDER" Display="expand" Level="1" Absent="disallow" AllowAdvertise="no" InstallDefault="local" TypicalDefault="install" >
 			<Feature Id="eBPF_Runtime_Components" Level="1" Title="Runtime Components" Absent="disallow" Display="expand" AllowAdvertise="no" >
@@ -46,6 +38,11 @@ SPDX-License-Identifier: MIT
 				</Feature>
 				<?endif?>
 				<?endif?>
+                <?if $(var.IncludeVCRedist) = True ?>
+                <Feature Id="VCRedist" Title="VC++ Redistributable" Level="11" Absent="disallow" AllowAdvertise="no" >
+                    <ComponentGroupRef Id="VCRedist" />
+                </Feature>
+                <?endif?>
 			</Feature>
 		</Feature>
 
@@ -114,51 +111,83 @@ SPDX-License-Identifier: MIT
 
 	<!-- Define the product's <Runtime> components -->
 	<Fragment>
+        <?if $(var.IncludeVCRedist) = True ?>
+        <ComponentGroup Id="VCRedist" Directory="INSTALLFOLDER">
+			<Component Id="concrt140" Guid="{BA96F793-1D16-4277-B12B-7588BC2E647A}">
+				<File Id="concrt140.dll" Name="concrt140.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\concrt140.dll" />
+			</Component>
+            <Component Id="msvcp140" Guid="{225C690D-C9B9-4F6C-B422-6579380E3A41}">
+				<File Id="msvcp140.dll" Name="msvcp140.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\msvcp140.dll" />
+			</Component>
+            <Component Id="msvcp140_1" Guid="{32C5D7C0-43CA-469E-A712-5A7ED0C18F68}">
+				<File Id="msvcp140_1.dll" Name="msvcp140_1.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\msvcp140_1.dll" />
+			</Component>
+            <Component Id="msvcp140_2" Guid="{CD0CB411-69A8-427F-B775-B1C0BB269D2A}">
+				<File Id="msvcp140_2.dll" Name="msvcp140_2.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\msvcp140_2.dll" />
+			</Component>
+            <Component Id="msvcp140_atomic_wait" Guid="{EDD2FCE1-0A0C-4DF0-A935-6A917BEC8FD2}">
+				<File Id="msvcp140_atomic_wait.dll" Name="msvcp140_atomic_wait.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\msvcp140_atomic_wait.dll" />
+			</Component>
+            <Component Id="msvcp140_codecvt_ids" Guid="{ED0E8435-4D52-4801-81A5-E4EF0DFA9CA7}">
+				<File Id="msvcp140_codecvt_ids.dll" Name="msvcp140_codecvt_ids.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\msvcp140_codecvt_ids.dll" />
+			</Component>
+            <Component Id="vccorlib140" Guid="{D1B5ADB1-10BB-491C-B10E-8B5445D71484}">
+				<File Id="vccorlib140.dll" Name="vccorlib140.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\vccorlib140.dll" />
+			</Component>
+            <Component Id="vcruntime140" Guid="{96C01CAE-A895-463D-B090-7E15DD03724E}">
+				<File Id="vcruntime140.dll" Name="vcruntime140.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\vcruntime140.dll" />
+			</Component>
+            <Component Id="vcruntime140_1" Guid="{2EC40012-1B68-4DAB-91B9-6B4190B4EB6D}">
+				<File Id="vcruntime140_1.dll" Name="vcruntime140_1.dll" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)x64\$(var.Configuration)\vcruntime140_1.dll" />
+			</Component>
+		</ComponentGroup>
+        <?endif?>
+
 		<ComponentGroup Id="eBPF_Runtime_Components" Directory="INSTALLFOLDER">
 			<Component Id ="eBpfPATH" Guid="{C062B980-4B93-4FC7-A4F9-A751C2B419FD}" KeyPath="yes">
 				<Environment Id="eBpfPATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="no" Part="last" Action="set" System="yes" Separator=";" />
 			</Component>
 			<Component Id="LICENSE" Guid="{AF22EAE5-7D8D-4F22-BB64-6B6A079A2947}">
-				<File Id="LICENSE.txt" Name="LICENSE.txt" DiskId="1" Source="$(var.SolutionDir)LICENSE.txt" />
+				<File Id="LICENSE.txt" Name="LICENSE.txt" DiskId="1" KeyPath="yes" Source="$(var.SolutionDir)LICENSE.txt" />
 			</Component>
 			<Component Id="BPF2C.EXE" DiskId="1" Guid="{BD23322B-91C3-4848-96E0-04E3745411E1}">
-				<File Id="BPF2C.EXE" Name="bpf2c.exe" Source="$(var.bpf2c.TargetDir)bpf2c.exe" />
+				<File Id="BPF2C.EXE" Name="bpf2c.exe" KeyPath="yes" Source="$(var.bpf2c.TargetDir)bpf2c.exe" />
 			</Component>
 			<Component Id="BPF2C.PDB" DiskId="1" Guid="{6DEC471C-F27D-431C-A0E0-6F46CA472BAC}">
-				<File Id="BPF2C.PDB" Name="bpf2c.pdb" Source="$(var.bpf2c.TargetDir)bpf2c.pdb" />
+				<File Id="BPF2C.PDB" Name="bpf2c.pdb" KeyPath="yes" Source="$(var.bpf2c.TargetDir)bpf2c.pdb" />
 			</Component>
 			<Component Id="EBPF_ALL.GUID" DiskId="1" Guid="{F3C808AC-A63B-4A29-B110-00B5A903F3C9}">
-				<File Id="EBPF_ALL.GUID" Name="ebpf-all.guid" Source="$(var.SolutionDir)\scripts\ebpf-all.guid" />
+				<File Id="EBPF_ALL.GUID" Name="ebpf-all.guid" KeyPath="yes" Source="$(var.SolutionDir)\scripts\ebpf-all.guid" />
 			</Component>
 			<Component Id="BPFTOOL.EXE" DiskId="1" Guid="{E168EB1A-35F6-47E3-B977-B16DF7DFBDB0}">
-				<File Id="BPFTOOL.EXE" Name="bpftool.exe" Source="$(var.bpftool.TargetDir)bpftool.exe" />
+				<File Id="BPFTOOL.EXE" Name="bpftool.exe" KeyPath="yes" Source="$(var.bpftool.TargetDir)bpftool.exe" />
 			</Component>
 			<Component Id="BPFTOOL.PDB" DiskId="1" Guid="{D2A6D747-A52C-43B9-A684-FF05A0DCE166}">
-				<File Id="BPFTOOL.PDB" Name="bpftool.pdb" Source="$(var.bpftool.TargetDir)bpftool.pdb" />
+				<File Id="BPFTOOL.PDB" Name="bpftool.pdb" KeyPath="yes" Source="$(var.bpftool.TargetDir)bpftool.pdb" />
 			</Component>
 			<Component Id="EBPFAPI.DLL" DiskId="1" Guid="{C44E4B08-901E-4B71-8FD1-F0B3D11D063F}">
-				<File Id="EBPFAPI.DLL" Name="EbpfApi.dll" Source="$(var.EbpfApi.TargetDir)EbpfApi.dll" />
+				<File Id="EBPFAPI.DLL" Name="EbpfApi.dll" KeyPath="yes" Source="$(var.EbpfApi.TargetDir)EbpfApi.dll" />
 			</Component>
 			<Component Id="EBPFAPI.PDB" DiskId="1" Guid="{6912E957-E682-41CB-9C53-1D0B886528F7}">
-				<File Id="EBPFAPI.PDB" Name="EbpfApi.pdb" Source="$(var.EbpfApi.TargetDir)EbpfApi.pdb" />
+				<File Id="EBPFAPI.PDB" Name="EbpfApi.pdb" KeyPath="yes" Source="$(var.EbpfApi.TargetDir)EbpfApi.pdb" />
 			</Component>
 			<Component Id="EBPF_PRINTK.GUID" DiskId="1" Guid="{77EB156D-046E-4BD6-8F57-CCA1DB031B0B}">
-				<File Id="EBPF_PRINTK.GUID" Name="ebpf-printk.guid" Source="$(var.SolutionDir)\scripts\ebpf-printk.guid" />
+				<File Id="EBPF_PRINTK.GUID" Name="ebpf-printk.guid" KeyPath="yes" Source="$(var.SolutionDir)\scripts\ebpf-printk.guid" />
 			</Component>
 			<Component Id="EBPFFORWINDOWS.WPRP" DiskId="1" Guid="{4E4838D3-0C49-4FA2-B8EE-E484CC0E7FA9}">
-				<File Id="EBPFFORWINDOWS.WPRP" Name="ebpfforwindows.wprp" Source="$(var.SolutionDir)\scripts\ebpfforwindows.wprp" />
+				<File Id="EBPFFORWINDOWS.WPRP" Name="ebpfforwindows.wprp" KeyPath="yes" Source="$(var.SolutionDir)\scripts\ebpfforwindows.wprp" />
 			</Component>
 			<Component Id="EBPFNETSH.DLL" DiskId="1" Guid="{95928460-8560-448F-83C3-E9040BECCF5D}">
-				<File Id="EBPFNETSH.DLL" Name="ebpfnetsh.dll" Source="$(var.ebpfnetsh.TargetDir)ebpfnetsh.dll" />
+				<File Id="EBPFNETSH.DLL" Name="ebpfnetsh.dll" KeyPath="yes" Source="$(var.ebpfnetsh.TargetDir)ebpfnetsh.dll" />
 			</Component>
 			<Component Id="EBPFNETSH.PDB" DiskId="1" Guid="{D0FB50BF-8822-4197-B3CF-0476C357DBDD}">
-				<File Id="EBPFNETSH.PDB" Name="ebpfnetsh.pdb" Source="$(var.ebpfnetsh.TargetDir)ebpfnetsh.pdb" />
+				<File Id="EBPFNETSH.PDB" Name="ebpfnetsh.pdb" KeyPath="yes" Source="$(var.ebpfnetsh.TargetDir)ebpfnetsh.pdb" />
 			</Component>
 			<Component Id="EXPORT_PROGRAM_INFO.EXE" DiskId="1" Guid="{7AF9A30B-D7BF-4FD2-88C0-C2947ED55DCD}">
-				<File Id="EXPORT_PROGRAM_INFO.EXE" Name="export_program_info.exe" Source="$(var.export_program_info.TargetDir)export_program_info.exe" />
+				<File Id="EXPORT_PROGRAM_INFO.EXE" Name="export_program_info.exe" KeyPath="yes" Source="$(var.export_program_info.TargetDir)export_program_info.exe" />
 			</Component>
 			<Component Id="EXPORT_PROGRAM_INFO.PDB" DiskId="1" Guid="{88356FE4-6247-4876-BA14-42EDA88CC5C7}">
-				<File Id="EXPORT_PROGRAM_INFO.PDB" Name="export_program_info.pdb" Source="$(var.export_program_info.TargetDir)export_program_info.pdb" />
+				<File Id="EXPORT_PROGRAM_INFO.PDB" Name="export_program_info.pdb" KeyPath="yes" Source="$(var.export_program_info.TargetDir)export_program_info.pdb" />
 			</Component>
 		</ComponentGroup>
 

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -20,13 +20,13 @@ SPDX-License-Identifier: MIT
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;IncludeJIT=True</DefineConstants>
+    <DefineConstants>Debug;IncludeJIT=True;IncludeVCRedist=False</DefineConstants>
     <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'NativeOnlyDebug|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;IncludeJIT=False</DefineConstants>
+    <DefineConstants>Debug;IncludeJIT=False;IncludeVCRedist=False</DefineConstants>
     <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
@@ -35,6 +35,7 @@ SPDX-License-Identifier: MIT
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'True' ">IncludeJIT=True</DefineConstants>
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
     <SuppressValidation>True</SuppressValidation>
+    <DefineConstants>$(DefineConstants);IncludeVCRedist=True</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'NativeOnlyRelease|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
@@ -42,6 +43,7 @@ SPDX-License-Identifier: MIT
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'True' ">IncludeJIT=True</DefineConstants>
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
     <SuppressValidation>True</SuppressValidation>
+    <DefineConstants>$(DefineConstants);IncludeVCRedist=True</DefineConstants>
   </PropertyGroup>
   <!-- In accordance to what defined in sample.vcxproj, the MSI build is disabled for the 'Analysis' CI/CD build, as it  does not generate the *.o artifacts. -->
   <ItemGroup Condition="'$(Analysis)'==''">

--- a/scripts/check_msi_installation_files_nativeonly_release.txt
+++ b/scripts/check_msi_installation_files_nativeonly_release.txt
@@ -18,3 +18,12 @@ C:\Program Files\ebpf-for-windows\drivers\eBPFCore.sys
 C:\Program Files\ebpf-for-windows\drivers\NetEbpfExt.inf
 C:\Program Files\ebpf-for-windows\drivers\NetEbpfExt.pdb
 C:\Program Files\ebpf-for-windows\drivers\NetEbpfExt.sys
+C:\Program Files\ebpf-for-windows\concrt140.dll
+C:\Program Files\ebpf-for-windows\msvcp140.dll
+C:\Program Files\ebpf-for-windows\msvcp140_1.dll
+C:\Program Files\ebpf-for-windows\msvcp140_2.dll
+C:\Program Files\ebpf-for-windows\msvcp140_atomic_wait.dll
+C:\Program Files\ebpf-for-windows\msvcp140_codecvt_ids.dll
+C:\Program Files\ebpf-for-windows\vccorlib140.dll
+C:\Program Files\ebpf-for-windows\vcruntime140.dll
+C:\Program Files\ebpf-for-windows\vcruntime140_1.dll

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -280,26 +280,48 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
     std::string output =
         _run_netsh_command(handle_ebpf_show_sections, L"tail_call_multiple_um.dll", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
-    const std::string expected_output = "\n"
-                                        "                                                            Size\n"
-                                        "             Section                 Program       Type  (bytes)\n"
-                                        "====================  ======================  =========  =======\n"
-#if defined(NDEBUG)
-                                        "        sample_ext/0                 callee0     sample       75\n"
-                                        "        sample_ext/1                 callee1     sample        6\n"
-                                        "          sample_ext                  caller     sample       73\n"
-#else
-                                        "        sample_ext/0                 callee0     sample      413\n"
-                                        "        sample_ext/1                 callee1     sample      190\n"
-                                        "          sample_ext                  caller     sample      413\n"
-#endif
-                                        "\n"
-                                        "                     Key  Value      Max\n"
-                                        "          Map Type  Size   Size  Entries  Name\n"
-                                        "==================  ====  =====  =======  ========\n"
-                                        "        prog_array     4      4       10  map\n";
 
-    REQUIRE(output == expected_output);
+    // Issue #3610: Different MSVC versions expect different numbers of bytes for the same program.
+    // As a workaround, check for both the expected outputs.
+    const std::string expected_output_old = "\n"
+                                            "                                                            Size\n"
+                                            "             Section                 Program       Type  (bytes)\n"
+                                            "====================  ======================  =========  =======\n"
+#if defined(NDEBUG)
+                                            "        sample_ext/0                 callee0     sample       73\n"
+                                            "        sample_ext/1                 callee1     sample        6\n"
+                                            "          sample_ext                  caller     sample       73\n"
+#else
+                                            "        sample_ext/0                 callee0     sample      413\n"
+                                            "        sample_ext/1                 callee1     sample      190\n"
+                                            "          sample_ext                  caller     sample      413\n"
+#endif
+                                            "\n"
+                                            "                     Key  Value      Max\n"
+                                            "          Map Type  Size   Size  Entries  Name\n"
+                                            "==================  ====  =====  =======  ========\n"
+                                            "        prog_array     4      4       10  map\n";
+
+    const std::string expected_output_new = "\n"
+                                            "                                                            Size\n"
+                                            "             Section                 Program       Type  (bytes)\n"
+                                            "====================  ======================  =========  =======\n"
+#if defined(NDEBUG)
+                                            "        sample_ext/0                 callee0     sample       75\n"
+                                            "        sample_ext/1                 callee1     sample        6\n"
+                                            "          sample_ext                  caller     sample       73\n"
+#else
+                                            "        sample_ext/0                 callee0     sample      413\n"
+                                            "        sample_ext/1                 callee1     sample      190\n"
+                                            "          sample_ext                  caller     sample      413\n"
+#endif
+                                            "\n"
+                                            "                     Key  Value      Max\n"
+                                            "          Map Type  Size   Size  Entries  Name\n"
+                                            "==================  ====  =====  =======  ========\n"
+                                            "        prog_array     4      4       10  map\n";
+
+    REQUIRE((output == expected_output_old || output == expected_output_new));
 }
 
 // Test a .sys file with multiple programs, including ones with long names.

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -285,7 +285,7 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
                                         "             Section                 Program       Type  (bytes)\n"
                                         "====================  ======================  =========  =======\n"
 #if defined(NDEBUG)
-                                        "        sample_ext/0                 callee0     sample       73\n"
+                                        "        sample_ext/0                 callee0     sample       75\n"
                                         "        sample_ext/1                 callee1     sample        6\n"
                                         "          sample_ext                  caller     sample       73\n"
 #else


### PR DESCRIPTION
Fixes #3610
Fixes #3624

## Description

This PR fixes multiple issues related to new MSVC version:

1. Update the failing test show sections `tail_call_multiple_um.dll` to accept both old and new values.
2. Include VC redist binaries in `Release / NativeOnlyRelease` MSI to mitigate the issue of mismatched VC redist binaries.

## Testing

Existing CICD

## Documentation

No

## Installation

No
