### PR TITLE
Upgrade all C_ASSERT to static_assert

### DIFF
--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#pragma pack(push)
+#pragma pack(1)
 struct tcphdr
 {
     uint16_t source;
@@ -27,9 +29,18 @@ struct tcphdr
     uint16_t check;   // Checksum
     uint16_t urg_ptr; // Urgent Pointer
 };
+#pragma pack(pop)
 
-// Verify the bit fields give the correct header size.
-#ifndef C_ASSERT
-#define C_ASSERT(e) typedef char __C_ASSERT__[(e) ? 1 : -1]
+#ifndef FIELD_OFFSET
+#define FIELD_OFFSET(type, field) ((long)&(((type*)0)->field))
 #endif
-C_ASSERT(sizeof(struct tcphdr) == 20);
+
+// check the offset of each field
+static_assert(FIELD_OFFSET(struct tcphdr, source) == 0, "source offset mismatch");
+static_assert(FIELD_OFFSET(struct tcphdr, dest) == 2, "dest offset mismatch");
+static_assert(FIELD_OFFSET(struct tcphdr, seq) == 4, "seq offset mismatch");
+static_assert(FIELD_OFFSET(struct tcphdr, ack_seq) == 8, "ack_seq offset mismatch");
+// Skip bit fields
+static_assert(FIELD_OFFSET(struct tcphdr, window) == 14, "window offset mismatch");
+static_assert(FIELD_OFFSET(struct tcphdr, check) == 16, "check offset mismatch");
+static_assert(FIELD_OFFSET(struct tcphdr, urg_ptr) == 18, "urg_ptr offset mismatch");

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -99,9 +99,10 @@ static const ebpf_extension_program_dispatch_table_t _ebpf_link_dispatch_table =
 };
 
 // Assert that the invoke function is aligned with ebpf_extension_dispatch_table_t->function.
-C_ASSERT(
+static_assert(
     EBPF_OFFSET_OF(ebpf_extension_dispatch_table_t, function) ==
-    EBPF_OFFSET_OF(ebpf_extension_program_dispatch_table_t, ebpf_program_invoke_function));
+        EBPF_OFFSET_OF(ebpf_extension_program_dispatch_table_t, ebpf_program_invoke_function),
+    "Invoke function offset mismatch.");
 
 NTSTATUS
 _ebpf_link_client_attach_provider(

--- a/libs/runtime/ebpf_bitmap.c
+++ b/libs/runtime/ebpf_bitmap.c
@@ -33,7 +33,7 @@ typedef struct _ebpf_bitmap_cursor_internal
     uint64_t current_block_copy; // Copy of the current block being searched.
 } ebpf_bitmap_cursor_internal_t;
 
-C_ASSERT(sizeof(ebpf_bitmap_cursor_internal_t) == sizeof(ebpf_bitmap_cursor_t));
+static_assert(sizeof(ebpf_bitmap_cursor_internal_t) == sizeof(ebpf_bitmap_cursor_t), "Size mismatch of cursor types.");
 
 // The number of bits within a block.
 #define BITS_IN_BLOCK (sizeof(uint64_t) * 8)


### PR DESCRIPTION
## Description

This pull request primarily focuses on modifying the assertions and structure packing in several files. The changes include replacing `C_ASSERT` with `static_assert` and adding more specific error messages, and adding `#pragma pack` directives to ensure correct alignment of structures in memory. 

Structural changes:

* [`include/net/tcp.h`](diffhunk://#diff-ff57716b18eaf625ed142c9cb45d80319f37663be3c35ef3001de8f614737111R5-R6): Added `#pragma pack(push)` and `#pragma pack(1)` before the `struct tcphdr` definition, and `#pragma pack(pop)` after it. This ensures that the structure is packed in memory without any padding, which is crucial for network protocols. [[1]](diffhunk://#diff-ff57716b18eaf625ed142c9cb45d80319f37663be3c35ef3001de8f614737111R5-R6) [[2]](diffhunk://#diff-ff57716b18eaf625ed142c9cb45d80319f37663be3c35ef3001de8f614737111R32-R46)

Assertion changes:

* [`include/net/tcp.h`](diffhunk://#diff-ff57716b18eaf625ed142c9cb45d80319f37663be3c35ef3001de8f614737111R32-R46): Replaced the `C_ASSERT` macro that checked the size of `struct tcphdr` with a series of `static_assert` statements that check the offset of each field in the structure. This provides more specific error messages if the structure layout does not match the expected layout.
* [`libs/execution_context/ebpf_link.c`](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L102-R105): Replaced a `C_ASSERT` statement with a `static_assert` statement, adding a specific error message.
* [`libs/runtime/ebpf_bitmap.c`](diffhunk://#diff-50768d17bee037575431cd2539abd9defed4b8b7b0f2a47a402f4925a9083384L36-R36): Replaced a `C_ASSERT` statement with a `static_assert` statement, adding a specific error message.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
