### PR TITLE
Add dependency for git_commit_id.h

### DIFF
--- a/ebpf-for-windows.sln
+++ b/ebpf-for-windows.sln
@@ -86,11 +86,13 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "runtime_kernel", "libs\runt
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EbpfCore", "ebpfcore\EbpfCore.vcxproj", "{97E52ABB-2F1E-4AD2-AEFD-6EB7FDC0A41D}"
 	ProjectSection(ProjectDependencies) = postProject
+		{231EE32B-EBA4-4FE5-A55B-DB18F539D403} = {231EE32B-EBA4-4FE5-A55B-DB18F539D403}
 		{675B59F8-089E-40B5-8388-56254447CFA3} = {675B59F8-089E-40B5-8388-56254447CFA3}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "netebpfext", "netebpfext\sys\netebpfext.vcxproj", "{55499E36-37D4-4F86-B694-9F2990315758}"
 	ProjectSection(ProjectDependencies) = postProject
+		{231EE32B-EBA4-4FE5-A55B-DB18F539D403} = {231EE32B-EBA4-4FE5-A55B-DB18F539D403}
 		{FA9BB88D-8259-40C1-9422-BDEDF9E9CE68} = {FA9BB88D-8259-40C1-9422-BDEDF9E9CE68}
 	EndProjectSection
 EndProject
@@ -222,6 +224,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "usersim_dll_skeleton", "external\usersim\usersim_dll_skeleton\usersim_dll_skeleton.vcxproj", "{1937DB41-F3EB-4955-A636-6386DCB394F6}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EbpfCore_Usersim", "ebpfcore\usersim\EbpfCore_Usersim.vcxproj", "{1FDAD2FD-EBD8-462A-B285-ED5174E55079}"
+	ProjectSection(ProjectDependencies) = postProject
+		{231EE32B-EBA4-4FE5-A55B-DB18F539D403} = {231EE32B-EBA4-4FE5-A55B-DB18F539D403}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "shared_user", "libs\shared\user\shared_user.vcxproj", "{9388DD45-7941-45D7-B4FF-BC00F550AF17}"
 EndProject


### PR DESCRIPTION
## Description

The drivers all depend on the generated git_commit_id.h file produced by the setup_build step. Adding a explicit dependency to ensure ordering.


This pull request includes changes to the `ebpf-for-windows.sln` file to add project dependencies to several projects. These changes ensure that the build order respects the dependencies between projects, which is crucial for successful builds.

### Added Project Dependencies:

* [`ebpfcore\EbpfCore.vcxproj`](diffhunk://#diff-d00efcb84ca2af40bde26b29fa41062f1b0b2c305e9b3513fd60f6049826f0bcR89-R95): Added dependency on project `{231EE32B-EBA4-4FE5-A55B-DB18F539D403}`.
* [`netebpfext\sys\netebpfext.vcxproj`](diffhunk://#diff-d00efcb84ca2af40bde26b29fa41062f1b0b2c305e9b3513fd60f6049826f0bcR89-R95): Added dependency on project `{231EE32B-EBA4-4FE5-A55B-DB18F539D403}`.
* [`ebpfcore\usersim\EbpfCore_Usersim.vcxproj`](diffhunk://#diff-d00efcb84ca2af40bde26b29fa41062f1b0b2c305e9b3513fd60f6049826f0bcR227-R229): Added dependency on project `{231EE32B-EBA4-4FE5-A55B-DB18F539D403}`.
* {231EE32B-EBA4-4FE5-A55B-DB18F539D403} is `scripts\setup_build\setup_build.vcxproj`


## Testing

CI/CD

## Documentation

No.

## Installation

No.
