### PR TITLE
Group dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,23 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
+    groups:
+      generic:
+        patterns:
+          - "external/win-c"
+          - "external/Catch2"
+          - "external/pe-parse"
+          - "tests/external/kissfft"
 
   - package-ecosystem: "docker"
     directory: "/images"


### PR DESCRIPTION
## Description

This PR will group all github action updates into a single PR, and also group all submodule updates that aren't eBPF-specific into a single PR.

See documentation at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-updates-into-one-pull-request

Fixes #3750

## Testing

Testing requires watching the CI/CD dependabot workflow to verify it does the right thing.

## Documentation

No impact.

## Installation

No impact.
