### PR TITLE
update version to 0.18.0

### DIFF
--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -6,63 +6,35 @@ The eBPF project follows [Semantic Versioning 2.0](https://semver.org) for versi
 minor versions respectively. "`Z`" is the patch version for servicing releases. A release is usually made once every month. Pre-release binaries are test signed.
 Official releases will be production signed using Microsoft certificates.
 
->**Note**: Currently the *major version* for all releases is set to "`0`" (i.e., "`0.Y.Z`") until the first official release is published with version `1.0.0`.
+>**Note**: The *major version* for all releases is set to "`0`" (i.e., "`0.Y.Z`") until the first official release is published with version `1.0.0`.
 
 ## Creating a new release
 
 An issue with the title `Scheduled eBPF release is due` is automatically created on the first day of every month requesting a new release with the minor
 version incremented every time. When this issue is triaged, a decision must be taken by the maintainers on whether to go ahead with the new monthly release. If
 the decision is to create a new release the release manager must proceed with the following process.
-1. Create a topic branch from "`main`" on your private repo fork, and check it out (e.g., `<user>/release-X-Y`).
-1. Follow the process in the [Updating the Release Version](ReleaseProcess.md#updating-the-release-version) to update the release version.
-1. Create a pull-request from your topic branch into the `main` branch of the [original "upstream" `ebpf-for-windows` repo]([https://github.com/microsoft/ebpf-for-windows), with the title of the PR as *"Release v`X.Y.0`"* (replace "`X`" and
-"`Y`" with the version number being released).
-1. Once the PR is approved and merged into the "`main`" branch, of the original `ebpf-for-windows` repo, create a new release branch from `main` from the
-**previous PR's commit**, and name it "`release/X.Y`".
-1. **IMPORTANT:** Once the release branch is created, no new feature work is allowed to be merged into that branch. However, bug fixes can be taken as deemed necessary by the
- maintainers and the release manager. Whenever applicable, these bug fixes should first be made in the main branch, and cherry-picked to the release branch. In
-  case bug-fix PRs are merged into the `release/X.Y` branch, the **latest commit** in the `release/X.Y` branch must be designated as the commit for the release.
+1. Create a release branch  in the ["upstream" `ebpf-for-windows` repo]([https://github.com/microsoft/ebpf-for-windows). 
+**Note:** Only release managers have authority to create new branches. One of the ways to create a release branch is as follows:
+   1. Create a topic branch from the "`main`" branch of a forked repo, and name it "`release/X.Y`" (where "`X`" and "`Y`" are the current version number
+   that is being released).
+   1. Push the topic branch into ["upstream" `ebpf-for-windows` remote]([https://github.com/microsoft/ebpf-for-windows). For example:
+      ```bash
+      git push upstream release/0.12
+1. Once the release branch is created, commits can be cherry-picked from the main branch (including feature work and bug fixes) as deemed necessary
+   by the maintainers and the release managers.
 1. Follow the process in the [Release Branch Validation](ReleaseProcess.md#release-branch-validation) to ensure the quality of the release branch.
-1. In the triage meeting after the validation of the release branch, the release manager must ask if any maintainer has any reasons to hold off the release. If
-not, move on to the following steps.
-1. The `sign-off` label will be added to the issue created in step 1 of the [Creating a new release](ReleaseProcess.md#creating-a-new-release) process. Next
-create a tag for the *latest commit on the `release/X.Y` branch*. The tag should reflect the version number being released and adhere to the following notation:
-"`Release-vX.Y.0`".
-1. The tag creation will automatically trigger the "`CI/CD - Release validation`" workflow for the `release/X.Y` branch. In case of failure, Follow the process in
-the [Release Branch Validation](ReleaseProcess.md#release-branch-validation).
-1. Publish the release as per the [Publishing a Release](ReleaseProcess.md#publishing-a-release) process.
-
-## Updating the Release Version
-
-1. Run the following script from the root directory of the repository, from a "*Developer Powershell for VS 2022"* terminal.
-
-    ```ps
-    # Set "X" and "Y" to the the new major and minor versions. If servicing a release, set "Z" to the revision or patch number.
-    .\scripts\update-release-version.ps1 X Y Z
-    ```
-    For example, a successful run of the script for version 0.12.0 produces the following output:
-
-    ```ps
-    PS D:\work\ebpf-for-windows> .\scripts\update-release-version.ps1 0 12 0
-    Updating the version number in the 'D:\work\ebpf-for-windows\scripts\..\resource\ebpf_version.h' file...
-    Version number updated to '0.12.0' in D:\work\ebpf-for-windows\scripts\..\resource\ebpf_version.h
-    Updating the version number in the 'D:\work\ebpf-for-windows\scripts\..\installer\Product.wxs' file...
-    Version number updated to '0.12.0' in D:\work\ebpf-for-windows\scripts\..\installer\Product.wxs
-    Rebuilding the solution, please wait...
-    Regenerating the expected 'bpf2c' output...
-    ...
-    ...
-    Expected 'bpf2c' output regenerated.
-    Please verify all the changes then submit the pull-request into the 'release/0.12' branch.
-    ```
-
-1. Verify all the changes then commit all in the working branch.
-    >NOTE: The formatting rules may complain about the formatting of the generated `.c` files from the script above. In this case,
-    override them with the following (so they'll work with the `bpf2c_tests` verifying their content):
-    >```bash
-    >git commit --no-verify -a -m "update release version to X.Y.Z".
-    >```
-
+1. If the release validation process finds a bug that is present only in the release branch (but not in the main branch), a fix can be committed directly
+   into the release branch instead of cherry-picking from the main branch.
+1. In the triage meeting after the successful validation of the release branch, the release manager must ask if any maintainer has any reasons to hold off the release. If 
+   not, move on to the following steps.
+1. The `sign-off` label will be added to the issue created in step 1 of the [Creating a new release](ReleaseProcess.md#creating-a-new-release) process.
+1. Create a tag "`Release-vX.Y.0`" on the *latest commit on the `release/X.Y` branch*.
+1. The tag creation will automatically trigger the "`CI/CD - Release validation`" workflow for the `release/X.Y` branch. In case of failure, Follow the process in 
+   the [Release Branch Validation](ReleaseProcess.md#release-branch-validation).
+2. Publish the release as per the [Publishing a Release](ReleaseProcess.md#publishing-a-release) process.
+3. Follow the process in the [Updating the Product Version](ReleaseProcess.md#updating-the-product-version) to update the version of the product in the main branch,
+   for the next release.
+ 
 ## Release Branch Validation
 
 The `CI/CD - Release validation` workflow(`cicd-release-validation.yml`) is used to validate a release branch. It contains more tests than the regular CI/CD
@@ -147,3 +119,34 @@ releasing process), but if you are a contributor and have been asked to do this,
 3. Commit all the changes in the working branch.
 4. Create a pull-request for your working branch into the [original "upstream" `ebpf-for-windows` repo]([https://github.com/microsoft/ebpf-for-windows)'s "`main`" branch, and title the PR as *"Backwards Integration of Release v`X.Y.Z`"* (replace "`X.Y.Z`" with the version number being released).
 5. Submit the PR for review for approval, and have it merged into the [original "upstream" `ebpf-for-windows` repo]([https://github.com/microsoft/ebpf-for-windows)'s "`main`" branch.
+
+## Updating the Product Version
+
+1. Run the following script from the root directory of the repository, from a "*Developer Powershell for VS 2022"* terminal.
+
+    ```ps
+    # Set "X" and "Y" to the the new major and minor versions. If servicing a release, set "Z" to the revision or patch number.
+    .\scripts\update-product-version.ps1 X Y Z
+    ```
+    For example, a successful run of the script for version 0.12.0 produces the following output:
+
+    ```ps
+    PS D:\work\ebpf-for-windows> .\scripts\update-product-version.ps1 0 12 0
+    Updating the version number in the 'D:\work\ebpf-for-windows\scripts\..\resource\ebpf_version.h' file...
+    Version number updated to '0.12.0' in D:\work\ebpf-for-windows\scripts\..\resource\ebpf_version.h
+    Updating the version number in the 'D:\work\ebpf-for-windows\scripts\..\installer\Product.wxs' file...
+    Version number updated to '0.12.0' in D:\work\ebpf-for-windows\scripts\..\installer\Product.wxs
+    Rebuilding the solution, please wait...
+    Regenerating the expected 'bpf2c' output...
+    ...
+    ...
+    Expected 'bpf2c' output regenerated.
+    Please verify all the changes then submit the pull-request into the 'release/0.12' branch.
+    ```
+
+1. Verify all the changes then commit all in the working branch.
+    >NOTE: The formatting rules may complain about the formatting of the generated `.c` files from the script above. In this case,
+    override them with the following (so they'll work with the `bpf2c_tests` verifying their content):
+    >```bash
+    >git commit --no-verify -a -m "update version to X.Y.Z".
+    >```

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 <?define ProductVersion="022C44B5-8969-4B75-8DB0-73F98B1BD7DC"?>
 <?define UpgradeCode="B6BCACB1-C872-4159-ABCB-43A50668056C"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:ui="http://schemas.microsoft.com/wix/UIExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-	<Product Id="$(var.ProductVersion)" Name="eBPF for Windows" Language="1033" Version="0.17.0" Manufacturer="Microsoft" UpgradeCode="$(var.UpgradeCode)">
+	<Product Id="$(var.ProductVersion)" Name="eBPF for Windows" Language="1033" Version="0.18.0" Manufacturer="Microsoft" UpgradeCode="$(var.UpgradeCode)">
 		<Package Description="eBPF for Windows" InstallerVersion="301" Compressed="yes" InstallScope="perMachine" Manufacturer="Microsoft" Platform="x64" />
 		<MajorUpgrade AllowSameVersionUpgrades="yes"
 					  Disallow="yes" DisallowUpgradeErrorMessage="An older version of [ProductName] is already installed. Please remove it first."

--- a/resource/ebpf_version.h
+++ b/resource/ebpf_version.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #define EBPF_VERSION_MAJOR 0
-#define EBPF_VERSION_MINOR 17
+#define EBPF_VERSION_MINOR 18
 #define EBPF_VERSION_REVISION 0
 
 #define QUOTE(str) #str

--- a/scripts/update-product-version.ps1
+++ b/scripts/update-product-version.ps1
@@ -36,8 +36,6 @@ if ("$majorVersion.$minorVersion.$revisionNumber" -match '^\d+\.\d+\.\d+$') {
         Write-Host -ForegroundColor DarkGreen "Regenerating the expected 'bpf2c' output..."
         .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
         Write-Host -ForegroundColor DarkGreen "Expected 'bpf2c' output regenerated."
-
-        Write-Host -ForegroundColor DarkYellow "Please verify all the changes then submit the pull-request into the 'release/$majorVersion.$minorVersion' branch."
     } else {
         Write-Host -ForegroundColor Red "'ebpf-for-windows.sln' not found in the current path."
         Write-Host -ForegroundColor DarkYellow "Please run this script from the root directory of the repository, within a Developer Poweshell for VS 2022."
@@ -45,6 +43,6 @@ if ("$majorVersion.$minorVersion.$revisionNumber" -match '^\d+\.\d+\.\d+$') {
 } else {
     Write-Host -ForegroundColor Red "Invalid version number format. Please enter the version number in the format 'X Y Z', e.g.:"
     Write-Host
-    Write-Host -ForegroundColor DarkGreen "   PS> .\scripts\update-release-version.ps1 0 9 0"
+    Write-Host -ForegroundColor DarkGreen "   PS> .\scripts\update-product-version.ps1 0 9 0"
     Write-Host
 }

--- a/tests/bpf2c_tests/elf_bpf.cpp
+++ b/tests/bpf2c_tests/elf_bpf.cpp
@@ -248,6 +248,8 @@ DECLARE_TEST("test_sample_ebpf", _test_mode::Verify)
 DECLARE_TEST("test_utility_helpers", _test_mode::Verify)
 DECLARE_TEST("cgroup_sock_addr", _test_mode::UseHashSHA512)
 DECLARE_TEST("cgroup_sock_addr2", _test_mode::UseHashX)
+DECLARE_TEST("xdp_adjust_head_unsafe", _test_mode::NoVerify)
+DECLARE_TEST("xdp_datasize_unsafe", _test_mode::NoVerify)
 
 DECLARE_TEST("no_such_file", _test_mode::FileNotFound)
 DECLARE_TEST_CUSTOM_PROGRAM_TYPE("bpf", _test_mode::UseHash, std::string("bind"))

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -180,7 +180,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -154,7 +154,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -315,7 +315,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_dll.c
@@ -151,7 +151,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_raw.c
@@ -125,7 +125,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_sys.c
@@ -286,7 +286,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -180,7 +180,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -154,7 +154,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -315,7 +315,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -596,7 +596,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -6255,7 +6255,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -6229,7 +6229,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -6390,7 +6390,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -570,7 +570,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -186,7 +186,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -160,7 +160,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -321,7 +321,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -731,7 +731,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -811,7 +811,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -785,7 +785,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -946,7 +946,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -178,7 +178,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -152,7 +152,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -313,7 +313,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -109,7 +109,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -83,7 +83,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -244,7 +244,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -257,7 +257,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
@@ -231,7 +231,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
@@ -392,7 +392,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -257,7 +257,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
@@ -231,7 +231,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
@@ -392,7 +392,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -198,7 +198,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
@@ -172,7 +172,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
@@ -333,7 +333,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -198,7 +198,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
@@ -172,7 +172,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
@@ -333,7 +333,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -988,7 +988,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -962,7 +962,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -1123,7 +1123,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -874,7 +874,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -848,7 +848,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -1009,7 +1009,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -514,7 +514,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -488,7 +488,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -649,7 +649,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -187,7 +187,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -161,7 +161,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -322,7 +322,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -336,7 +336,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -310,7 +310,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -471,7 +471,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
@@ -217,7 +217,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_raw.c
@@ -191,7 +191,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_sys.c
@@ -352,7 +352,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/empty_dll.c
+++ b/tests/bpf2c_tests/expected/empty_dll.c
@@ -73,7 +73,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/empty_raw.c
+++ b/tests/bpf2c_tests/expected/empty_raw.c
@@ -47,7 +47,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/empty_sys.c
+++ b/tests/bpf2c_tests/expected/empty_sys.c
@@ -208,7 +208,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -1218,7 +1218,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -1192,7 +1192,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -1353,7 +1353,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -226,7 +226,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_raw.c
@@ -200,7 +200,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_sys.c
@@ -361,7 +361,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -324,7 +324,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_raw.c
+++ b/tests/bpf2c_tests/expected/inner_map_raw.c
@@ -298,7 +298,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_sys.c
+++ b/tests/bpf2c_tests/expected/inner_map_sys.c
@@ -459,7 +459,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_dll.c
@@ -859,7 +859,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_raw.c
@@ -833,7 +833,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_sys.c
@@ -994,7 +994,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps1_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_dll.c
@@ -157,7 +157,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps1_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_raw.c
@@ -131,7 +131,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps1_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_sys.c
@@ -292,7 +292,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps2_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_dll.c
@@ -853,7 +853,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps2_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_raw.c
@@ -827,7 +827,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps2_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_sys.c
@@ -988,7 +988,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps3_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps3_dll.c
@@ -128,7 +128,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps3_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps3_raw.c
@@ -102,7 +102,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/invalid_maps3_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps3_sys.c
@@ -263,7 +263,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -9527,7 +9527,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -226,7 +226,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
@@ -200,7 +200,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
@@ -361,7 +361,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -226,7 +226,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
@@ -200,7 +200,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
@@ -361,7 +361,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -226,7 +226,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
@@ -200,7 +200,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
@@ -361,7 +361,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -9501,7 +9501,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -283,7 +283,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -257,7 +257,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -418,7 +418,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -283,7 +283,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -257,7 +257,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -418,7 +418,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -9662,7 +9662,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -229,7 +229,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -203,7 +203,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -364,7 +364,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -685,7 +685,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -570,7 +570,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -544,7 +544,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -705,7 +705,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -659,7 +659,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -820,7 +820,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_dll.c
@@ -148,7 +148,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_unsafe_raw.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_raw.c
@@ -122,7 +122,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_sys.c
@@ -283,7 +283,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -814,7 +814,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -788,7 +788,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -949,7 +949,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -698,7 +698,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -672,7 +672,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -833,7 +833,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -262,7 +262,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -236,7 +236,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -397,7 +397,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -257,7 +257,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -250,7 +250,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -224,7 +224,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -385,7 +385,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -7710,7 +7710,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
@@ -7684,7 +7684,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
@@ -7845,7 +7845,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -284,7 +284,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -258,7 +258,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -419,7 +419,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -231,7 +231,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -270,7 +270,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
@@ -244,7 +244,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
@@ -405,7 +405,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
@@ -311,7 +311,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
@@ -285,7 +285,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
@@ -446,7 +446,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -6935,7 +6935,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
@@ -6909,7 +6909,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
@@ -7070,7 +7070,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -310,7 +310,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -284,7 +284,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -445,7 +445,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -334,7 +334,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -308,7 +308,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -469,7 +469,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -540,7 +540,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_raw.c
+++ b/tests/bpf2c_tests/expected/utility_raw.c
@@ -514,7 +514,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_sys.c
+++ b/tests/bpf2c_tests/expected/utility_sys.c
@@ -675,7 +675,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_dll.c
@@ -1,0 +1,216 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from xdp_adjust_head_unsafe.o
+
+#include "bpf2c.h"
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+#define metadata_table xdp_adjust_head_unsafe##_metadata_table
+extern metadata_table_t metadata_table;
+
+bool APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = NULL;
+    *count = 0;
+}
+
+static helper_function_entry_t xdp_adjust_head_unsafe_helpers[] = {
+    {NULL, 65536, "helper_id_65536"},
+};
+
+static GUID xdp_adjust_head_unsafe_program_type_guid = {
+    0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID xdp_adjust_head_unsafe_attach_type_guid = {
+    0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+#pragma code_seg(push, "xdp")
+static uint64_t
+xdp_adjust_head_unsafe(void* context)
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+{
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    // Prologue
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r0 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r1 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r2 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r3 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r4 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r5 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r6 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r7 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r8 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r10 = 0;
+
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = (uintptr_t)context;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r7 src=r1 offset=0 imm=0
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r7 = r1;
+    // EBPF_OP_MOV64_IMM pc=1 dst=r6 src=r0 offset=0 imm=2
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r6 = IMMEDIATE(2);
+    // EBPF_OP_LDXDW pc=2 dst=r2 src=r7 offset=8 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r2 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(8));
+    // EBPF_OP_LDXDW pc=3 dst=r1 src=r7 offset=0 imm=0
+#line 22 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=4 dst=r3 src=r1 offset=0 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r3 = r1;
+    // EBPF_OP_ADD64_IMM pc=5 dst=r3 src=r0 offset=0 imm=14
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r3 += IMMEDIATE(14);
+    // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=12 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if (r3 > r2) {
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        goto label_1;
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r8 src=r0 offset=0 imm=2048
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r8 = IMMEDIATE(2048);
+    // EBPF_OP_STXH pc=8 dst=r1 src=r8 offset=12 imm=0
+#line 31 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    *(uint16_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r7 offset=0 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = r7;
+    // EBPF_OP_MOV64_IMM pc=10 dst=r2 src=r0 offset=0 imm=14
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r2 = IMMEDIATE(14);
+    // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=65536
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = xdp_adjust_head_unsafe_helpers[0].address(r1, r2, r3, r4, r5);
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if ((xdp_adjust_head_unsafe_helpers[0].tail_call) && (r0 == 0)) {
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        return 0;
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=12 dst=r0 src=r0 offset=0 imm=32
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=13 dst=r0 src=r0 offset=0 imm=32
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_MOV64_IMM pc=14 dst=r1 src=r0 offset=0 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=15 dst=r1 src=r0 offset=3 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if ((int64_t)r1 > (int64_t)r0) {
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        goto label_1;
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_LDXDW pc=16 dst=r1 src=r7 offset=0 imm=0
+#line 41 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_STXH pc=17 dst=r1 src=r8 offset=12 imm=0
+#line 42 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    *(uint16_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_IMM pc=18 dst=r6 src=r0 offset=0 imm=1
+#line 42 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r6 = IMMEDIATE(1);
+label_1:
+    // EBPF_OP_MOV64_REG pc=19 dst=r0 src=r6 offset=0 imm=0
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = r6;
+    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    return r0;
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        xdp_adjust_head_unsafe,
+        "xdp",
+        "xdp",
+        "xdp_adjust_head_unsafe",
+        NULL,
+        0,
+        xdp_adjust_head_unsafe_helpers,
+        1,
+        21,
+        &xdp_adjust_head_unsafe_program_type_guid,
+        &xdp_adjust_head_unsafe_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 18;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t xdp_adjust_head_unsafe_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_raw.c
+++ b/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_raw.c
@@ -1,0 +1,190 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from xdp_adjust_head_unsafe.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = NULL;
+    *count = 0;
+}
+
+static helper_function_entry_t xdp_adjust_head_unsafe_helpers[] = {
+    {NULL, 65536, "helper_id_65536"},
+};
+
+static GUID xdp_adjust_head_unsafe_program_type_guid = {
+    0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID xdp_adjust_head_unsafe_attach_type_guid = {
+    0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+#pragma code_seg(push, "xdp")
+static uint64_t
+xdp_adjust_head_unsafe(void* context)
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+{
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    // Prologue
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r0 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r1 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r2 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r3 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r4 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r5 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r6 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r7 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r8 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r10 = 0;
+
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = (uintptr_t)context;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r7 src=r1 offset=0 imm=0
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r7 = r1;
+    // EBPF_OP_MOV64_IMM pc=1 dst=r6 src=r0 offset=0 imm=2
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r6 = IMMEDIATE(2);
+    // EBPF_OP_LDXDW pc=2 dst=r2 src=r7 offset=8 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r2 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(8));
+    // EBPF_OP_LDXDW pc=3 dst=r1 src=r7 offset=0 imm=0
+#line 22 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=4 dst=r3 src=r1 offset=0 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r3 = r1;
+    // EBPF_OP_ADD64_IMM pc=5 dst=r3 src=r0 offset=0 imm=14
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r3 += IMMEDIATE(14);
+    // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=12 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if (r3 > r2) {
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        goto label_1;
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r8 src=r0 offset=0 imm=2048
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r8 = IMMEDIATE(2048);
+    // EBPF_OP_STXH pc=8 dst=r1 src=r8 offset=12 imm=0
+#line 31 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    *(uint16_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r7 offset=0 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = r7;
+    // EBPF_OP_MOV64_IMM pc=10 dst=r2 src=r0 offset=0 imm=14
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r2 = IMMEDIATE(14);
+    // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=65536
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = xdp_adjust_head_unsafe_helpers[0].address(r1, r2, r3, r4, r5);
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if ((xdp_adjust_head_unsafe_helpers[0].tail_call) && (r0 == 0)) {
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        return 0;
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=12 dst=r0 src=r0 offset=0 imm=32
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=13 dst=r0 src=r0 offset=0 imm=32
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_MOV64_IMM pc=14 dst=r1 src=r0 offset=0 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=15 dst=r1 src=r0 offset=3 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if ((int64_t)r1 > (int64_t)r0) {
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        goto label_1;
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_LDXDW pc=16 dst=r1 src=r7 offset=0 imm=0
+#line 41 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_STXH pc=17 dst=r1 src=r8 offset=12 imm=0
+#line 42 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    *(uint16_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_IMM pc=18 dst=r6 src=r0 offset=0 imm=1
+#line 42 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r6 = IMMEDIATE(1);
+label_1:
+    // EBPF_OP_MOV64_REG pc=19 dst=r0 src=r6 offset=0 imm=0
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = r6;
+    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    return r0;
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        xdp_adjust_head_unsafe,
+        "xdp",
+        "xdp",
+        "xdp_adjust_head_unsafe",
+        NULL,
+        0,
+        xdp_adjust_head_unsafe_helpers,
+        1,
+        21,
+        &xdp_adjust_head_unsafe_program_type_guid,
+        &xdp_adjust_head_unsafe_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 18;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t xdp_adjust_head_unsafe_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_sys.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Do not alter this generated file.
-// This file was generated from tail_call.o
+// This file was generated from xdp_adjust_head_unsafe.o
 
 #define NO_CRT
 #include "bpf2c.h"
@@ -15,7 +15,7 @@ DRIVER_INITIALIZE DriverEntry;
 DRIVER_UNLOAD DriverUnload;
 RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
 
-#define metadata_table tail_call##_metadata_table
+#define metadata_table xdp_adjust_head_unsafe##_metadata_table
 
 static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
                              0xc847aac8,
@@ -173,177 +173,135 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
     *hash = NULL;
     *size = 0;
 }
-#pragma data_seg(push, "maps")
-static map_entry_t _maps[] = {
-    {NULL,
-     {
-         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
-         4,                       // Size in bytes of a map key.
-         4,                       // Size in bytes of a map value.
-         10,                      // Maximum number of entries allowed in the map.
-         0,                       // Inner map index.
-         LIBBPF_PIN_NONE,         // Pinning type for the map.
-         10,                      // Identifier for a map template.
-         0,                       // The id of the inner map template.
-     },
-     "map"},
-    {NULL,
-     {
-         BPF_MAP_TYPE_ARRAY, // Type of map.
-         4,                  // Size in bytes of a map key.
-         4,                  // Size in bytes of a map value.
-         1,                  // Maximum number of entries allowed in the map.
-         0,                  // Inner map index.
-         LIBBPF_PIN_NONE,    // Pinning type for the map.
-         16,                 // Identifier for a map template.
-         0,                  // The id of the inner map template.
-     },
-     "canary"},
-};
-#pragma data_seg(pop)
-
 static void
 _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
-    *maps = _maps;
-    *count = 2;
+    *maps = NULL;
+    *count = 0;
 }
 
-static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-#pragma code_seg(push, "sample~1")
-static uint64_t
-callee(void* context)
-#line 49 "sample/undocked/tail_call.c"
-{
-#line 49 "sample/undocked/tail_call.c"
-    // Prologue
-#line 49 "sample/undocked/tail_call.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 49 "sample/undocked/tail_call.c"
-    register uint64_t r0 = 0;
-#line 49 "sample/undocked/tail_call.c"
-    register uint64_t r1 = 0;
-#line 49 "sample/undocked/tail_call.c"
-    register uint64_t r10 = 0;
-
-#line 49 "sample/undocked/tail_call.c"
-    r1 = (uintptr_t)context;
-#line 49 "sample/undocked/tail_call.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=42
-#line 49 "sample/undocked/tail_call.c"
-    r0 = IMMEDIATE(42);
-    // EBPF_OP_EXIT pc=1 dst=r0 src=r0 offset=0 imm=0
-#line 49 "sample/undocked/tail_call.c"
-    return r0;
-#line 49 "sample/undocked/tail_call.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static helper_function_entry_t caller_helpers[] = {
-    {NULL, 5, "helper_id_5"},
-    {NULL, 1, "helper_id_1"},
+static helper_function_entry_t xdp_adjust_head_unsafe_helpers[] = {
+    {NULL, 65536, "helper_id_65536"},
 };
 
-static GUID caller_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-static GUID caller_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-static uint16_t caller_maps[] = {
-    0,
-    1,
-};
-
-#pragma code_seg(push, "sample~2")
+static GUID xdp_adjust_head_unsafe_program_type_guid = {
+    0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID xdp_adjust_head_unsafe_attach_type_guid = {
+    0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+#pragma code_seg(push, "xdp")
 static uint64_t
-caller(void* context)
-#line 33 "sample/undocked/tail_call.c"
+xdp_adjust_head_unsafe(void* context)
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
 {
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     // Prologue
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r0 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r1 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r2 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r3 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r4 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r5 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r6 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r7 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    register uint64_t r8 = 0;
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     register uint64_t r10 = 0;
 
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     r1 = (uintptr_t)context;
-#line 33 "sample/undocked/tail_call.c"
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=0
-#line 33 "sample/undocked/tail_call.c"
-    r2 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1 dst=r10 src=r2 offset=-4 imm=0
-#line 35 "sample/undocked/tail_call.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r2;
-    // EBPF_OP_LDDW pc=2 dst=r2 src=r1 offset=0 imm=1
-#line 38 "sample/undocked/tail_call.c"
-    r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=9
-#line 38 "sample/undocked/tail_call.c"
-    r3 = IMMEDIATE(9);
-    // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
-#line 38 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
-#line 38 "sample/undocked/tail_call.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
-#line 38 "sample/undocked/tail_call.c"
-        return 0;
-#line 38 "sample/undocked/tail_call.c"
-    }
-    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
-#line 38 "sample/undocked/tail_call.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
-#line 38 "sample/undocked/tail_call.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r1 offset=0 imm=2
-#line 41 "sample/undocked/tail_call.c"
-    r1 = POINTER(_maps[1].address);
-    // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=1
-#line 41 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
-#line 41 "sample/undocked/tail_call.c"
-        return 0;
-#line 41 "sample/undocked/tail_call.c"
-    }
-    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
-#line 42 "sample/undocked/tail_call.c"
-    if (r0 == IMMEDIATE(0)) {
-#line 42 "sample/undocked/tail_call.c"
+    // EBPF_OP_MOV64_REG pc=0 dst=r7 src=r1 offset=0 imm=0
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r7 = r1;
+    // EBPF_OP_MOV64_IMM pc=1 dst=r6 src=r0 offset=0 imm=2
+#line 17 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r6 = IMMEDIATE(2);
+    // EBPF_OP_LDXDW pc=2 dst=r2 src=r7 offset=8 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r2 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(8));
+    // EBPF_OP_LDXDW pc=3 dst=r1 src=r7 offset=0 imm=0
+#line 22 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=4 dst=r3 src=r1 offset=0 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r3 = r1;
+    // EBPF_OP_ADD64_IMM pc=5 dst=r3 src=r0 offset=0 imm=14
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r3 += IMMEDIATE(14);
+    // EBPF_OP_JGT_REG pc=6 dst=r3 src=r2 offset=12 imm=0
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if (r3 > r2) {
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
         goto label_1;
-#line 42 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
     }
-    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 42 "sample/undocked/tail_call.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0
-#line 43 "sample/undocked/tail_call.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_IMM pc=7 dst=r8 src=r0 offset=0 imm=2048
+#line 26 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r8 = IMMEDIATE(2048);
+    // EBPF_OP_STXH pc=8 dst=r1 src=r8 offset=12 imm=0
+#line 31 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    *(uint16_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r7 offset=0 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = r7;
+    // EBPF_OP_MOV64_IMM pc=10 dst=r2 src=r0 offset=0 imm=14
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r2 = IMMEDIATE(14);
+    // EBPF_OP_CALL pc=11 dst=r0 src=r0 offset=0 imm=65536
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = xdp_adjust_head_unsafe_helpers[0].address(r1, r2, r3, r4, r5);
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if ((xdp_adjust_head_unsafe_helpers[0].tail_call) && (r0 == 0)) {
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        return 0;
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_LSH64_IMM pc=12 dst=r0 src=r0 offset=0 imm=32
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=13 dst=r0 src=r0 offset=0 imm=32
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_MOV64_IMM pc=14 dst=r1 src=r0 offset=0 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=15 dst=r1 src=r0 offset=3 imm=0
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    if ((int64_t)r1 > (int64_t)r0) {
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+        goto label_1;
+#line 34 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    }
+    // EBPF_OP_LDXDW pc=16 dst=r1 src=r7 offset=0 imm=0
+#line 41 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_STXH pc=17 dst=r1 src=r8 offset=12 imm=0
+#line 42 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    *(uint16_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_IMM pc=18 dst=r6 src=r0 offset=0 imm=1
+#line 42 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r6 = IMMEDIATE(1);
 label_1:
-    // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=6
-#line 46 "sample/undocked/tail_call.c"
-    r0 = IMMEDIATE(6);
-    // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 46 "sample/undocked/tail_call.c"
+    // EBPF_OP_MOV64_REG pc=19 dst=r0 src=r6 offset=0 imm=0
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
+    r0 = r6;
+    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
     return r0;
-#line 46 "sample/undocked/tail_call.c"
+#line 45 "sample/unsafe/xdp_adjust_head_unsafe.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -352,31 +310,17 @@ label_1:
 static program_entry_t _programs[] = {
     {
         0,
-        callee,
-        "sample~1",
-        "sample_ext/0",
-        "callee",
+        xdp_adjust_head_unsafe,
+        "xdp",
+        "xdp",
+        "xdp_adjust_head_unsafe",
         NULL,
         0,
-        NULL,
-        0,
-        2,
-        &callee_program_type_guid,
-        &callee_attach_type_guid,
-    },
-    {
-        0,
-        caller,
-        "sample~2",
-        "sample_ext",
-        "caller",
-        caller_maps,
-        2,
-        caller_helpers,
-        2,
-        16,
-        &caller_program_type_guid,
-        &caller_attach_type_guid,
+        xdp_adjust_head_unsafe_helpers,
+        1,
+        21,
+        &xdp_adjust_head_unsafe_program_type_guid,
+        &xdp_adjust_head_unsafe_attach_type_guid,
     },
 };
 #pragma data_seg(pop)
@@ -385,7 +329,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 2;
+    *count = 1;
 }
 
 static void
@@ -403,5 +347,5 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
     *count = 0;
 }
 
-metadata_table_t tail_call_metadata_table = {
+metadata_table_t xdp_adjust_head_unsafe_metadata_table = {
     sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/xdp_datasize_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_datasize_unsafe_dll.c
@@ -1,0 +1,170 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from xdp_datasize_unsafe.o
+
+#include "bpf2c.h"
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+#define metadata_table xdp_datasize_unsafe##_metadata_table
+extern metadata_table_t metadata_table;
+
+bool APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = NULL;
+    *count = 0;
+}
+
+static GUID unsafe_program_program_type_guid = {
+    0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID unsafe_program_attach_type_guid = {
+    0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+#pragma code_seg(push, "xdp")
+static uint64_t
+unsafe_program(void* context)
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+{
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    // Prologue
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r0 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r1 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r2 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r3 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r10 = 0;
+
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = (uintptr_t)context;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=1 dst=r2 src=r1 offset=0 imm=0
+#line 20 "sample/unsafe/xdp_datasize_unsafe.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=8 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_MOV64_REG pc=3 dst=r3 src=r2 offset=0 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r3 = r2;
+    // EBPF_OP_ADD64_IMM pc=4 dst=r3 src=r0 offset=0 imm=14
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r3 += IMMEDIATE(14);
+    // EBPF_OP_JGT_REG pc=5 dst=r3 src=r1 offset=4 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r3 > r1) {
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r1 src=r2 offset=12 imm=0
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
+    // EBPF_OP_JEQ_IMM pc=7 dst=r1 src=r0 offset=2 imm=8
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r1 == IMMEDIATE(8)) {
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=8 dst=r1 src=r0 offset=1 imm=56710
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r1 == IMMEDIATE(56710)) {
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=2
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    r0 = IMMEDIATE(2);
+label_1:
+    // EBPF_OP_EXIT pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 43 "sample/unsafe/xdp_datasize_unsafe.c"
+    return r0;
+#line 43 "sample/unsafe/xdp_datasize_unsafe.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        unsafe_program,
+        "xdp",
+        "xdp",
+        "unsafe_program",
+        NULL,
+        0,
+        NULL,
+        0,
+        11,
+        &unsafe_program_program_type_guid,
+        &unsafe_program_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 18;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t xdp_datasize_unsafe_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/xdp_datasize_unsafe_raw.c
+++ b/tests/bpf2c_tests/expected/xdp_datasize_unsafe_raw.c
@@ -1,0 +1,144 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from xdp_datasize_unsafe.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = NULL;
+    *count = 0;
+}
+
+static GUID unsafe_program_program_type_guid = {
+    0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID unsafe_program_attach_type_guid = {
+    0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+#pragma code_seg(push, "xdp")
+static uint64_t
+unsafe_program(void* context)
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+{
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    // Prologue
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r0 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r1 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r2 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r3 = 0;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    register uint64_t r10 = 0;
+
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = (uintptr_t)context;
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=1 dst=r2 src=r1 offset=0 imm=0
+#line 20 "sample/unsafe/xdp_datasize_unsafe.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=8 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_MOV64_REG pc=3 dst=r3 src=r2 offset=0 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r3 = r2;
+    // EBPF_OP_ADD64_IMM pc=4 dst=r3 src=r0 offset=0 imm=14
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r3 += IMMEDIATE(14);
+    // EBPF_OP_JGT_REG pc=5 dst=r3 src=r1 offset=4 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r3 > r1) {
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_LDXH pc=6 dst=r1 src=r2 offset=12 imm=0
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
+    // EBPF_OP_JEQ_IMM pc=7 dst=r1 src=r0 offset=2 imm=8
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r1 == IMMEDIATE(8)) {
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=8 dst=r1 src=r0 offset=1 imm=56710
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r1 == IMMEDIATE(56710)) {
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=2
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    r0 = IMMEDIATE(2);
+label_1:
+    // EBPF_OP_EXIT pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 43 "sample/unsafe/xdp_datasize_unsafe.c"
+    return r0;
+#line 43 "sample/unsafe/xdp_datasize_unsafe.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        unsafe_program,
+        "xdp",
+        "xdp",
+        "unsafe_program",
+        NULL,
+        0,
+        NULL,
+        0,
+        11,
+        &unsafe_program_program_type_guid,
+        &unsafe_program_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 18;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t xdp_datasize_unsafe_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/xdp_datasize_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/xdp_datasize_unsafe_sys.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Do not alter this generated file.
-// This file was generated from tail_call.o
+// This file was generated from xdp_datasize_unsafe.o
 
 #define NO_CRT
 #include "bpf2c.h"
@@ -15,7 +15,7 @@ DRIVER_INITIALIZE DriverEntry;
 DRIVER_UNLOAD DriverUnload;
 RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
 
-#define metadata_table tail_call##_metadata_table
+#define metadata_table xdp_datasize_unsafe##_metadata_table
 
 static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
                              0xc847aac8,
@@ -173,177 +173,89 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
     *hash = NULL;
     *size = 0;
 }
-#pragma data_seg(push, "maps")
-static map_entry_t _maps[] = {
-    {NULL,
-     {
-         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
-         4,                       // Size in bytes of a map key.
-         4,                       // Size in bytes of a map value.
-         10,                      // Maximum number of entries allowed in the map.
-         0,                       // Inner map index.
-         LIBBPF_PIN_NONE,         // Pinning type for the map.
-         10,                      // Identifier for a map template.
-         0,                       // The id of the inner map template.
-     },
-     "map"},
-    {NULL,
-     {
-         BPF_MAP_TYPE_ARRAY, // Type of map.
-         4,                  // Size in bytes of a map key.
-         4,                  // Size in bytes of a map value.
-         1,                  // Maximum number of entries allowed in the map.
-         0,                  // Inner map index.
-         LIBBPF_PIN_NONE,    // Pinning type for the map.
-         16,                 // Identifier for a map template.
-         0,                  // The id of the inner map template.
-     },
-     "canary"},
-};
-#pragma data_seg(pop)
-
 static void
 _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
-    *maps = _maps;
-    *count = 2;
+    *maps = NULL;
+    *count = 0;
 }
 
-static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-#pragma code_seg(push, "sample~1")
+static GUID unsafe_program_program_type_guid = {
+    0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID unsafe_program_attach_type_guid = {
+    0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+#pragma code_seg(push, "xdp")
 static uint64_t
-callee(void* context)
-#line 49 "sample/undocked/tail_call.c"
+unsafe_program(void* context)
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
 {
-#line 49 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     // Prologue
-#line 49 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 49 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     register uint64_t r0 = 0;
-#line 49 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     register uint64_t r1 = 0;
-#line 49 "sample/undocked/tail_call.c"
-    register uint64_t r10 = 0;
-
-#line 49 "sample/undocked/tail_call.c"
-    r1 = (uintptr_t)context;
-#line 49 "sample/undocked/tail_call.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=42
-#line 49 "sample/undocked/tail_call.c"
-    r0 = IMMEDIATE(42);
-    // EBPF_OP_EXIT pc=1 dst=r0 src=r0 offset=0 imm=0
-#line 49 "sample/undocked/tail_call.c"
-    return r0;
-#line 49 "sample/undocked/tail_call.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static helper_function_entry_t caller_helpers[] = {
-    {NULL, 5, "helper_id_5"},
-    {NULL, 1, "helper_id_1"},
-};
-
-static GUID caller_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-static GUID caller_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
-static uint16_t caller_maps[] = {
-    0,
-    1,
-};
-
-#pragma code_seg(push, "sample~2")
-static uint64_t
-caller(void* context)
-#line 33 "sample/undocked/tail_call.c"
-{
-#line 33 "sample/undocked/tail_call.c"
-    // Prologue
-#line 33 "sample/undocked/tail_call.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 33 "sample/undocked/tail_call.c"
-    register uint64_t r0 = 0;
-#line 33 "sample/undocked/tail_call.c"
-    register uint64_t r1 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     register uint64_t r2 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     register uint64_t r3 = 0;
-#line 33 "sample/undocked/tail_call.c"
-    register uint64_t r4 = 0;
-#line 33 "sample/undocked/tail_call.c"
-    register uint64_t r5 = 0;
-#line 33 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     register uint64_t r10 = 0;
 
-#line 33 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     r1 = (uintptr_t)context;
-#line 33 "sample/undocked/tail_call.c"
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=0
-#line 33 "sample/undocked/tail_call.c"
-    r2 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1 dst=r10 src=r2 offset=-4 imm=0
-#line 35 "sample/undocked/tail_call.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r2;
-    // EBPF_OP_LDDW pc=2 dst=r2 src=r1 offset=0 imm=1
-#line 38 "sample/undocked/tail_call.c"
-    r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=4 dst=r3 src=r0 offset=0 imm=9
-#line 38 "sample/undocked/tail_call.c"
-    r3 = IMMEDIATE(9);
-    // EBPF_OP_CALL pc=5 dst=r0 src=r0 offset=0 imm=5
-#line 38 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[0].address(r1, r2, r3, r4, r5);
-#line 38 "sample/undocked/tail_call.c"
-    if ((caller_helpers[0].tail_call) && (r0 == 0)) {
-#line 38 "sample/undocked/tail_call.c"
-        return 0;
-#line 38 "sample/undocked/tail_call.c"
-    }
-    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
-#line 38 "sample/undocked/tail_call.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
-#line 38 "sample/undocked/tail_call.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r1 offset=0 imm=2
-#line 41 "sample/undocked/tail_call.c"
-    r1 = POINTER(_maps[1].address);
-    // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=1
-#line 41 "sample/undocked/tail_call.c"
-    r0 = caller_helpers[1].address(r1, r2, r3, r4, r5);
-#line 41 "sample/undocked/tail_call.c"
-    if ((caller_helpers[1].tail_call) && (r0 == 0)) {
-#line 41 "sample/undocked/tail_call.c"
-        return 0;
-#line 41 "sample/undocked/tail_call.c"
-    }
-    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
-#line 42 "sample/undocked/tail_call.c"
-    if (r0 == IMMEDIATE(0)) {
-#line 42 "sample/undocked/tail_call.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/unsafe/xdp_datasize_unsafe.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=1 dst=r2 src=r1 offset=0 imm=0
+#line 20 "sample/unsafe/xdp_datasize_unsafe.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=8 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_MOV64_REG pc=3 dst=r3 src=r2 offset=0 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r3 = r2;
+    // EBPF_OP_ADD64_IMM pc=4 dst=r3 src=r0 offset=0 imm=14
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    r3 += IMMEDIATE(14);
+    // EBPF_OP_JGT_REG pc=5 dst=r3 src=r1 offset=4 imm=0
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r3 > r1) {
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
         goto label_1;
-#line 42 "sample/undocked/tail_call.c"
+#line 32 "sample/unsafe/xdp_datasize_unsafe.c"
     }
-    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 42 "sample/undocked/tail_call.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0
-#line 43 "sample/undocked/tail_call.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
+    // EBPF_OP_LDXH pc=6 dst=r1 src=r2 offset=12 imm=0
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
+    // EBPF_OP_JEQ_IMM pc=7 dst=r1 src=r0 offset=2 imm=8
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r1 == IMMEDIATE(8)) {
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_JEQ_IMM pc=8 dst=r1 src=r0 offset=1 imm=56710
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    if (r1 == IMMEDIATE(56710)) {
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+        goto label_1;
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=2
+#line 38 "sample/unsafe/xdp_datasize_unsafe.c"
+    r0 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=6
-#line 46 "sample/undocked/tail_call.c"
-    r0 = IMMEDIATE(6);
-    // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 46 "sample/undocked/tail_call.c"
+    // EBPF_OP_EXIT pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 43 "sample/unsafe/xdp_datasize_unsafe.c"
     return r0;
-#line 46 "sample/undocked/tail_call.c"
+#line 43 "sample/unsafe/xdp_datasize_unsafe.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -352,31 +264,17 @@ label_1:
 static program_entry_t _programs[] = {
     {
         0,
-        callee,
-        "sample~1",
-        "sample_ext/0",
-        "callee",
+        unsafe_program,
+        "xdp",
+        "xdp",
+        "unsafe_program",
         NULL,
         0,
         NULL,
         0,
-        2,
-        &callee_program_type_guid,
-        &callee_attach_type_guid,
-    },
-    {
-        0,
-        caller,
-        "sample~2",
-        "sample_ext",
-        "caller",
-        caller_maps,
-        2,
-        caller_helpers,
-        2,
-        16,
-        &caller_program_type_guid,
-        &caller_attach_type_guid,
+        11,
+        &unsafe_program_program_type_guid,
+        &unsafe_program_attach_type_guid,
     },
 };
 #pragma data_seg(pop)
@@ -385,7 +283,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 2;
+    *count = 1;
 }
 
 static void
@@ -403,5 +301,5 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
     *count = 0;
 }
 
-metadata_table_t tail_call_metadata_table = {
+metadata_table_t xdp_datasize_unsafe_metadata_table = {
     sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
@@ -178,7 +178,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_raw.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_raw.c
@@ -152,7 +152,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_sys.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_sys.c
@@ -313,7 +313,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 17;
+    version->minor = 18;
     version->revision = 0;
 }
 


### PR DESCRIPTION
## Description

Fixes #3669 .
Updates the release policy to update the product version immediately after a release branch is forked. Updating the version to 0.18.0.

## Testing
CI.

## Documentation

No documentation changes.

## Installation

No setup changes.
