### PR TITLE
Update regression tests to 0.17

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -259,7 +259,7 @@ jobs:
     if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file" -TestMode "Regression" -RegressionArtifactsVersion "0.15.1"
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file" -TestMode "Regression" -RegressionArtifactsVersion "0.17.0"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Regression"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       name: regression_driver_ws2022

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -1,4 +1,4 @@
-# Copyright (c) eBPF for Windows contributors
+﻿# Copyright (c) eBPF for Windows contributors
 # SPDX-License-Identifier: MIT
 
 param ([Parameter(Mandatory=$True)] [string] $Admin,
@@ -600,23 +600,29 @@ function Get-RegressionTestArtifacts
 
     # Download regression test artifacts for each version.
     $DownloadPath = "$RegressionTestArtifactsPath"
-    $ArtifactName = "Release-v$ArtifactVersion/Build-x64-$Configuration.zip"
+    $ArtifactName = "Release-v$ArtifactVersion/Build-x64.$Configuration.zip"
     $ArtifactUrl = "https://github.com/microsoft/ebpf-for-windows/releases/download/" + $ArtifactName
 
     Write-Log "Downloading regression test artifacts for version $ArtifactVersion" -ForegroundColor Green
     $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri $ArtifactUrl -OutFile "$DownloadPath\artifact.zip"
+    Invoke-WebRequest -Uri $ArtifactUrl -OutFile "$DownloadPath\Build-x64.$Configuration.zip"
 
-    Write-Log "Extracting $ArtifactName"
-    Expand-Archive -Path "$DownloadPath\artifact.zip" -DestinationPath $DownloadPath -Force
-    Write-Log "Extracting $DownloadPath\build-$Configuration.zip"
-    Expand-Archive -Path "$DownloadPath\build-$Configuration.zip" -DestinationPath $DownloadPath -Force
+    if (Test-Path -Path $DownloadPath\Build-x64.$Configuration) {
+        Remove-Item -Path $DownloadPath\Build-x64.$Configuration -Recurse -Force
+    }
 
+    Write-Log "Extracting Build-x64.$Configuration.zip"
+    Expand-Archive -Path "$DownloadPath\Build-x64.$Configuration.zip" -DestinationPath $DownloadPath -Force
+
+    $DownloadedArtifactPath = "$DownloadPath\Build-x64 $Configuration"
+
+    if (!(Test-Path -Path $DownloadedArtifactPath)) {
+        throw ("Path ""$DownloadedArtifactPath"" not found.")
+    }
 
     # Copy all the drivers, DLLs, exe and .o files to pwd.
     Write-Log "Copy regression test artifacts to main folder" -ForegroundColor Green
-    $ArtifactPath = "$DownloadPath\$Configuration"
-    Push-Location $ArtifactPath
+    Push-Location $DownloadedArtifactPath
     Get-ChildItem -Path .\* -Include *.sys | Move-Item -Destination $OriginalPath -Force
     Get-ChildItem -Path .\* -Include *.dll | Move-Item -Destination $OriginalPath -Force
     Get-ChildItem -Path .\* -Include *.exe | Move-Item -Destination $OriginalPath -Force

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -98,7 +98,7 @@ function Invoke-CICDTests
     # load_native_program_invalid4 has been deleted from the test list, but 0.17 tests still have this test.
     # That causes the regression test to fail. So, we are skipping this test for now.
     $TestList = @(
-        "api_test.exe ~[load_native_program_invalid4]",
+        "api_test.exe ~`"load_native_program_invalid4`"",
         "bpftool_tests.exe",
         "sample_ext_app.exe",
         "socket_tests.exe")

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -1,4 +1,4 @@
-# Copyright (c) eBPF for Windows contributors
+﻿# Copyright (c) eBPF for Windows contributors
 # SPDX-License-Identifier: MIT
 
 param ([Parameter(Mandatory=$True)] [string] $WorkingDirectory,
@@ -95,8 +95,10 @@ function Invoke-CICDTests
     Push-Location $WorkingDirectory
     $env:EBPF_ENABLE_WER_REPORT = "yes"
 
+    # load_native_program_invalid4 has been deleted from the test list, but 0.17 tests still have this test.
+    # That causes the regression test to fail. So, we are skipping this test for now.
     $TestList = @(
-        "api_test.exe",
+        "api_test.exe ~[load_native_program_invalid4]",
         "bpftool_tests.exe",
         "sample_ext_app.exe",
         "socket_tests.exe")


### PR DESCRIPTION
## Description

This PR contains the following changes:

1. Update regression tests to consume 0.17.0 artifacts.
2. Update script for the new URL of the release artifacts.
3. Skip test case `load_native_program_invalid4`: This test case has already been removed in the `main` branch as it is no longer valid (an empty sys file is allowed to be loaded). But this test exists in 0.17 release artifacts, and when the 0.17 tests are run against the latest ebpf runtime, the test fails. As a workaround to avoid a churn in 0.17 release, skipping this test.

## Testing

Existing CICD, updated tests.

## Documentation

No

## Installation

_Is there any installer impact for this change?_

