### PR TITLE
Add test case for program order in native module

### DIFF
--- a/tests/sample/multiple_programs.c
+++ b/tests/sample/multiple_programs.c
@@ -1,0 +1,43 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Whenever this sample program changes, bpf2c_tests will fail unless the
+// expected files in tests\bpf2c_tests\expected are updated. The following
+// script can be used to regenerate the expected files:
+//     generate_expected_bpf2c_output.ps1
+//
+// Usage:
+// .\scripts\generate_expected_bpf2c_output.ps1 <build_output_path>
+// Example:
+// .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
+
+#include "bpf_helpers.h"
+#include "ebpf_nethooks.h"
+
+SEC("bind_2")
+int
+program3(bind_md_t* ctx)
+{
+    return 3;
+}
+
+SEC("bind_4")
+int
+program1(bind_md_t* ctx)
+{
+    return 1;
+}
+
+SEC("bind_3")
+int
+program2(bind_md_t* ctx)
+{
+    return 2;
+}
+
+SEC("bind_1")
+int
+program4(bind_md_t* ctx)
+{
+    return 4;
+}

--- a/tests/sample/sample.vcxproj.filters
+++ b/tests/sample/sample.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright (c) eBPF for Windows contributors
   SPDX-License-Identifier: MIT
@@ -118,6 +118,9 @@
       <Filter>Source Files</Filter>
     </CustomBuild>
     <CustomBuild Include="cgroup_sendto_count3.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="multiple_programs.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
   </ItemGroup>


### PR DESCRIPTION
## Description

PR #3557 changed the order in which the programs are listed in the native module (and the corresponding order in ebpfapi).
This caused a regression where the eBPF programs from an older native module got FDs in a wrong order when run against new ePBF runtime

This PR adds a test case to validate that the program order does not change. This PR adds a new sample program where the below 3 sorts will generate different order:
1. sort by section name
2. sort by program name
3. sort by the order the programs appear in the ELF file.

## Testing

Added tests

## Documentation

No

## Installation

No.
