### PR TITLE
Include `export_program_info.exe` in redist nuspec

### DIFF
--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -25,6 +25,8 @@
 		<file src="ebpfapi.pdb" target="package\bin"/>
 		<file src="ebpfnetsh.dll" target="package\bin"/>
 		<file src="ebpfnetsh.pdb" target="package\bin"/>
+		<file src="export_program_info.exe" target="package\bin"/>
+		<file src="export_program_info.pdb" target="package\bin"/>
 		<!--eBPF drivers-->
 		<file src="eBPFCore.sys" target="package\bin\drivers"/>
 		<file src="eBPFCore.pdb" target="package\bin\drivers"/>


### PR DESCRIPTION
## Description

This PR adds `export_program_info.exe` to the redist packge. Earlier extension drivers used to populate the eBPF store (HKLM), but since that support is now removed, the redist package also needs to include `export_program_info.exe` that will be used to populate the eBPF store on the target machine.

## Testing

Existing CICD

## Documentation

No

## Installation

No
