### PR TITLE
Turn netperf on for daily runs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -614,7 +614,7 @@ jobs:
       configurations: '["Release"]'
 
   netperf:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/netperf.yml
     with:
       sha: ${{ github.sha }}


### PR DESCRIPTION
Netperf tests were disabled in daily runs due to issues in the netperf repo. They appear to be fixed now, so re-enable it.

## Description

This pull request includes a change to the `cicd.yml` file in the `.github/workflows` directory. The `netperf` job has been updated to trigger not only on `workflow_dispatch` events, but also on `schedule` events. This means that the job will now run both when manually triggered and on a set schedule.

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L617-R617): Updated the `if` condition for the `netperf` job to also trigger on `schedule` events. This allows the job to run both when manually triggered and on a set schedule.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
