### PR TITLE
Add hint to LTCG that code should be inlined

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,6 +66,8 @@
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WholeProgramOptimization Condition="'$(EnableAsan)' != 'true'">true</WholeProgramOptimization>
+      <!-- /Ob3 enable hinting to link time code generation that a function should be inlined -->
+      <AdditionalOptions>/Ob3 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -64,6 +64,7 @@ extern "C"
      * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_find_entry(
         _Inout_ ebpf_map_t* map,
@@ -84,6 +85,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this entry.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry(
         _Inout_ ebpf_map_t* map,
@@ -122,6 +124,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are
      *  invalid.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
 
@@ -155,6 +158,7 @@ extern "C"
      * @param[in] key_size Size of value to search for.
      * @returns Program pointer, or NULL if none.
      */
+    EBPF_INLINE_HINT
     _Ret_maybenull_ struct _ebpf_program*
     ebpf_map_get_program_from_entry(_Inout_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key);
 
@@ -236,6 +240,7 @@ extern "C"
      * @retval EBPF_SUCCESS Successfully wrote record into ring buffer.
      * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_output(_Inout_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length);
 
@@ -251,6 +256,7 @@ extern "C"
      *  entry.
      * @retval EBPF_OUT_OF_SPACE Map is full and BPF_EXIST was not supplied.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_push_entry(
         _Inout_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags);
@@ -266,6 +272,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_pop_entry(_Inout_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
@@ -280,6 +287,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_peek_entry(_Inout_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -192,6 +192,7 @@ extern "C"
      * @retval EBPF_SUCCESS The program was successfully invoked.
      * @retval EBPF_EXTENSION_FAILED_TO_LOAD The program information provider is not available.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_invoke(
         _In_ const ebpf_program_t* program,
@@ -281,6 +282,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT Internal error.
      * @retval EBPF_NO_MORE_TAIL_CALLS Program has executed to many tail calls.
      */
+    EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program);
 

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -20,6 +20,15 @@ extern "C"
 {
 #endif
 
+/**
+ * @brief Hint to compiler that this function should be inlined during link time code generation.
+ */
+#if defined(NDEBUG)
+#define EBPF_INLINE_HINT extern __forceinline
+#else
+#define EBPF_INLINE_HINT
+#endif
+
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
     {                                         \
         ((uint8_t*)(x)), sizeof((x)) - 1      \
@@ -242,6 +251,7 @@ extern "C"
      *    be preempted by other execution.
      * @retval True if this execution can be preempted.
      */
+    EBPF_INLINE_HINT
     bool
     ebpf_is_preemptible();
 
@@ -608,6 +618,7 @@ extern "C"
      * @param[in] include_suspended_time Include time the system spent in a suspended state.
      * @return Time elapsed since boot in 100 nanosecond units.
      */
+    EBPF_INLINE_HINT
     uint64_t
     ebpf_query_time_since_boot(bool include_suspended_time);
 
@@ -653,6 +664,7 @@ extern "C"
      *
      * @returns Process ID.
      */
+    EBPF_INLINE_HINT
     uint32_t
     ebpf_platform_process_id();
 
@@ -661,6 +673,7 @@ extern "C"
      *
      * @returns Thread ID.
      */
+    EBPF_INLINE_HINT
     uint32_t
     ebpf_platform_thread_id();
 
@@ -799,6 +812,7 @@ extern "C"
      *
      * @return result of the operation.
      */
+    EBPF_INLINE_HINT
     _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t
         ebpf_platform_get_authentication_id(_Out_ uint64_t* authentication_id);
 

--- a/libs/runtime/ebpf_random.h
+++ b/libs/runtime/ebpf_random.h
@@ -29,6 +29,7 @@ extern "C"
      *
      * @return A pseudorandom number.
      */
+    EBPF_INLINE_HINT
     uint32_t
     ebpf_random_uint32();
 


### PR DESCRIPTION
Elide extra stack frame from BPF helper function calls, removing unnecessary wrapper functions from the final image.

## Description

This pull request primarily involves two categories of changes: the addition of the `EBPF_INLINE_HINT` macro to various function definitions in the `libs/execution_context/ebpf_maps.h`, `libs/execution_context/ebpf_program.h`, `libs/runtime/ebpf_platform.h`, and `libs/runtime/ebpf_random.h` files, and the addition of an `AdditionalOptions` tag in the `Directory.Build.props` file. The `EBPF_INLINE_HINT` macro serves as a hint to the compiler that the function should be inlined during link time code generation. The `AdditionalOptions` tag enables hinting to link time code generation that a function should be inlined.

Addition of `EBPF_INLINE_HINT`:

* [`libs/execution_context/ebpf_maps.h`](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R67): Added `EBPF_INLINE_HINT` to various function definitions including `ebpf_map_find_entry`, `ebpf_map_update_entry`, `ebpf_map_delete_entry`, `ebpf_map_get_program_from_entry`, `ebpf_ring_buffer_map_output`, `ebpf_map_push_entry`, `ebpf_map_pop_entry`, `ebpf_map_peek_entry`. [[1]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R67) [[2]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R88) [[3]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R127) [[4]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R161) [[5]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R243) [[6]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R259) [[7]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R275) [[8]](diffhunk://#diff-d2aa4cc6dbc2357ca6f49f58e20a89d39177b8ca83612fa4dc7a0048c2cf94c5R290)
* [`libs/execution_context/ebpf_program.h`](diffhunk://#diff-a985fbe56d390f6845d5fa952b092e115360794cc7b8a6f36501cdb55c4870e1R284): Added `EBPF_INLINE_HINT` to `ebpf_program_set_tail_call` function definition.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R23-R31): Added `EBPF_INLINE_HINT` to various function definitions including `ebpf_is_preemptible`, `ebpf_query_time_since_boot`, `ebpf_platform_process_id`, `ebpf_platform_thread_id`, `ebpf_platform_get_authentication_id`. Also, defined the `EBPF_INLINE_HINT` macro. [[1]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R23-R31) [[2]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R254) [[3]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R621) [[4]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R667) [[5]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R676) [[6]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R815)
* [`libs/runtime/ebpf_random.h`](diffhunk://#diff-50d0994f82b7e7b09dc92b44cdfce9aefb55220c313d6b208700bb2eef5390beR32): Added `EBPF_INLINE_HINT` to `ebpf_random_uint32` function definition.

Addition of `AdditionalOptions`:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR69-R70): Added an `AdditionalOptions` tag to enable hinting to link time code generation that a function should be inlined.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
