### PR TITLE
Remove VC++ Redist package from installation instruction

### DIFF
--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -8,7 +8,6 @@ install or update the eBPF installation in the VM.
 
 Do the following from within the VM:
 
-1. Download and install the *VC++ Redist* package from [this location](https://aka.ms/vs/17/release/vc_redist.x64.exe).
 1. Download the `eBPF-for-Windows.x.x.x.msi` file from the [latest release on GitHub](https://github.com/microsoft/ebpf-for-windows/releases).
 1. Execute the MSI file you downloaded.
 1. After accepting the License and selecting the desired installation folder (default will be "`C:\Program Files\ebpf-for-windows`"), the following components will be selectable from the *Installation Wizard*:


### PR DESCRIPTION
## Description

With fix #3623 , VC redist package is no longer needed for Release MSI. Hence this PR removes the instruction from the installation.

## Testing

_Do any existing tests cover this change? N/A
Are new tests needed? N/A

## Documentation

_Is there any documentation impact for this change? Yes

## Installation

_Is there any installer impact for this change? N/A
