### PR TITLE
UM API to write into a ring buffer map.

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -140,3 +140,4 @@ EXPORTS
     libbpf_strerror
     ring_buffer__new
     ring_buffer__free
+    ebpf_ring_buffer_map_write

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -125,6 +125,7 @@ EXPORTS
     ebpf_program_attach
     ebpf_program_attach_by_fd
     ebpf_program_query_info
+    ebpf_ring_buffer_map_write
     ebpf_store_delete_program_information
     ebpf_store_delete_section_information
     ebpf_store_update_program_information_array
@@ -140,4 +141,3 @@ EXPORTS
     libbpf_strerror
     ring_buffer__new
     ring_buffer__free
-    ebpf_ring_buffer_map_write

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -567,9 +567,9 @@ extern "C"
     /**
      * @brief Write data into the ring buffer map.
      *
-     * @param ring_buffer_map_fd ring buffer map file descriptor.
-     * @param data Pointer to data to be written.
-     * @param data_length Length of data to be written.
+     * @param [in] ring_buffer_map_fd ring buffer map file descriptor.
+     * @param [in]  data Pointer to data to be written.
+     * @param [in] data_length Length of data to be written.
      * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
      * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
      * @retval EBPF_NO_MEMORY Out of memory.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -564,6 +564,20 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options) EBPF_NO_EXCEPT;
 
+    /**
+     * @brief Write data into the ring buffer map.
+     *
+     * @param ring_buffer_map_fd ring buffer map file descriptor.
+     * @param data Pointer to data to be written.
+     * @param data_length Length of data to be written.
+     * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
+     * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
+     * @retval EBPF_NO_MEMORY Out of memory.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_ring_buffer_map_write(
+        fd_t ring_buffer_map_fd, _In_reads_bytes_(data_length) const void* data, size_t data_length) EBPF_NO_EXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4491,7 +4491,6 @@ ebpf_ring_buffer_map_write(fd_t map_fd, _In_reads_bytes_(data_length) const void
         request->header.length = static_cast<uint16_t>(request_buffer.size());
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_WRITE_DATA;
         request->map_handle = (uint64_t)map_handle;
-        request->data_length = data_length;
         std::copy((uint8_t*)data, (uint8_t*)data + data_length, request->data);
 
         result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer));

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -363,6 +363,11 @@ ring_buffer__new(int map_fd, ring_buffer_sample_fn sample_cb, void* ctx, const s
     ebpf_result result = EBPF_SUCCESS;
     ring_buffer_t* local_ring_buffer = nullptr;
 
+    if (sample_cb == nullptr) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
     try {
         std::unique_ptr<ring_buffer_t> ring_buffer = std::make_unique<ring_buffer_t>();
         ring_buffer_subscription_t* subscription = nullptr;
@@ -378,6 +383,7 @@ ring_buffer__new(int map_fd, ring_buffer_sample_fn sample_cb, void* ctx, const s
     }
 Exit:
     if (result != EBPF_SUCCESS) {
+        errno = libbpf_result_err(result);
         EBPF_LOG_FUNCTION_ERROR(result);
     }
     EBPF_RETURN_POINTER(ring_buffer_t*, local_ring_buffer);

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2102,7 +2102,13 @@ _ebpf_core_protocol_ring_buffer_map_write_data(_In_ const ebpf_operation_ring_bu
             result);
         goto Exit;
     }
-    data_length = request->header.length - EBPF_OFFSET_OF(ebpf_operation_ring_buffer_map_write_data_request_t, data);
+    result = ebpf_safe_size_t_subtract(
+        request->header.length,
+        EBPF_OFFSET_OF(ebpf_operation_ring_buffer_map_write_data_request_t, data),
+        &data_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
     result = ebpf_ring_buffer_map_output(map, (uint8_t*)request->data, data_length);
 Exit:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2021,6 +2021,11 @@ _ebpf_core_protocol_ring_buffer_map_query_buffer(
 
     if (ebpf_map_get_definition(map)->type != BPF_MAP_TYPE_RINGBUF) {
         result = EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE_ERROR(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_CORE,
+            "query buffer operation called on a map that is not of the ring buffer type.",
+            result);
         goto Exit;
     }
 
@@ -2053,6 +2058,11 @@ _ebpf_core_protocol_ring_buffer_map_async_query(
 
     if (ebpf_map_get_definition(map)->type != BPF_MAP_TYPE_RINGBUF) {
         result = EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE_ERROR(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_CORE,
+            "async query operation called on a map that is not of the ring buffer type.",
+            result);
         goto Exit;
     }
 
@@ -2084,6 +2094,11 @@ _ebpf_core_protocol_ring_buffer_map_write_data(_In_ const ebpf_operation_ring_bu
     }
     if (ebpf_map_get_definition(map)->type != BPF_MAP_TYPE_RINGBUF) {
         result = EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE_ERROR(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_CORE,
+            "write data operation called on a map that is not of the ring buffer type.",
+            result);
         goto Exit;
     }
     result = ebpf_ring_buffer_map_output(map, (uint8_t*)request->data, request->data_length);

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2073,6 +2073,25 @@ Exit:
     return result;
 }
 
+static ebpf_result_t
+_ebpf_core_protocol_ring_buffer_map_write_data(_In_ const ebpf_operation_ring_buffer_map_write_data_request_t* request)
+{
+    ebpf_map_t* map = NULL;
+    ebpf_result_t result =
+        EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    if (ebpf_map_get_definition(map)->type != BPF_MAP_TYPE_RINGBUF) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+    result = ebpf_ring_buffer_map_output(map, (uint8_t*)request->data, request->data_length);
+Exit:
+    EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
+    EBPF_RETURN_RESULT(result);
+}
+
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
@@ -2606,6 +2625,7 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(bind_map, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(ring_buffer_map_query_buffer, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY_ASYNC(ring_buffer_map_async_query, PROTOCOL_ALL_MODES),
+    DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_NO_REPLY(ring_buffer_map_write_data, data, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_FIXED_REPLY(load_native_module, data, PROTOCOL_NATIVE_MODE),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_VARIABLE_REPLY(load_native_programs, data, PROTOCOL_NATIVE_MODE),
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY_ASYNC(program_test_run, data, data, PROTOCOL_ALL_MODES),

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2087,6 +2087,7 @@ static ebpf_result_t
 _ebpf_core_protocol_ring_buffer_map_write_data(_In_ const ebpf_operation_ring_buffer_map_write_data_request_t* request)
 {
     ebpf_map_t* map = NULL;
+    size_t data_length = 0;
     ebpf_result_t result =
         EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (result != EBPF_SUCCESS) {
@@ -2101,7 +2102,8 @@ _ebpf_core_protocol_ring_buffer_map_write_data(_In_ const ebpf_operation_ring_bu
             result);
         goto Exit;
     }
-    result = ebpf_ring_buffer_map_output(map, (uint8_t*)request->data, request->data_length);
+    data_length = request->header.length - EBPF_OFFSET_OF(ebpf_operation_ring_buffer_map_write_data_request_t, data);
+    result = ebpf_ring_buffer_map_output(map, (uint8_t*)request->data, data_length);
 Exit:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
     EBPF_RETURN_RESULT(result);

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -39,6 +39,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_BIND_MAP,
     EBPF_OPERATION_RING_BUFFER_MAP_QUERY_BUFFER,
     EBPF_OPERATION_RING_BUFFER_MAP_ASYNC_QUERY,
+    EBPF_OPERATION_RING_BUFFER_MAP_WRITE_DATA,
     EBPF_OPERATION_LOAD_NATIVE_MODULE,
     EBPF_OPERATION_LOAD_NATIVE_PROGRAMS,
     EBPF_OPERATION_PROGRAM_TEST_RUN,
@@ -389,6 +390,14 @@ typedef struct _ebpf_operation_ring_buffer_map_async_query_reply
     struct _ebpf_operation_header header;
     ebpf_ring_buffer_map_async_query_result_t async_query_result;
 } ebpf_operation_ring_buffer_map_async_query_reply_t;
+
+typedef struct _ebpf_operation_ring_buffer_map_write_data_request
+{
+    struct _ebpf_operation_header header;
+    ebpf_handle_t map_handle;
+    size_t data_length;
+    uint8_t data[1];
+} ebpf_operation_ring_buffer_map_write_data_request_t;
 
 typedef struct _ebpf_operation_load_native_module_request
 {

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -395,7 +395,6 @@ typedef struct _ebpf_operation_ring_buffer_map_write_data_request
 {
     struct _ebpf_operation_header header;
     ebpf_handle_t map_handle;
-    size_t data_length;
     uint8_t data[1];
 } ebpf_operation_ring_buffer_map_write_data_request_t;
 

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -189,16 +189,29 @@ void
 ring_buffer_api_test_helper(
     fd_t ring_buffer_map, std::vector<std::vector<char>>& expected_records, std::function<void(int)> generate_event)
 {
+    std::vector<std::vector<char>> records = expected_records;
+
+    // Add a couple of interleaved messages to the records vector.
+    std::string message = "Interleaved message #1";
+    std::vector<char> record(message.begin(), message.end());
+    record.push_back('\0');
+    records.push_back(record);
+    record[record.size() - 2] = '2';
+    records.push_back(record);
+
     // Ring buffer event callback context.
     std::unique_ptr<ring_buffer_test_event_context_t> context = std::make_unique<ring_buffer_test_event_context_t>();
-    context->test_event_count = RING_BUFFER_TEST_EVENT_COUNT;
+    context->test_event_count = RING_BUFFER_TEST_EVENT_COUNT + 2;
 
-    context->records = &expected_records;
+    context->records = &records;
 
     // Generate events prior to subscribing for ring buffer events.
     for (int i = 0; i < RING_BUFFER_TEST_EVENT_COUNT / 2; i++) {
         generate_event(i);
     }
+
+    // Write an interleaved message to the ring buffer map.
+    REQUIRE(ebpf_ring_buffer_map_write(ring_buffer_map, message.c_str(), message.length() + 1) == EBPF_SUCCESS);
 
     // Get the std::future from the promise field in ring buffer event context, which should be in ready state
     // once notifications for all events are received.
@@ -215,10 +228,14 @@ ring_buffer_api_test_helper(
         generate_event(i);
     }
 
+    // Write another interleaved message to the ring buffer map.
+    message[message.length() - 1] = '2';
+    REQUIRE(ebpf_ring_buffer_map_write(ring_buffer_map, message.c_str(), message.length() + 1) == EBPF_SUCCESS);
+
     // Wait for event handler getting notifications for all RING_BUFFER_TEST_EVENT_COUNT events.
     REQUIRE(ring_buffer_event_callback.wait_for(1s) == std::future_status::ready);
 
-    REQUIRE(context->matched_entry_count == RING_BUFFER_TEST_EVENT_COUNT);
+    REQUIRE(context->matched_entry_count == context->test_event_count);
 
     // Mark the event context as canceled, such that the event callback stops processing events.
     context->canceled = true;


### PR DESCRIPTION
## Description

Fixes #3572.

Add a new API in eBPF API.dll to write into a ring buffer map from user mode. This API issues an IOCTL which calls `bpf_ring_buffer_output` function to write user specified data into the ring buffer.

## Testing

Updated unit and api tests to write messages into ring buffer interleaved with events that invoke eBPF programs (which in turn write into the same ring buffer).

## Documentation

No documentation impact.

## Installation

No installation impact.
