### PR TITLE
Upload netperf results on schedule runs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -637,7 +637,7 @@ jobs:
 
   upload_netperf_results_azure_2022:
     needs: netperf
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_netperf_results_azure_2022
@@ -650,7 +650,7 @@ jobs:
 
   upload_netperf_results_lab_2022:
     needs: netperf
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_netperf_results_lab_2022


### PR DESCRIPTION
## Description

This pull request includes updates to the `.github/workflows/cicd.yml` file to enhance the conditions under which certain jobs are triggered. The changes ensure that the `upload_netperf_results_azure_2022` and `upload_netperf_results_lab_2022` jobs can now be triggered by both scheduled events and manual workflow dispatches.

Trigger condition updates:

* [`jobs.upload_netperf_results_azure_2022`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L640-R640): Modified the `if` condition to trigger on both `schedule` and `workflow_dispatch` events. (`.github/workflows/cicd.yml`, [.github/workflows/cicd.ymlL640-R640](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L640-R640))
* [`jobs.upload_netperf_results_lab_2022`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L653-R653): Modified the `if` condition to trigger on both `schedule` and `workflow_dispatch` events. (`.github/workflows/cicd.yml`, [.github/workflows/cicd.ymlL653-R653](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L653-R653))

## Testing

CI/CD

## Documentation

No.

## Installation

No.
