### PR TITLE
_ebpf_link_instance_invoke_with_context_header should call correct batch_end api

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -581,7 +581,7 @@ _ebpf_link_instance_invoke_with_context_header(
 
     return_value = _ebpf_link_instance_invoke_batch_with_context_header(
         extension_client_binding_context, program_context, result, &state);
-    (void)_ebpf_link_instance_invoke_batch_end(&state);
+    (void)_ebpf_link_instance_invoke_batch_end_with_context_header(&state);
 
 Done:
     return return_value;


### PR DESCRIPTION
Resolves: #3708

## Description

This pull request includes a change to the function `_ebpf_link_instance_invoke_with_context_header` in the file `libs/execution_context/ebpf_link.c`. The function call to `_ebpf_link_instance_invoke_batch_end` has been replaced with a call to `_ebpf_link_instance_invoke_batch_end_with_context_header`. 

## Testing

CI/CD

## Documentation

No.

## Installation

No.
