### PR TITLE
Use `context_header` for tail call perf improvement

### DIFF
--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -33,6 +33,11 @@ jobs:
     netperf:
       runs-on: windows-latest
       steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
       - name: Run NetPerf Workflow
         shell: pwsh
         env:

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -108,7 +108,7 @@ context structure and populates the returned data and context buffers.
 `supports_context_header`:
 
 Flag indicating that extension supports adding a context header at the start of each context passed to the eBPF program.
-An extension can choose to opt-in to support context header at the start of each program context structure that is
+An extension can choose to opt in to support context header at the start of each program context structure that is
 passed to the eBPF program. To support this feature, the extension can use the macro `EBPF_CONTEXT_HEADER` to include
 the context header at the start of the program context structure. Even when the context header is added, the pointer
 passed to the eBPF program is after the context header.

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -109,7 +109,8 @@ context structure and populates the returned data and context buffers.
 Flag indicating that extension supports adding a context header at the start of each context passed to the eBPF program.
 An extension can choose to opt-in to support context header at the start of each program context structure that is
 passed to the eBPF program. To support this feature, the extension can use the macro `EBPF_CONTEXT_HEADER` to include
-the context header at the start of the program context structure.
+the context header at the start of the program context structure. Even when the context header is added, the pointer
+passed to the eBPF program is after the context header.
 
 *Example*
 
@@ -117,7 +118,7 @@ Below is an example of sample extension where it is now including context header
 structure:
 
 ```c
-// Original sample extension program context.
+// Original sample extension program context that is passed to the eBPF program.
 typedef struct _sample_program_context
 {
     uint8_t* data_start;
@@ -133,6 +134,8 @@ typedef struct _sample_program_context_header
     sample_program_context_t context;
 } sample_program_context_header_t;
 ```
+The extension passes a pointer to `context` inside `sample_program_context_header_t`, and not a pointer to
+`sample_program_context_header_t`, when invoking the eBPF program.
 
 #### `ebpf_program_info_t` Struct
 The various fields of this structure should be set as follows:

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -101,10 +101,11 @@ structure from provided data and context buffers.
 context structure and populates the returned data and context buffers.
 * `required_irql`: IRQL at which the eBPF program is invoked by bpf_prog_test_run_opts.
 * `capabilities`: 32-bit integer describing the optional capabilities / features supported by the extension.
+   * `supports_context_header`: Flag indicating extension supports adding a context header at the start of each context passed to the eBPF program.
 
 **Capabilities**
 
-`PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER`:
+`supports_context_header`:
 
 Flag indicating that extension supports adding a context header at the start of each context passed to the eBPF program.
 An extension can choose to opt-in to support context header at the start of each program context structure that is

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -100,6 +100,39 @@ structure from provided data and context buffers.
 * `context_destroy`: Pointer to `ebpf_program_context_destroy_t` function that destroys a program type specific
 context structure and populates the returned data and context buffers.
 * `required_irql`: IRQL at which the eBPF program is invoked by bpf_prog_test_run_opts.
+* `capabilities`: 32-bit integer describing the optional capabilities / features supported by the extension.
+
+**Capabilities**
+
+`PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER`:
+
+Flag indicating that extension supports adding a context header at the start of each context passed to the eBPF program.
+An extension can choose to opt-in to support context header at the start of each program context structure that is
+passed to the eBPF program. To support this feature, the extension can use the macro `EBPF_CONTEXT_HEADER` to include
+the context header at the start of the program context structure.
+
+*Example*
+
+Below is an example of sample extension where it is now including context header start the of the original context
+structure:
+
+```c
+// Original sample extension program context.
+typedef struct _sample_program_context
+{
+    uint8_t* data_start;
+    uint8_t* data_end;
+    uint32_t uint32_data;
+    uint16_t uint16_data;
+} sample_program_context_t;
+
+// Program context including the context header.
+typedef struct _sample_program_context_header
+{
+    EBPF_CONTEXT_HEADER;
+    sample_program_context_t context;
+} sample_program_context_header_t;
+```
 
 #### `ebpf_program_info_t` Struct
 The various fields of this structure should be set as follows:

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -115,8 +115,8 @@ passed to the eBPF program is after the context header.
 
 *Example*
 
-Below is an example of sample extension where it is now including context header start the of the original context
-structure:
+Below is an example of a sample extension where it is now including eBPF context header at the start of the original
+context structure:
 
 ```c
 // Original sample extension program context that is passed to the eBPF program.

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -125,3 +125,5 @@ typedef struct _ebpf_execution_context_state
         uint32_t count;
     } tail_call_state;
 } ebpf_execution_context_state_t;
+
+#define EBPF_CONTEXT_HEADER uint64_t context_header[8]

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -9,6 +9,8 @@
 #define EBPF_MAX_PROGRAM_DESCRIPTOR_NAME_LENGTH 256
 #define EBPF_MAX_HELPER_FUNCTION_NAME_LENGTH 256
 
+#define PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER 1 << 0
+
 // This is the type definition for the eBPF program type descriptor
 // when version is EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION.
 typedef struct _ebpf_program_type_descriptor
@@ -87,7 +89,7 @@ typedef struct _ebpf_program_data
     ebpf_program_context_create_t context_create;   ///< Pointer to context create function.
     ebpf_program_context_destroy_t context_destroy; ///< Pointer to context destroy function.
     uint8_t required_irql;                          ///< IRQL at which the program is invoked.
-    bool context_header;                            ///< Whether the program context supports a context header.
+    uint32_t capabilities;                          ///< Capabilities supported by the program information provider.
 } ebpf_program_data_t;
 
 // This is the type definition for the eBPF program section information

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -87,6 +87,7 @@ typedef struct _ebpf_program_data
     ebpf_program_context_create_t context_create;   ///< Pointer to context create function.
     ebpf_program_context_destroy_t context_destroy; ///< Pointer to context destroy function.
     uint8_t required_irql;                          ///< IRQL at which the program is invoked.
+    bool context_header;                            ///< Whether the program context supports a context header.
 } ebpf_program_data_t;
 
 // This is the type definition for the eBPF program section information

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -9,8 +9,6 @@
 #define EBPF_MAX_PROGRAM_DESCRIPTOR_NAME_LENGTH 256
 #define EBPF_MAX_HELPER_FUNCTION_NAME_LENGTH 256
 
-#define PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER 1 << 0
-
 // This is the type definition for the eBPF program type descriptor
 // when version is EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION.
 typedef struct _ebpf_program_type_descriptor
@@ -75,6 +73,17 @@ typedef void (*ebpf_program_context_destroy_t)(
     _Out_writes_bytes_to_opt_(*context_size_out, *context_size_out) uint8_t* context_out,
     _Inout_ size_t* context_size_out);
 
+#pragma warning(push)
+#pragma warning(disable : 4201) // nonstandard extension used: nameless struct/union
+typedef union _program_data_capabilities
+{
+    uint32_t value;
+    struct
+    {
+        bool supports_context_header : 1; // Program supports context header.
+    };
+} program_data_capabilities_t;
+
 // This is the type definition for the eBPF program data
 // when version is EBPF_PROGRAM_DATA_CURRENT_VERSION.
 typedef struct _ebpf_program_data
@@ -89,8 +98,12 @@ typedef struct _ebpf_program_data
     ebpf_program_context_create_t context_create;   ///< Pointer to context create function.
     ebpf_program_context_destroy_t context_destroy; ///< Pointer to context destroy function.
     uint8_t required_irql;                          ///< IRQL at which the program is invoked.
-    uint32_t capabilities;                          ///< Capabilities supported by the program information provider.
+    program_data_capabilities_t capabilities;       ///< Capabilities supported by the program information provider.
 } ebpf_program_data_t;
+#pragma warning(pop)
+
+static_assert(
+    EBPF_FIELD_SIZE(ebpf_program_data_t, capabilities) == sizeof(uint32_t), "Size of capabilities is 32 bits.");
 
 // This is the type definition for the eBPF program section information
 // when version is EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION.

--- a/include/ebpf_windows.h
+++ b/include/ebpf_windows.h
@@ -124,7 +124,7 @@ typedef enum _ebpf_helper_function
     }
 
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION 1
-#define EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, required_irql)
+#define EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, context_header)
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_program_data_t)
 #define EBPF_PROGRAM_DATA_HEADER                                                   \
     {                                                                              \

--- a/include/ebpf_windows.h
+++ b/include/ebpf_windows.h
@@ -124,7 +124,7 @@ typedef enum _ebpf_helper_function
     }
 
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION 1
-#define EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, context_header)
+#define EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, capabilities)
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_program_data_t)
 #define EBPF_PROGRAM_DATA_HEADER                                                   \
     {                                                                              \

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2115,14 +2115,12 @@ _ebpf_core_map_find_and_delete_element(_Inout_ ebpf_map_t* map, _In_ const uint8
 static int64_t
 _ebpf_core_tail_call(void* context, ebpf_map_t* map, uint32_t index)
 {
-    UNREFERENCED_PARAMETER(context);
-
     // Get program from map[index].
     ebpf_program_t* callee = ebpf_map_get_program_from_entry(map, sizeof(index), (uint8_t*)&index);
     if (callee == NULL) {
         return -EBPF_INVALID_ARGUMENT;
     }
-    return -ebpf_program_set_tail_call(callee);
+    return -ebpf_program_set_tail_call(context, callee);
 }
 
 static uint32_t

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -220,7 +220,7 @@ _ebpf_link_client_attach_provider(
     lock_held = false;
 
     status = NmrClientAttachProvider(
-        nmr_binding_handle, link, &client_dispatch_table, &provider_binding_context, &provider_dispatch);
+        nmr_binding_handle, link, client_dispatch_table, &provider_binding_context, &provider_dispatch);
 
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_MESSAGE_NTSTATUS(

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -315,7 +315,8 @@ ebpf_link_create(
 
     // Note: This must be the last thing done in this function as it inserts the object into the global list.
     // After this point, the object can be accessed by other threads.
-    ebpf_result_t result = EBPF_OBJECT_INITIALIZE(&local_link->object, EBPF_OBJECT_LINK, _ebpf_link_free, NULL, NULL);
+    ebpf_result_t result =
+        EBPF_OBJECT_INITIALIZE(&local_link->object, EBPF_OBJECT_LINK, _ebpf_link_free, NULL, NULL, NULL);
     if (result != EBPF_SUCCESS) {
         EBPF_LOG_MESSAGE_ERROR(
             EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_LINK, "ebpf_object_initialize failed for link", result);

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -614,7 +614,6 @@ static ebpf_result_t
 _ebpf_link_instance_invoke_batch_end_with_context_header(_Inout_ void* state)
 {
     ebpf_execution_context_state_t* execution_context_state = (ebpf_execution_context_state_t*)state;
-    ebpf_assert_success(ebpf_state_store(ebpf_program_get_state_index(), 0, execution_context_state));
     ebpf_epoch_exit((ebpf_epoch_state_t*)(execution_context_state->epoch_state));
     return EBPF_SUCCESS;
 }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -30,7 +30,6 @@ typedef struct _ebpf_core_object_map
     ebpf_map_definition_in_memory_t inner_template_map_definition;
     bool is_program_type_set;
     ebpf_program_type_t program_type;
-    bool context_header;
 } ebpf_core_object_map_t;
 
 // Generations:

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -29,6 +29,7 @@ typedef struct _ebpf_core_object_map
     ebpf_lock_t lock;
     ebpf_map_definition_in_memory_t inner_template_map_definition;
     bool is_program_type_set;
+    bool supports_context_header;
     ebpf_program_type_t program_type;
 } ebpf_core_object_map_t;
 
@@ -160,7 +161,7 @@ typedef struct _ebpf_core_lru_map
 {
     ebpf_core_map_t core_map; //< Core map structure.
     size_t partition_count;   //< Number of LRU partitions. Limited to a maximum of EBPF_LRU_MAXIMUM_PARTITIONS.
-    uint8_t padding[24];      //< Required to ensure partitions are cache aligned.
+    uint8_t padding[16];      //< Required to ensure partitions are cache aligned.
     ebpf_lru_partition_t
         partitions[1]; //< Array of LRU partitions. Limited to a maximum of EBPF_LRU_MAXIMUM_PARTITIONS.
 } ebpf_core_lru_map_t;
@@ -658,9 +659,10 @@ _associate_program_with_prog_array_map(_Inout_ ebpf_core_map_t* map, _In_ const 
     ebpf_assert(map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY);
     ebpf_core_object_map_t* program_array = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
 
-    // Validate that the program type is
+    // Validate that the program type and context header support is
     // not in conflict with the map's program type.
     ebpf_program_type_t program_type = ebpf_program_type_uuid(program);
+    bool supports_context_header = ebpf_program_supports_context_header(program);
     ebpf_result_t result = EBPF_SUCCESS;
 
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&program_array->lock);
@@ -668,7 +670,10 @@ _associate_program_with_prog_array_map(_Inout_ ebpf_core_map_t* map, _In_ const 
     if (!program_array->is_program_type_set) {
         program_array->is_program_type_set = TRUE;
         program_array->program_type = program_type;
-    } else if (memcmp(&program_array->program_type, &program_type, sizeof(program_type)) != 0) {
+        program_array->supports_context_header = supports_context_header;
+    } else if (
+        memcmp(&program_array->program_type, &program_type, sizeof(program_type)) != 0 ||
+        program_array->supports_context_header != supports_context_header) {
         result = EBPF_INVALID_FD;
     }
 
@@ -708,10 +713,13 @@ static _Requires_lock_held_(object_map->lock) ebpf_result_t _validate_map_value_
     const ebpf_core_map_t* map = &object_map->core_map;
 
     ebpf_program_type_t value_program_type = {0};
+    bool value_supports_context_header = false;
     bool is_program_type_set = false;
 
     if (value_object->get_program_type) {
         value_program_type = value_object->get_program_type(value_object);
+        ebpf_assert(value_object->get_context_header_support != NULL);
+        value_supports_context_header = value_object->get_context_header_support(value_object);
         is_program_type_set = true;
     }
 
@@ -729,7 +737,10 @@ static _Requires_lock_held_(object_map->lock) ebpf_result_t _validate_map_value_
         if (!object_map->is_program_type_set) {
             object_map->is_program_type_set = TRUE;
             object_map->program_type = value_program_type;
-        } else if (memcmp(&object_map->program_type, &value_program_type, sizeof(value_program_type)) != 0) {
+            object_map->supports_context_header = value_supports_context_header;
+        } else if (
+            memcmp(&object_map->program_type, &value_program_type, sizeof(value_program_type)) != 0 ||
+            object_map->supports_context_header != value_supports_context_header) {
             result = EBPF_INVALID_FD;
             goto Error;
         }
@@ -2401,7 +2412,8 @@ ebpf_map_create(
 
     const ebpf_map_metadata_table_t* table = &ebpf_map_metadata_tables[local_map->ebpf_map_definition.type];
     ebpf_object_get_program_type_t get_program_type = (table->get_object_from_entry) ? _get_map_program_type : NULL;
-    result = EBPF_OBJECT_INITIALIZE(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, NULL, get_program_type);
+    result =
+        EBPF_OBJECT_INITIALIZE(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, NULL, get_program_type, NULL);
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -896,7 +896,7 @@ _delete_map_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* ke
  * @param[in] key Pointer to the key to search for.
  * @returns Object pointer, or NULL if none.
  */
-static _Ret_maybenull_ ebpf_core_object_t*
+_Ret_maybenull_ ebpf_core_object_t*
 _get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     uint32_t index = *(uint32_t*)key;

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -346,6 +346,13 @@ _get_map_program_type(_In_ const ebpf_core_object_t* object)
     return map->program_type;
 }
 
+static bool
+_ebpf_map_get_program_context_header_support(_In_ const ebpf_core_object_t* object)
+{
+    const ebpf_core_object_map_t* map = (const ebpf_core_object_map_t*)object;
+    return map->supports_context_header;
+}
+
 typedef struct _ebpf_map_metadata_table
 {
     ebpf_map_type_t map_type;
@@ -2413,8 +2420,10 @@ ebpf_map_create(
 
     const ebpf_map_metadata_table_t* table = &ebpf_map_metadata_tables[local_map->ebpf_map_definition.type];
     ebpf_object_get_program_type_t get_program_type = (table->get_object_from_entry) ? _get_map_program_type : NULL;
-    result =
-        EBPF_OBJECT_INITIALIZE(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, NULL, get_program_type, NULL);
+    ebpf_object_get_context_header_support_t get_context_header_support =
+        (table->get_object_from_entry) ? _ebpf_map_get_program_context_header_support : NULL;
+    result = EBPF_OBJECT_INITIALIZE(
+        &local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, NULL, get_program_type, get_context_header_support);
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -719,6 +719,7 @@ static _Requires_lock_held_(object_map->lock) ebpf_result_t _validate_map_value_
     if (value_object->get_program_type) {
         value_program_type = value_object->get_program_type(value_object);
         ebpf_assert(value_object->get_context_header_support != NULL);
+        __analysis_assume(value_object->get_context_header_support != NULL);
         value_supports_context_header = value_object->get_context_header_support(value_object);
         is_program_type_set = true;
     }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -896,7 +896,7 @@ _delete_map_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* ke
  * @param[in] key Pointer to the key to search for.
  * @returns Object pointer, or NULL if none.
  */
-_Ret_maybenull_ ebpf_core_object_t*
+static _Ret_maybenull_ ebpf_core_object_t*
 _get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     uint32_t index = *(uint32_t*)key;

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -30,6 +30,7 @@ typedef struct _ebpf_core_object_map
     ebpf_map_definition_in_memory_t inner_template_map_definition;
     bool is_program_type_set;
     ebpf_program_type_t program_type;
+    bool context_header;
 } ebpf_core_object_map_t;
 
 // Generations:

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1470,9 +1470,9 @@ ebpf_program_set_tail_call(_In_ const void* context, _In_ const ebpf_program_t* 
     ebpf_result_t result;
     ebpf_execution_context_state_t* state = NULL;
 
-    // BPF_PROG_ARRAY_MAP validates that either all programs in the map either support context header,
-    // or none of them do. So, if the next program supports context header, then the current program
-    // must also support context header.
+    // BPF_PROG_ARRAY_MAP validates that either all programs in the map either support a context header,
+    // or none of them do. So, if the next program supports a context header, then the current program
+    // must also support a context header.
     if (next_program->context_header_support == CONTEXT_HEADER_SUPPORTED) {
         ebpf_program_get_runtime_state(context, &state);
     } else {

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -25,8 +25,6 @@
 static size_t _ebpf_program_state_index = MAXUINT64;
 #define EBPF_MAX_HASH_SIZE 128
 
-#define CAPABILITY_CONTEXT_HEADER(capabilities) (capabilities & PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER)
-
 // Global flag to disable invoking programs. This is used when fuzzing the IOCTL interface.
 bool ebpf_program_disable_invoke = false;
 
@@ -460,7 +458,7 @@ _ebpf_program_type_specific_program_information_attach_provider(
     // have loaded and attached, either of them can be detached and reattached in any order. Also the hook info
     // provider uses this information to determine what version of dispatch table to provide to the hook info provider.
     // To avoid any race conditions, the context header support should be set only once and should not be changed.
-    context_header_support_t new_value = CAPABILITY_CONTEXT_HEADER(extension_program_data->capabilities)
+    context_header_support_t new_value = extension_program_data->capabilities.supports_context_header
                                              ? CONTEXT_HEADER_SUPPORTED
                                              : CONTEXT_HEADER_NOT_SUPPORTED;
     if (program->context_header_support != CONTEXT_HEADER_SUPPORT_NOT_SET) {
@@ -2389,7 +2387,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     ebpf_epoch_enter(&epoch_state);
     in_epoch = true;
 
-    supports_context_header = CAPABILITY_CONTEXT_HEADER(context->program_data->capabilities);
+    supports_context_header = context->program_data->capabilities.supports_context_header;
     if (supports_context_header) {
         ebpf_program_set_runtime_state(&execution_context_state, program_context);
     } else {

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -25,6 +25,8 @@
 static size_t _ebpf_program_state_index = MAXUINT64;
 #define EBPF_MAX_HASH_SIZE 128
 
+#define CAPABILITY_CONTEXT_HEADER(capabilities) (capabilities & PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER)
+
 // Global flag to disable invoking programs. This is used when fuzzing the IOCTL interface.
 bool ebpf_program_disable_invoke = false;
 
@@ -104,7 +106,7 @@ typedef struct _ebpf_program
 
     _Guarded_by_(lock) ebpf_helper_function_addresses_changed_callback_t helper_function_addresses_changed_callback;
     _Guarded_by_(lock) void* helper_function_addresses_changed_context;
-    _Guarded_by_(lock) context_header_support_t context_header;
+    _Guarded_by_(lock) context_header_support_t context_header_support;
 } ebpf_program_t;
 
 static struct
@@ -458,10 +460,11 @@ _ebpf_program_type_specific_program_information_attach_provider(
     // have loaded and attached, either of them can be detached and reattached in any order. Also the hook info
     // provider uses this information to determine what version of dispatch table to provide to the hook info provider.
     // To avoid any race conditions, the context header support should be set only once and should not be changed.
-    context_header_support_t new_value =
-        extension_program_data->context_header ? CONTEXT_HEADER_SUPPORTED : CONTEXT_HEADER_NOT_SUPPORTED;
-    if (program->context_header != CONTEXT_HEADER_SUPPORT_NOT_SET) {
-        if (new_value != program->context_header) {
+    context_header_support_t new_value = CAPABILITY_CONTEXT_HEADER(extension_program_data->capabilities)
+                                             ? CONTEXT_HEADER_SUPPORTED
+                                             : CONTEXT_HEADER_NOT_SUPPORTED;
+    if (program->context_header_support != CONTEXT_HEADER_SUPPORT_NOT_SET) {
+        if (new_value != program->context_header_support) {
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR,
                 EBPF_TRACELOG_KEYWORD_PROGRAM,
@@ -471,7 +474,7 @@ _ebpf_program_type_specific_program_information_attach_provider(
             goto Done;
         }
     } else {
-        program->context_header = new_value;
+        program->context_header_support = new_value;
     }
 
     if (ebpf_duplicate_utf8_string(&hash_algorithm, &program->parameters.program_info_hash_type) != EBPF_SUCCESS) {
@@ -654,6 +657,14 @@ static ebpf_program_type_t
 _ebpf_program_get_program_type(_In_ const ebpf_core_object_t* object)
 {
     return ebpf_program_type_uuid((const ebpf_program_t*)object);
+}
+
+static bool
+_ebpf_program_get_context_header_support(_In_ const ebpf_core_object_t* object)
+{
+    ebpf_program_t* program = (ebpf_program_t*)object;
+    ebpf_assert(program->context_header_support != CONTEXT_HEADER_SUPPORT_NOT_SET);
+    return program->context_header_support == CONTEXT_HEADER_SUPPORTED;
 }
 
 static const bpf_prog_type_t
@@ -908,7 +919,8 @@ ebpf_program_create(_In_ const ebpf_program_parameters_t* program_parameters, _O
         EBPF_OBJECT_PROGRAM,
         _ebpf_program_free,
         _ebpf_program_zero_ref_count,
-        _ebpf_program_get_program_type);
+        _ebpf_program_get_program_type,
+        _ebpf_program_get_context_header_support);
 
     if (retval != EBPF_SUCCESS) {
         goto Done;
@@ -1460,7 +1472,10 @@ ebpf_program_set_tail_call(_In_ const void* context, _In_ const ebpf_program_t* 
     ebpf_result_t result;
     ebpf_execution_context_state_t* state = NULL;
 
-    if (next_program->extension_program_data->context_header) {
+    // BPF_PROG_ARRAY_MAP validates that either all programs in the map either support context header,
+    // or none of them do. So, if the next program supports context header, then the current program
+    // must also support context header.
+    if (next_program->context_header_support == CONTEXT_HEADER_SUPPORTED) {
         ebpf_program_get_runtime_state(context, &state);
     } else {
         result = ebpf_state_load(_ebpf_program_state_index, (uintptr_t*)&state);
@@ -2350,6 +2365,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     bool thread_affinity_set = false;
     bool state_stored = false;
     void* program_context = NULL;
+    bool supports_context_header;
 
     result = ebpf_set_current_thread_affinity((uintptr_t)1 << options->cpu, &old_thread_affinity);
     if (result != EBPF_SUCCESS) {
@@ -2373,7 +2389,8 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     ebpf_epoch_enter(&epoch_state);
     in_epoch = true;
 
-    if (context->program_data->context_header) {
+    supports_context_header = CAPABILITY_CONTEXT_HEADER(context->program_data->capabilities);
+    if (supports_context_header) {
         ebpf_program_set_runtime_state(&execution_context_state, program_context);
     } else {
         ebpf_get_execution_context_state(&execution_context_state);
@@ -2415,11 +2432,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
             ebpf_epoch_enter(&epoch_state);
         }
         result = ebpf_program_invoke(
-            context->program,
-            context->program_data->context_header,
-            program_context,
-            &return_value,
-            &execution_context_state);
+            context->program, supports_context_header, program_context, &return_value, &execution_context_state);
         if (result != EBPF_SUCCESS) {
             break;
         }
@@ -2603,7 +2616,7 @@ ebpf_program_supports_context_header(_In_ const ebpf_program_t* program)
 {
     bool return_value;
     ebpf_lock_state_t state = ebpf_lock_lock((ebpf_lock_t*)&program->lock);
-    return_value = program->context_header == CONTEXT_HEADER_SUPPORTED ? true : false;
+    return_value = program->context_header_support == CONTEXT_HEADER_SUPPORTED ? true : false;
     ebpf_lock_unlock((ebpf_lock_t*)&program->lock, state);
     return return_value;
 }

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -186,7 +186,7 @@ extern "C"
      * @brief Invoke an ebpf_program_t instance.
      *
      * @param[in] program Program to invoke.
-     * @param[in] use_context_header Whether to use program context header to store state information.
+     * @param[in] use_context_header Whether to use a context header to store state information.
      * @param[in,out] context Pointer to eBPF context for this program.
      * @param[out] result Output from the program.
      * @param[in] execution_state Execution context state.

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -186,6 +186,7 @@ extern "C"
      * @brief Invoke an ebpf_program_t instance.
      *
      * @param[in] program Program to invoke.
+     * @param[in] use_context_header Whether to use program context header to store state information.
      * @param[in,out] context Pointer to eBPF context for this program.
      * @param[out] result Output from the program.
      * @param[in] execution_state Execution context state.
@@ -196,6 +197,7 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_invoke(
         _In_ const ebpf_program_t* program,
+        bool use_context_header,
         _Inout_ void* context,
         _Out_ uint32_t* result,
         _Inout_ ebpf_execution_context_state_t* execution_state);
@@ -277,6 +279,7 @@ extern "C"
     /**
      * @brief Store the pointer to the program to execute on tail call.
      *
+     * @param[in] context Program context.
      * @param[in] next_program Next program to execute.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT Internal error.
@@ -284,7 +287,7 @@ extern "C"
      */
     EBPF_INLINE_HINT
     _Must_inspect_result_ ebpf_result_t
-    ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program);
+    ebpf_program_set_tail_call(_In_ const void* context, _In_ const ebpf_program_t* next_program);
 
     /**
      * @brief Get bpf_prog_info about a program.
@@ -413,6 +416,39 @@ extern "C"
      */
     size_t
     ebpf_program_get_state_index();
+
+    /**
+     * @brief Get whether the program information provider supports the context header.
+     *
+     * @param[in] program Pointer to the program object.
+     *
+     * @return true when the program supports the context header.
+     * @return false when the program does not support the context header.
+     */
+    bool
+    ebpf_program_supports_context_header(_In_ const ebpf_program_t* program);
+
+    /**
+     * @brief Set the runtime state in the program context.
+     *
+     * @param[in] state Pointer to the execution context state.
+     * @param[in,out] program_context Pointer to the program context.
+     */
+    EBPF_INLINE_HINT
+    void
+    ebpf_program_set_runtime_state(_In_ const ebpf_execution_context_state_t* state, _Inout_ void* program_context);
+
+    /**
+     * @brief Get the runtime state from the program context.
+     *  Slot [0] contains the program information.
+     *
+     * @param[in] program_context Pointer to the program context.
+     * @param[out] state Pointer to the execution context state.
+     */
+    EBPF_INLINE_HINT
+    void
+    ebpf_program_get_runtime_state(
+        _In_ const void* program_context, _Outptr_ const ebpf_execution_context_state_t** state);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -832,7 +832,7 @@ TEST_CASE("program", "[execution_context]")
     sample_program_context_t ctx{0};
     ebpf_execution_context_state_t state{};
     ebpf_get_execution_context_state(&state);
-    ebpf_result_t ebpf_result = ebpf_program_invoke(program.get(), &ctx, &result, &state);
+    ebpf_result_t ebpf_result = ebpf_program_invoke(program.get(), false, &ctx, &result, &state);
     REQUIRE(ebpf_result == EBPF_SUCCESS);
     REQUIRE(result == TEST_FUNCTION_RETURN);
 

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -195,6 +195,7 @@ ebpf_object_initialize(
     _In_ ebpf_free_object_t free_function,
     _In_opt_ ebpf_zero_ref_count_t zero_ref_count_function,
     ebpf_object_get_program_type_t get_program_type_function,
+    ebpf_object_get_context_header_support_t get_context_header_support_function,
     ebpf_file_id_t file_id,
     uint32_t line)
 {
@@ -210,6 +211,7 @@ ebpf_object_initialize(
     object->free_function = free_function;
     object->zero_ref_count = zero_ref_count_function;
     object->get_program_type = get_program_type_function;
+    object->get_context_header_support = get_context_header_support_function;
     object->id = ebpf_interlocked_increment_int32((volatile int32_t*)&_ebpf_next_id);
     // Skip invalid IDs.
     while (object->id == 0 || object->id == EBPF_ID_NONE) {

--- a/libs/runtime/ebpf_object.h
+++ b/libs/runtime/ebpf_object.h
@@ -94,14 +94,21 @@ extern "C"
  * @brief Macro to initialize an object and record the file and line number of the reference.
  *EBPF_OBJECT_INITIALIZE
  */
-#define EBPF_OBJECT_INITIALIZE(object, object_type, free_function, zero_ref_function, get_program_type_function) \
-    ebpf_object_initialize(                                                                                      \
-        (ebpf_core_object_t*)(object),                                                                           \
-        (object_type),                                                                                           \
-        (free_function),                                                                                         \
-        (zero_ref_function),                                                                                     \
-        (get_program_type_function),                                                                             \
-        EBPF_FILE_ID,                                                                                            \
+#define EBPF_OBJECT_INITIALIZE(                \
+    object,                                    \
+    object_type,                               \
+    free_function,                             \
+    zero_ref_function,                         \
+    get_program_type_function,                 \
+    get_context_header_support_function)       \
+    ebpf_object_initialize(                    \
+        (ebpf_core_object_t*)(object),         \
+        (object_type),                         \
+        (free_function),                       \
+        (zero_ref_function),                   \
+        (get_program_type_function),           \
+        (get_context_header_support_function), \
+        EBPF_FILE_ID,                          \
         __LINE__)
 
     typedef enum _ebpf_object_type
@@ -120,6 +127,7 @@ extern "C"
     typedef void (*ebpf_zero_ref_count_t)(ebpf_core_object_t* object);
     typedef void (*ebpf_free_object_t)(ebpf_core_object_t* object);
     typedef const ebpf_program_type_t (*ebpf_object_get_program_type_t)(_In_ const ebpf_core_object_t* object);
+    typedef const bool (*ebpf_object_get_context_header_support_t)(_In_ const ebpf_core_object_t* object);
 
     /**
      * @brief Base object for all reference counted eBPF objects. This struct is embedded as the first entry in all
@@ -147,10 +155,12 @@ extern "C"
         ebpf_zero_ref_count_t zero_ref_count; ///< Function to notify the object that the reference count has reached
                                               ///< zero.
         ebpf_object_get_program_type_t get_program_type; ///< Function to get the program type of this object.
-        ebpf_id_t id;                                    ///< ID of this object.
-        ebpf_list_entry_t object_list_entry;             ///< Entry in the object list.
-        volatile int32_t pinned_path_count;              ///< Number of pinned paths for this object.
-        struct _ebpf_epoch_work_item* free_work_item;    ///< Work item to free this object when the epoch ends.
+        ebpf_object_get_context_header_support_t
+            get_context_header_support;               ///< Function to get context header support for this object.
+        ebpf_id_t id;                                 ///< ID of this object.
+        ebpf_list_entry_t object_list_entry;          ///< Entry in the object list.
+        volatile int32_t pinned_path_count;           ///< Number of pinned paths for this object.
+        struct _ebpf_epoch_work_item* free_work_item; ///< Work item to free this object when the epoch ends.
     } ebpf_core_object_t;
 
     /**
@@ -190,6 +200,7 @@ extern "C"
         _In_ ebpf_free_object_t free_function,
         _In_opt_ ebpf_zero_ref_count_t zero_ref_count_function,
         ebpf_object_get_program_type_t get_program_type_function,
+        ebpf_object_get_context_header_support_t get_context_header_support_function,
         ebpf_file_id_t file_id,
         uint32_t line);
 

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -460,6 +460,7 @@ TEST_CASE("pinning_test", "[platform]")
                     some_object->signal.signal();
                 },
                 NULL,
+                NULL,
                 NULL);
             if (return_value == EBPF_SUCCESS) {
                 finalized = false;

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -51,7 +51,7 @@ size_t _ebpf_program_info_supported_size[] = {EBPF_PROGRAM_INFO_SIZE_0};
 size_t _ebpf_helper_function_addresses_supported_size[] = {EBPF_HELPER_FUNCTION_ADDRESSES_SIZE_0};
 
 #define EBPF_PROGRAM_DATA_SIZE_0 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, required_irql)
-#define EBPF_PROGRAM_DATA_SIZE_1 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, context_header)
+#define EBPF_PROGRAM_DATA_SIZE_1 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, capabilities)
 size_t _ebpf_program_data_supported_size[] = {EBPF_PROGRAM_DATA_SIZE_0, EBPF_PROGRAM_DATA_SIZE_1};
 
 #define EBPF_PROGRAM_SECTION_SIZE_0 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_section_info_t, bpf_attach_type)

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -50,8 +50,9 @@ size_t _ebpf_program_info_supported_size[] = {EBPF_PROGRAM_INFO_SIZE_0};
     EBPF_OFFSET_OF(ebpf_helper_function_addresses_t, helper_function_address) + sizeof(uint64_t*)
 size_t _ebpf_helper_function_addresses_supported_size[] = {EBPF_HELPER_FUNCTION_ADDRESSES_SIZE_0};
 
-#define EBPF_PROGRAM_DATA_SIZE_0 EBPF_OFFSET_OF(ebpf_program_data_t, required_irql) + sizeof(uint8_t)
-size_t _ebpf_program_data_supported_size[] = {EBPF_PROGRAM_DATA_SIZE_0};
+#define EBPF_PROGRAM_DATA_SIZE_0 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, required_irql)
+#define EBPF_PROGRAM_DATA_SIZE_1 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, context_header)
+size_t _ebpf_program_data_supported_size[] = {EBPF_PROGRAM_DATA_SIZE_0, EBPF_PROGRAM_DATA_SIZE_1};
 
 #define EBPF_PROGRAM_SECTION_SIZE_0 EBPF_SIZE_INCLUDING_FIELD(ebpf_program_section_info_t, bpf_attach_type)
 size_t _ebpf_program_section_supported_size[] = {EBPF_PROGRAM_SECTION_SIZE_0};

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -68,7 +68,7 @@ static ebpf_program_data_t _ebpf_bind_program_data = {
     .context_create = _ebpf_bind_context_create,
     .context_destroy = _ebpf_bind_context_destroy,
     .required_irql = PASSIVE_LEVEL,
-    .context_header = true,
+    .capabilities = PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER,
 };
 
 // Set the program type as the provider module id.

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -68,7 +68,7 @@ static ebpf_program_data_t _ebpf_bind_program_data = {
     .context_create = _ebpf_bind_context_create,
     .context_destroy = _ebpf_bind_context_destroy,
     .required_irql = PASSIVE_LEVEL,
-    .capabilities = PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER,
+    .capabilities = {.supports_context_header = true},
 };
 
 // Set the program type as the provider module id.

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -9,6 +9,12 @@
 #include "ebpf_shared_framework.h"
 #include "net_ebpf_ext_bind.h"
 
+typedef struct _bind_context_header
+{
+    EBPF_CONTEXT_HEADER;
+    bind_md_t context;
+} bind_context_header_t;
+
 //
 // WFP filter related globals for bind hook.
 //
@@ -62,6 +68,7 @@ static ebpf_program_data_t _ebpf_bind_program_data = {
     .context_create = _ebpf_bind_context_create,
     .context_destroy = _ebpf_bind_context_destroy,
     .required_irql = PASSIVE_LEVEL,
+    .context_header = true,
 };
 
 // Set the program type as the provider module id.
@@ -239,7 +246,8 @@ net_ebpf_ext_resource_allocation_classify(
 {
     SOCKADDR_IN addr = {AF_INET};
     uint32_t result;
-    bind_md_t ctx;
+    bind_context_header_t context_header = {0};
+    bind_md_t* ctx = &context_header.context;
     net_ebpf_extension_wfp_filter_context_t* filter_context = NULL;
     net_ebpf_extension_hook_client_t* attached_client = NULL;
 
@@ -280,20 +288,20 @@ net_ebpf_ext_resource_allocation_classify(
     addr.sin_addr.S_un.S_addr =
         incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_ADDRESS].value.uint32;
 
-    ctx.process_id = incoming_metadata_values->processId;
-    memcpy(&ctx.socket_address, &addr, sizeof(addr));
-    ctx.socket_address_length = sizeof(addr);
-    ctx.operation = BIND_OPERATION_BIND;
-    ctx.protocol = incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8;
+    ctx->process_id = incoming_metadata_values->processId;
+    memcpy(&ctx->socket_address, &addr, sizeof(addr));
+    ctx->socket_address_length = sizeof(addr);
+    ctx->operation = BIND_OPERATION_BIND;
+    ctx->protocol = incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8;
 
-    ctx.app_id_start =
+    ctx->app_id_start =
         incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob->data;
-    ctx.app_id_end =
-        ctx.app_id_start +
+    ctx->app_id_end =
+        ctx->app_id_start +
         incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob->size;
 
-    _net_ebpf_ext_resource_truncate_appid(&ctx);
-    if (net_ebpf_extension_hook_invoke_program(attached_client, &ctx, &result) == EBPF_SUCCESS) {
+    _net_ebpf_ext_resource_truncate_appid(ctx);
+    if (net_ebpf_extension_hook_invoke_program(attached_client, ctx, &result) == EBPF_SUCCESS) {
         switch (result) {
         case BIND_PERMIT:
         case BIND_REDIRECT:
@@ -330,7 +338,8 @@ net_ebpf_ext_resource_release_classify(
 {
     SOCKADDR_IN addr = {AF_INET};
     uint32_t result;
-    bind_md_t ctx;
+    bind_context_header_t context_header = {0};
+    bind_md_t* ctx = &context_header.context;
     net_ebpf_extension_wfp_filter_context_t* filter_context = NULL;
     net_ebpf_extension_hook_client_t* attached_client = NULL;
 
@@ -370,22 +379,22 @@ net_ebpf_ext_resource_release_classify(
     addr.sin_addr.S_un.S_addr =
         incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_RELEASE_V4_IP_LOCAL_ADDRESS].value.uint32;
 
-    ctx.process_id = incoming_metadata_values->processId;
-    memcpy(&ctx.socket_address, &addr, sizeof(addr));
-    ctx.socket_address_length = sizeof(addr);
-    ctx.operation = BIND_OPERATION_UNBIND;
-    ctx.protocol = incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_RELEASE_V4_IP_PROTOCOL].value.uint8;
+    ctx->process_id = incoming_metadata_values->processId;
+    memcpy(&ctx->socket_address, &addr, sizeof(addr));
+    ctx->socket_address_length = sizeof(addr);
+    ctx->operation = BIND_OPERATION_UNBIND;
+    ctx->protocol = incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_RELEASE_V4_IP_PROTOCOL].value.uint8;
 
-    ctx.app_id_start =
+    ctx->app_id_start =
         incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_RELEASE_V4_ALE_APP_ID].value.byteBlob->data;
-    ctx.app_id_end =
-        ctx.app_id_start +
+    ctx->app_id_end =
+        ctx->app_id_start +
         incoming_fixed_values->incomingValue[FWPS_FIELD_ALE_RESOURCE_RELEASE_V4_ALE_APP_ID].value.byteBlob->size;
 
-    _net_ebpf_ext_resource_truncate_appid(&ctx);
+    _net_ebpf_ext_resource_truncate_appid(ctx);
 
     // Ignore the result of this call as we don't want to block the unbind.
-    (void)net_ebpf_extension_hook_invoke_program(attached_client, &ctx, &result);
+    (void)net_ebpf_extension_hook_invoke_program(attached_client, ctx, &result);
 
     classify_output->actionType = FWP_ACTION_PERMIT;
 
@@ -406,6 +415,7 @@ _ebpf_bind_context_create(
 {
     NET_EBPF_EXT_LOG_ENTRY();
     ebpf_result_t result;
+    bind_context_header_t* context_header = NULL;
     bind_md_t* bind_context = NULL;
 
     *context = NULL;
@@ -417,10 +427,12 @@ _ebpf_bind_context_create(
         goto Exit;
     }
 
-    bind_context =
-        (bind_md_t*)ExAllocatePoolUninitialized(NonPagedPoolNx, sizeof(bind_md_t), NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(NET_EBPF_EXT_TRACELOG_KEYWORD_BIND, bind_context, "bind_context", result);
+    context_header = (bind_context_header_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(bind_context_header_t), NET_EBPF_EXTENSION_POOL_TAG);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_BIND, context_header, "bind_context", result);
 
+    bind_context = &context_header->context;
     // Copy the context from the caller.
     memcpy(bind_context, context_in, sizeof(bind_md_t));
 
@@ -429,13 +441,13 @@ _ebpf_bind_context_create(
     bind_context->app_id_end = (uint8_t*)data_in + data_size_in;
 
     *context = bind_context;
-    bind_context = NULL;
+    context_header = NULL;
     result = EBPF_SUCCESS;
 
 Exit:
-    if (bind_context) {
-        ExFreePool(bind_context);
-        bind_context = NULL;
+    if (context_header) {
+        ExFreePool(context_header);
+        context_header = NULL;
     }
     NET_EBPF_EXT_RETURN_RESULT(result);
 }
@@ -452,10 +464,13 @@ _ebpf_bind_context_destroy(
 
     bind_md_t* bind_context = (bind_md_t*)context;
     bind_md_t* bind_context_out = (bind_md_t*)context_out;
+    bind_context_header_t* header = NULL;
 
     if (!bind_context) {
         goto Exit;
     }
+
+    header = CONTAINING_RECORD(bind_context, bind_context_header_t, context);
 
     if (context_out != NULL && *context_size_out >= sizeof(bind_md_t)) {
         // Copy the context to the caller.
@@ -477,7 +492,7 @@ _ebpf_bind_context_destroy(
         *data_size_out = 0;
     }
 
-    ExFreePool(bind_context);
+    ExFreePool(header);
 
 Exit:
     NET_EBPF_EXT_LOG_EXIT();

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -521,6 +521,7 @@ static ebpf_program_data_t _ebpf_sock_addr_program_data = {
     .context_create = &_ebpf_sock_addr_context_create,
     .context_destroy = &_ebpf_sock_addr_context_destroy,
     .required_irql = DISPATCH_LEVEL,
+    .capabilities = (PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER),
 };
 
 // Set the program type as the provider module id.

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -521,7 +521,7 @@ static ebpf_program_data_t _ebpf_sock_addr_program_data = {
     .context_create = &_ebpf_sock_addr_context_create,
     .context_destroy = &_ebpf_sock_addr_context_destroy,
     .required_irql = DISPATCH_LEVEL,
-    .capabilities = (PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER),
+    .capabilities = {.supports_context_header = true},
 };
 
 // Set the program type as the provider module id.

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -176,6 +176,7 @@ _net_ebpf_ext_log_sock_addr_classify(
 
 typedef struct _net_ebpf_bpf_sock_addr
 {
+    EBPF_CONTEXT_HEADER;
     bpf_sock_addr_t base;
     TOKEN_ACCESS_INFORMATION* access_information;
     uint64_t process_id;
@@ -1958,6 +1959,7 @@ _ebpf_sock_addr_context_create(
     NET_EBPF_EXT_LOG_ENTRY();
 
     ebpf_result_t result;
+    net_ebpf_sock_addr_t* ctx = NULL;
     bpf_sock_addr_t* sock_addr_ctx = NULL;
 
     *context = NULL;
@@ -1978,21 +1980,21 @@ _ebpf_sock_addr_context_create(
         goto Exit;
     }
 
-    sock_addr_ctx = (bpf_sock_addr_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(bpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
-        NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, sock_addr_ctx, "sock_addr_ctx", result);
+    ctx = (net_ebpf_sock_addr_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(net_ebpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, ctx, "sock_addr_ctx", result);
 
+    sock_addr_ctx = &ctx->base;
     memcpy(sock_addr_ctx, context_in, sizeof(bpf_sock_addr_t));
 
     result = EBPF_SUCCESS;
     *context = sock_addr_ctx;
 
-    sock_addr_ctx = NULL;
+    ctx = NULL;
 
 Exit:
-    if (sock_addr_ctx) {
-        ExFreePool(sock_addr_ctx);
+    if (ctx) {
+        ExFreePool(ctx);
     }
     NET_EBPF_EXT_RETURN_RESULT(result);
 }
@@ -2006,6 +2008,7 @@ _ebpf_sock_addr_context_destroy(
     _Inout_ size_t* context_size_out)
 {
     NET_EBPF_EXT_LOG_ENTRY();
+    net_ebpf_sock_addr_t* sock_addr_ctx = NULL;
 
     UNREFERENCED_PARAMETER(data_out);
     *data_size_out = 0;
@@ -2013,6 +2016,7 @@ _ebpf_sock_addr_context_destroy(
     if (!context) {
         return;
     }
+    sock_addr_ctx = CONTAINING_RECORD(context, net_ebpf_sock_addr_t, base);
 
     if (context_out != NULL && *context_size_out >= sizeof(bpf_sock_addr_t)) {
         memcpy(context_out, context, sizeof(bpf_sock_addr_t));
@@ -2021,8 +2025,8 @@ _ebpf_sock_addr_context_destroy(
         *context_size_out = 0;
     }
 
-    if (context) {
-        ExFreePool(context);
+    if (sock_addr_ctx) {
+        ExFreePool(sock_addr_ctx);
     }
     NET_EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -90,7 +90,7 @@ static ebpf_program_data_t _ebpf_sock_ops_program_data = {
     .context_create = &_ebpf_sock_ops_context_create,
     .context_destroy = &_ebpf_sock_ops_context_destroy,
     .required_irql = DISPATCH_LEVEL,
-    .capabilities = PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER,
+    .capabilities = {.supports_context_header = true},
 };
 
 // Set the program type as the provider module id.

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -90,7 +90,7 @@ static ebpf_program_data_t _ebpf_sock_ops_program_data = {
     .context_create = &_ebpf_sock_ops_context_create,
     .context_destroy = &_ebpf_sock_ops_context_destroy,
     .required_irql = DISPATCH_LEVEL,
-    .context_header = true,
+    .capabilities = PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER,
 };
 
 // Set the program type as the provider module id.

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -17,6 +17,12 @@
 
 struct _net_ebpf_extension_sock_ops_wfp_filter_context;
 
+typedef struct _net_ebpf_bpf_sock_ops
+{
+    EBPF_CONTEXT_HEADER;
+    bpf_sock_ops_t context;
+} net_ebpf_bpf_sock_ops_t;
+
 /**
  * @brief Custom context associated with WFP flows that are notified to eBPF programs.
  */
@@ -25,8 +31,8 @@ typedef struct _net_ebpf_extension_sock_ops_wfp_flow_context
     LIST_ENTRY link;                                         ///< Link to next flow context.
     net_ebpf_extension_flow_context_parameters_t parameters; ///< WFP flow parameters.
     struct _net_ebpf_extension_sock_ops_wfp_filter_context*
-        filter_context;     ///< WFP filter context associated with this flow.
-    bpf_sock_ops_t context; ///< sock_ops context.
+        filter_context;              ///< WFP filter context associated with this flow.
+    net_ebpf_bpf_sock_ops_t context; ///< sock_ops context.
 } net_ebpf_extension_sock_ops_wfp_flow_context_t;
 
 typedef struct _net_ebpf_extension_sock_ops_wfp_flow_context_list
@@ -84,6 +90,7 @@ static ebpf_program_data_t _ebpf_sock_ops_program_data = {
     .context_create = &_ebpf_sock_ops_context_create,
     .context_destroy = &_ebpf_sock_ops_context_destroy,
     .required_irql = DISPATCH_LEVEL,
+    .context_header = true,
 };
 
 // Set the program type as the provider module id.
@@ -430,7 +437,7 @@ net_ebpf_extension_sock_ops_flow_established_classify(
     REFERENCE_FILTER_CONTEXT(&filter_context->base);
     local_flow_context->filter_context = filter_context;
 
-    sock_ops_context = &local_flow_context->context;
+    sock_ops_context = &local_flow_context->context.context;
     _net_ebpf_extension_sock_ops_copy_wfp_connection_fields(incoming_fixed_values, sock_ops_context);
 
     client_compartment_id = filter_context->compartment_id;
@@ -552,7 +559,7 @@ net_ebpf_extension_sock_ops_flow_delete(uint16_t layer_id, uint32_t callout_id, 
         local_flow_context->parameters.flow_id);
 
     // Invoke eBPF program with connection deleted socket event.
-    sock_ops_context = &local_flow_context->context;
+    sock_ops_context = &local_flow_context->context.context;
     sock_ops_context->op = BPF_SOCK_OPS_CONNECTION_DELETED_CB;
     if (net_ebpf_extension_hook_invoke_program(attached_client, sock_ops_context, &result) != EBPF_SUCCESS) {
         goto Exit;
@@ -582,6 +589,7 @@ _ebpf_sock_ops_context_create(
 {
     ebpf_result_t result;
     bpf_sock_ops_t* sock_ops_context = NULL;
+    net_ebpf_bpf_sock_ops_t* context_header = NULL;
 
     *context = NULL;
 
@@ -601,23 +609,24 @@ _ebpf_sock_ops_context_create(
         goto Exit;
     }
 
-    sock_ops_context = (bpf_sock_ops_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(bpf_sock_ops_t), NET_EBPF_EXTENSION_POOL_TAG);
+    context_header = (net_ebpf_bpf_sock_ops_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(net_ebpf_bpf_sock_ops_t), NET_EBPF_EXTENSION_POOL_TAG);
 
-    if (sock_ops_context == NULL) {
+    if (context_header == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
+    sock_ops_context = &context_header->context;
 
     memcpy(sock_ops_context, context_in, sizeof(bpf_sock_ops_t));
 
     *context = sock_ops_context;
-    sock_ops_context = NULL;
+    context_header = NULL;
     result = EBPF_SUCCESS;
 
 Exit:
-    if (sock_ops_context != NULL) {
-        ExFreePool(sock_ops_context);
+    if (context_header != NULL) {
+        ExFreePool(context_header);
     }
 
     NET_EBPF_EXT_RETURN_RESULT(result);
@@ -632,10 +641,13 @@ _ebpf_sock_ops_context_destroy(
     _Inout_ size_t* context_size_out)
 {
     NET_EBPF_EXT_LOG_ENTRY();
+    net_ebpf_bpf_sock_ops_t* context_header = NULL;
+
     UNREFERENCED_PARAMETER(data_out);
     if (context == NULL) {
         goto Exit;
     }
+    context_header = CONTAINING_RECORD(context, net_ebpf_bpf_sock_ops_t, context);
 
     // This provider doesn't support data.
 
@@ -648,7 +660,7 @@ _ebpf_sock_ops_context_destroy(
         *context_size_out = 0;
     }
 
-    ExFreePool(context);
+    ExFreePool(context_header);
 Exit:
     NET_EBPF_EXT_LOG_EXIT();
 }

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -3176,6 +3176,58 @@ extension_reload_test_common(_In_ const char* file_name, ebpf_execution_type_t e
         REQUIRE(hook.fire(ctx, &hook_result) != EBPF_SUCCESS);
         REQUIRE(hook_result != 42);
     }
+
+    // Reload the extension again with original data
+    {
+        ebpf_program_data_t changed_program_data = _test_ebpf_sample_extension_program_data;
+
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
+        program_info_provider_t sample_program_info;
+        REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE, &changed_program_data) == EBPF_SUCCESS);
+
+        // Program should re-attach to the hook.
+
+        // Program should run.
+        uint32_t hook_result = MAXUINT32;
+        REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result == 42);
+    }
+
+    // Reload the extension with changed context_header support.
+    {
+        ebpf_program_data_t changed_program_data = _test_ebpf_sample_extension_program_data;
+        changed_program_data.capabilities = 0;
+
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
+        program_info_provider_t sample_program_info;
+        REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE, &changed_program_data) == EBPF_SUCCESS);
+
+        // Program should re-attach to the hook.
+
+        // Program should not run.
+        uint32_t hook_result = MAXUINT32;
+        REQUIRE(hook.fire(ctx, &hook_result) != EBPF_SUCCESS);
+        REQUIRE(hook_result != 42);
+    }
+
+    // Reload the extension again with original data
+    {
+        ebpf_program_data_t changed_program_data = _test_ebpf_sample_extension_program_data;
+
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
+        program_info_provider_t sample_program_info;
+        REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE, &changed_program_data) == EBPF_SUCCESS);
+
+        // Program should re-attach to the hook.
+
+        // Program should run.
+        uint32_t hook_result = MAXUINT32;
+        REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result == 42);
+    }
 }
 
 static void

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -3067,7 +3067,6 @@ extension_reload_test_common(_In_ const char* file_name, ebpf_execution_type_t e
     // Should fail.
     REQUIRE(
         ebpf_program_load(
-            // execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o",
             file_name,
             BPF_PROG_TYPE_UNSPEC,
             execution_type,

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -542,10 +542,10 @@ divide_by_zero_test_um(ebpf_execution_type_t execution_type)
     auto packet = prepare_udp_packet(0, ETHERNET_TYPE_IPV4);
 
     // Empty context (not used by the eBPF program).
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT;
 
     uint32_t hook_result;
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 0);
 
     hook.detach_and_close_link(&link);
@@ -626,11 +626,12 @@ emulate_bind(std::function<ebpf_result_t(void*, uint32_t*)>& invoke, uint64_t pi
 {
     uint32_t result;
     std::string app_id = appid;
-    bind_md_t ctx{0};
-    ctx.app_id_start = (uint8_t*)app_id.c_str();
-    ctx.app_id_end = (uint8_t*)(app_id.c_str()) + app_id.size();
-    ctx.process_id = pid;
-    ctx.operation = BIND_OPERATION_BIND;
+    INITIALIZE_BIND_CONTEXT
+
+    ctx->app_id_start = (uint8_t*)app_id.c_str();
+    ctx->app_id_end = (uint8_t*)(app_id.c_str()) + app_id.size();
+    ctx->process_id = pid;
+    ctx->operation = BIND_OPERATION_BIND;
     REQUIRE(invoke(reinterpret_cast<void*>(&ctx), &result) == EBPF_SUCCESS);
     return static_cast<bind_action_t>(result);
 }
@@ -640,10 +641,11 @@ emulate_unbind(std::function<ebpf_result_t(void*, uint32_t*)>& invoke, uint64_t 
 {
     uint32_t result;
     std::string app_id = appid;
-    bind_md_t ctx{0};
-    ctx.process_id = pid;
-    ctx.operation = BIND_OPERATION_UNBIND;
-    REQUIRE(invoke(&ctx, &result) == EBPF_SUCCESS);
+    INITIALIZE_BIND_CONTEXT
+
+    ctx->process_id = pid;
+    ctx->operation = BIND_OPERATION_UNBIND;
+    REQUIRE(invoke(ctx, &result) == EBPF_SUCCESS);
 }
 
 void
@@ -960,10 +962,10 @@ _utility_helper_functions_test(ebpf_execution_type_t execution_type)
     bpf_object* object = program_helper.get_object();
 
     // Dummy context (not used by the eBPF program).
-    sample_program_context_t ctx{};
+    INITIALIZE_SAMPLE_CONTEXT
 
     uint32_t hook_result;
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 0);
 
     verify_utility_helper_results(object, true);
@@ -999,8 +1001,8 @@ map_test(ebpf_execution_type_t execution_type)
 
     REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
     uint32_t hook_result;
-    sample_program_context_t ctx = {0};
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    INITIALIZE_SAMPLE_CONTEXT
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     // Program should return 0 if all the map tests pass.
     REQUIRE(hook_result >= 0);
 
@@ -1840,11 +1842,11 @@ TEST_CASE("printk", "[end_to_end]")
     // The current bind hook only works with IPv4, so compose a sample IPv4 context.
     SOCKADDR_IN addr = {AF_INET};
     addr.sin_port = htons(80);
-    bind_md_t ctx = {0};
-    ctx.process_id = GetCurrentProcessId();
-    ctx.protocol = 2;
-    ctx.socket_address_length = sizeof(addr);
-    memcpy(&ctx.socket_address, &addr, ctx.socket_address_length);
+    INITIALIZE_BIND_CONTEXT
+    ctx->process_id = GetCurrentProcessId();
+    ctx->protocol = 2;
+    ctx->socket_address_length = sizeof(addr);
+    memcpy(&ctx->socket_address, &addr, ctx->socket_address_length);
 
     capture_helper_t capture;
     std::vector<std::string> output;
@@ -1853,7 +1855,7 @@ TEST_CASE("printk", "[end_to_end]")
     if (error == NO_ERROR) {
         usersim_trace_logging_set_enabled(true, EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_PRINTK);
 #pragma warning(suppress : 28193) // hook_fire_result is examined
-        ebpf_result_t hook_fire_result = hook.fire(&ctx, &hook_result);
+        ebpf_result_t hook_fire_result = hook.fire(ctx, &hook_result);
         usersim_trace_logging_set_enabled(false, 0, 0);
 
         output = capture.buffer_to_printk_vector(capture.get_stdout_contents());
@@ -1862,11 +1864,11 @@ TEST_CASE("printk", "[end_to_end]")
     std::vector<std::string> expected_output = {
         "Hello, world",
         "Hello, world",
-        "PID: " + std::to_string(ctx.process_id) + " using %u",
-        "PID: " + std::to_string(ctx.process_id) + " using %lu",
-        "PID: " + std::to_string(ctx.process_id) + " using %llu",
-        "PID: " + std::to_string(ctx.process_id) + " PROTO: 2",
-        "PID: " + std::to_string(ctx.process_id) + " PROTO: 2 ADDRLEN: 16",
+        "PID: " + std::to_string(ctx->process_id) + " using %u",
+        "PID: " + std::to_string(ctx->process_id) + " using %lu",
+        "PID: " + std::to_string(ctx->process_id) + " using %llu",
+        "PID: " + std::to_string(ctx->process_id) + " PROTO: 2",
+        "PID: " + std::to_string(ctx->process_id) + " PROTO: 2 ADDRLEN: 16",
         "100% done"};
     REQUIRE(output.size() == expected_output.size());
     size_t output_length = 0;
@@ -1965,10 +1967,10 @@ TEST_CASE("link_tests", "[end_to_end]")
         SAMPLE_PATH "bpf.o", BPF_PROG_TYPE_SAMPLE, "func", EBPF_EXECUTION_INTERPRET, nullptr, 0, hook);
 
     // Dummy context (not used by the eBPF program).
-    sample_program_context_t ctx = {0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t result;
 
-    REQUIRE(hook.fire(&ctx, &result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &result) == EBPF_SUCCESS);
     bpf_program* program = bpf_object__find_program_by_name(program_helper.get_object(), "func");
     REQUIRE(program != nullptr);
 
@@ -2035,10 +2037,10 @@ _map_reuse_test(ebpf_execution_type_t execution_type)
     REQUIRE(bpf_obj_get_info_by_fd(outer_map_fd, &info, &info_size) == 0);
     REQUIRE(info.name[0] == 0);
 
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t hook_result;
 
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
 
     key = 0;
@@ -2145,10 +2147,10 @@ _auto_pinned_maps_test(ebpf_execution_type_t execution_type)
     fd_t port_map_fd = bpf_obj_get("/ebpf/global/port_map");
     REQUIRE(port_map_fd > 0);
 
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t hook_result;
 
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
 
     key = 0;
@@ -2218,10 +2220,10 @@ TEST_CASE("auto_pinned_maps_custom_path", "[end_to_end]")
     fd_t port_map_fd = bpf_obj_get("/custompath/global/port_map");
     REQUIRE(port_map_fd > 0);
 
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t hook_result;
 
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
 
     key = 0;
@@ -2329,10 +2331,10 @@ _map_reuse_2_test(ebpf_execution_type_t execution_type)
     program_load_attach_helper_t program_helper;
     program_helper.initialize(file_name, BPF_PROG_TYPE_SAMPLE, "lookup_update", EBPF_EXECUTION_ANY, nullptr, 0, hook);
 
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t hook_result;
 
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
 
     key = 0;
@@ -2405,10 +2407,10 @@ _map_reuse_3_test(ebpf_execution_type_t execution_type)
     program_load_attach_helper_t program_helper;
     program_helper.initialize(file_name, BPF_PROG_TYPE_SAMPLE, "lookup_update", EBPF_EXECUTION_ANY, nullptr, 0, hook);
 
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t hook_result;
 
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
 
     key = 0;
@@ -3048,13 +3050,13 @@ TEST_CASE("test_ebpf_object_set_execution_type", "[end_to_end]")
 }
 
 static void
-extension_reload_test(ebpf_execution_type_t execution_type)
+extension_reload_test_common(_In_ const char* file_name, ebpf_execution_type_t execution_type)
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
 
     // Empty context (not used by the eBPF program).
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
 
     // Try loading without the extension loaded.
     bpf_object_ptr unique_test_sample_ebpf_object;
@@ -3065,7 +3067,8 @@ extension_reload_test(ebpf_execution_type_t execution_type)
     // Should fail.
     REQUIRE(
         ebpf_program_load(
-            execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o",
+            // execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o",
+            file_name,
             BPF_PROG_TYPE_UNSPEC,
             execution_type,
             &unique_test_sample_ebpf_object,
@@ -3082,7 +3085,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
         REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
 
         result = ebpf_program_load(
-            execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o",
+            file_name,
             BPF_PROG_TYPE_UNSPEC,
             execution_type,
             &unique_test_sample_ebpf_object,
@@ -3103,7 +3106,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
 
         // Program should run.
         uint32_t hook_result = MAXUINT32;
-        REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
         REQUIRE(hook_result == 42);
 
         // Unload the extension (sample_program_info and hook will be destroyed).
@@ -3120,7 +3123,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
 
         // Program should run.
         uint32_t hook_result = MAXUINT32;
-        REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
         REQUIRE(hook_result == 42);
     }
 
@@ -3142,7 +3145,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
 
         // Program should not run.
         uint32_t hook_result = MAXUINT32;
-        REQUIRE(hook.fire(&ctx, &hook_result) != EBPF_SUCCESS);
+        REQUIRE(hook.fire(ctx, &hook_result) != EBPF_SUCCESS);
         REQUIRE(hook_result != 42);
     }
 
@@ -3170,12 +3173,30 @@ extension_reload_test(ebpf_execution_type_t execution_type)
 
         // Program should not run.
         uint32_t hook_result = MAXUINT32;
-        REQUIRE(hook.fire(&ctx, &hook_result) != EBPF_SUCCESS);
+        REQUIRE(hook.fire(ctx, &hook_result) != EBPF_SUCCESS);
         REQUIRE(hook_result != 42);
     }
 }
 
+static void
+extension_reload_test(ebpf_execution_type_t execution_type)
+{
+    const char* file_name = execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o";
+    extension_reload_test_common(file_name, execution_type);
+}
+
 DECLARE_ALL_TEST_CASES("extension_reload_test", "[end_to_end]", extension_reload_test);
+
+static void
+_extension_reload_test_implicit_context(ebpf_execution_type_t execution_type)
+{
+    const char* file_name = execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_implicit_helpers_um.dll"
+                                                                    : "test_sample_implicit_helpers.o";
+    extension_reload_test_common(file_name, execution_type);
+}
+
+DECLARE_ALL_TEST_CASES(
+    "extension_reload_test_implicit_context", "[end_to_end]", _extension_reload_test_implicit_context);
 
 // This test tests resource reclamation and clean-up after a premature/abnormal user mode application exit.
 TEST_CASE("close_unload_test", "[close_cleanup]")

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -632,7 +632,7 @@ emulate_bind(std::function<ebpf_result_t(void*, uint32_t*)>& invoke, uint64_t pi
     ctx->app_id_end = (uint8_t*)(app_id.c_str()) + app_id.size();
     ctx->process_id = pid;
     ctx->operation = BIND_OPERATION_BIND;
-    REQUIRE(invoke(reinterpret_cast<void*>(&ctx), &result) == EBPF_SUCCESS);
+    REQUIRE(invoke(reinterpret_cast<void*>(ctx), &result) == EBPF_SUCCESS);
     return static_cast<bind_action_t>(result);
 }
 
@@ -3186,17 +3186,6 @@ extension_reload_test(ebpf_execution_type_t execution_type)
 }
 
 DECLARE_ALL_TEST_CASES("extension_reload_test", "[end_to_end]", extension_reload_test);
-
-static void
-_extension_reload_test_implicit_context(ebpf_execution_type_t execution_type)
-{
-    const char* file_name = execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_implicit_helpers_um.dll"
-                                                                    : "test_sample_implicit_helpers.o";
-    extension_reload_test_common(file_name, execution_type);
-}
-
-DECLARE_ALL_TEST_CASES(
-    "extension_reload_test_implicit_context", "[end_to_end]", _extension_reload_test_implicit_context);
 
 // This test tests resource reclamation and clean-up after a premature/abnormal user mode application exit.
 TEST_CASE("close_unload_test", "[close_cleanup]")

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -3197,7 +3197,7 @@ extension_reload_test_common(_In_ const char* file_name, ebpf_execution_type_t e
     // Reload the extension with changed context_header support.
     {
         ebpf_program_data_t changed_program_data = _test_ebpf_sample_extension_program_data;
-        changed_program_data.capabilities = 0;
+        changed_program_data.capabilities.value = 0;
 
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
         REQUIRE(hook.initialize() == EBPF_SUCCESS);

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -673,14 +673,7 @@ static ebpf_program_data_t _ebpf_xdp_test_program_data = {
 
 // Bind.
 static ebpf_program_data_t _ebpf_bind_program_data = {
-    EBPF_PROGRAM_DATA_HEADER,
-    &_ebpf_bind_program_info,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    0,
-    PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER};
+    EBPF_PROGRAM_DATA_HEADER, &_ebpf_bind_program_info, NULL, NULL, NULL, NULL, 0, {true}};
 
 // SOCK_ADDR.
 static int
@@ -911,7 +904,7 @@ static ebpf_program_data_t _test_ebpf_sample_extension_program_data = {
     _sample_test_context_create,
     _sample_test_context_destroy,
     0,
-    PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER};
+    {true}};
 
 #define TEST_EBPF_SAMPLE_EXTENSION_NPI_PROVIDER_VERSION 0
 

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -673,7 +673,14 @@ static ebpf_program_data_t _ebpf_xdp_test_program_data = {
 
 // Bind.
 static ebpf_program_data_t _ebpf_bind_program_data = {
-    EBPF_PROGRAM_DATA_HEADER, &_ebpf_bind_program_info, NULL, NULL, NULL, NULL, 0, true};
+    EBPF_PROGRAM_DATA_HEADER,
+    &_ebpf_bind_program_info,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    0,
+    PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER};
 
 // SOCK_ADDR.
 static int
@@ -904,7 +911,7 @@ static ebpf_program_data_t _test_ebpf_sample_extension_program_data = {
     _sample_test_context_create,
     _sample_test_context_destroy,
     0,
-    true};
+    PROGRAM_DATA_CAPABILITY_CONTEXT_HEADER};
 
 #define TEST_EBPF_SAMPLE_EXTENSION_NPI_PROVIDER_VERSION 0
 

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -673,7 +673,7 @@ static ebpf_program_data_t _ebpf_xdp_test_program_data = {
 
 // Bind.
 static ebpf_program_data_t _ebpf_bind_program_data = {
-    EBPF_PROGRAM_DATA_HEADER, &_ebpf_bind_program_info, NULL, NULL, NULL, NULL, 0, {true}};
+    EBPF_PROGRAM_DATA_HEADER, &_ebpf_bind_program_info, NULL, NULL, NULL, NULL, 0, {.supports_context_header = true}};
 
 // SOCK_ADDR.
 static int
@@ -904,7 +904,7 @@ static ebpf_program_data_t _test_ebpf_sample_extension_program_data = {
     _sample_test_context_create,
     _sample_test_context_destroy,
     0,
-    {true}};
+    {.supports_context_header = true}};
 
 #define TEST_EBPF_SAMPLE_EXTENSION_NPI_PROVIDER_VERSION 0
 

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -82,7 +82,7 @@ typedef class _ebpf_program_test_state
         ebpf_epoch_state_t epoch_state;
         ebpf_epoch_enter(&epoch_state);
         ebpf_get_execution_context_state(&state);
-        result = ebpf_program_invoke(program, context, &result, &state);
+        result = ebpf_program_invoke(program, false, context, &result, &state);
         ebpf_epoch_exit(&epoch_state);
         REQUIRE(result == EBPF_SUCCESS);
     }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1673,7 +1673,7 @@ TEST_CASE("disallow prog_array mixed context_header support", "[libbpf]")
     // Now load program without context header support.
     {
         ebpf_program_data_t changed_program_data = _test_ebpf_sample_extension_program_data;
-        changed_program_data.capabilities = 0;
+        changed_program_data.capabilities.value = 0;
         program_info_provider_t sample_program_info;
         REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE, &changed_program_data) == EBPF_SUCCESS);
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1839,9 +1839,9 @@ _array_of_maps_test(ebpf_execution_type_t execution_type, _In_ PCSTR dll_name, _
     REQUIRE(link != nullptr);
 
     // Now run the ebpf program.
-    sample_program_context_t ctx{0};
+    INITIALIZE_SAMPLE_CONTEXT
     uint32_t result;
-    REQUIRE(hook.fire(&ctx, &result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx, &result) == EBPF_SUCCESS);
 
     // Verify the return value is what we saved in the inner map.
     REQUIRE(result == inner_value);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1641,6 +1641,71 @@ TEST_CASE("disallow prog_array mixed program type values", "[libbpf]")
     bpf_object__close(bind_object);
     bpf_object__close(sample_object);
 }
+
+TEST_CASE("disallow prog_array mixed context_header support", "[libbpf]")
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+    program_info_provider_t bind_program_info;
+    REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
+    int program1_fd;
+    int program2_fd;
+    struct bpf_object* sample_object1 = nullptr;
+    struct bpf_object* sample_object2 = nullptr;
+
+    // Load the same program 2 times, but with different "context_header" support from providers.
+
+    // First load program with context header support.
+    {
+        program_info_provider_t sample_program_info;
+        REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+        sample_object1 = bpf_object__open("test_sample_ebpf.o");
+        REQUIRE(sample_object1 != nullptr);
+        // Load the program(s).
+        REQUIRE(bpf_object__load(sample_object1) == 0);
+        struct bpf_program* sample_program = bpf_object__find_program_by_name(sample_object1, "test_program_entry");
+        program1_fd = bpf_program__fd(const_cast<const bpf_program*>(sample_program));
+
+        // Extension will unload now.
+    }
+
+    // Now load program without context header support.
+    {
+        ebpf_program_data_t changed_program_data = _test_ebpf_sample_extension_program_data;
+        changed_program_data.capabilities = 0;
+        program_info_provider_t sample_program_info;
+        REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE, &changed_program_data) == EBPF_SUCCESS);
+
+        sample_object2 = bpf_object__open("test_sample_ebpf.o");
+        REQUIRE(sample_object2 != nullptr);
+        // Load the program(s).
+        REQUIRE(bpf_object__load(sample_object2) == 0);
+        struct bpf_program* sample_program = bpf_object__find_program_by_name(sample_object2, "test_program_entry");
+        program2_fd = bpf_program__fd(const_cast<const bpf_program*>(sample_program));
+
+        // Extension will unload now.
+    }
+
+    // Create a map.
+    int map_fd = bpf_map_create(BPF_MAP_TYPE_PROG_ARRAY, nullptr, sizeof(uint32_t), sizeof(uint32_t), 2, nullptr);
+    REQUIRE(map_fd > 0);
+
+    // Since the map is not yet associated with a program, the first program fd
+    // we add will become the PROG_ARRAY's program type.
+    int index = 0;
+    int error = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&program1_fd, 0);
+    REQUIRE(error == 0);
+
+    // Adding an entry with same program type but different context_header support should fail.
+    error = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&program2_fd, 0);
+    REQUIRE(error < 0);
+    REQUIRE(errno == EBADF);
+
+    Platform::_close(map_fd);
+    bpf_object__close(sample_object1);
+    bpf_object__close(sample_object2);
+}
 #endif
 
 static void

--- a/undocked/tests/sample/ext/drv/sample_ext.c
+++ b/undocked/tests/sample/ext/drv/sample_ext.c
@@ -77,7 +77,9 @@ static ebpf_program_data_t _sample_ebpf_extension_program_data = {
     .program_type_specific_helper_function_addresses = &_sample_ebpf_extension_helper_function_address_table,
     .global_helper_function_addresses = &_sample_global_helper_function_address_table,
     .context_create = &_sample_context_create,
-    .context_destroy = &_sample_context_destroy};
+    .context_destroy = &_sample_context_destroy,
+    DISPATCH_LEVEL,
+    true};
 
 NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_program_info_provider_moduleid = {
     sizeof(NPI_MODULEID), MIT_GUID, EBPF_PROGRAM_TYPE_SAMPLE_GUID};
@@ -589,9 +591,10 @@ sample_ebpf_extension_profile_program(
     LARGE_INTEGER end;
     uint32_t result;
     KIRQL old_irql = PASSIVE_LEVEL;
-    sample_program_context_t program_context = {
-        request->data, request->data + request_length - FIELD_OFFSET(sample_ebpf_ext_profile_request_t, data)};
+    sample_program_context_header_t context_header = {
+        {0}, request->data, request->data + request_length - FIELD_OFFSET(sample_ebpf_ext_profile_request_t, data)};
 
+    sample_program_context_t* program_context = (sample_program_context_t*)&context_header.context;
     sample_ebpf_extension_hook_provider_t* hook_provider_context = &_sample_ebpf_extension_hook_provider_context;
 
     sample_ebpf_extension_hook_client_t* hook_client = hook_provider_context->attached_client;
@@ -603,14 +606,14 @@ sample_ebpf_extension_profile_program(
     ebpf_program_invoke_function_t invoke_program = hook_client->invoke_program;
     const void* client_binding_context = hook_client->client_binding_context;
 
-    program_context.uint32_data = KeGetCurrentProcessorNumber();
+    program_context->uint32_data = KeGetCurrentProcessorNumber();
 
     KeQueryPerformanceCounter(&start);
     if (request->flags & SAMPLE_EBPF_EXT_FLAG_DISPATCH) {
         KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
     }
     for (size_t i = 0; i < request->iterations; i++) {
-        invoke_program(client_binding_context, &program_context, &result);
+        invoke_program(client_binding_context, program_context, &result);
     }
     if (request->flags & SAMPLE_EBPF_EXT_FLAG_DISPATCH) {
         KeLowerIrql(old_irql);
@@ -688,6 +691,7 @@ _sample_context_create(
     _Outptr_ void** context)
 {
     ebpf_result_t result;
+    sample_program_context_header_t* context_header = NULL;
     sample_program_context_t* sample_context = NULL;
 
     *context = NULL;
@@ -704,22 +708,23 @@ _sample_context_create(
         goto Exit;
     }
 
-    sample_context =
-        cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, sizeof(sample_program_context_t), SAMPLE_EXT_POOL_TAG_DEFAULT);
-    if (sample_context == NULL) {
+    context_header = cxplat_allocate(
+        CXPLAT_POOL_FLAG_NON_PAGED, sizeof(sample_program_context_header_t), SAMPLE_EXT_POOL_TAG_DEFAULT);
+    if (context_header == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
+    sample_context = (sample_program_context_t*)&context_header->context;
 
     memcpy(sample_context, context_in, sizeof(sample_program_context_t));
 
     *context = sample_context;
-    sample_context = NULL;
+    context_header = NULL;
     result = EBPF_SUCCESS;
 
 Exit:
-    if (sample_context != NULL) {
-        CXPLAT_FREE(sample_context);
+    if (context_header != NULL) {
+        CXPLAT_FREE(context_header);
     }
 
     return result;
@@ -734,9 +739,11 @@ _sample_context_destroy(
     _Inout_ size_t* context_size_out)
 {
     UNREFERENCED_PARAMETER(data_out);
+    sample_program_context_header_t* context_header = NULL;
     if (context == NULL) {
         return;
     }
+    context_header = CONTAINING_RECORD(context, sample_program_context_header_t, context);
 
     // This provider doesn't support data.
     *data_size_out = 0;
@@ -748,5 +755,5 @@ _sample_context_destroy(
         *context_size_out = 0;
     }
 
-    CXPLAT_FREE(context);
+    CXPLAT_FREE(context_header);
 }

--- a/undocked/tests/sample/ext/drv/sample_ext.h
+++ b/undocked/tests/sample/ext/drv/sample_ext.h
@@ -8,12 +8,17 @@
  */
 
 #include "ebpf_extension.h"
+#include "sample_ext_helpers.h"
 #include "sample_ext_ioctls.h"
 
 #include <ntifs.h> // Must be included before ntddk.h
 #include <ntddk.h>
 
-typedef struct _sample_program_context sample_program_context_t;
+typedef struct _sample_program_context_header
+{
+    EBPF_CONTEXT_HEADER;
+    sample_program_context_t context;
+} sample_program_context_header_t;
 
 /**
  * @brief Register program information NPI provider.

--- a/undocked/tests/sample/ext/drv/sample_ext_drv.c
+++ b/undocked/tests/sample/ext/drv/sample_ext_drv.c
@@ -217,7 +217,8 @@ _sample_ebpf_ext_driver_io_device_control(
     void* output_buffer = NULL;
     size_t actual_input_length = 0;
     size_t actual_output_length = 0;
-    sample_program_context_t program_context = {0};
+    sample_program_context_header_t context_header = {0};
+    sample_program_context_t* program_context = &context_header.context;
     uint32_t program_result = 0;
     ebpf_result_t result = EBPF_INVALID_ARGUMENT;
 
@@ -284,9 +285,9 @@ _sample_ebpf_ext_driver_io_device_control(
                 }
 
                 // Invoke the eBPF program. Pass the output buffer as program context data.
-                program_context.data_start = output_buffer;
-                program_context.data_end = (uint8_t*)output_buffer + output_buffer_length;
-                result = sample_ebpf_extension_invoke_program(&program_context, &program_result);
+                program_context->data_start = output_buffer;
+                program_context->data_end = (uint8_t*)output_buffer + output_buffer_length;
+                result = sample_ebpf_extension_invoke_program(program_context, &program_result);
             }
         } else {
             status = STATUS_INVALID_PARAMETER;
@@ -365,12 +366,12 @@ _sample_ebpf_ext_driver_io_device_control(
                 goto Done;
             }
 
-            program_context.data_start = batch_run_request->data;
-            program_context.data_end = (uint8_t*)batch_run_request + input_buffer_length;
+            program_context->data_start = batch_run_request->data;
+            program_context->data_end = (uint8_t*)batch_run_request + input_buffer_length;
 
             // Invoke the eBPF program. Pass the output buffer as program context data.
             for (uint32_t i = 0; i < batch_run_request->count; i++) {
-                result = sample_ebpf_extension_invoke_batch_program(&program_context, &context_state, &program_result);
+                result = sample_ebpf_extension_invoke_batch_program(program_context, &context_state, &program_result);
                 if (result != EBPF_SUCCESS) {
                     status = STATUS_UNSUCCESSFUL;
                     break;


### PR DESCRIPTION
Fixes part of #3645

## Description

This PR adds (an optional) support for new `context_header`, where an extension can opt in to allocate an array of `uint64_t` of size 8 in the context passed to the eBPF program. The extra header allocated by the extension is then used by the eBPF runtime to store the eBPF state, instead of relying on per-CPU or per-thread runtime state to store tail call information.

### Perf Numbers:
With these changes, there is around **22**% improvement in the tail call numbers.

#### Baseline:
```
C:\performance>release\bpf_performance_runner.exe -i tests.yml -e .sys -r -t "bpf_tail_call"
Timestamp,Test,Average Duration (ns),CPU 0 Duration (ns),CPU 1 Duration (ns),CPU 2 Duration (ns),CPU 3 Duration (ns),CPU 4 Duration (ns),CPU 5 Duration (ns),CPU 6 Duration (ns),CPU 7 Duration (ns)
2024-07-11T03:26:31-0800,bpf_tail_call,278,279,282,275,279,276,278,277,279
```

#### After:
```
C:\performance>release\bpf_performance_runner.exe -i tests.yml -e .sys -r -t "bpf_tail_call"
Timestamp,Test,Average Duration (ns),CPU 0 Duration (ns),CPU 1 Duration (ns),CPU 2 Duration (ns),CPU 3 Duration (ns),CPU 4 Duration (ns),CPU 5 Duration (ns),CPU 6 Duration (ns),CPU 7 Duration (ns)
2024-07-11T03:24:22-0800,bpf_tail_call,215,218,214,215,215,215,215,216,215
```

### Code Changes:
1. Add capabilities field in `ebpf_program_data_t` where the program information provider (i.e. extension) can declare whether it supports `context_header`.
2. Changes in tail call and program invocation path to use "fast path" when the program information provider does support this.
3. Changes in PROG_ARRAY_MAP validation to ensure that all programs added to prog array map either support or dont support `context_header`.
4. Updated `sample ext`, `sock_addr`, `sock_ops` providers to support `context_header`

## Testing

Existing CICD. Also added tests to validate the below cases:
1. extension restart
2. prog_array map update

## Documentation

Updated documentation for extension development.

## Installation

No
