### PR TITLE
Fix conflict between Windows and ubpf headers

### DIFF
--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -31,6 +31,10 @@
 #pragma warning(disable : 6387)  // ubpf_jit.c(70): error C6387: 'buffer' could be '0'
 #pragma warning(disable : 26451) // Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the
                                  // result to a 8 byte value.
+
+// Windows headers define near and far which conflict with the ubpf headers.
+#undef near
+#undef far
 #include "ubpf_jit.c"
 #include "ubpf_jit_support.c"
 #include "ubpf_jit_x86_64.c"


### PR DESCRIPTION
## Description

This pull request primarily focuses on updating the `ubpf` submodule and resolving conflicts between Windows headers and `ubpf` headers. 

Here are the key changes:

* [`external/ubpf`](diffhunk://#diff-ef001804bec5d3e67f97267c6195ad049b67fc392c2f42fbb86c15f358ef9173L1-R1): The `ubpf` submodule was updated. The commit hash was changed from `d370804a852b67f81c3aeed225ab646420d6b23e` to `2c2a68a2d9d3d9c4db159a03391a2841e8baa964`. This update could include various changes in the `ubpf` project that are not directly visible in this pull request.

* [`libs/ubpf/user/ubpf_user.c`](diffhunk://#diff-8390ee49b3d19d236d625f845a64b770c2e0be7bc5607d18bc1b60950c9b567fR34-R37): To avoid conflicts with the Windows headers, `near` and `far` were undefined before including the `ubpf` headers. These identifiers are defined in Windows headers and were causing conflicts with the `ubpf` headers.

## Testing

CI/CD

## Documentation

No

## Installation

No
