### PR TITLE
Update store APIs to also update HKLM

### DIFF
--- a/include/ebpf_store_helper.h
+++ b/include/ebpf_store_helper.h
@@ -16,7 +16,8 @@ extern "C"
 
     typedef HKEY ebpf_store_key_t;
 
-    extern ebpf_store_key_t ebpf_store_root_key;
+    extern ebpf_store_key_t ebpf_store_hkcu_root_key;
+    extern ebpf_store_key_t ebpf_store_hklm_root_key;
     extern const wchar_t* ebpf_store_root_sub_key;
 
     /**

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -57,15 +57,17 @@ SPDX-License-Identifier: MIT
 			<Custom Action="NetEbpfExt_Driver_uninstall_rollback" Before="NetEbpfExt_Driver_install">NOT Installed</Custom>
 
 			<!--Install sequence-->
-			<Custom Action="Clear_eBPF_store" After="InstallFiles">NOT Installed</Custom>
-			<Custom Action="Setup_eBPF_store" After="Clear_eBPF_store">NOT Installed</Custom>
+			<Custom Action="Clear_eBPF_store_HKLM" After="InstallFiles">NOT Installed</Custom>
+			<Custom Action="Setup_eBPF_store_HKLM" After="Clear_eBPF_store_HKLM">NOT Installed</Custom>
+			<Custom Action="Clear_eBPF_store_HKCU" After="Setup_eBPF_store_HKLM">NOT Installed</Custom>
+			<Custom Action="Setup_eBPF_store_HKCU" After="Clear_eBPF_store_HKCU">NOT Installed</Custom>
 
-			<Custom Action="eBPF_netsh_helper_install" After="Setup_eBPF_store">NOT Installed</Custom>
+			<Custom Action="eBPF_netsh_helper_install" After="Setup_eBPF_store_HKCU">NOT Installed</Custom>
 
-			<Custom Action="eBPFCore_Driver_install" After="Setup_eBPF_store">NOT Installed</Custom>
+			<Custom Action="eBPFCore_Driver_install" After="Setup_eBPF_store_HKCU">NOT Installed</Custom>
 			<Custom Action="eBPFCore_Driver_start" After="eBPFCore_Driver_install">NOT Installed</Custom>
 
-			<Custom Action="NetEbpfExt_Driver_install" After="Setup_eBPF_store">NOT Installed</Custom>
+			<Custom Action="NetEbpfExt_Driver_install" After="Setup_eBPF_store_HKCU">NOT Installed</Custom>
 			<Custom Action="NetEbpfExt_Driver_start" After="NetEbpfExt_Driver_install">NOT Installed</Custom>
 
 			<!--Uninstall sequence-->
@@ -77,7 +79,8 @@ SPDX-License-Identifier: MIT
 			<Custom Action="NetEbpfExt_Driver_stop" After="InstallInitialize">REMOVE="ALL"</Custom>
 			<Custom Action="NetEbpfExt_Driver_uninstall" After="NetEbpfExt_Driver_stop">REMOVE="ALL"</Custom>
 
-			<Custom Action="Clear_eBPF_store_uninstall" After="NetEbpfExt_Driver_uninstall">REMOVE="ALL"</Custom>
+			<Custom Action="Clear_eBPF_store_uninstall_HKLM" After="NetEbpfExt_Driver_uninstall">REMOVE="ALL"</Custom>
+			<Custom Action="Clear_eBPF_store_uninstall_HKCU" After="Clear_eBPF_store_uninstall_HKLM">REMOVE="ALL"</Custom>
 			<Custom Action="eBPFCore_Driver_uninstall_flush" After="InstallFinalize">REMOVE="ALL"</Custom>
 		</InstallExecuteSequence>
 
@@ -192,10 +195,14 @@ SPDX-License-Identifier: MIT
 		</ComponentGroup>
 
 		<!--Clear/Setup the eBPF store-->
-		<CustomAction Id="Clear_eBPF_store" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="check" Impersonate="no"/>
-		<CustomAction Id="Clear_eBPF_store_uninstall" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="ignore" Impersonate="no"/>
-		<SetProperty Id="Setup_eBPF_store" Value='"[#EXPORT_PROGRAM_INFO.EXE]"' Before="Setup_eBPF_store" Sequence="execute"/>
-		<CustomAction Id="Setup_eBPF_store" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no"/>
+		<CustomAction Id="Clear_eBPF_store_HKLM" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="check" Impersonate="no"/>
+		<CustomAction Id="Clear_eBPF_store_HKCU" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="check" Impersonate="yes"/>
+		<CustomAction Id="Clear_eBPF_store_uninstall_HKLM" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="ignore" Impersonate="no"/>
+		<CustomAction Id="Clear_eBPF_store_uninstall_HKCU" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="ignore" Impersonate="yes"/>
+		<SetProperty Id="Setup_eBPF_store_HKLM" Value='"[#EXPORT_PROGRAM_INFO.EXE]"' Before="Setup_eBPF_store_HKLM" Sequence="execute"/>
+		<CustomAction Id="Setup_eBPF_store_HKLM" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no"/>
+		<SetProperty Id="Setup_eBPF_store_HKCU" Value='"[#EXPORT_PROGRAM_INFO.EXE]"' Before="Setup_eBPF_store_HKCU" Sequence="execute"/>
+		<CustomAction Id="Setup_eBPF_store_HKCU" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="yes"/>
 
 		<!--Install/Uninstall the netsh helper-->
 		<!--qtexec does not currently support a working directory (ref. https://github.com/wixtoolset/issues/issues/1265)-->

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -192,10 +192,10 @@ SPDX-License-Identifier: MIT
 		</ComponentGroup>
 
 		<!--Clear/Setup the eBPF store-->
-		<CustomAction Id="Clear_eBPF_store" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="check" Impersonate="yes"/>
-		<CustomAction Id="Clear_eBPF_store_uninstall" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="ignore" Impersonate="yes"/>
+		<CustomAction Id="Clear_eBPF_store" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="check" Impersonate="no"/>
+		<CustomAction Id="Clear_eBPF_store_uninstall" ExeCommand='"[#EXPORT_PROGRAM_INFO.EXE]" --clear' Directory="INSTALLFOLDER" Execute="deferred" Return="ignore" Impersonate="no"/>
 		<SetProperty Id="Setup_eBPF_store" Value='"[#EXPORT_PROGRAM_INFO.EXE]"' Before="Setup_eBPF_store" Sequence="execute"/>
-		<CustomAction Id="Setup_eBPF_store" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="yes"/>
+		<CustomAction Id="Setup_eBPF_store" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no"/>
 
 		<!--Install/Uninstall the netsh helper-->
 		<!--qtexec does not currently support a working directory (ref. https://github.com/wixtoolset/issues/issues/1265)-->

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -16,7 +16,8 @@
 #define GUID_STRING_LENGTH 38 // not including the null terminator.
 #define _EBPF_RESULT(x) win32_error_code_to_ebpf_result(x)
 
-ebpf_store_key_t ebpf_store_root_key = HKEY_CURRENT_USER; // TODO: Issue #1231 Change to using HKEY_LOCAL_MACHINE
+ebpf_store_key_t ebpf_store_hkcu_root_key = HKEY_CURRENT_USER;
+ebpf_store_key_t ebpf_store_hklm_root_key = HKEY_LOCAL_MACHINE;
 const wchar_t* ebpf_store_root_sub_key = EBPF_ROOT_RELATIVE_PATH;
 
 wchar_t*


### PR DESCRIPTION
## Description

**Issue:**
When using libbpf APIs for attaching eBPF programs, the app / service needs to provide `bpf_attach_type` enum. ebpfapi.dll uses eBPF store to convert this enum to ebpf attach type guid. We recently took a change where we stopped populating eBPF store entries in HKLM, and they are now only updated in HKCU. That caused a regression and breaks any app / service that is running as LOCAL_SYSTEM.

**Fix:**
To mitigate the regressions, only in 0.17 release, update the store APIs to also attempt to update / delete / read from HKLM. If the update or delete operation fails due to ACCESS_DENIED, that error is absorbed, as the app may not be running as admin.

## Testing

Existing tests.

## Documentation

No.

## Installation

_Is there any installer impact for this change?_
