### PR TITLE
Set errno for bpf_object__find_map_by_name

### DIFF
--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -247,6 +247,8 @@ bpf_object__close(struct bpf_object* object);
  * @param[in] name The name to look for.
  *
  * @returns The map found, or NULL if none.
+ *
+ * @exception ENOENT The map was not found.
  */
 struct bpf_map*
 bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name);

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -241,7 +241,7 @@ bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name)
             return pos;
         }
     }
-    return NULL;
+    return (struct bpf_map*)libbpf_err_ptr(-ENOENT);
 }
 
 int

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -483,6 +483,10 @@ TEST_CASE("libbpf program", "[libbpf]")
     REQUIRE(bpf_object__find_program_by_name(object, "not_a_valid_name") == NULL);
     REQUIRE(errno == ENOENT);
 
+    // Testing invalid map name.
+    REQUIRE(bpf_object__find_map_by_name(object, "not_a_valid_map") == NULL);
+    REQUIRE(errno == ENOENT);
+
     name = bpf_program__section_name(program);
     REQUIRE(strcmp(name, "sample_ext") == 0);
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -480,10 +480,12 @@ TEST_CASE("libbpf program", "[libbpf]")
     struct bpf_program* program = bpf_object__find_program_by_name(object, "test_program_entry");
     REQUIRE(program != nullptr);
 
+    errno = 0;
     REQUIRE(bpf_object__find_program_by_name(object, "not_a_valid_name") == NULL);
     REQUIRE(errno == ENOENT);
 
     // Testing invalid map name.
+    errno = 0;
     REQUIRE(bpf_object__find_map_by_name(object, "not_a_valid_map") == NULL);
     REQUIRE(errno == ENOENT);
 


### PR DESCRIPTION
## Description
bpf_object__find_map_by_name():
 - Set errno to ENOENT.
 - Add a case to check errno set for invalid map name.
 - Added errno in doxygen comment.

## Testing

_Do any existing tests cover this change? No. 
Are new tests needed? Yes

## Documentation

_Is there any documentation impact for this change? No

## Installation

_Is there any installer impact for this change?No
