### PR TITLE
Add support for program loading flags - breaking change version

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -393,6 +393,12 @@ ebpf_extension_data_t* extension_data = (ebpf_extension_data_t*)ClientRegistrati
 attach_parameter = extension_data->data;
 ```
 
+### `ebpf_extension_data_t` Struct
+This structure contains the additional data passed from the application to the attach provider. It contains the following fields:
+* `data` Attach type specific data. See documentation for the attach type provider for the format of this data.
+* `data_size` The length of the attach type specific data.
+* `prog_attach_flags` A collection of attach type specific flags passed from the application to the attach provider.
+
 The per-client data structure should be returned as the `ProviderBindingContext` output parameter.
 
 Upon

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -79,6 +79,7 @@ EXPORTS
     bpf_program__attach_xdp
     bpf_program__autoload
     bpf_program__fd
+    bpf_program__flags
     bpf_program__get_expected_attach_type
     bpf_program__get_type=bpf_program__type
     bpf_program__insn_cnt
@@ -90,6 +91,7 @@ EXPORTS
     bpf_program__section_name
     bpf_program__set_autoload
     bpf_program__set_expected_attach_type
+    bpf_program__set_flags
     bpf_program__set_type
     bpf_program__type
     bpf_program__unload

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -921,7 +921,7 @@ ring_buffer__free(struct ring_buffer* rb);
  * @brief Query the BPF program flags.
  *
  * @param[in] prog A pointer to the BPF program.
- * @return The flags of the BPF program.
+ * @return The flags of the BPF program that were last set by this process.
  */
 __u32
 bpf_program__flags(const struct bpf_program* prog);

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -917,6 +917,31 @@ void
 ring_buffer__free(struct ring_buffer* rb);
 /** @} */
 
+/**
+ * @brief Query the BPF program flags.
+ *
+ * @param[in] prog A pointer to the BPF program.
+ * @return The flags of the BPF program.
+ */
+__u32
+bpf_program__flags(const struct bpf_program* prog);
+
+/**
+ * @brief Set the BPF program flags.
+ * The set of flags is defined by the program type. Neither libbpf nor the eBPF runtime check the flags and only
+ * the extension that handles this program type will interpret them.  See the documentation for the
+ * program type for what flags are defined for that program type.
+ *
+ * @param[in] prog A pointer to the BPF program.
+ * @param[in] flags The flags to set.
+ *
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occurred, and errno was set.
+ *
+ */
+int
+bpf_program__set_flags(struct bpf_program* prog, __u32 flags);
+
 #else
 #pragma warning(push)
 #pragma warning(disable : 4200) // Zero-sized array in struct/union

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -95,6 +95,8 @@ typedef struct _ebpf_extension_data
 {
     ebpf_extension_header_t header;
     const void* data;
+    size_t data_size;
+    uint64_t prog_attach_flags;
 } ebpf_extension_data_t;
 
 typedef struct _ebpf_attach_provider_data

--- a/include/ebpf_windows.h
+++ b/include/ebpf_windows.h
@@ -73,6 +73,14 @@ typedef enum _ebpf_helper_function
 #define EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION 1
 #define EBPF_PROGRAM_INFORMATION_CLIENT_DATA_CURRENT_VERSION 1
 
+#define EBPF_ATTACH_CLIENT_DATA_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_extension_data_t, prog_attach_flags)
+#define EBPF_ATTACH_CLIENT_DATA_VERSION_TOTAL_SIZE sizeof(ebpf_extension_data_t)
+#define EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION                                         \
+    {                                                                                  \
+        EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION, EBPF_ATTACH_CLIENT_DATA_VERSION_SIZE, \
+            EBPF_ATTACH_CLIENT_DATA_VERSION_TOTAL_SIZE                                 \
+    }
+
 // Version 1 of the eBPF extension data structures and their lengths.
 #define EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION 1
 #define EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_attach_provider_data_t, link_type)

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -30,6 +30,7 @@ typedef struct bpf_program
     bool pinned;
     const char* log_buffer;
     uint32_t log_buffer_size;
+    uint64_t flags;
 } ebpf_program_t;
 
 typedef struct bpf_map
@@ -768,3 +769,15 @@ prog_is_subprog(const struct bpf_object* obj, const struct bpf_program* prog)
 {
     return (strcmp(prog->section_name, ".text") == 0) && (obj->programs.size() > 1);
 }
+
+/**
+ * @brief Set the flags on a program
+ *
+ * @param[in] program_fd File descriptor for the program.
+ * @param[in] flags Flags to set on the program.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
+ */
+_Must_inspect_result_ ebpf_result_t
+ebpf_program_set_flags(fd_t program_fd, uint64_t flags) noexcept;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2117,6 +2117,12 @@ _initialize_ebpf_programs_native(
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
+        if (program->flags != 0) {
+            result = ebpf_program_set_flags(program->fd, program->flags);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+        }
         program->handle = program_handles[i];
         program_handles[i] = ebpf_handle_invalid;
         program->program_type = info.type_uuid;
@@ -3282,6 +3288,13 @@ _Requires_lock_not_held_(_ebpf_state_mutex) static ebpf_result_t
         }
 
         program->fd = _create_file_descriptor_for_handle(program->handle);
+
+        if (program->flags != 0) {
+            result = ebpf_program_set_flags(program->fd, program->flags);
+            if (result != EBPF_SUCCESS) {
+                break;
+            }
+        }
 
         // Populate load_info.
         ebpf_program_load_info load_info = {0};
@@ -4670,4 +4683,21 @@ ebpf_api_thread_local_initialize() noexcept
 {
     // Nothing to do.
     // Added for symmetry with ebpf_api_thread_local_cleanup.
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_program_set_flags(fd_t program_fd, uint64_t flags) noexcept
+{
+    ebpf_handle_t program_handle = _get_handle_from_file_descriptor(program_fd);
+    if (program_handle == ebpf_handle_invalid) {
+        return EBPF_INVALID_FD;
+    }
+
+    ebpf_operation_program_set_flags_request_t request;
+    request.header.id = ebpf_operation_id_t::EBPF_OPERATION_PROGRAM_SET_FLAGS;
+    request.header.length = sizeof(request);
+    request.program_handle = program_handle;
+    request.flags = flags;
+
+    return win32_error_code_to_ebpf_result(invoke_ioctl(request));
 }

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -755,3 +755,19 @@ bpf_prog_test_run_opts(int prog_fd, struct bpf_test_run_opts* opts)
 
     return 0;
 }
+
+__u32
+bpf_program__flags(const struct bpf_program* prog)
+{
+    return static_cast<uint32_t>(prog->flags);
+}
+
+int
+bpf_program__set_flags(struct bpf_program* prog, __u32 flags)
+{
+    if (prog->object->loaded) {
+        return libbpf_err(-EBUSY);
+    }
+    prog->flags = flags;
+    return 0;
+}

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2194,6 +2194,30 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
+static ebpf_result_t
+_ebpf_core_protocol_program_set_flags(_In_ const ebpf_operation_program_set_flags_request_t* request)
+{
+    EBPF_LOG_ENTRY();
+
+    ebpf_program_t* program = NULL;
+
+    ebpf_result_t result =
+        EBPF_OBJECT_REFERENCE_BY_HANDLE(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
+
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
+    ebpf_program_set_flags(program, request->flags);
+
+Exit:
+    if (program) {
+        EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)program);
+    }
+
+    EBPF_RETURN_RESULT(result);
+}
+
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
@@ -2756,6 +2780,7 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_FIXED_REPLY(map_delete_element_batch, keys, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY(
         map_get_next_key_value_batch, previous_key, data, PROTOCOL_ALL_MODES),
+    DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(program_set_flags, PROTOCOL_ALL_MODES),
 };
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -254,7 +254,7 @@ _ebpf_link_client_detach_provider(void* client_binding_context)
 }
 
 static void
-_ebpf_link_free(_Frees_ptr_ ebpf_core_object_t* object)
+_ebpf_link_free(_In_ _Frees_ptr_ ebpf_core_object_t* object)
 {
     ebpf_link_t* link = (ebpf_link_t*)object;
     ebpf_free((void*)link->client_data.data);
@@ -290,7 +290,9 @@ ebpf_link_create(
     ebpf_lock_state_t state = ebpf_lock_lock(&local_link->lock);
     lock_held = true;
 
-    local_link->client_data.header.size = context_data_length;
+    ebpf_extension_header_t header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION;
+
+    local_link->client_data.header = header;
 
     if (context_data_length > 0) {
         local_link->client_data.data = ebpf_allocate_with_tag(context_data_length, EBPF_POOL_TAG_LINK);
@@ -299,6 +301,7 @@ ebpf_link_create(
             goto Exit;
         }
         memcpy((void*)local_link->client_data.data, context_data, context_data_length);
+        local_link->client_data.data_size = context_data_length;
     }
 
     local_link->module_id.Guid = module_id;
@@ -365,6 +368,7 @@ ebpf_link_attach_program(_Inout_ ebpf_link_t* link, _Inout_ ebpf_program_t* prog
 
     link->program = program;
     link->program_type = ebpf_program_type_uuid(link->program);
+    link->client_data.prog_attach_flags = ebpf_program_get_flags(link->program);
 
     // Attach the program to the link.
     ebpf_program_attach_link(program, link);
@@ -479,7 +483,7 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     ebpf_free((void*)link->client_data.data);
 
     link->client_data.data = NULL;
-    link->client_data.header.size = 0;
+    link->client_data.data_size = 0;
     link->program = NULL;
 
 Done:
@@ -660,10 +664,10 @@ ebpf_link_get_info(
 
     // Copy any additional parameters.
     size_t size = sizeof(struct bpf_link_info) - FIELD_OFFSET(struct bpf_link_info, attach_data);
-    if ((link->client_data.header.size > 0) && (link->client_data.header.size <= size)) {
-        memcpy(&info->attach_data, link->client_data.data, link->client_data.header.size);
-    }
 
+    if ((link->client_data.data_size > 0) && (link->client_data.data_size <= size)) {
+        memcpy(&info->attach_data, link->client_data.data, link->client_data.data_size);
+    }
     ebpf_lock_unlock((ebpf_lock_t*)&link->lock, state);
 
     *info_size = sizeof(*info);

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -93,6 +93,7 @@ typedef struct _ebpf_program
     size_t helper_function_count;
     uint32_t* helper_function_ids;
     bool helper_ids_set;
+    uint64_t flags;
 
     // Lock protecting the fields below.
     ebpf_lock_t lock;
@@ -2695,4 +2696,16 @@ ebpf_program_get_runtime_state(_In_ const void* program_context, _Outptr_ const 
     // slot [0] contains the execution context state.
     ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
     *state = (ebpf_execution_context_state_t*)header->context_header[0];
+}
+
+uint64_t
+ebpf_program_get_flags(_In_ const ebpf_program_t* program)
+{
+    return program->flags;
+}
+
+void
+ebpf_program_set_flags(_Inout_ ebpf_program_t* program, uint64_t flags)
+{
+    program->flags = flags;
 }

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -455,6 +455,24 @@ extern "C"
     ebpf_program_get_runtime_state(
         _In_ const void* program_context, _Outptr_ const ebpf_execution_context_state_t** state);
 
+    /**
+     * @brief Query the flags set on the program.
+     *
+     * @param[in] program The program to query.
+     * @return The flags set on the program.
+     */
+    uint64_t
+    ebpf_program_get_flags(_In_ const ebpf_program_t* program);
+
+    /**
+     * @brief Set the flags on the program.
+     *
+     * @param[in] program The program to set the flags on.
+     * @param[in] flags The flags to set on the program.
+     */
+    void
+    ebpf_program_set_flags(_Inout_ ebpf_program_t* program, uint64_t flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -46,6 +46,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_MAP_UPDATE_ELEMENT_BATCH,
     EBPF_OPERATION_MAP_DELETE_ELEMENT_BATCH,
     EBPF_OPERATION_MAP_GET_NEXT_KEY_VALUE_BATCH,
+    EBPF_OPERATION_PROGRAM_SET_FLAGS,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -526,3 +527,10 @@ typedef struct _ebpf_operation_map_get_next_key_value_batch_reply
     // Data is a concatenation of key+value.
     uint8_t data[1];
 } ebpf_operation_map_get_next_key_value_batch_reply_t;
+
+typedef struct _ebpf_operation_program_set_flags_request
+{
+    struct _ebpf_operation_header header;
+    ebpf_handle_t program_handle;
+    uint64_t flags;
+} ebpf_operation_program_set_flags_request_t;

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -31,9 +31,8 @@ uint16_t _supported_ebpf_extension_version[] = {
     EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION,
 };
 
-#define EBPF_ATTACH_PROVIDER_DATA_SIZE_0 \
-    EBPF_OFFSET_OF(ebpf_attach_provider_data_t, link_type) + sizeof(enum bpf_link_type)
-size_t _ebpf_attach_provider_data_supported_size[] = {EBPF_ATTACH_PROVIDER_DATA_SIZE_0};
+#define EBPF_ATTACH_PROVIDER_DATA_SIZE_1 EBPF_SIZE_INCLUDING_FIELD(ebpf_attach_provider_data_t, link_type)
+size_t _ebpf_attach_provider_data_supported_size[] = {EBPF_ATTACH_PROVIDER_DATA_SIZE_1};
 
 #define EBPF_PROGRAM_TYPE_DESCRIPTOR_SIZE_0 EBPF_OFFSET_OF(ebpf_program_type_descriptor_t, is_privileged) + sizeof(char)
 size_t _ebpf_program_type_descriptor_supported_size[] = {EBPF_PROGRAM_TYPE_DESCRIPTOR_SIZE_0};

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -499,7 +499,7 @@ _net_ebpf_extension_hook_provider_attach_client(
         // Check if the attach parameter is already present in the list of filter contexts.
         net_ebpf_extension_wfp_filter_context_t* matching_context = NULL;
         matching_context = net_ebpf_extension_get_matching_filter_context(
-            hook_client->client_data->header.size, hook_client->client_data->data, local_provider_context);
+            hook_client->client_data->data_size, hook_client->client_data->data, local_provider_context);
         if (matching_context != NULL) {
             // Insert the new client in the filter context.
             result = net_ebpf_ext_add_client_context(matching_context, hook_client);
@@ -532,7 +532,7 @@ _net_ebpf_extension_hook_provider_attach_client(
             // Check if the attach parameter is already present in the list of filter contexts.
             net_ebpf_extension_wfp_filter_context_t* matching_context = NULL;
             matching_context = net_ebpf_extension_get_matching_filter_context(
-                hook_client->client_data->header.size, hook_client->client_data->data, local_provider_context);
+                hook_client->client_data->data_size, hook_client->client_data->data, local_provider_context);
 
             if (matching_context != NULL) {
                 NET_EBPF_EXT_LOG_MESSAGE(

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -609,6 +609,15 @@ _net_ebpf_extension_sock_addr_validate_client_data(
     uint32_t compartment_id;
     *is_wildcard = FALSE;
 
+    if (client_data->header.version < EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION) {
+        result = EBPF_INVALID_ARGUMENT;
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_XDP,
+            "Attach attempt rejected. Invalid client data version.");
+        goto Exit;
+    }
+
     // SOCK_ADDR hook clients must always provide data.
     if (client_data == NULL) {
         NET_EBPF_EXT_LOG_MESSAGE(
@@ -619,8 +628,8 @@ _net_ebpf_extension_sock_addr_validate_client_data(
         goto Exit;
     }
 
-    if (client_data->header.size > 0) {
-        if ((client_data->header.size != sizeof(uint32_t)) || (client_data->data == NULL)) {
+    if (client_data->data_size > 0) {
+        if ((client_data->data_size != sizeof(uint32_t)) || (client_data->data == NULL)) {
             NET_EBPF_EXT_LOG_MESSAGE(
                 NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
                 NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
@@ -667,7 +676,7 @@ _net_ebpf_extension_sock_addr_create_filter_context(
     net_ebpf_extension_wfp_filter_parameters_array_t* filter_parameters_array = NULL;
     const ebpf_extension_data_t* client_data = net_ebpf_extension_hook_client_get_client_data(attaching_client);
 
-    if (client_data->header.size > 0) {
+    if (client_data->data_size > 0) {
         // Note: No need to validate the client data here, as it has already been validated by the caller.
         compartment_id = *(uint32_t*)client_data->data;
     }

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -158,7 +158,7 @@ _net_ebpf_extension_sock_ops_create_filter_context(
     FWPM_FILTER_CONDITION condition = {0};
     const ebpf_extension_data_t* client_data = net_ebpf_extension_hook_client_get_client_data(attaching_client);
 
-    if (client_data->header.size > 0) {
+    if (client_data->data != NULL) {
         // Note: No need to validate the client data here, as it has already been validated by the caller.
         compartment_id = *(uint32_t*)client_data->data;
     }
@@ -223,8 +223,8 @@ _net_ebpf_extension_sock_ops_validate_client_data(
         goto Exit;
     }
 
-    if (client_data->header.size > 0) {
-        if ((client_data->header.size != sizeof(uint32_t)) || (client_data->data == NULL)) {
+    if (client_data->data_size > 0) {
+        if ((client_data->data_size != sizeof(uint32_t)) || (client_data->data == NULL)) {
             NET_EBPF_EXT_LOG_MESSAGE(
                 NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
                 NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS,

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -132,7 +132,7 @@ _net_ebpf_extension_xdp_create_filter_context(
     FWPM_FILTER_CONDITION condition = {0};
     net_ebpf_extension_xdp_wfp_filter_context_t* xdp_filter_context = NULL;
 
-    if (client_data->header.size > 0) {
+    if (client_data->data_size != 0) {
         // Note: No need to validate the client data here, as it has already been validated by the caller.
         if_index = *(uint32_t*)client_data->data;
     } else {
@@ -210,8 +210,17 @@ _net_ebpf_extension_xdp_validate_client_data(_In_ const ebpf_extension_data_t* c
         goto Exit;
     }
 
-    if (client_data->header.size > 0) {
-        if ((client_data->header.size != sizeof(uint32_t)) || (client_data->data == NULL)) {
+    if (client_data->header.version < EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION) {
+        result = EBPF_INVALID_ARGUMENT;
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_XDP,
+            "Attach attempt rejected. Invalid client data version.");
+        goto Exit;
+    }
+
+    if (client_data->data_size != 0) {
+        if ((client_data->data_size != sizeof(uint32_t)) || (client_data->data == NULL)) {
             result = EBPF_INVALID_ARGUMENT;
             NET_EBPF_EXT_LOG_MESSAGE(
                 NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -7,6 +7,7 @@
 #include "ebpf_nethooks.h"
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
+#include "ebpf_windows.h"
 #include "net_ebpf_ext_program_info.h"
 #include "net_ebpf_ext_xdp_hooks.h"
 #include "sample_ext_program_info.h"
@@ -283,6 +284,12 @@ typedef class _single_instance_hook : public _hook_helper
         return batch_end_function(state);
     }
 
+    const ebpf_extension_data_t*
+    get_client_data() const
+    {
+        return client_data;
+    }
+
   private:
     static NTSTATUS
     provider_attach_client_callback(
@@ -305,6 +312,8 @@ typedef class _single_instance_hook : public _hook_helper
         hook->client_binding_context = client_binding_context;
         hook->nmr_binding_handle = nmr_binding_handle;
         hook->client_dispatch_table = (ebpf_extension_dispatch_table_t*)client_dispatch;
+        hook->client_data =
+            reinterpret_cast<const ebpf_extension_data_t*>(client_registration_instance->NpiSpecificCharacteristics);
         *provider_binding_context = provider_context;
         *provider_dispatch = NULL;
         return STATUS_SUCCESS;

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -80,14 +80,16 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     bpf_prog_type_t prog_type = (bpf_prog_type_t)metadata->prog_type;
 
     NET_IFINDEX if_index = 0;
-    ebpf_extension_data_t npi_specific_characteristics = {.data = &if_index};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+        .data = &if_index,
+        .data_size = sizeof(if_index),
+    };
     test_client_context_t client_context = {};
     netebpf_ext_helper_t helper(
         &npi_specific_characteristics,
         (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_program,
         &client_context.base);
-
-    npi_specific_characteristics.header.size = sizeof(if_index);
 
     // Look up the context descriptor for the requested program type.
     std::vector<GUID> guids = helper.program_info_provider_guids();

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -117,11 +117,13 @@ netebpfext_unit_invoke_xdp_program(
 TEST_CASE("classify_packet", "[netebpfext]")
 {
     NET_IFINDEX if_index = 0;
-    ebpf_extension_data_t npi_specific_characteristics = {.data = &if_index};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+        .data = &if_index,
+        .data_size = sizeof(if_index),
+    };
     test_xdp_client_context_t client_context = {};
     client_context.base.desired_attach_type = BPF_XDP_TEST;
-
-    npi_specific_characteristics.header.size = sizeof(if_index);
 
     netebpf_ext_helper_t helper(
         &npi_specific_characteristics,
@@ -230,7 +232,9 @@ netebpfext_unit_invoke_bind_program(
 
 TEST_CASE("bind_invoke", "[netebpfext]")
 {
-    ebpf_extension_data_t npi_specific_characteristics = {};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
     test_bind_client_context_t client_context = {};
     fwp_classify_parameters_t parameters = {};
 
@@ -503,7 +507,9 @@ netebpfext_unit_invoke_sock_addr_program(
 
 TEST_CASE("sock_addr_invoke", "[netebpfext]")
 {
-    ebpf_extension_data_t npi_specific_characteristics = {};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
     test_sock_addr_client_context_t client_context = {};
     fwp_classify_parameters_t parameters = {};
 
@@ -648,7 +654,9 @@ sock_addr_thread_function(
 
 TEST_CASE("sock_addr_invoke_concurrent1", "[netebpfext_concurrent]")
 {
-    ebpf_extension_data_t npi_specific_characteristics = {};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
     test_sock_addr_client_context_t client_context = {};
     fwp_classify_parameters_t parameters = {};
     std::vector<std::jthread> threads;
@@ -696,7 +704,9 @@ TEST_CASE("sock_addr_invoke_concurrent1", "[netebpfext_concurrent]")
 // Invoke SOCK_ADDR_CONNECT concurrently with different classify parameters.
 TEST_CASE("sock_addr_invoke_concurrent2", "[netebpfext_concurrent]")
 {
-    ebpf_extension_data_t npi_specific_characteristics = {};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
     test_sock_addr_client_context_t client_context = {};
     std::vector<std::jthread> threads;
     std::vector<fwp_classify_parameters_t> parameters;
@@ -744,7 +754,9 @@ TEST_CASE("sock_addr_invoke_concurrent2", "[netebpfext_concurrent]")
 // Invoke SOCK_ADDR_RECV_ACCEPT concurrently with different classify parameters.
 TEST_CASE("sock_addr_invoke_concurrent3", "[netebpfext_concurrent]")
 {
-    ebpf_extension_data_t npi_specific_characteristics = {};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
     test_sock_addr_client_context_t client_context = {};
     std::vector<std::jthread> threads;
     std::vector<fwp_classify_parameters_t> parameters;
@@ -879,7 +891,9 @@ netebpfext_unit_invoke_sock_ops_program(
 
 TEST_CASE("sock_ops_invoke", "[netebpfext]")
 {
-    ebpf_extension_data_t npi_specific_characteristics = {};
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
     test_sock_ops_client_context_t client_context = {};
     fwp_classify_parameters_t parameters = {};
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -4054,7 +4054,7 @@ _utility_test(ebpf_execution_type_t execution_type)
     bpf_object__close(process_object);
 }
 
-DECLARE_ALL_TEST_CASES("utility_test", "[libbf]", _utility_test);
+DECLARE_ALL_TEST_CASES("utility_test", "[libbpf]", _utility_test);
 
 static void
 _strings_test(ebpf_execution_type_t execution_type)
@@ -4096,3 +4096,68 @@ _strings_test(ebpf_execution_type_t execution_type)
     bpf_object__close(process_object);
 }
 DECLARE_ALL_TEST_CASES("strings_test", "[libbpf]", _strings_test);
+
+static void
+_program_flags_test(ebpf_execution_type_t execution_type)
+{
+    _test_helper_end_to_end test_helper;
+    const char dll_name[] = "utility_um.dll";
+    const char obj_name[] = "utility.o";
+    test_helper.initialize();
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
+
+    const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? dll_name : obj_name);
+    struct bpf_object* process_object = bpf_object__open(file_name);
+    REQUIRE(process_object != nullptr);
+
+    // Set the flag on each program in the object.
+    struct bpf_program* program;
+    bpf_object__for_each_program(program, process_object)
+    {
+        // Set some flags on the program. The test attach provider does not use these flags.
+        REQUIRE(bpf_program__set_flags(program, 0xCCCCCCCC) == 0);
+
+        // Get the flags and verify they are correct.
+        REQUIRE(bpf_program__flags(program) == 0xCCCCCCCC);
+    }
+
+    // Load the program(s).
+    REQUIRE(bpf_object__load(process_object) == 0);
+
+    // Verify that setting the flag after load fails.
+    bpf_object__for_each_program(program, process_object)
+    {
+        REQUIRE(bpf_program__set_flags(program, 0xCCCCCCCC) == -EBUSY);
+    }
+
+    struct bpf_program* caller = bpf_object__find_program_by_name(process_object, "UtilityTest");
+    REQUIRE(caller != nullptr);
+
+    bpf_link_ptr link(bpf_program__attach(caller));
+    REQUIRE(link != nullptr);
+
+    auto client_data = hook.get_client_data();
+
+    REQUIRE(client_data != nullptr);
+    REQUIRE(client_data->header.version == EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION);
+    REQUIRE(client_data->prog_attach_flags == 0xCCCCCCCC);
+
+    // Now run the ebpf program.
+    INITIALIZE_BIND_CONTEXT
+    ctx->operation = BIND_OPERATION_BIND;
+
+    uint32_t result;
+    REQUIRE(hook.fire(ctx, &result) == EBPF_SUCCESS);
+
+    // Verify the result.
+    REQUIRE(result == 0);
+
+    result = bpf_link__destroy(link.release());
+    REQUIRE(result == 0);
+    bpf_object__close(process_object);
+}
+
+DECLARE_ALL_TEST_CASES("program_flag_test", "[libbpf]", _program_flags_test);


### PR DESCRIPTION
Resolves: #3576 

As requested by @shankarseal this is a breaking change (to keep the change simple) as the ebpf_extension_data_t wasn't following the correct contract for structures exposed to extensions.

## Description

This pull request introduces several enhancements and new features to the eBPF program management system, primarily focusing on adding support for program flags and improving the handling of extension data. Below are the most significant changes grouped by theme:

### Enhancements to Program Flags:

* Added functions to query and set BPF program flags in `libbpf.h` and `libbpf_program.cpp`, allowing for better control over program behavior. [[1]](diffhunk://#diff-51005a88f9d069f59b4799b56c3a9430d710a514feea4ee723e63cddc50edcb2R920-R944) [[2]](diffhunk://#diff-780511a42f3cac926001942e228bf075fec98dafebcbef6f1c6f5ce257068839R758-R773)
* Updated `ebpf_program_t` structure to include a `flags` field in `api_internal.h` and `ebpf_program.c`, and added corresponding getter and setter functions. [[1]](diffhunk://#diff-545d6b59394e62a7162e59b142ddf08db2534ef3072a47b414e5cda5b311bca6R33) [[2]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320R96) [[3]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320R2668-R2679)
* Implemented the `ebpf_program_set_flags` function in `ebpf_api.cpp` to set flags on a program during initialization. [[1]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeR2134-R2139) [[2]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeR4689-R4705)
* Added new protocol operation `EBPF_OPERATION_PROGRAM_SET_FLAGS` to handle setting flags via IOCTL in `ebpf_protocol.h` and `ebpf_core.c`. [[1]](diffhunk://#diff-8ed704d86d8cbd581386c6cb0486d2f594cb73c97b06864425f673cc0e4a1f00R49) [[2]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R2117-R2140)

### Enhancements to Extension Data:

* Expanded the `ebpf_extension_data_t` struct to include `data_size` and `prog_attach_flags` fields in `ebpf_extension.h` and updated related documentation. [[1]](diffhunk://#diff-109fb2b1c7e8562c572738a90786c028f5b95ad108d3f401545379352f0560d7R98-R99) [[2]](diffhunk://#diff-b183ad62c09db1f1cb4109ad107cba4e40c085d2e4a4635b5e7723fbce474310R396-R401)
* Modified `ebpf_link.c` to handle the new fields in `ebpf_extension_data_t`, ensuring proper initialization and usage during link creation and attachment. [[1]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L257-R257) [[2]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L293-R295) [[3]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1R304) [[4]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1R371) [[5]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L663-R670)
* Updated `ebpf_windows.h` to define new constants for version and size of `ebpf_extension_data_t`.

### API and Export Updates:

* Added new exports `bpf_program__flags` and `bpf_program__set_flags` to `ebpfapi/Source.def` to expose the new flag functionalities. [[1]](diffhunk://#diff-2f82d1ff51a61fb435467ba5290591820cb88e359100a25e9b9a8e7913c6577cR82) [[2]](diffhunk://#diff-2f82d1ff51a61fb435467ba5290591820cb88e359100a25e9b9a8e7913c6577cR94)

### Testing and Documentation:

* Updated `helpers.h` in end-to-end tests to include `ebpf_windows.h` and added methods to access client data in the `_single_instance_hook` class. [[1]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cR10) [[2]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cR283-R288) [[3]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cR311-R312)

These changes collectively enhance the flexibility and control over eBPF programs by introducing a robust mechanism for handling program-specific flags and improving the management of extension data.

## Testing

CI/CD

## Documentation

Yes.

## Installation

No.
