### PR TITLE
Remove netperf from daily schedule until it's fixed

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -598,7 +598,7 @@ jobs:
       configurations: '["Release"]'
 
   netperf:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/netperf.yml
     with:
       sha: ${{ github.sha }}
@@ -621,7 +621,7 @@ jobs:
 
   upload_netperf_results_azure_2022:
     needs: netperf
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_netperf_results_azure_2022
@@ -634,7 +634,7 @@ jobs:
 
   upload_netperf_results_lab_2022:
     needs: netperf
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_netperf_results_lab_2022


### PR DESCRIPTION
The netperf repo is undergoing restructuring to become compliant with the MSFT internal policies. Until this is complete, the repo is unable to execute eBPF jobs correctly, so removing this from the daily scheduled run.

## Description

This pull request includes changes to the `.github/workflows/cicd.yml` file that modify the conditions under which certain jobs are executed. The jobs `netperf`, `upload_netperf_results_azure_2022`, and `upload_netperf_results_lab_2022` will now only run if the GitHub event name is 'workflow_dispatch', as opposed to previously when they would run on either 'schedule' or 'workflow_dispatch'. 

Here are the key changes:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L601-R601): The `netperf` job will now only run if the GitHub event name is 'workflow_dispatch'.
* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L624-R624): The `upload_netperf_results_azure_2022` job will now only run if the GitHub event name is 'workflow_dispatch'.
* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L637-R637): The `upload_netperf_results_lab_2022` job will now only run if the GitHub event name is 'workflow_dispatch'.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
