### PR TITLE
Override `bpf_get_current_pid_tgid` for sock_ops hook.

### DIFF
--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -161,8 +161,8 @@ typedef enum
 
 /**
  * @brief Get current pid and tgid (sock_addr specific only).
- * This helper function is there only to support legacy programs.
- * New sock_addr programs should use bpf_get_current_pid_tgid helper instead.
+ *
+ * @deprecated Use bpf_get_current_pid_tgid instead.
  *
  * @param[in] ctx Pointer to bpf_sock_addr_t context.
  *

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -160,23 +160,6 @@ typedef enum
 } ebpf_sock_addr_helper_id_t;
 
 /**
- * @brief Get current pid and tgid (sock_addr specific only).
- *
- * @param[in] ctx Pointer to bpf_sock_addr_t context.
- *
- * @returns a 64-bit integer containing the current tgid
- *  and pid, and created as such:
- *
- * 	*current_task*\ **->tgid << 32 \|**
- * 	*current_task*\ **->pid**.
- */
-EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx));
-#ifndef __doxygen
-#define bpf_sock_addr_get_current_pid_tgid \
-    ((bpf_sock_addr_get_current_pid_tgid_t)BPF_FUNC_sock_addr_get_current_pid_tgid)
-#endif
-
-/**
  * @brief Set a context for consumption by a user-mode application (sock_addr specific only).
  * This function is not supported for the recv_accept hooks.
  *

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -160,6 +160,25 @@ typedef enum
 } ebpf_sock_addr_helper_id_t;
 
 /**
+ * @brief Get current pid and tgid (sock_addr specific only).
+ * This helper function is there only to support legacy programs.
+ * New sock_addr programs should use bpf_get_current_pid_tgid helper instead.
+ *
+ * @param[in] ctx Pointer to bpf_sock_addr_t context.
+ *
+ * @returns a 64-bit integer containing the current tgid
+ *  and pid, and created as such:
+ *
+ * 	*current_task*\ **->tgid << 32 \|**
+ * 	*current_task*\ **->pid**.
+ */
+EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx));
+#ifndef __doxygen
+#define bpf_sock_addr_get_current_pid_tgid \
+    ((bpf_sock_addr_get_current_pid_tgid_t)BPF_FUNC_sock_addr_get_current_pid_tgid)
+#endif
+
+/**
  * @brief Set a context for consumption by a user-mode application (sock_addr specific only).
  * This function is not supported for the recv_accept hooks.
  *

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -11,6 +11,11 @@
 
 #define HELPER_FUNCTION_REALLOCATE_PACKET TRUE
 
+enum _xdp_test_helper_functions
+{
+    XDP_TEST_HELPER_ADJUST_HEAD,
+};
+
 // XDP_TEST helper function prototype descriptors.
 static const ebpf_helper_function_prototype_t _xdp_test_ebpf_extension_helper_function_prototype[] = {
     {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
@@ -71,13 +76,32 @@ static const ebpf_program_section_info_t _ebpf_bind_section_info[] = {
      BPF_PROG_TYPE_BIND,
      BPF_ATTACH_TYPE_BIND}};
 
+enum _sock_addr_helper_functions
+{
+    SOCK_ADDR_HELPER_GET_CURRENT_PID_TGID,
+    SOCK_ADDR_HELPER_SET_REDIRECT_CONTEXT,
+};
+
 // CGROUP_SOCK_ADDR extension specific helper function prototypes.
 static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
+    {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
+     BPF_FUNC_sock_addr_get_current_pid_tgid,
+     "bpf_sock_addr_get_current_pid_tgid",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
     {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
      BPF_FUNC_sock_addr_set_redirect_context,
      "bpf_sock_addr_set_redirect_context",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
+
+enum _sock_addr_global_helper_functions
+{
+    SOCK_ADDR_GLOBAL_HELPER_GET_CURRENT_PID_TGID,
+    SOCK_ADDR_GLOBAL_HELPER_GET_CURRENT_LOGON_ID,
+    SOCK_ADDR_GLOBAL_HELPER_IS_CURRENT_ADMIN,
+    SOCK_ADDR_GLOBAL_HELPER_GET_SOCKET_COOKIE,
+};
 
 // CGROUP_SOCK_ADDR global helper function prototypes.
 static const ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {
@@ -167,6 +191,12 @@ static const ebpf_program_type_descriptor_t _ebpf_sock_ops_program_type_descript
     EBPF_PROGRAM_TYPE_SOCK_OPS_GUID,
     BPF_PROG_TYPE_SOCK_OPS,
     0};
+
+enum _sock_ops_global_helper_functions
+{
+    SOCK_OPS_GLOBAL_HELPER_GET_CURRENT_PID_TGID,
+};
+
 // SOCK_OPS global helper function prototypes.
 static const ebpf_helper_function_prototype_t _ebpf_sock_ops_global_helper_function_prototype[] = {
     {.header = EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -166,8 +166,21 @@ static const ebpf_program_type_descriptor_t _ebpf_sock_ops_program_type_descript
     EBPF_PROGRAM_TYPE_SOCK_OPS_GUID,
     BPF_PROG_TYPE_SOCK_OPS,
     0};
+// SOCK_OPS global helper function prototypes.
+static const ebpf_helper_function_prototype_t _ebpf_sock_ops_global_helper_function_prototype[] = {
+    {.header = EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
+     .helper_id = BPF_FUNC_get_current_pid_tgid,
+     .name = "bpf_get_current_pid_tgid",
+     .return_type = EBPF_RETURN_TYPE_INTEGER,
+     .arguments = {},
+     .implicit_context = true}};
 static const ebpf_program_info_t _ebpf_sock_ops_program_info = {
-    EBPF_PROGRAM_INFORMATION_HEADER, &_ebpf_sock_ops_program_type_descriptor, 0, NULL, 0, NULL};
+    EBPF_PROGRAM_INFORMATION_HEADER,
+    &_ebpf_sock_ops_program_type_descriptor,
+    0,
+    NULL,
+    EBPF_COUNT_OF(_ebpf_sock_ops_global_helper_function_prototype),
+    _ebpf_sock_ops_global_helper_function_prototype};
 
 static const ebpf_program_section_info_t _ebpf_sock_ops_section_info[] = {
     {{EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION, EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_SIZE},

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -74,11 +74,6 @@ static const ebpf_program_section_info_t _ebpf_bind_section_info[] = {
 // CGROUP_SOCK_ADDR extension specific helper function prototypes.
 static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
     {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
-     BPF_FUNC_sock_addr_get_current_pid_tgid,
-     "bpf_sock_addr_get_current_pid_tgid",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
-    {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
      BPF_FUNC_sock_addr_set_redirect_context,
      "bpf_sock_addr_set_redirect_context",
      EBPF_RETURN_TYPE_INTEGER,
@@ -86,6 +81,12 @@ static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_f
 
 // CGROUP_SOCK_ADDR global helper function prototypes.
 static const ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {
+    {.header = EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
+     .helper_id = BPF_FUNC_get_current_pid_tgid,
+     .name = "bpf_get_current_pid_tgid",
+     .return_type = EBPF_RETURN_TYPE_INTEGER,
+     .arguments = {},
+     .implicit_context = true},
     {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
      BPF_FUNC_get_current_logon_id,
      "bpf_get_current_logon_id",

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -252,20 +252,26 @@ static GENERIC_MAPPING _net_ebpf_ext_generic_mapping = {0};
 // sock_addr helper functions.
 //
 static uint32_t
-_get_process_id()
-{
-    return (uint32_t)(uintptr_t)PsGetCurrentProcessId();
-}
-
-static uint32_t
 _get_thread_id()
 {
     return (uint32_t)(uintptr_t)PsGetCurrentThreadId();
 }
 
 static uint64_t
-_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
+_ebpf_sock_addr_get_current_pid_tgid(
+    uint64_t dummy_param1,
+    uint64_t dummy_param2,
+    uint64_t dummy_param3,
+    uint64_t dummy_param4,
+    uint64_t dummy_param5,
+    _In_ const bpf_sock_addr_t* ctx)
 {
+    UNREFERENCED_PARAMETER(dummy_param1);
+    UNREFERENCED_PARAMETER(dummy_param2);
+    UNREFERENCED_PARAMETER(dummy_param3);
+    UNREFERENCED_PARAMETER(dummy_param4);
+    UNREFERENCED_PARAMETER(dummy_param5);
+
     net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
     return (sock_addr_ctx->process_id << 32 | _get_thread_id());
 }
@@ -495,8 +501,7 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_blocked_contexts
 // SOCK_ADDR Program Information NPI Provider.
 //
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
@@ -504,6 +509,7 @@ static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function
     (uint64_t*)_ebpf_sock_addr_specific_helper_functions};
 
 static const void* _ebpf_sock_addr_global_helper_functions[] = {
+    (void*)_ebpf_sock_addr_get_current_pid_tgid,
     (void*)_ebpf_sock_addr_get_current_logon_id,
     (void*)_ebpf_sock_addr_is_current_admin,
     (void*)_ebpf_sock_addr_get_socket_cookie};

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -258,7 +258,7 @@ _get_thread_id()
 }
 
 static uint64_t
-_ebpf_sock_addr_get_current_pid_tgid(
+_ebpf_sock_addr_get_current_pid_tgid_implicit(
     uint64_t dummy_param1,
     uint64_t dummy_param2,
     uint64_t dummy_param3,
@@ -291,6 +291,13 @@ _ebpf_sock_addr_get_socket_cookie(_In_ const bpf_sock_addr_t* ctx)
 {
     net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
     return sock_addr_ctx->transport_endpoint_handle;
+}
+
+static uint64_t
+_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
+{
+    net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
+    return (sock_addr_ctx->process_id << 32 | _get_thread_id());
 }
 
 static int
@@ -501,7 +508,8 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_blocked_contexts
 // SOCK_ADDR Program Information NPI Provider.
 //
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_set_redirect_context};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {
+    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
@@ -509,7 +517,7 @@ static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function
     (uint64_t*)_ebpf_sock_addr_specific_helper_functions};
 
 static const void* _ebpf_sock_addr_global_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid,
+    (void*)_ebpf_sock_addr_get_current_pid_tgid_implicit,
     (void*)_ebpf_sock_addr_get_current_logon_id,
     (void*)_ebpf_sock_addr_is_current_admin,
     (void*)_ebpf_sock_addr_get_socket_cookie};

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -9,7 +9,7 @@ param ([parameter(Mandatory = $false)][string] $AdminTarget = "TEST_VM",
        [parameter(Mandatory = $false)][bool] $Coverage = $false,
        [parameter(Mandatory = $false)][string] $TestMode = "CI/CD",
        [parameter(Mandatory = $false)][string[]] $Options = @("None"),
-       [parameter(Mandatory = $false)][string] $SelfHostedRunnerName,
+       [parameter(Mandatory = $false)][string] $SelfHostedRunnerName = [System.Net.Dns]::GetHostName(),
        [parameter(Mandatory = $false)][int] $TestHangTimeout = 3600,
        [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps"
 )

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -78,7 +78,7 @@ static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65537, "helper_id_65537"},
-    {NULL, 65536, "helper_id_65536"},
+    {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 26, "helper_id_26"},
@@ -186,7 +186,7 @@ connect_redirect4(void* context)
         goto label_1;
 #line 61 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_JNE_IMM pc=20 dst=r1 src=r0 offset=76 imm=6
+    // EBPF_OP_JNE_IMM pc=20 dst=r1 src=r0 offset=75 imm=6
 #line 61 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6)) {
 #line 61 "sample/cgroup_sock_addr2.c"
@@ -197,7 +197,7 @@ label_1:
     // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=74 imm=2
+    // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=73 imm=2
 #line 61 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(2)) {
 #line 61 "sample/cgroup_sock_addr2.c"
@@ -344,7 +344,7 @@ label_1:
     // EBPF_OP_ARSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=30 imm=0
+    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=29 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0) {
 #line 79 "sample/cgroup_sock_addr2.c"
@@ -371,10 +371,7 @@ label_3:
     // EBPF_OP_STXDW pc=72 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
-#line 44 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=74 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=19
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address(r1, r2, r3, r4, r5, context);
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -383,16 +380,16 @@ label_3:
         return 0;
 #line 44 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_MOV64_REG pc=75 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address(r1, r2, r3, r4, r5, context);
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -401,13 +398,13 @@ label_3:
         return 0;
 #line 45 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r0 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address(r1, r2, r3, r4, r5, context);
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -416,19 +413,19 @@ label_3:
         return 0;
 #line 46 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXW pc=82 dst=r10 src=r0 offset=-88 imm=0
+    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=83 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=83 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=26
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address(r1, r2, r3, r4, r5, context);
 #line 48 "sample/cgroup_sock_addr2.c"
@@ -437,31 +434,31 @@ label_3:
         return 0;
 #line 48 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-80 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=88 dst=r2 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=89 dst=r2 src=r0 offset=0 imm=-8
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=90 dst=r3 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=91 dst=r3 src=r0 offset=0 imm=-104
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=93 dst=r1 src=r1 offset=0 imm=2
+    // EBPF_OP_LDDW pc=92 dst=r1 src=r1 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=94 dst=r4 src=r0 offset=0 imm=0
 #line 51 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[7].address(r1, r2, r3, r4, r5, context);
 #line 51 "sample/cgroup_sock_addr2.c"
@@ -471,10 +468,10 @@ label_3:
 #line 51 "sample/cgroup_sock_addr2.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r0 src=r7 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=97 dst=r0 src=r0 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 142 "sample/cgroup_sock_addr2.c"
@@ -486,7 +483,7 @@ static helper_function_entry_t connect_redirect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
     {NULL, 65537, "helper_id_65537"},
-    {NULL, 65536, "helper_id_65536"},
+    {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 26, "helper_id_26"},
@@ -585,7 +582,7 @@ connect_redirect6(void* context)
         goto label_1;
 #line 102 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=87 imm=6
+    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=86 imm=6
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6)) {
 #line 102 "sample/cgroup_sock_addr2.c"
@@ -596,7 +593,7 @@ label_1:
     // EBPF_OP_LDXW pc=18 dst=r2 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=19 dst=r2 src=r0 offset=85 imm=23
+    // EBPF_OP_JNE_IMM pc=19 dst=r2 src=r0 offset=84 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(23)) {
 #line 102 "sample/cgroup_sock_addr2.c"
@@ -755,7 +752,7 @@ label_1:
     // EBPF_OP_ARSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 123 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=38 imm=0
+    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=37 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0) {
 #line 123 "sample/cgroup_sock_addr2.c"
@@ -806,10 +803,7 @@ label_3:
     // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-24 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
-#line 44 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=19
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address(r1, r2, r3, r4, r5, context);
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -818,16 +812,16 @@ label_3:
         return 0;
 #line 44 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-32 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address(r1, r2, r3, r4, r5, context);
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -836,13 +830,13 @@ label_3:
         return 0;
 #line 45 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-40 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address(r1, r2, r3, r4, r5, context);
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -851,19 +845,19 @@ label_3:
         return 0;
 #line 46 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-24 imm=0
+    // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-24 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-20 imm=0
+    // EBPF_OP_STXH pc=91 dst=r10 src=r1 offset=-20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=92 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=26
+    // EBPF_OP_CALL pc=93 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address(r1, r2, r3, r4, r5, context);
 #line 48 "sample/cgroup_sock_addr2.c"
@@ -872,31 +866,31 @@ label_3:
         return 0;
 #line 48 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=94 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_STXDW pc=96 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=95 dst=r10 src=r8 offset=-8 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=97 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r2 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=98 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=97 dst=r2 src=r0 offset=0 imm=-8
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=99 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=98 dst=r3 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=100 dst=r3 src=r0 offset=0 imm=-40
+    // EBPF_OP_ADD64_IMM pc=99 dst=r3 src=r0 offset=0 imm=-40
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-40);
-    // EBPF_OP_LDDW pc=101 dst=r1 src=r1 offset=0 imm=2
+    // EBPF_OP_LDDW pc=100 dst=r1 src=r1 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=103 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=102 dst=r4 src=r0 offset=0 imm=0
 #line 51 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=104 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[7].address(r1, r2, r3, r4, r5, context);
 #line 51 "sample/cgroup_sock_addr2.c"
@@ -906,10 +900,10 @@ label_3:
 #line 51 "sample/cgroup_sock_addr2.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=105 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=104 dst=r0 src=r7 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=106 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=105 dst=r0 src=r0 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 149 "sample/cgroup_sock_addr2.c"
@@ -929,7 +923,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         8,
-        99,
+        98,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -943,7 +937,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         8,
-        107,
+        106,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -52,7 +52,7 @@ static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65537, "helper_id_65537"},
-    {NULL, 65536, "helper_id_65536"},
+    {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 26, "helper_id_26"},
@@ -160,7 +160,7 @@ connect_redirect4(void* context)
         goto label_1;
 #line 61 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_JNE_IMM pc=20 dst=r1 src=r0 offset=76 imm=6
+    // EBPF_OP_JNE_IMM pc=20 dst=r1 src=r0 offset=75 imm=6
 #line 61 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6)) {
 #line 61 "sample/cgroup_sock_addr2.c"
@@ -171,7 +171,7 @@ label_1:
     // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=74 imm=2
+    // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=73 imm=2
 #line 61 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(2)) {
 #line 61 "sample/cgroup_sock_addr2.c"
@@ -318,7 +318,7 @@ label_1:
     // EBPF_OP_ARSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=30 imm=0
+    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=29 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0) {
 #line 79 "sample/cgroup_sock_addr2.c"
@@ -345,10 +345,7 @@ label_3:
     // EBPF_OP_STXDW pc=72 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
-#line 44 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=74 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=19
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address(r1, r2, r3, r4, r5, context);
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -357,16 +354,16 @@ label_3:
         return 0;
 #line 44 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_MOV64_REG pc=75 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address(r1, r2, r3, r4, r5, context);
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -375,13 +372,13 @@ label_3:
         return 0;
 #line 45 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r0 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address(r1, r2, r3, r4, r5, context);
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -390,19 +387,19 @@ label_3:
         return 0;
 #line 46 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXW pc=82 dst=r10 src=r0 offset=-88 imm=0
+    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=83 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=83 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=26
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address(r1, r2, r3, r4, r5, context);
 #line 48 "sample/cgroup_sock_addr2.c"
@@ -411,31 +408,31 @@ label_3:
         return 0;
 #line 48 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-80 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=88 dst=r2 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=89 dst=r2 src=r0 offset=0 imm=-8
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=90 dst=r3 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=91 dst=r3 src=r0 offset=0 imm=-104
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=93 dst=r1 src=r1 offset=0 imm=2
+    // EBPF_OP_LDDW pc=92 dst=r1 src=r1 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=94 dst=r4 src=r0 offset=0 imm=0
 #line 51 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[7].address(r1, r2, r3, r4, r5, context);
 #line 51 "sample/cgroup_sock_addr2.c"
@@ -445,10 +442,10 @@ label_3:
 #line 51 "sample/cgroup_sock_addr2.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r0 src=r7 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=97 dst=r0 src=r0 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 142 "sample/cgroup_sock_addr2.c"
@@ -460,7 +457,7 @@ static helper_function_entry_t connect_redirect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
     {NULL, 65537, "helper_id_65537"},
-    {NULL, 65536, "helper_id_65536"},
+    {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 26, "helper_id_26"},
@@ -559,7 +556,7 @@ connect_redirect6(void* context)
         goto label_1;
 #line 102 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=87 imm=6
+    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=86 imm=6
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6)) {
 #line 102 "sample/cgroup_sock_addr2.c"
@@ -570,7 +567,7 @@ label_1:
     // EBPF_OP_LDXW pc=18 dst=r2 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=19 dst=r2 src=r0 offset=85 imm=23
+    // EBPF_OP_JNE_IMM pc=19 dst=r2 src=r0 offset=84 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(23)) {
 #line 102 "sample/cgroup_sock_addr2.c"
@@ -729,7 +726,7 @@ label_1:
     // EBPF_OP_ARSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 123 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=38 imm=0
+    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=37 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0) {
 #line 123 "sample/cgroup_sock_addr2.c"
@@ -780,10 +777,7 @@ label_3:
     // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-24 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
-#line 44 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=19
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address(r1, r2, r3, r4, r5, context);
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -792,16 +786,16 @@ label_3:
         return 0;
 #line 44 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-32 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address(r1, r2, r3, r4, r5, context);
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -810,13 +804,13 @@ label_3:
         return 0;
 #line 45 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-40 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address(r1, r2, r3, r4, r5, context);
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -825,19 +819,19 @@ label_3:
         return 0;
 #line 46 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-24 imm=0
+    // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-24 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-20 imm=0
+    // EBPF_OP_STXH pc=91 dst=r10 src=r1 offset=-20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=92 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=26
+    // EBPF_OP_CALL pc=93 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address(r1, r2, r3, r4, r5, context);
 #line 48 "sample/cgroup_sock_addr2.c"
@@ -846,31 +840,31 @@ label_3:
         return 0;
 #line 48 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=94 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_STXDW pc=96 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=95 dst=r10 src=r8 offset=-8 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=97 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r2 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=98 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=97 dst=r2 src=r0 offset=0 imm=-8
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=99 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=98 dst=r3 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=100 dst=r3 src=r0 offset=0 imm=-40
+    // EBPF_OP_ADD64_IMM pc=99 dst=r3 src=r0 offset=0 imm=-40
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-40);
-    // EBPF_OP_LDDW pc=101 dst=r1 src=r1 offset=0 imm=2
+    // EBPF_OP_LDDW pc=100 dst=r1 src=r1 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=103 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=102 dst=r4 src=r0 offset=0 imm=0
 #line 51 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=104 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[7].address(r1, r2, r3, r4, r5, context);
 #line 51 "sample/cgroup_sock_addr2.c"
@@ -880,10 +874,10 @@ label_3:
 #line 51 "sample/cgroup_sock_addr2.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=105 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=104 dst=r0 src=r7 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=106 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=105 dst=r0 src=r0 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 149 "sample/cgroup_sock_addr2.c"
@@ -903,7 +897,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         8,
-        99,
+        98,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -917,7 +911,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         8,
-        107,
+        106,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -213,7 +213,7 @@ static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65537, "helper_id_65537"},
-    {NULL, 65536, "helper_id_65536"},
+    {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 26, "helper_id_26"},
@@ -321,7 +321,7 @@ connect_redirect4(void* context)
         goto label_1;
 #line 61 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_JNE_IMM pc=20 dst=r1 src=r0 offset=76 imm=6
+    // EBPF_OP_JNE_IMM pc=20 dst=r1 src=r0 offset=75 imm=6
 #line 61 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6)) {
 #line 61 "sample/cgroup_sock_addr2.c"
@@ -332,7 +332,7 @@ label_1:
     // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=74 imm=2
+    // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=73 imm=2
 #line 61 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(2)) {
 #line 61 "sample/cgroup_sock_addr2.c"
@@ -479,7 +479,7 @@ label_1:
     // EBPF_OP_ARSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=30 imm=0
+    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=29 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0) {
 #line 79 "sample/cgroup_sock_addr2.c"
@@ -506,10 +506,7 @@ label_3:
     // EBPF_OP_STXDW pc=72 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
-#line 44 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=74 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=19
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address(r1, r2, r3, r4, r5, context);
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -518,16 +515,16 @@ label_3:
         return 0;
 #line 44 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_MOV64_REG pc=75 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address(r1, r2, r3, r4, r5, context);
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -536,13 +533,13 @@ label_3:
         return 0;
 #line 45 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r0 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address(r1, r2, r3, r4, r5, context);
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -551,19 +548,19 @@ label_3:
         return 0;
 #line 46 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXW pc=82 dst=r10 src=r0 offset=-88 imm=0
+    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=83 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=83 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=26
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address(r1, r2, r3, r4, r5, context);
 #line 48 "sample/cgroup_sock_addr2.c"
@@ -572,31 +569,31 @@ label_3:
         return 0;
 #line 48 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-80 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=88 dst=r2 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=89 dst=r2 src=r0 offset=0 imm=-8
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=90 dst=r3 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=91 dst=r3 src=r0 offset=0 imm=-104
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=93 dst=r1 src=r1 offset=0 imm=2
+    // EBPF_OP_LDDW pc=92 dst=r1 src=r1 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=94 dst=r4 src=r0 offset=0 imm=0
 #line 51 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[7].address(r1, r2, r3, r4, r5, context);
 #line 51 "sample/cgroup_sock_addr2.c"
@@ -606,10 +603,10 @@ label_3:
 #line 51 "sample/cgroup_sock_addr2.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r0 src=r7 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=97 dst=r0 src=r0 offset=0 imm=0
 #line 142 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 142 "sample/cgroup_sock_addr2.c"
@@ -621,7 +618,7 @@ static helper_function_entry_t connect_redirect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
     {NULL, 65537, "helper_id_65537"},
-    {NULL, 65536, "helper_id_65536"},
+    {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 26, "helper_id_26"},
@@ -720,7 +717,7 @@ connect_redirect6(void* context)
         goto label_1;
 #line 102 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=87 imm=6
+    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=86 imm=6
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6)) {
 #line 102 "sample/cgroup_sock_addr2.c"
@@ -731,7 +728,7 @@ label_1:
     // EBPF_OP_LDXW pc=18 dst=r2 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=19 dst=r2 src=r0 offset=85 imm=23
+    // EBPF_OP_JNE_IMM pc=19 dst=r2 src=r0 offset=84 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(23)) {
 #line 102 "sample/cgroup_sock_addr2.c"
@@ -890,7 +887,7 @@ label_1:
     // EBPF_OP_ARSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
 #line 123 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=38 imm=0
+    // EBPF_OP_JSGT_REG pc=66 dst=r7 src=r0 offset=37 imm=0
 #line 123 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0) {
 #line 123 "sample/cgroup_sock_addr2.c"
@@ -941,10 +938,7 @@ label_3:
     // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-24 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
-#line 44 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=19
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address(r1, r2, r3, r4, r5, context);
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -953,16 +947,16 @@ label_3:
         return 0;
 #line 44 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-32 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address(r1, r2, r3, r4, r5, context);
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -971,13 +965,13 @@ label_3:
         return 0;
 #line 45 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-40 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address(r1, r2, r3, r4, r5, context);
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -986,19 +980,19 @@ label_3:
         return 0;
 #line 46 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-24 imm=0
+    // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-24 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-20 imm=0
+    // EBPF_OP_STXH pc=91 dst=r10 src=r1 offset=-20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=92 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=26
+    // EBPF_OP_CALL pc=93 dst=r0 src=r0 offset=0 imm=26
 #line 48 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address(r1, r2, r3, r4, r5, context);
 #line 48 "sample/cgroup_sock_addr2.c"
@@ -1007,31 +1001,31 @@ label_3:
         return 0;
 #line 48 "sample/cgroup_sock_addr2.c"
     }
-    // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=94 dst=r10 src=r0 offset=-16 imm=0
 #line 48 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_STXDW pc=96 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=95 dst=r10 src=r8 offset=-8 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=97 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r2 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=98 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=97 dst=r2 src=r0 offset=0 imm=-8
 #line 50 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=99 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=98 dst=r3 src=r10 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=100 dst=r3 src=r0 offset=0 imm=-40
+    // EBPF_OP_ADD64_IMM pc=99 dst=r3 src=r0 offset=0 imm=-40
 #line 50 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-40);
-    // EBPF_OP_LDDW pc=101 dst=r1 src=r1 offset=0 imm=2
+    // EBPF_OP_LDDW pc=100 dst=r1 src=r1 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=103 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=102 dst=r4 src=r0 offset=0 imm=0
 #line 51 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=104 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=103 dst=r0 src=r0 offset=0 imm=2
 #line 51 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[7].address(r1, r2, r3, r4, r5, context);
 #line 51 "sample/cgroup_sock_addr2.c"
@@ -1041,10 +1035,10 @@ label_3:
 #line 51 "sample/cgroup_sock_addr2.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=105 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=104 dst=r0 src=r7 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=106 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=105 dst=r0 src=r0 offset=0 imm=0
 #line 149 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 149 "sample/cgroup_sock_addr2.c"
@@ -1064,7 +1058,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         8,
-        99,
+        98,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -1078,7 +1072,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         8,
-        107,
+        106,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -75,6 +75,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connection_monitor_helpers[] = {
+    {NULL, 19, "helper_id_19"},
     {NULL, 1, "helper_id_1"},
     {NULL, 11, "helper_id_11"},
 };
@@ -91,549 +92,585 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
 {
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     // Prologue
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r0 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r1 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r2 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r3 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r4 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r5 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r6 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r7 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r10 = 0;
 
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     r1 = (uintptr_t)context;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=2
-#line 72 "sample/sockops.c"
-    r2 = IMMEDIATE(2);
-    // EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 72 "sample/sockops.c"
-    r4 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=2 dst=r3 src=r1 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=3 dst=r3 src=r0 offset=8 imm=0
-#line 77 "sample/sockops.c"
-    if (r3 == IMMEDIATE(0)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r6 src=r0 offset=0 imm=2
+#line 78 "sample/sockops.c"
+    r6 = IMMEDIATE(2);
+    // EBPF_OP_MOV64_IMM pc=1 dst=r3 src=r0 offset=0 imm=1
+#line 78 "sample/sockops.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
+#line 83 "sample/sockops.c"
+    if (r2 == IMMEDIATE(0)) {
+#line 83 "sample/sockops.c"
         goto label_2;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
-    // EBPF_OP_JEQ_IMM pc=4 dst=r3 src=r0 offset=5 imm=2
-#line 77 "sample/sockops.c"
-    if (r3 == IMMEDIATE(2)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+#line 83 "sample/sockops.c"
+    if (r2 == IMMEDIATE(2)) {
+#line 83 "sample/sockops.c"
         goto label_1;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
     // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=7 dst=r3 src=r0 offset=164 imm=1
-#line 77 "sample/sockops.c"
-    if (r3 != IMMEDIATE(1)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=172 imm=1
+#line 83 "sample/sockops.c"
+    if (r2 != IMMEDIATE(1)) {
+#line 83 "sample/sockops.c"
         goto label_5;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     goto label_2;
 label_1:
-    // EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r2 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_LDXW pc=12 dst=r3 src=r1 offset=4 imm=0
-#line 94 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
-    // EBPF_OP_JNE_IMM pc=13 dst=r3 src=r0 offset=33 imm=2
-#line 94 "sample/sockops.c"
-    if (r3 != IMMEDIATE(2)) {
-#line 94 "sample/sockops.c"
-        goto label_3;
-#line 94 "sample/sockops.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=14 dst=r3 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=10 dst=r3 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=15 dst=r10 src=r3 offset=-8 imm=0
+    // EBPF_OP_MOV64_IMM pc=11 dst=r6 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r6 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
+#line 100 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=37 imm=2
+#line 100 "sample/sockops.c"
+    if (r2 != IMMEDIATE(2)) {
+#line 100 "sample/sockops.c"
+        goto label_3;
+#line 100 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=14 dst=r2 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r2 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r2 offset=-8 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r3 offset=-16 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r2 offset=-16 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r3 offset=-24 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r2 offset=-24 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=18 dst=r10 src=r3 offset=-32 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=18 dst=r10 src=r2 offset=-32 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r3 offset=-40 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r2 offset=-40 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=20 dst=r10 src=r3 offset=-48 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=20 dst=r10 src=r2 offset=-48 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=21 dst=r10 src=r3 offset=-56 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r2 offset=-56 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=22 dst=r10 src=r3 offset=-64 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=22 dst=r10 src=r2 offset=-64 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r3;
-    // EBPF_OP_LDXW pc=23 dst=r3 src=r1 offset=8 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=23 dst=r10 src=r2 offset=-72 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=24 dst=r2 src=r1 offset=8 imm=0
 #line 38 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
-    // EBPF_OP_STXW pc=24 dst=r10 src=r3 offset=-64 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXW pc=25 dst=r10 src=r2 offset=-72 imm=0
 #line 38 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r3;
-    // EBPF_OP_LDXW pc=25 dst=r3 src=r1 offset=24 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=26 dst=r2 src=r1 offset=24 imm=0
 #line 39 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
-    // EBPF_OP_STXH pc=26 dst=r10 src=r3 offset=-48 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=27 dst=r10 src=r2 offset=-56 imm=0
 #line 39 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
-    // EBPF_OP_LDXW pc=27 dst=r3 src=r1 offset=28 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint16_t)r2;
+    // EBPF_OP_LDXW pc=28 dst=r2 src=r1 offset=28 imm=0
 #line 40 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
-    // EBPF_OP_STXW pc=28 dst=r10 src=r3 offset=-44 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXW pc=29 dst=r10 src=r2 offset=-52 imm=0
 #line 40 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r3;
-    // EBPF_OP_OR64_REG pc=29 dst=r2 src=r4 offset=0 imm=0
-#line 44 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_LDXW pc=30 dst=r3 src=r1 offset=44 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint32_t)r2;
+    // EBPF_OP_OR64_REG pc=30 dst=r6 src=r3 offset=0 imm=0
+#line 47 "sample/sockops.c"
+    r6 |= r3;
+    // EBPF_OP_LDXW pc=31 dst=r2 src=r1 offset=44 imm=0
 #line 41 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
-    // EBPF_OP_STXH pc=31 dst=r10 src=r3 offset=-28 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=32 dst=r10 src=r2 offset=-36 imm=0
 #line 41 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
-    // EBPF_OP_LDXB pc=32 dst=r3 src=r1 offset=48 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint16_t)r2;
+    // EBPF_OP_LDXB pc=33 dst=r2 src=r1 offset=48 imm=0
 #line 42 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-24 imm=0
+    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=34 dst=r10 src=r2 offset=-32 imm=0
 #line 42 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-    // EBPF_OP_LDXDW pc=34 dst=r1 src=r1 offset=56 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r1 offset=56 imm=0
 #line 43 "sample/sockops.c"
     r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=35 dst=r10 src=r2 offset=-8 imm=0
-#line 45 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-24 imm=0
 #line 43 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 43 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_CALL pc=37 dst=r0 src=r0 offset=0 imm=19
+#line 44 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 44 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+#line 44 "sample/sockops.c"
+        return 0;
+#line 44 "sample/sockops.c"
+    }
+    // EBPF_OP_STXB pc=38 dst=r10 src=r6 offset=-8 imm=0
+#line 48 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r6;
+    // EBPF_OP_RSH64_IMM pc=39 dst=r0 src=r0 offset=0 imm=32
+#line 46 "sample/sockops.c"
+    r0 >>= (IMMEDIATE(32) & 63);
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r0 offset=-16 imm=0
+#line 46 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=41 dst=r2 src=r10 offset=0 imm=0
+#line 46 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-64
-#line 43 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r1 offset=0 imm=1
+    // EBPF_OP_ADD64_IMM pc=42 dst=r2 src=r0 offset=0 imm=-72
+#line 46 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=43 dst=r1 src=r1 offset=0 imm=1
 #line 26 "sample/sockops.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
 #line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
-    // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
+    // EBPF_OP_LDDW pc=47 dst=r0 src=r0 offset=0 imm=-1
 #line 26 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=126 imm=0
+    // EBPF_OP_JEQ_IMM pc=49 dst=r1 src=r0 offset=130 imm=0
 #line 26 "sample/sockops.c"
     if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=118 imm=0
+    // EBPF_OP_JA pc=50 dst=r0 src=r0 offset=122 imm=0
 #line 26 "sample/sockops.c"
     goto label_4;
 label_3:
-    // EBPF_OP_MOV64_REG pc=47 dst=r3 src=r1 offset=0 imm=0
-#line 94 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_IMM pc=48 dst=r3 src=r0 offset=0 imm=28
-#line 94 "sample/sockops.c"
-    r3 += IMMEDIATE(28);
-    // EBPF_OP_MOV64_IMM pc=49 dst=r5 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
-    r5 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r5 offset=-8 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=51 dst=r10 src=r5 offset=-16 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r5 offset=-24 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r5 offset=-32 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r5 offset=-40 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r5 offset=-48 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r5;
-    // EBPF_OP_LDXB pc=56 dst=r0 src=r1 offset=17 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
-    // EBPF_OP_LSH64_IMM pc=57 dst=r0 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=58 dst=r5 src=r1 offset=16 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
-    // EBPF_OP_OR64_REG pc=59 dst=r0 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r5;
-    // EBPF_OP_LDXB pc=60 dst=r6 src=r1 offset=18 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
-    // EBPF_OP_LSH64_IMM pc=61 dst=r6 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=62 dst=r5 src=r1 offset=19 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
-    // EBPF_OP_LSH64_IMM pc=63 dst=r5 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=64 dst=r5 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_OR64_REG pc=65 dst=r5 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r0;
-    // EBPF_OP_LDXB pc=66 dst=r6 src=r1 offset=21 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
-    // EBPF_OP_LSH64_IMM pc=67 dst=r6 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=68 dst=r0 src=r1 offset=20 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
-    // EBPF_OP_OR64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_LDXB pc=70 dst=r7 src=r1 offset=22 imm=0
-#line 57 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
-    // EBPF_OP_LSH64_IMM pc=71 dst=r7 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=72 dst=r0 src=r1 offset=23 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
-    // EBPF_OP_LSH64_IMM pc=73 dst=r0 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=74 dst=r0 src=r7 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r7;
-    // EBPF_OP_OR64_REG pc=75 dst=r0 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r6;
-    // EBPF_OP_LSH64_IMM pc=76 dst=r0 src=r0 offset=0 imm=32
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=77 dst=r0 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r5;
-    // EBPF_OP_LDXB pc=78 dst=r6 src=r1 offset=9 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=79 dst=r6 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=80 dst=r5 src=r1 offset=8 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=81 dst=r6 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r5;
-    // EBPF_OP_LDXB pc=82 dst=r7 src=r1 offset=10 imm=0
-#line 57 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
-    // EBPF_OP_LSH64_IMM pc=83 dst=r7 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=84 dst=r5 src=r1 offset=11 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=85 dst=r5 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=86 dst=r5 src=r7 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r7;
-    // EBPF_OP_OR64_REG pc=87 dst=r2 src=r4 offset=0 imm=0
-#line 64 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r0 offset=-56 imm=0
-#line 57 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
-    // EBPF_OP_OR64_REG pc=89 dst=r5 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_LDXB pc=90 dst=r4 src=r1 offset=13 imm=0
-#line 57 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=91 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=92 dst=r0 src=r1 offset=12 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=93 dst=r4 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r4 |= r0;
-    // EBPF_OP_LDXB pc=94 dst=r0 src=r1 offset=14 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
-    // EBPF_OP_LSH64_IMM pc=95 dst=r0 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=96 dst=r6 src=r1 offset=15 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=97 dst=r6 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=98 dst=r6 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_OR64_REG pc=99 dst=r6 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r4;
-    // EBPF_OP_LSH64_IMM pc=100 dst=r6 src=r0 offset=0 imm=32
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=101 dst=r6 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r5;
-    // EBPF_OP_STXDW pc=102 dst=r10 src=r6 offset=-64 imm=0
-#line 57 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r6;
-    // EBPF_OP_LDXW pc=103 dst=r4 src=r1 offset=24 imm=0
-#line 58 "sample/sockops.c"
-    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
-    // EBPF_OP_STXH pc=104 dst=r10 src=r4 offset=-48 imm=0
-#line 58 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r4;
-    // EBPF_OP_LDXB pc=105 dst=r5 src=r3 offset=13 imm=0
+    // EBPF_OP_MOV64_REG pc=51 dst=r2 src=r1 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r2 = r1;
+    // EBPF_OP_ADD64_IMM pc=52 dst=r2 src=r0 offset=0 imm=28
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(28);
+    // EBPF_OP_MOV64_IMM pc=53 dst=r4 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=54 dst=r10 src=r4 offset=-8 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r4 offset=-16 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r4 offset=-24 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=57 dst=r10 src=r4 offset=-32 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r4 offset=-40 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=59 dst=r10 src=r4 offset=-48 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=60 dst=r10 src=r4 offset=-56 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_LDXB pc=61 dst=r5 src=r1 offset=17 imm=0
 #line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=106 dst=r5 src=r0 offset=0 imm=8
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_LSH64_IMM pc=62 dst=r5 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
     r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=107 dst=r4 src=r3 offset=12 imm=0
+    // EBPF_OP_LDXB pc=63 dst=r4 src=r1 offset=16 imm=0
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=108 dst=r5 src=r4 offset=0 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_OR64_REG pc=64 dst=r5 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r5 |= r4;
-    // EBPF_OP_LDXB pc=109 dst=r0 src=r3 offset=14 imm=0
+    // EBPF_OP_LDXB pc=65 dst=r0 src=r1 offset=18 imm=0
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
-    // EBPF_OP_LSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=16
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
     r0 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=111 dst=r4 src=r3 offset=15 imm=0
+    // EBPF_OP_LDXB pc=67 dst=r4 src=r1 offset=19 imm=0
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=112 dst=r4 src=r0 offset=0 imm=24
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_LSH64_IMM pc=68 dst=r4 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
     r4 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=113 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=69 dst=r4 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r4 |= r0;
-    // EBPF_OP_LDXB pc=114 dst=r6 src=r3 offset=1 imm=0
+    // EBPF_OP_OR64_REG pc=70 dst=r4 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
-    // EBPF_OP_LSH64_IMM pc=115 dst=r6 src=r0 offset=0 imm=8
+    r4 |= r5;
+    // EBPF_OP_LDXB pc=71 dst=r0 src=r1 offset=21 imm=0
 #line 60 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=116 dst=r0 src=r3 offset=0 imm=0
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_LSH64_IMM pc=72 dst=r0 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_OR64_REG pc=117 dst=r6 src=r0 offset=0 imm=0
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=73 dst=r5 src=r1 offset=20 imm=0
 #line 60 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_LDXB pc=118 dst=r7 src=r3 offset=2 imm=0
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_OR64_REG pc=74 dst=r0 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
-    // EBPF_OP_LSH64_IMM pc=119 dst=r7 src=r0 offset=0 imm=16
+    r0 |= r5;
+    // EBPF_OP_LDXB pc=75 dst=r7 src=r1 offset=22 imm=0
+#line 60 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_LSH64_IMM pc=76 dst=r7 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
     r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=120 dst=r0 src=r3 offset=3 imm=0
+    // EBPF_OP_LDXB pc=77 dst=r5 src=r1 offset=23 imm=0
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
-    // EBPF_OP_LSH64_IMM pc=121 dst=r0 src=r0 offset=0 imm=24
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_LSH64_IMM pc=78 dst=r5 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=122 dst=r0 src=r7 offset=0 imm=0
+    r5 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=79 dst=r5 src=r7 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r0 |= r7;
-    // EBPF_OP_OR64_REG pc=123 dst=r0 src=r6 offset=0 imm=0
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=80 dst=r5 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r0 |= r6;
-    // EBPF_OP_OR64_REG pc=124 dst=r4 src=r5 offset=0 imm=0
+    r5 |= r0;
+    // EBPF_OP_LSH64_IMM pc=81 dst=r5 src=r0 offset=0 imm=32
 #line 60 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=125 dst=r5 src=r3 offset=9 imm=0
+    r5 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=82 dst=r5 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=126 dst=r5 src=r0 offset=0 imm=8
+    r5 |= r4;
+    // EBPF_OP_LDXB pc=83 dst=r0 src=r1 offset=9 imm=0
 #line 60 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=127 dst=r6 src=r3 offset=8 imm=0
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=84 dst=r0 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=128 dst=r5 src=r6 offset=0 imm=0
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=85 dst=r4 src=r1 offset=8 imm=0
 #line 60 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_LDXB pc=129 dst=r6 src=r3 offset=10 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=86 dst=r0 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
-    // EBPF_OP_LSH64_IMM pc=130 dst=r6 src=r0 offset=0 imm=16
+    r0 |= r4;
+    // EBPF_OP_LDXB pc=87 dst=r7 src=r1 offset=10 imm=0
 #line 60 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=131 dst=r7 src=r3 offset=11 imm=0
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_LSH64_IMM pc=88 dst=r7 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=132 dst=r7 src=r0 offset=0 imm=24
+    r7 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=89 dst=r4 src=r1 offset=11 imm=0
 #line 60 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=133 dst=r7 src=r6 offset=0 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=90 dst=r4 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
-    r7 |= r6;
-    // EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
+    r4 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=91 dst=r4 src=r7 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r7 |= r5;
-    // EBPF_OP_STXW pc=135 dst=r10 src=r7 offset=-36 imm=0
+    r4 |= r7;
+    // EBPF_OP_OR64_REG pc=92 dst=r6 src=r3 offset=0 imm=0
+#line 70 "sample/sockops.c"
+    r6 |= r3;
+    // EBPF_OP_STXDW pc=93 dst=r10 src=r5 offset=-64 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=136 dst=r10 src=r4 offset=-32 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
+    // EBPF_OP_OR64_REG pc=94 dst=r4 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r4;
-    // EBPF_OP_STXW pc=137 dst=r10 src=r0 offset=-44 imm=0
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=95 dst=r3 src=r1 offset=13 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r0;
-    // EBPF_OP_LDXB pc=138 dst=r4 src=r3 offset=5 imm=0
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=96 dst=r3 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=97 dst=r5 src=r1 offset=12 imm=0
 #line 60 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=140 dst=r5 src=r3 offset=4 imm=0
-#line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=141 dst=r4 src=r5 offset=0 imm=0
-#line 60 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=142 dst=r5 src=r3 offset=6 imm=0
-#line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(6));
-    // EBPF_OP_LSH64_IMM pc=143 dst=r5 src=r0 offset=0 imm=16
-#line 60 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=144 dst=r3 src=r3 offset=7 imm=0
-#line 60 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=145 dst=r3 src=r0 offset=0 imm=24
-#line 60 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=146 dst=r3 src=r5 offset=0 imm=0
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=98 dst=r3 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r3 |= r5;
-    // EBPF_OP_OR64_REG pc=147 dst=r3 src=r4 offset=0 imm=0
+    // EBPF_OP_LDXB pc=99 dst=r5 src=r1 offset=14 imm=0
 #line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_LSH64_IMM pc=100 dst=r5 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=101 dst=r0 src=r1 offset=15 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=102 dst=r0 src=r0 offset=0 imm=24
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=103 dst=r0 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_OR64_REG pc=104 dst=r0 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r3;
+    // EBPF_OP_LSH64_IMM pc=105 dst=r0 src=r0 offset=0 imm=32
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=106 dst=r0 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r4;
+    // EBPF_OP_STXDW pc=107 dst=r10 src=r0 offset=-72 imm=0
+#line 60 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
+    // EBPF_OP_LDXW pc=108 dst=r3 src=r1 offset=24 imm=0
+#line 61 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=109 dst=r10 src=r3 offset=-56 imm=0
+#line 61 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=110 dst=r4 src=r2 offset=13 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=111 dst=r4 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=112 dst=r3 src=r2 offset=12 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=113 dst=r4 src=r3 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_LDXB pc=114 dst=r5 src=r2 offset=14 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
+    // EBPF_OP_LSH64_IMM pc=115 dst=r5 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=116 dst=r3 src=r2 offset=15 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=117 dst=r3 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=118 dst=r3 src=r5 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r3 |= r5;
+    // EBPF_OP_LDXB pc=119 dst=r0 src=r2 offset=1 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(1));
+    // EBPF_OP_LSH64_IMM pc=120 dst=r0 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=121 dst=r5 src=r2 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_OR64_REG pc=122 dst=r0 src=r5 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_LDXB pc=123 dst=r7 src=r2 offset=2 imm=0
+#line 63 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(2));
+    // EBPF_OP_LSH64_IMM pc=124 dst=r7 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r7 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=125 dst=r5 src=r2 offset=3 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(3));
+    // EBPF_OP_LSH64_IMM pc=126 dst=r5 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=127 dst=r5 src=r7 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=128 dst=r5 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 |= r0;
+    // EBPF_OP_OR64_REG pc=129 dst=r3 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
     r3 |= r4;
-    // EBPF_OP_STXW pc=148 dst=r10 src=r3 offset=-40 imm=0
-#line 60 "sample/sockops.c"
+    // EBPF_OP_LDXB pc=130 dst=r4 src=r2 offset=9 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=131 dst=r4 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=132 dst=r0 src=r2 offset=8 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=133 dst=r4 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=134 dst=r0 src=r2 offset=10 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(10));
+    // EBPF_OP_LSH64_IMM pc=135 dst=r0 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=136 dst=r7 src=r2 offset=11 imm=0
+#line 63 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=137 dst=r7 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r7 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=138 dst=r7 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r7 |= r0;
+    // EBPF_OP_OR64_REG pc=139 dst=r7 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r7 |= r4;
+    // EBPF_OP_STXW pc=140 dst=r10 src=r7 offset=-44 imm=0
+#line 63 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r7;
+    // EBPF_OP_STXW pc=141 dst=r10 src=r3 offset=-40 imm=0
+#line 63 "sample/sockops.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r3;
-    // EBPF_OP_LDXW pc=149 dst=r3 src=r1 offset=44 imm=0
-#line 61 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
-    // EBPF_OP_STXH pc=150 dst=r10 src=r3 offset=-28 imm=0
-#line 61 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
-    // EBPF_OP_LDXB pc=151 dst=r3 src=r1 offset=48 imm=0
-#line 62 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=152 dst=r10 src=r3 offset=-24 imm=0
-#line 62 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-    // EBPF_OP_LDXDW pc=153 dst=r1 src=r1 offset=56 imm=0
+    // EBPF_OP_STXW pc=142 dst=r10 src=r5 offset=-52 imm=0
 #line 63 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=154 dst=r10 src=r2 offset=-8 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint32_t)r5;
+    // EBPF_OP_LDXB pc=143 dst=r3 src=r2 offset=5 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(5));
+    // EBPF_OP_LSH64_IMM pc=144 dst=r3 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=145 dst=r4 src=r2 offset=4 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(4));
+    // EBPF_OP_OR64_REG pc=146 dst=r3 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=147 dst=r4 src=r2 offset=6 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(6));
+    // EBPF_OP_LSH64_IMM pc=148 dst=r4 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=149 dst=r2 src=r2 offset=7 imm=0
+#line 63 "sample/sockops.c"
+    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(7));
+    // EBPF_OP_LSH64_IMM pc=150 dst=r2 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r2 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=151 dst=r2 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 |= r4;
+    // EBPF_OP_OR64_REG pc=152 dst=r2 src=r3 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_STXW pc=153 dst=r10 src=r2 offset=-48 imm=0
+#line 63 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=154 dst=r2 src=r1 offset=44 imm=0
+#line 64 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=155 dst=r10 src=r2 offset=-36 imm=0
+#line 64 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint16_t)r2;
+    // EBPF_OP_LDXB pc=156 dst=r2 src=r1 offset=48 imm=0
 #line 65 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=155 dst=r10 src=r1 offset=-16 imm=0
-#line 63 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=156 dst=r2 src=r10 offset=0 imm=0
-#line 63 "sample/sockops.c"
+    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=157 dst=r10 src=r2 offset=-32 imm=0
+#line 65 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXDW pc=158 dst=r1 src=r1 offset=56 imm=0
+#line 66 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXDW pc=159 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_CALL pc=160 dst=r0 src=r0 offset=0 imm=19
+#line 67 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 67 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+#line 67 "sample/sockops.c"
+        return 0;
+#line 67 "sample/sockops.c"
+    }
+    // EBPF_OP_STXB pc=161 dst=r10 src=r6 offset=-8 imm=0
+#line 71 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r6;
+    // EBPF_OP_RSH64_IMM pc=162 dst=r0 src=r0 offset=0 imm=32
+#line 69 "sample/sockops.c"
+    r0 >>= (IMMEDIATE(32) & 63);
+    // EBPF_OP_STXDW pc=163 dst=r10 src=r0 offset=-16 imm=0
+#line 69 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=164 dst=r2 src=r10 offset=0 imm=0
+#line 69 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=157 dst=r2 src=r0 offset=0 imm=-64
-#line 94 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=158 dst=r1 src=r1 offset=0 imm=1
+    // EBPF_OP_ADD64_IMM pc=165 dst=r2 src=r0 offset=0 imm=-72
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=166 dst=r1 src=r1 offset=0 imm=1
 #line 26 "sample/sockops.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=160 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=168 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
 #line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_REG pc=161 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
-    // EBPF_OP_LDDW pc=162 dst=r0 src=r0 offset=0 imm=-1
+    // EBPF_OP_LDDW pc=170 dst=r0 src=r0 offset=0 imm=-1
 #line 26 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=164 dst=r1 src=r0 offset=7 imm=0
+    // EBPF_OP_JEQ_IMM pc=172 dst=r1 src=r0 offset=7 imm=0
 #line 26 "sample/sockops.c"
     if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
@@ -641,35 +678,35 @@ label_3:
 #line 26 "sample/sockops.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=165 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=173 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=166 dst=r2 src=r0 offset=0 imm=-64
-#line 94 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=167 dst=r1 src=r1 offset=0 imm=2
-#line 94 "sample/sockops.c"
+    // EBPF_OP_ADD64_IMM pc=174 dst=r2 src=r0 offset=0 imm=-72
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=175 dst=r1 src=r1 offset=0 imm=2
+#line 100 "sample/sockops.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=169 dst=r3 src=r0 offset=0 imm=64
-#line 94 "sample/sockops.c"
-    r3 = IMMEDIATE(64);
-    // EBPF_OP_MOV64_IMM pc=170 dst=r4 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=177 dst=r3 src=r0 offset=0 imm=72
+#line 100 "sample/sockops.c"
+    r3 = IMMEDIATE(72);
+    // EBPF_OP_MOV64_IMM pc=178 dst=r4 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=171 dst=r0 src=r0 offset=0 imm=11
-#line 94 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
-#line 94 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
-#line 94 "sample/sockops.c"
+    // EBPF_OP_CALL pc=179 dst=r0 src=r0 offset=0 imm=11
+#line 100 "sample/sockops.c"
+    r0 = connection_monitor_helpers[2].address(r1, r2, r3, r4, r5, context);
+#line 100 "sample/sockops.c"
+    if ((connection_monitor_helpers[2].tail_call) && (r0 == 0)) {
+#line 100 "sample/sockops.c"
         return 0;
-#line 94 "sample/sockops.c"
+#line 100 "sample/sockops.c"
     }
 label_5:
-    // EBPF_OP_EXIT pc=172 dst=r0 src=r0 offset=0 imm=0
-#line 97 "sample/sockops.c"
+    // EBPF_OP_EXIT pc=180 dst=r0 src=r0 offset=0 imm=0
+#line 103 "sample/sockops.c"
     return r0;
-#line 97 "sample/sockops.c"
+#line 103 "sample/sockops.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -685,8 +722,8 @@ static program_entry_t _programs[] = {
         connection_monitor_maps,
         2,
         connection_monitor_helpers,
-        2,
-        173,
+        3,
+        181,
         &connection_monitor_program_type_guid,
         &connection_monitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -49,6 +49,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connection_monitor_helpers[] = {
+    {NULL, 19, "helper_id_19"},
     {NULL, 1, "helper_id_1"},
     {NULL, 11, "helper_id_11"},
 };
@@ -65,549 +66,585 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
 {
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     // Prologue
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r0 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r1 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r2 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r3 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r4 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r5 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r6 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r7 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r10 = 0;
 
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     r1 = (uintptr_t)context;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=2
-#line 72 "sample/sockops.c"
-    r2 = IMMEDIATE(2);
-    // EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 72 "sample/sockops.c"
-    r4 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=2 dst=r3 src=r1 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=3 dst=r3 src=r0 offset=8 imm=0
-#line 77 "sample/sockops.c"
-    if (r3 == IMMEDIATE(0)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r6 src=r0 offset=0 imm=2
+#line 78 "sample/sockops.c"
+    r6 = IMMEDIATE(2);
+    // EBPF_OP_MOV64_IMM pc=1 dst=r3 src=r0 offset=0 imm=1
+#line 78 "sample/sockops.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
+#line 83 "sample/sockops.c"
+    if (r2 == IMMEDIATE(0)) {
+#line 83 "sample/sockops.c"
         goto label_2;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
-    // EBPF_OP_JEQ_IMM pc=4 dst=r3 src=r0 offset=5 imm=2
-#line 77 "sample/sockops.c"
-    if (r3 == IMMEDIATE(2)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+#line 83 "sample/sockops.c"
+    if (r2 == IMMEDIATE(2)) {
+#line 83 "sample/sockops.c"
         goto label_1;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
     // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=7 dst=r3 src=r0 offset=164 imm=1
-#line 77 "sample/sockops.c"
-    if (r3 != IMMEDIATE(1)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=172 imm=1
+#line 83 "sample/sockops.c"
+    if (r2 != IMMEDIATE(1)) {
+#line 83 "sample/sockops.c"
         goto label_5;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     goto label_2;
 label_1:
-    // EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r2 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_LDXW pc=12 dst=r3 src=r1 offset=4 imm=0
-#line 94 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
-    // EBPF_OP_JNE_IMM pc=13 dst=r3 src=r0 offset=33 imm=2
-#line 94 "sample/sockops.c"
-    if (r3 != IMMEDIATE(2)) {
-#line 94 "sample/sockops.c"
-        goto label_3;
-#line 94 "sample/sockops.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=14 dst=r3 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=10 dst=r3 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=15 dst=r10 src=r3 offset=-8 imm=0
+    // EBPF_OP_MOV64_IMM pc=11 dst=r6 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r6 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
+#line 100 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=37 imm=2
+#line 100 "sample/sockops.c"
+    if (r2 != IMMEDIATE(2)) {
+#line 100 "sample/sockops.c"
+        goto label_3;
+#line 100 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=14 dst=r2 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r2 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r2 offset=-8 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r3 offset=-16 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r2 offset=-16 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r3 offset=-24 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r2 offset=-24 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=18 dst=r10 src=r3 offset=-32 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=18 dst=r10 src=r2 offset=-32 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r3 offset=-40 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r2 offset=-40 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=20 dst=r10 src=r3 offset=-48 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=20 dst=r10 src=r2 offset=-48 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=21 dst=r10 src=r3 offset=-56 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r2 offset=-56 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=22 dst=r10 src=r3 offset=-64 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=22 dst=r10 src=r2 offset=-64 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r3;
-    // EBPF_OP_LDXW pc=23 dst=r3 src=r1 offset=8 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=23 dst=r10 src=r2 offset=-72 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=24 dst=r2 src=r1 offset=8 imm=0
 #line 38 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
-    // EBPF_OP_STXW pc=24 dst=r10 src=r3 offset=-64 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXW pc=25 dst=r10 src=r2 offset=-72 imm=0
 #line 38 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r3;
-    // EBPF_OP_LDXW pc=25 dst=r3 src=r1 offset=24 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=26 dst=r2 src=r1 offset=24 imm=0
 #line 39 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
-    // EBPF_OP_STXH pc=26 dst=r10 src=r3 offset=-48 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=27 dst=r10 src=r2 offset=-56 imm=0
 #line 39 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
-    // EBPF_OP_LDXW pc=27 dst=r3 src=r1 offset=28 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint16_t)r2;
+    // EBPF_OP_LDXW pc=28 dst=r2 src=r1 offset=28 imm=0
 #line 40 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
-    // EBPF_OP_STXW pc=28 dst=r10 src=r3 offset=-44 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXW pc=29 dst=r10 src=r2 offset=-52 imm=0
 #line 40 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r3;
-    // EBPF_OP_OR64_REG pc=29 dst=r2 src=r4 offset=0 imm=0
-#line 44 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_LDXW pc=30 dst=r3 src=r1 offset=44 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint32_t)r2;
+    // EBPF_OP_OR64_REG pc=30 dst=r6 src=r3 offset=0 imm=0
+#line 47 "sample/sockops.c"
+    r6 |= r3;
+    // EBPF_OP_LDXW pc=31 dst=r2 src=r1 offset=44 imm=0
 #line 41 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
-    // EBPF_OP_STXH pc=31 dst=r10 src=r3 offset=-28 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=32 dst=r10 src=r2 offset=-36 imm=0
 #line 41 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
-    // EBPF_OP_LDXB pc=32 dst=r3 src=r1 offset=48 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint16_t)r2;
+    // EBPF_OP_LDXB pc=33 dst=r2 src=r1 offset=48 imm=0
 #line 42 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-24 imm=0
+    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=34 dst=r10 src=r2 offset=-32 imm=0
 #line 42 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-    // EBPF_OP_LDXDW pc=34 dst=r1 src=r1 offset=56 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r1 offset=56 imm=0
 #line 43 "sample/sockops.c"
     r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=35 dst=r10 src=r2 offset=-8 imm=0
-#line 45 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-24 imm=0
 #line 43 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 43 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_CALL pc=37 dst=r0 src=r0 offset=0 imm=19
+#line 44 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 44 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+#line 44 "sample/sockops.c"
+        return 0;
+#line 44 "sample/sockops.c"
+    }
+    // EBPF_OP_STXB pc=38 dst=r10 src=r6 offset=-8 imm=0
+#line 48 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r6;
+    // EBPF_OP_RSH64_IMM pc=39 dst=r0 src=r0 offset=0 imm=32
+#line 46 "sample/sockops.c"
+    r0 >>= (IMMEDIATE(32) & 63);
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r0 offset=-16 imm=0
+#line 46 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=41 dst=r2 src=r10 offset=0 imm=0
+#line 46 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-64
-#line 43 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r1 offset=0 imm=1
+    // EBPF_OP_ADD64_IMM pc=42 dst=r2 src=r0 offset=0 imm=-72
+#line 46 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=43 dst=r1 src=r1 offset=0 imm=1
 #line 26 "sample/sockops.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
 #line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
-    // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
+    // EBPF_OP_LDDW pc=47 dst=r0 src=r0 offset=0 imm=-1
 #line 26 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=126 imm=0
+    // EBPF_OP_JEQ_IMM pc=49 dst=r1 src=r0 offset=130 imm=0
 #line 26 "sample/sockops.c"
     if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=118 imm=0
+    // EBPF_OP_JA pc=50 dst=r0 src=r0 offset=122 imm=0
 #line 26 "sample/sockops.c"
     goto label_4;
 label_3:
-    // EBPF_OP_MOV64_REG pc=47 dst=r3 src=r1 offset=0 imm=0
-#line 94 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_IMM pc=48 dst=r3 src=r0 offset=0 imm=28
-#line 94 "sample/sockops.c"
-    r3 += IMMEDIATE(28);
-    // EBPF_OP_MOV64_IMM pc=49 dst=r5 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
-    r5 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r5 offset=-8 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=51 dst=r10 src=r5 offset=-16 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r5 offset=-24 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r5 offset=-32 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r5 offset=-40 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r5 offset=-48 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r5;
-    // EBPF_OP_LDXB pc=56 dst=r0 src=r1 offset=17 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
-    // EBPF_OP_LSH64_IMM pc=57 dst=r0 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=58 dst=r5 src=r1 offset=16 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
-    // EBPF_OP_OR64_REG pc=59 dst=r0 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r5;
-    // EBPF_OP_LDXB pc=60 dst=r6 src=r1 offset=18 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
-    // EBPF_OP_LSH64_IMM pc=61 dst=r6 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=62 dst=r5 src=r1 offset=19 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
-    // EBPF_OP_LSH64_IMM pc=63 dst=r5 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=64 dst=r5 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_OR64_REG pc=65 dst=r5 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r0;
-    // EBPF_OP_LDXB pc=66 dst=r6 src=r1 offset=21 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
-    // EBPF_OP_LSH64_IMM pc=67 dst=r6 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=68 dst=r0 src=r1 offset=20 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
-    // EBPF_OP_OR64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_LDXB pc=70 dst=r7 src=r1 offset=22 imm=0
-#line 57 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
-    // EBPF_OP_LSH64_IMM pc=71 dst=r7 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=72 dst=r0 src=r1 offset=23 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
-    // EBPF_OP_LSH64_IMM pc=73 dst=r0 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=74 dst=r0 src=r7 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r7;
-    // EBPF_OP_OR64_REG pc=75 dst=r0 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r6;
-    // EBPF_OP_LSH64_IMM pc=76 dst=r0 src=r0 offset=0 imm=32
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=77 dst=r0 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r5;
-    // EBPF_OP_LDXB pc=78 dst=r6 src=r1 offset=9 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=79 dst=r6 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=80 dst=r5 src=r1 offset=8 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=81 dst=r6 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r5;
-    // EBPF_OP_LDXB pc=82 dst=r7 src=r1 offset=10 imm=0
-#line 57 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
-    // EBPF_OP_LSH64_IMM pc=83 dst=r7 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=84 dst=r5 src=r1 offset=11 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=85 dst=r5 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=86 dst=r5 src=r7 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r7;
-    // EBPF_OP_OR64_REG pc=87 dst=r2 src=r4 offset=0 imm=0
-#line 64 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r0 offset=-56 imm=0
-#line 57 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
-    // EBPF_OP_OR64_REG pc=89 dst=r5 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_LDXB pc=90 dst=r4 src=r1 offset=13 imm=0
-#line 57 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=91 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=92 dst=r0 src=r1 offset=12 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=93 dst=r4 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r4 |= r0;
-    // EBPF_OP_LDXB pc=94 dst=r0 src=r1 offset=14 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
-    // EBPF_OP_LSH64_IMM pc=95 dst=r0 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=96 dst=r6 src=r1 offset=15 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=97 dst=r6 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=98 dst=r6 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_OR64_REG pc=99 dst=r6 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r4;
-    // EBPF_OP_LSH64_IMM pc=100 dst=r6 src=r0 offset=0 imm=32
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=101 dst=r6 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r5;
-    // EBPF_OP_STXDW pc=102 dst=r10 src=r6 offset=-64 imm=0
-#line 57 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r6;
-    // EBPF_OP_LDXW pc=103 dst=r4 src=r1 offset=24 imm=0
-#line 58 "sample/sockops.c"
-    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
-    // EBPF_OP_STXH pc=104 dst=r10 src=r4 offset=-48 imm=0
-#line 58 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r4;
-    // EBPF_OP_LDXB pc=105 dst=r5 src=r3 offset=13 imm=0
+    // EBPF_OP_MOV64_REG pc=51 dst=r2 src=r1 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r2 = r1;
+    // EBPF_OP_ADD64_IMM pc=52 dst=r2 src=r0 offset=0 imm=28
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(28);
+    // EBPF_OP_MOV64_IMM pc=53 dst=r4 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=54 dst=r10 src=r4 offset=-8 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r4 offset=-16 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r4 offset=-24 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=57 dst=r10 src=r4 offset=-32 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r4 offset=-40 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=59 dst=r10 src=r4 offset=-48 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=60 dst=r10 src=r4 offset=-56 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_LDXB pc=61 dst=r5 src=r1 offset=17 imm=0
 #line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=106 dst=r5 src=r0 offset=0 imm=8
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_LSH64_IMM pc=62 dst=r5 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
     r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=107 dst=r4 src=r3 offset=12 imm=0
+    // EBPF_OP_LDXB pc=63 dst=r4 src=r1 offset=16 imm=0
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=108 dst=r5 src=r4 offset=0 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_OR64_REG pc=64 dst=r5 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r5 |= r4;
-    // EBPF_OP_LDXB pc=109 dst=r0 src=r3 offset=14 imm=0
+    // EBPF_OP_LDXB pc=65 dst=r0 src=r1 offset=18 imm=0
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
-    // EBPF_OP_LSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=16
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
     r0 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=111 dst=r4 src=r3 offset=15 imm=0
+    // EBPF_OP_LDXB pc=67 dst=r4 src=r1 offset=19 imm=0
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=112 dst=r4 src=r0 offset=0 imm=24
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_LSH64_IMM pc=68 dst=r4 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
     r4 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=113 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=69 dst=r4 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r4 |= r0;
-    // EBPF_OP_LDXB pc=114 dst=r6 src=r3 offset=1 imm=0
+    // EBPF_OP_OR64_REG pc=70 dst=r4 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
-    // EBPF_OP_LSH64_IMM pc=115 dst=r6 src=r0 offset=0 imm=8
+    r4 |= r5;
+    // EBPF_OP_LDXB pc=71 dst=r0 src=r1 offset=21 imm=0
 #line 60 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=116 dst=r0 src=r3 offset=0 imm=0
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_LSH64_IMM pc=72 dst=r0 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_OR64_REG pc=117 dst=r6 src=r0 offset=0 imm=0
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=73 dst=r5 src=r1 offset=20 imm=0
 #line 60 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_LDXB pc=118 dst=r7 src=r3 offset=2 imm=0
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_OR64_REG pc=74 dst=r0 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
-    // EBPF_OP_LSH64_IMM pc=119 dst=r7 src=r0 offset=0 imm=16
+    r0 |= r5;
+    // EBPF_OP_LDXB pc=75 dst=r7 src=r1 offset=22 imm=0
+#line 60 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_LSH64_IMM pc=76 dst=r7 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
     r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=120 dst=r0 src=r3 offset=3 imm=0
+    // EBPF_OP_LDXB pc=77 dst=r5 src=r1 offset=23 imm=0
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
-    // EBPF_OP_LSH64_IMM pc=121 dst=r0 src=r0 offset=0 imm=24
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_LSH64_IMM pc=78 dst=r5 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=122 dst=r0 src=r7 offset=0 imm=0
+    r5 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=79 dst=r5 src=r7 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r0 |= r7;
-    // EBPF_OP_OR64_REG pc=123 dst=r0 src=r6 offset=0 imm=0
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=80 dst=r5 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r0 |= r6;
-    // EBPF_OP_OR64_REG pc=124 dst=r4 src=r5 offset=0 imm=0
+    r5 |= r0;
+    // EBPF_OP_LSH64_IMM pc=81 dst=r5 src=r0 offset=0 imm=32
 #line 60 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=125 dst=r5 src=r3 offset=9 imm=0
+    r5 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=82 dst=r5 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=126 dst=r5 src=r0 offset=0 imm=8
+    r5 |= r4;
+    // EBPF_OP_LDXB pc=83 dst=r0 src=r1 offset=9 imm=0
 #line 60 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=127 dst=r6 src=r3 offset=8 imm=0
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=84 dst=r0 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=128 dst=r5 src=r6 offset=0 imm=0
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=85 dst=r4 src=r1 offset=8 imm=0
 #line 60 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_LDXB pc=129 dst=r6 src=r3 offset=10 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=86 dst=r0 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
-    // EBPF_OP_LSH64_IMM pc=130 dst=r6 src=r0 offset=0 imm=16
+    r0 |= r4;
+    // EBPF_OP_LDXB pc=87 dst=r7 src=r1 offset=10 imm=0
 #line 60 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=131 dst=r7 src=r3 offset=11 imm=0
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_LSH64_IMM pc=88 dst=r7 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=132 dst=r7 src=r0 offset=0 imm=24
+    r7 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=89 dst=r4 src=r1 offset=11 imm=0
 #line 60 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=133 dst=r7 src=r6 offset=0 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=90 dst=r4 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
-    r7 |= r6;
-    // EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
+    r4 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=91 dst=r4 src=r7 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r7 |= r5;
-    // EBPF_OP_STXW pc=135 dst=r10 src=r7 offset=-36 imm=0
+    r4 |= r7;
+    // EBPF_OP_OR64_REG pc=92 dst=r6 src=r3 offset=0 imm=0
+#line 70 "sample/sockops.c"
+    r6 |= r3;
+    // EBPF_OP_STXDW pc=93 dst=r10 src=r5 offset=-64 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=136 dst=r10 src=r4 offset=-32 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
+    // EBPF_OP_OR64_REG pc=94 dst=r4 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r4;
-    // EBPF_OP_STXW pc=137 dst=r10 src=r0 offset=-44 imm=0
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=95 dst=r3 src=r1 offset=13 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r0;
-    // EBPF_OP_LDXB pc=138 dst=r4 src=r3 offset=5 imm=0
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=96 dst=r3 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=97 dst=r5 src=r1 offset=12 imm=0
 #line 60 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=140 dst=r5 src=r3 offset=4 imm=0
-#line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=141 dst=r4 src=r5 offset=0 imm=0
-#line 60 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=142 dst=r5 src=r3 offset=6 imm=0
-#line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(6));
-    // EBPF_OP_LSH64_IMM pc=143 dst=r5 src=r0 offset=0 imm=16
-#line 60 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=144 dst=r3 src=r3 offset=7 imm=0
-#line 60 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=145 dst=r3 src=r0 offset=0 imm=24
-#line 60 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=146 dst=r3 src=r5 offset=0 imm=0
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=98 dst=r3 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r3 |= r5;
-    // EBPF_OP_OR64_REG pc=147 dst=r3 src=r4 offset=0 imm=0
+    // EBPF_OP_LDXB pc=99 dst=r5 src=r1 offset=14 imm=0
 #line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_LSH64_IMM pc=100 dst=r5 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=101 dst=r0 src=r1 offset=15 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=102 dst=r0 src=r0 offset=0 imm=24
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=103 dst=r0 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_OR64_REG pc=104 dst=r0 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r3;
+    // EBPF_OP_LSH64_IMM pc=105 dst=r0 src=r0 offset=0 imm=32
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=106 dst=r0 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r4;
+    // EBPF_OP_STXDW pc=107 dst=r10 src=r0 offset=-72 imm=0
+#line 60 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
+    // EBPF_OP_LDXW pc=108 dst=r3 src=r1 offset=24 imm=0
+#line 61 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=109 dst=r10 src=r3 offset=-56 imm=0
+#line 61 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=110 dst=r4 src=r2 offset=13 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=111 dst=r4 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=112 dst=r3 src=r2 offset=12 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=113 dst=r4 src=r3 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_LDXB pc=114 dst=r5 src=r2 offset=14 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
+    // EBPF_OP_LSH64_IMM pc=115 dst=r5 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=116 dst=r3 src=r2 offset=15 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=117 dst=r3 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=118 dst=r3 src=r5 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r3 |= r5;
+    // EBPF_OP_LDXB pc=119 dst=r0 src=r2 offset=1 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(1));
+    // EBPF_OP_LSH64_IMM pc=120 dst=r0 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=121 dst=r5 src=r2 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_OR64_REG pc=122 dst=r0 src=r5 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_LDXB pc=123 dst=r7 src=r2 offset=2 imm=0
+#line 63 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(2));
+    // EBPF_OP_LSH64_IMM pc=124 dst=r7 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r7 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=125 dst=r5 src=r2 offset=3 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(3));
+    // EBPF_OP_LSH64_IMM pc=126 dst=r5 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=127 dst=r5 src=r7 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=128 dst=r5 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 |= r0;
+    // EBPF_OP_OR64_REG pc=129 dst=r3 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
     r3 |= r4;
-    // EBPF_OP_STXW pc=148 dst=r10 src=r3 offset=-40 imm=0
-#line 60 "sample/sockops.c"
+    // EBPF_OP_LDXB pc=130 dst=r4 src=r2 offset=9 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=131 dst=r4 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=132 dst=r0 src=r2 offset=8 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=133 dst=r4 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=134 dst=r0 src=r2 offset=10 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(10));
+    // EBPF_OP_LSH64_IMM pc=135 dst=r0 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=136 dst=r7 src=r2 offset=11 imm=0
+#line 63 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=137 dst=r7 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r7 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=138 dst=r7 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r7 |= r0;
+    // EBPF_OP_OR64_REG pc=139 dst=r7 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r7 |= r4;
+    // EBPF_OP_STXW pc=140 dst=r10 src=r7 offset=-44 imm=0
+#line 63 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r7;
+    // EBPF_OP_STXW pc=141 dst=r10 src=r3 offset=-40 imm=0
+#line 63 "sample/sockops.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r3;
-    // EBPF_OP_LDXW pc=149 dst=r3 src=r1 offset=44 imm=0
-#line 61 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
-    // EBPF_OP_STXH pc=150 dst=r10 src=r3 offset=-28 imm=0
-#line 61 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
-    // EBPF_OP_LDXB pc=151 dst=r3 src=r1 offset=48 imm=0
-#line 62 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=152 dst=r10 src=r3 offset=-24 imm=0
-#line 62 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-    // EBPF_OP_LDXDW pc=153 dst=r1 src=r1 offset=56 imm=0
+    // EBPF_OP_STXW pc=142 dst=r10 src=r5 offset=-52 imm=0
 #line 63 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=154 dst=r10 src=r2 offset=-8 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint32_t)r5;
+    // EBPF_OP_LDXB pc=143 dst=r3 src=r2 offset=5 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(5));
+    // EBPF_OP_LSH64_IMM pc=144 dst=r3 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=145 dst=r4 src=r2 offset=4 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(4));
+    // EBPF_OP_OR64_REG pc=146 dst=r3 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=147 dst=r4 src=r2 offset=6 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(6));
+    // EBPF_OP_LSH64_IMM pc=148 dst=r4 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=149 dst=r2 src=r2 offset=7 imm=0
+#line 63 "sample/sockops.c"
+    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(7));
+    // EBPF_OP_LSH64_IMM pc=150 dst=r2 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r2 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=151 dst=r2 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 |= r4;
+    // EBPF_OP_OR64_REG pc=152 dst=r2 src=r3 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_STXW pc=153 dst=r10 src=r2 offset=-48 imm=0
+#line 63 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=154 dst=r2 src=r1 offset=44 imm=0
+#line 64 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=155 dst=r10 src=r2 offset=-36 imm=0
+#line 64 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint16_t)r2;
+    // EBPF_OP_LDXB pc=156 dst=r2 src=r1 offset=48 imm=0
 #line 65 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=155 dst=r10 src=r1 offset=-16 imm=0
-#line 63 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=156 dst=r2 src=r10 offset=0 imm=0
-#line 63 "sample/sockops.c"
+    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=157 dst=r10 src=r2 offset=-32 imm=0
+#line 65 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXDW pc=158 dst=r1 src=r1 offset=56 imm=0
+#line 66 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXDW pc=159 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_CALL pc=160 dst=r0 src=r0 offset=0 imm=19
+#line 67 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 67 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+#line 67 "sample/sockops.c"
+        return 0;
+#line 67 "sample/sockops.c"
+    }
+    // EBPF_OP_STXB pc=161 dst=r10 src=r6 offset=-8 imm=0
+#line 71 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r6;
+    // EBPF_OP_RSH64_IMM pc=162 dst=r0 src=r0 offset=0 imm=32
+#line 69 "sample/sockops.c"
+    r0 >>= (IMMEDIATE(32) & 63);
+    // EBPF_OP_STXDW pc=163 dst=r10 src=r0 offset=-16 imm=0
+#line 69 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=164 dst=r2 src=r10 offset=0 imm=0
+#line 69 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=157 dst=r2 src=r0 offset=0 imm=-64
-#line 94 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=158 dst=r1 src=r1 offset=0 imm=1
+    // EBPF_OP_ADD64_IMM pc=165 dst=r2 src=r0 offset=0 imm=-72
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=166 dst=r1 src=r1 offset=0 imm=1
 #line 26 "sample/sockops.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=160 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=168 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
 #line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_REG pc=161 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
-    // EBPF_OP_LDDW pc=162 dst=r0 src=r0 offset=0 imm=-1
+    // EBPF_OP_LDDW pc=170 dst=r0 src=r0 offset=0 imm=-1
 #line 26 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=164 dst=r1 src=r0 offset=7 imm=0
+    // EBPF_OP_JEQ_IMM pc=172 dst=r1 src=r0 offset=7 imm=0
 #line 26 "sample/sockops.c"
     if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
@@ -615,35 +652,35 @@ label_3:
 #line 26 "sample/sockops.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=165 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=173 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=166 dst=r2 src=r0 offset=0 imm=-64
-#line 94 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=167 dst=r1 src=r1 offset=0 imm=2
-#line 94 "sample/sockops.c"
+    // EBPF_OP_ADD64_IMM pc=174 dst=r2 src=r0 offset=0 imm=-72
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=175 dst=r1 src=r1 offset=0 imm=2
+#line 100 "sample/sockops.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=169 dst=r3 src=r0 offset=0 imm=64
-#line 94 "sample/sockops.c"
-    r3 = IMMEDIATE(64);
-    // EBPF_OP_MOV64_IMM pc=170 dst=r4 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=177 dst=r3 src=r0 offset=0 imm=72
+#line 100 "sample/sockops.c"
+    r3 = IMMEDIATE(72);
+    // EBPF_OP_MOV64_IMM pc=178 dst=r4 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=171 dst=r0 src=r0 offset=0 imm=11
-#line 94 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
-#line 94 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
-#line 94 "sample/sockops.c"
+    // EBPF_OP_CALL pc=179 dst=r0 src=r0 offset=0 imm=11
+#line 100 "sample/sockops.c"
+    r0 = connection_monitor_helpers[2].address(r1, r2, r3, r4, r5, context);
+#line 100 "sample/sockops.c"
+    if ((connection_monitor_helpers[2].tail_call) && (r0 == 0)) {
+#line 100 "sample/sockops.c"
         return 0;
-#line 94 "sample/sockops.c"
+#line 100 "sample/sockops.c"
     }
 label_5:
-    // EBPF_OP_EXIT pc=172 dst=r0 src=r0 offset=0 imm=0
-#line 97 "sample/sockops.c"
+    // EBPF_OP_EXIT pc=180 dst=r0 src=r0 offset=0 imm=0
+#line 103 "sample/sockops.c"
     return r0;
-#line 97 "sample/sockops.c"
+#line 103 "sample/sockops.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -659,8 +696,8 @@ static program_entry_t _programs[] = {
         connection_monitor_maps,
         2,
         connection_monitor_helpers,
-        2,
-        173,
+        3,
+        181,
         &connection_monitor_program_type_guid,
         &connection_monitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -210,6 +210,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connection_monitor_helpers[] = {
+    {NULL, 19, "helper_id_19"},
     {NULL, 1, "helper_id_1"},
     {NULL, 11, "helper_id_11"},
 };
@@ -226,549 +227,585 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
 {
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     // Prologue
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r0 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r1 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r2 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r3 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r4 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r5 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r6 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r7 = 0;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     register uint64_t r10 = 0;
 
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     r1 = (uintptr_t)context;
-#line 72 "sample/sockops.c"
+#line 78 "sample/sockops.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=2
-#line 72 "sample/sockops.c"
-    r2 = IMMEDIATE(2);
-    // EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 72 "sample/sockops.c"
-    r4 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=2 dst=r3 src=r1 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=3 dst=r3 src=r0 offset=8 imm=0
-#line 77 "sample/sockops.c"
-    if (r3 == IMMEDIATE(0)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r6 src=r0 offset=0 imm=2
+#line 78 "sample/sockops.c"
+    r6 = IMMEDIATE(2);
+    // EBPF_OP_MOV64_IMM pc=1 dst=r3 src=r0 offset=0 imm=1
+#line 78 "sample/sockops.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
+#line 83 "sample/sockops.c"
+    if (r2 == IMMEDIATE(0)) {
+#line 83 "sample/sockops.c"
         goto label_2;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
-    // EBPF_OP_JEQ_IMM pc=4 dst=r3 src=r0 offset=5 imm=2
-#line 77 "sample/sockops.c"
-    if (r3 == IMMEDIATE(2)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+#line 83 "sample/sockops.c"
+    if (r2 == IMMEDIATE(2)) {
+#line 83 "sample/sockops.c"
         goto label_1;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
     // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=7 dst=r3 src=r0 offset=164 imm=1
-#line 77 "sample/sockops.c"
-    if (r3 != IMMEDIATE(1)) {
-#line 77 "sample/sockops.c"
+    // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=172 imm=1
+#line 83 "sample/sockops.c"
+    if (r2 != IMMEDIATE(1)) {
+#line 83 "sample/sockops.c"
         goto label_5;
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 77 "sample/sockops.c"
+#line 83 "sample/sockops.c"
     goto label_2;
 label_1:
-    // EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
-    r2 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_LDXW pc=12 dst=r3 src=r1 offset=4 imm=0
-#line 94 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
-    // EBPF_OP_JNE_IMM pc=13 dst=r3 src=r0 offset=33 imm=2
-#line 94 "sample/sockops.c"
-    if (r3 != IMMEDIATE(2)) {
-#line 94 "sample/sockops.c"
-        goto label_3;
-#line 94 "sample/sockops.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=14 dst=r3 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=10 dst=r3 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=15 dst=r10 src=r3 offset=-8 imm=0
+    // EBPF_OP_MOV64_IMM pc=11 dst=r6 src=r0 offset=0 imm=0
+#line 83 "sample/sockops.c"
+    r6 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
+#line 100 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=37 imm=2
+#line 100 "sample/sockops.c"
+    if (r2 != IMMEDIATE(2)) {
+#line 100 "sample/sockops.c"
+        goto label_3;
+#line 100 "sample/sockops.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=14 dst=r2 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r2 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r2 offset=-8 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r3 offset=-16 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r2 offset=-16 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r3 offset=-24 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r2 offset=-24 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=18 dst=r10 src=r3 offset=-32 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=18 dst=r10 src=r2 offset=-32 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r3 offset=-40 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r2 offset=-40 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=20 dst=r10 src=r3 offset=-48 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=20 dst=r10 src=r2 offset=-48 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=21 dst=r10 src=r3 offset=-56 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r2 offset=-56 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r3;
-    // EBPF_OP_STXDW pc=22 dst=r10 src=r3 offset=-64 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=22 dst=r10 src=r2 offset=-64 imm=0
 #line 36 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r3;
-    // EBPF_OP_LDXW pc=23 dst=r3 src=r1 offset=8 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r2;
+    // EBPF_OP_STXDW pc=23 dst=r10 src=r2 offset=-72 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=24 dst=r2 src=r1 offset=8 imm=0
 #line 38 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
-    // EBPF_OP_STXW pc=24 dst=r10 src=r3 offset=-64 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXW pc=25 dst=r10 src=r2 offset=-72 imm=0
 #line 38 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r3;
-    // EBPF_OP_LDXW pc=25 dst=r3 src=r1 offset=24 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=26 dst=r2 src=r1 offset=24 imm=0
 #line 39 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
-    // EBPF_OP_STXH pc=26 dst=r10 src=r3 offset=-48 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=27 dst=r10 src=r2 offset=-56 imm=0
 #line 39 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
-    // EBPF_OP_LDXW pc=27 dst=r3 src=r1 offset=28 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint16_t)r2;
+    // EBPF_OP_LDXW pc=28 dst=r2 src=r1 offset=28 imm=0
 #line 40 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
-    // EBPF_OP_STXW pc=28 dst=r10 src=r3 offset=-44 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXW pc=29 dst=r10 src=r2 offset=-52 imm=0
 #line 40 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r3;
-    // EBPF_OP_OR64_REG pc=29 dst=r2 src=r4 offset=0 imm=0
-#line 44 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_LDXW pc=30 dst=r3 src=r1 offset=44 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint32_t)r2;
+    // EBPF_OP_OR64_REG pc=30 dst=r6 src=r3 offset=0 imm=0
+#line 47 "sample/sockops.c"
+    r6 |= r3;
+    // EBPF_OP_LDXW pc=31 dst=r2 src=r1 offset=44 imm=0
 #line 41 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
-    // EBPF_OP_STXH pc=31 dst=r10 src=r3 offset=-28 imm=0
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=32 dst=r10 src=r2 offset=-36 imm=0
 #line 41 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
-    // EBPF_OP_LDXB pc=32 dst=r3 src=r1 offset=48 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint16_t)r2;
+    // EBPF_OP_LDXB pc=33 dst=r2 src=r1 offset=48 imm=0
 #line 42 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-24 imm=0
+    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=34 dst=r10 src=r2 offset=-32 imm=0
 #line 42 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-    // EBPF_OP_LDXDW pc=34 dst=r1 src=r1 offset=56 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXDW pc=35 dst=r1 src=r1 offset=56 imm=0
 #line 43 "sample/sockops.c"
     r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=35 dst=r10 src=r2 offset=-8 imm=0
-#line 45 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-24 imm=0
 #line 43 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 43 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_CALL pc=37 dst=r0 src=r0 offset=0 imm=19
+#line 44 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 44 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+#line 44 "sample/sockops.c"
+        return 0;
+#line 44 "sample/sockops.c"
+    }
+    // EBPF_OP_STXB pc=38 dst=r10 src=r6 offset=-8 imm=0
+#line 48 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r6;
+    // EBPF_OP_RSH64_IMM pc=39 dst=r0 src=r0 offset=0 imm=32
+#line 46 "sample/sockops.c"
+    r0 >>= (IMMEDIATE(32) & 63);
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r0 offset=-16 imm=0
+#line 46 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=41 dst=r2 src=r10 offset=0 imm=0
+#line 46 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-64
-#line 43 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r1 offset=0 imm=1
+    // EBPF_OP_ADD64_IMM pc=42 dst=r2 src=r0 offset=0 imm=-72
+#line 46 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=43 dst=r1 src=r1 offset=0 imm=1
 #line 26 "sample/sockops.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=45 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
 #line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
-    // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
+    // EBPF_OP_LDDW pc=47 dst=r0 src=r0 offset=0 imm=-1
 #line 26 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=126 imm=0
+    // EBPF_OP_JEQ_IMM pc=49 dst=r1 src=r0 offset=130 imm=0
 #line 26 "sample/sockops.c"
     if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
         goto label_5;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=118 imm=0
+    // EBPF_OP_JA pc=50 dst=r0 src=r0 offset=122 imm=0
 #line 26 "sample/sockops.c"
     goto label_4;
 label_3:
-    // EBPF_OP_MOV64_REG pc=47 dst=r3 src=r1 offset=0 imm=0
-#line 94 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_IMM pc=48 dst=r3 src=r0 offset=0 imm=28
-#line 94 "sample/sockops.c"
-    r3 += IMMEDIATE(28);
-    // EBPF_OP_MOV64_IMM pc=49 dst=r5 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
-    r5 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r5 offset=-8 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=51 dst=r10 src=r5 offset=-16 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r5 offset=-24 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r5 offset=-32 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r5 offset=-40 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r5;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r5 offset=-48 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r5;
-    // EBPF_OP_LDXB pc=56 dst=r0 src=r1 offset=17 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
-    // EBPF_OP_LSH64_IMM pc=57 dst=r0 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=58 dst=r5 src=r1 offset=16 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
-    // EBPF_OP_OR64_REG pc=59 dst=r0 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r5;
-    // EBPF_OP_LDXB pc=60 dst=r6 src=r1 offset=18 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
-    // EBPF_OP_LSH64_IMM pc=61 dst=r6 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=62 dst=r5 src=r1 offset=19 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
-    // EBPF_OP_LSH64_IMM pc=63 dst=r5 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=64 dst=r5 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_OR64_REG pc=65 dst=r5 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r0;
-    // EBPF_OP_LDXB pc=66 dst=r6 src=r1 offset=21 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
-    // EBPF_OP_LSH64_IMM pc=67 dst=r6 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=68 dst=r0 src=r1 offset=20 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
-    // EBPF_OP_OR64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_LDXB pc=70 dst=r7 src=r1 offset=22 imm=0
-#line 57 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
-    // EBPF_OP_LSH64_IMM pc=71 dst=r7 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=72 dst=r0 src=r1 offset=23 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
-    // EBPF_OP_LSH64_IMM pc=73 dst=r0 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=74 dst=r0 src=r7 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r7;
-    // EBPF_OP_OR64_REG pc=75 dst=r0 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r6;
-    // EBPF_OP_LSH64_IMM pc=76 dst=r0 src=r0 offset=0 imm=32
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=77 dst=r0 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r0 |= r5;
-    // EBPF_OP_LDXB pc=78 dst=r6 src=r1 offset=9 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=79 dst=r6 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=80 dst=r5 src=r1 offset=8 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=81 dst=r6 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r5;
-    // EBPF_OP_LDXB pc=82 dst=r7 src=r1 offset=10 imm=0
-#line 57 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
-    // EBPF_OP_LSH64_IMM pc=83 dst=r7 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=84 dst=r5 src=r1 offset=11 imm=0
-#line 57 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=85 dst=r5 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=86 dst=r5 src=r7 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r7;
-    // EBPF_OP_OR64_REG pc=87 dst=r2 src=r4 offset=0 imm=0
-#line 64 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r0 offset=-56 imm=0
-#line 57 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
-    // EBPF_OP_OR64_REG pc=89 dst=r5 src=r6 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_LDXB pc=90 dst=r4 src=r1 offset=13 imm=0
-#line 57 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=91 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=92 dst=r0 src=r1 offset=12 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=93 dst=r4 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r4 |= r0;
-    // EBPF_OP_LDXB pc=94 dst=r0 src=r1 offset=14 imm=0
-#line 57 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
-    // EBPF_OP_LSH64_IMM pc=95 dst=r0 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=96 dst=r6 src=r1 offset=15 imm=0
-#line 57 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=97 dst=r6 src=r0 offset=0 imm=24
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=98 dst=r6 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_OR64_REG pc=99 dst=r6 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r4;
-    // EBPF_OP_LSH64_IMM pc=100 dst=r6 src=r0 offset=0 imm=32
-#line 57 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=101 dst=r6 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
-    r6 |= r5;
-    // EBPF_OP_STXDW pc=102 dst=r10 src=r6 offset=-64 imm=0
-#line 57 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r6;
-    // EBPF_OP_LDXW pc=103 dst=r4 src=r1 offset=24 imm=0
-#line 58 "sample/sockops.c"
-    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
-    // EBPF_OP_STXH pc=104 dst=r10 src=r4 offset=-48 imm=0
-#line 58 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r4;
-    // EBPF_OP_LDXB pc=105 dst=r5 src=r3 offset=13 imm=0
+    // EBPF_OP_MOV64_REG pc=51 dst=r2 src=r1 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r2 = r1;
+    // EBPF_OP_ADD64_IMM pc=52 dst=r2 src=r0 offset=0 imm=28
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(28);
+    // EBPF_OP_MOV64_IMM pc=53 dst=r4 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=54 dst=r10 src=r4 offset=-8 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r4 offset=-16 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r4 offset=-24 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=57 dst=r10 src=r4 offset=-32 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r4 offset=-40 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=59 dst=r10 src=r4 offset=-48 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=60 dst=r10 src=r4 offset=-56 imm=0
+#line 56 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_LDXB pc=61 dst=r5 src=r1 offset=17 imm=0
 #line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=106 dst=r5 src=r0 offset=0 imm=8
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_LSH64_IMM pc=62 dst=r5 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
     r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=107 dst=r4 src=r3 offset=12 imm=0
+    // EBPF_OP_LDXB pc=63 dst=r4 src=r1 offset=16 imm=0
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=108 dst=r5 src=r4 offset=0 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_OR64_REG pc=64 dst=r5 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r5 |= r4;
-    // EBPF_OP_LDXB pc=109 dst=r0 src=r3 offset=14 imm=0
+    // EBPF_OP_LDXB pc=65 dst=r0 src=r1 offset=18 imm=0
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
-    // EBPF_OP_LSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=16
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
     r0 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=111 dst=r4 src=r3 offset=15 imm=0
+    // EBPF_OP_LDXB pc=67 dst=r4 src=r1 offset=19 imm=0
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=112 dst=r4 src=r0 offset=0 imm=24
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_LSH64_IMM pc=68 dst=r4 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
     r4 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=113 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=69 dst=r4 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r4 |= r0;
-    // EBPF_OP_LDXB pc=114 dst=r6 src=r3 offset=1 imm=0
+    // EBPF_OP_OR64_REG pc=70 dst=r4 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
-    // EBPF_OP_LSH64_IMM pc=115 dst=r6 src=r0 offset=0 imm=8
+    r4 |= r5;
+    // EBPF_OP_LDXB pc=71 dst=r0 src=r1 offset=21 imm=0
 #line 60 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=116 dst=r0 src=r3 offset=0 imm=0
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_LSH64_IMM pc=72 dst=r0 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_OR64_REG pc=117 dst=r6 src=r0 offset=0 imm=0
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=73 dst=r5 src=r1 offset=20 imm=0
 #line 60 "sample/sockops.c"
-    r6 |= r0;
-    // EBPF_OP_LDXB pc=118 dst=r7 src=r3 offset=2 imm=0
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_OR64_REG pc=74 dst=r0 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
-    // EBPF_OP_LSH64_IMM pc=119 dst=r7 src=r0 offset=0 imm=16
+    r0 |= r5;
+    // EBPF_OP_LDXB pc=75 dst=r7 src=r1 offset=22 imm=0
+#line 60 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_LSH64_IMM pc=76 dst=r7 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
     r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=120 dst=r0 src=r3 offset=3 imm=0
+    // EBPF_OP_LDXB pc=77 dst=r5 src=r1 offset=23 imm=0
 #line 60 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
-    // EBPF_OP_LSH64_IMM pc=121 dst=r0 src=r0 offset=0 imm=24
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_LSH64_IMM pc=78 dst=r5 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
-    r0 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=122 dst=r0 src=r7 offset=0 imm=0
+    r5 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=79 dst=r5 src=r7 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r0 |= r7;
-    // EBPF_OP_OR64_REG pc=123 dst=r0 src=r6 offset=0 imm=0
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=80 dst=r5 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r0 |= r6;
-    // EBPF_OP_OR64_REG pc=124 dst=r4 src=r5 offset=0 imm=0
+    r5 |= r0;
+    // EBPF_OP_LSH64_IMM pc=81 dst=r5 src=r0 offset=0 imm=32
 #line 60 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=125 dst=r5 src=r3 offset=9 imm=0
+    r5 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=82 dst=r5 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=126 dst=r5 src=r0 offset=0 imm=8
+    r5 |= r4;
+    // EBPF_OP_LDXB pc=83 dst=r0 src=r1 offset=9 imm=0
 #line 60 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=127 dst=r6 src=r3 offset=8 imm=0
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=84 dst=r0 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=128 dst=r5 src=r6 offset=0 imm=0
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=85 dst=r4 src=r1 offset=8 imm=0
 #line 60 "sample/sockops.c"
-    r5 |= r6;
-    // EBPF_OP_LDXB pc=129 dst=r6 src=r3 offset=10 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=86 dst=r0 src=r4 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
-    // EBPF_OP_LSH64_IMM pc=130 dst=r6 src=r0 offset=0 imm=16
+    r0 |= r4;
+    // EBPF_OP_LDXB pc=87 dst=r7 src=r1 offset=10 imm=0
 #line 60 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=131 dst=r7 src=r3 offset=11 imm=0
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_LSH64_IMM pc=88 dst=r7 src=r0 offset=0 imm=16
 #line 60 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=132 dst=r7 src=r0 offset=0 imm=24
+    r7 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=89 dst=r4 src=r1 offset=11 imm=0
 #line 60 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=133 dst=r7 src=r6 offset=0 imm=0
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=90 dst=r4 src=r0 offset=0 imm=24
 #line 60 "sample/sockops.c"
-    r7 |= r6;
-    // EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
+    r4 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=91 dst=r4 src=r7 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    r7 |= r5;
-    // EBPF_OP_STXW pc=135 dst=r10 src=r7 offset=-36 imm=0
+    r4 |= r7;
+    // EBPF_OP_OR64_REG pc=92 dst=r6 src=r3 offset=0 imm=0
+#line 70 "sample/sockops.c"
+    r6 |= r3;
+    // EBPF_OP_STXDW pc=93 dst=r10 src=r5 offset=-64 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=136 dst=r10 src=r4 offset=-32 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
+    // EBPF_OP_OR64_REG pc=94 dst=r4 src=r0 offset=0 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r4;
-    // EBPF_OP_STXW pc=137 dst=r10 src=r0 offset=-44 imm=0
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=95 dst=r3 src=r1 offset=13 imm=0
 #line 60 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r0;
-    // EBPF_OP_LDXB pc=138 dst=r4 src=r3 offset=5 imm=0
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=96 dst=r3 src=r0 offset=0 imm=8
 #line 60 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=97 dst=r5 src=r1 offset=12 imm=0
 #line 60 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=140 dst=r5 src=r3 offset=4 imm=0
-#line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=141 dst=r4 src=r5 offset=0 imm=0
-#line 60 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=142 dst=r5 src=r3 offset=6 imm=0
-#line 60 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(6));
-    // EBPF_OP_LSH64_IMM pc=143 dst=r5 src=r0 offset=0 imm=16
-#line 60 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LDXB pc=144 dst=r3 src=r3 offset=7 imm=0
-#line 60 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=145 dst=r3 src=r0 offset=0 imm=24
-#line 60 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(24) & 63);
-    // EBPF_OP_OR64_REG pc=146 dst=r3 src=r5 offset=0 imm=0
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=98 dst=r3 src=r5 offset=0 imm=0
 #line 60 "sample/sockops.c"
     r3 |= r5;
-    // EBPF_OP_OR64_REG pc=147 dst=r3 src=r4 offset=0 imm=0
+    // EBPF_OP_LDXB pc=99 dst=r5 src=r1 offset=14 imm=0
 #line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_LSH64_IMM pc=100 dst=r5 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=101 dst=r0 src=r1 offset=15 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=102 dst=r0 src=r0 offset=0 imm=24
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=103 dst=r0 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_OR64_REG pc=104 dst=r0 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r3;
+    // EBPF_OP_LSH64_IMM pc=105 dst=r0 src=r0 offset=0 imm=32
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=106 dst=r0 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r4;
+    // EBPF_OP_STXDW pc=107 dst=r10 src=r0 offset=-72 imm=0
+#line 60 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
+    // EBPF_OP_LDXW pc=108 dst=r3 src=r1 offset=24 imm=0
+#line 61 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=109 dst=r10 src=r3 offset=-56 imm=0
+#line 61 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=110 dst=r4 src=r2 offset=13 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=111 dst=r4 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=112 dst=r3 src=r2 offset=12 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=113 dst=r4 src=r3 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_LDXB pc=114 dst=r5 src=r2 offset=14 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
+    // EBPF_OP_LSH64_IMM pc=115 dst=r5 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=116 dst=r3 src=r2 offset=15 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=117 dst=r3 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=118 dst=r3 src=r5 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r3 |= r5;
+    // EBPF_OP_LDXB pc=119 dst=r0 src=r2 offset=1 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(1));
+    // EBPF_OP_LSH64_IMM pc=120 dst=r0 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=121 dst=r5 src=r2 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_OR64_REG pc=122 dst=r0 src=r5 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_LDXB pc=123 dst=r7 src=r2 offset=2 imm=0
+#line 63 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(2));
+    // EBPF_OP_LSH64_IMM pc=124 dst=r7 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r7 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=125 dst=r5 src=r2 offset=3 imm=0
+#line 63 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(3));
+    // EBPF_OP_LSH64_IMM pc=126 dst=r5 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=127 dst=r5 src=r7 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=128 dst=r5 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r5 |= r0;
+    // EBPF_OP_OR64_REG pc=129 dst=r3 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
     r3 |= r4;
-    // EBPF_OP_STXW pc=148 dst=r10 src=r3 offset=-40 imm=0
-#line 60 "sample/sockops.c"
+    // EBPF_OP_LDXB pc=130 dst=r4 src=r2 offset=9 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=131 dst=r4 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=132 dst=r0 src=r2 offset=8 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=133 dst=r4 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=134 dst=r0 src=r2 offset=10 imm=0
+#line 63 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(10));
+    // EBPF_OP_LSH64_IMM pc=135 dst=r0 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=136 dst=r7 src=r2 offset=11 imm=0
+#line 63 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=137 dst=r7 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r7 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=138 dst=r7 src=r0 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r7 |= r0;
+    // EBPF_OP_OR64_REG pc=139 dst=r7 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r7 |= r4;
+    // EBPF_OP_STXW pc=140 dst=r10 src=r7 offset=-44 imm=0
+#line 63 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r7;
+    // EBPF_OP_STXW pc=141 dst=r10 src=r3 offset=-40 imm=0
+#line 63 "sample/sockops.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r3;
-    // EBPF_OP_LDXW pc=149 dst=r3 src=r1 offset=44 imm=0
-#line 61 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
-    // EBPF_OP_STXH pc=150 dst=r10 src=r3 offset=-28 imm=0
-#line 61 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
-    // EBPF_OP_LDXB pc=151 dst=r3 src=r1 offset=48 imm=0
-#line 62 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=152 dst=r10 src=r3 offset=-24 imm=0
-#line 62 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-    // EBPF_OP_LDXDW pc=153 dst=r1 src=r1 offset=56 imm=0
+    // EBPF_OP_STXW pc=142 dst=r10 src=r5 offset=-52 imm=0
 #line 63 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=154 dst=r10 src=r2 offset=-8 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint32_t)r5;
+    // EBPF_OP_LDXB pc=143 dst=r3 src=r2 offset=5 imm=0
+#line 63 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(5));
+    // EBPF_OP_LSH64_IMM pc=144 dst=r3 src=r0 offset=0 imm=8
+#line 63 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=145 dst=r4 src=r2 offset=4 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(4));
+    // EBPF_OP_OR64_REG pc=146 dst=r3 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=147 dst=r4 src=r2 offset=6 imm=0
+#line 63 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(6));
+    // EBPF_OP_LSH64_IMM pc=148 dst=r4 src=r0 offset=0 imm=16
+#line 63 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_LDXB pc=149 dst=r2 src=r2 offset=7 imm=0
+#line 63 "sample/sockops.c"
+    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(7));
+    // EBPF_OP_LSH64_IMM pc=150 dst=r2 src=r0 offset=0 imm=24
+#line 63 "sample/sockops.c"
+    r2 <<= (IMMEDIATE(24) & 63);
+    // EBPF_OP_OR64_REG pc=151 dst=r2 src=r4 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 |= r4;
+    // EBPF_OP_OR64_REG pc=152 dst=r2 src=r3 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_STXW pc=153 dst=r10 src=r2 offset=-48 imm=0
+#line 63 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=154 dst=r2 src=r1 offset=44 imm=0
+#line 64 "sample/sockops.c"
+    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=155 dst=r10 src=r2 offset=-36 imm=0
+#line 64 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint16_t)r2;
+    // EBPF_OP_LDXB pc=156 dst=r2 src=r1 offset=48 imm=0
 #line 65 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=155 dst=r10 src=r1 offset=-16 imm=0
-#line 63 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=156 dst=r2 src=r10 offset=0 imm=0
-#line 63 "sample/sockops.c"
+    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=157 dst=r10 src=r2 offset=-32 imm=0
+#line 65 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXDW pc=158 dst=r1 src=r1 offset=56 imm=0
+#line 66 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXDW pc=159 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_CALL pc=160 dst=r0 src=r0 offset=0 imm=19
+#line 67 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 67 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+#line 67 "sample/sockops.c"
+        return 0;
+#line 67 "sample/sockops.c"
+    }
+    // EBPF_OP_STXB pc=161 dst=r10 src=r6 offset=-8 imm=0
+#line 71 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r6;
+    // EBPF_OP_RSH64_IMM pc=162 dst=r0 src=r0 offset=0 imm=32
+#line 69 "sample/sockops.c"
+    r0 >>= (IMMEDIATE(32) & 63);
+    // EBPF_OP_STXDW pc=163 dst=r10 src=r0 offset=-16 imm=0
+#line 69 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=164 dst=r2 src=r10 offset=0 imm=0
+#line 69 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=157 dst=r2 src=r0 offset=0 imm=-64
-#line 94 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=158 dst=r1 src=r1 offset=0 imm=1
+    // EBPF_OP_ADD64_IMM pc=165 dst=r2 src=r0 offset=0 imm=-72
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=166 dst=r1 src=r1 offset=0 imm=1
 #line 26 "sample/sockops.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=160 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=168 dst=r0 src=r0 offset=0 imm=1
 #line 26 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address(r1, r2, r3, r4, r5, context);
+    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
 #line 26 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) {
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
 #line 26 "sample/sockops.c"
         return 0;
 #line 26 "sample/sockops.c"
     }
-    // EBPF_OP_MOV64_REG pc=161 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r1 = r0;
-    // EBPF_OP_LDDW pc=162 dst=r0 src=r0 offset=0 imm=-1
+    // EBPF_OP_LDDW pc=170 dst=r0 src=r0 offset=0 imm=-1
 #line 26 "sample/sockops.c"
     r0 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=164 dst=r1 src=r0 offset=7 imm=0
+    // EBPF_OP_JEQ_IMM pc=172 dst=r1 src=r0 offset=7 imm=0
 #line 26 "sample/sockops.c"
     if (r1 == IMMEDIATE(0)) {
 #line 26 "sample/sockops.c"
@@ -776,35 +813,35 @@ label_3:
 #line 26 "sample/sockops.c"
     }
 label_4:
-    // EBPF_OP_MOV64_REG pc=165 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=173 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/sockops.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=166 dst=r2 src=r0 offset=0 imm=-64
-#line 94 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=167 dst=r1 src=r1 offset=0 imm=2
-#line 94 "sample/sockops.c"
+    // EBPF_OP_ADD64_IMM pc=174 dst=r2 src=r0 offset=0 imm=-72
+#line 100 "sample/sockops.c"
+    r2 += IMMEDIATE(-72);
+    // EBPF_OP_LDDW pc=175 dst=r1 src=r1 offset=0 imm=2
+#line 100 "sample/sockops.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=169 dst=r3 src=r0 offset=0 imm=64
-#line 94 "sample/sockops.c"
-    r3 = IMMEDIATE(64);
-    // EBPF_OP_MOV64_IMM pc=170 dst=r4 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=177 dst=r3 src=r0 offset=0 imm=72
+#line 100 "sample/sockops.c"
+    r3 = IMMEDIATE(72);
+    // EBPF_OP_MOV64_IMM pc=178 dst=r4 src=r0 offset=0 imm=0
+#line 100 "sample/sockops.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=171 dst=r0 src=r0 offset=0 imm=11
-#line 94 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address(r1, r2, r3, r4, r5, context);
-#line 94 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) {
-#line 94 "sample/sockops.c"
+    // EBPF_OP_CALL pc=179 dst=r0 src=r0 offset=0 imm=11
+#line 100 "sample/sockops.c"
+    r0 = connection_monitor_helpers[2].address(r1, r2, r3, r4, r5, context);
+#line 100 "sample/sockops.c"
+    if ((connection_monitor_helpers[2].tail_call) && (r0 == 0)) {
+#line 100 "sample/sockops.c"
         return 0;
-#line 94 "sample/sockops.c"
+#line 100 "sample/sockops.c"
     }
 label_5:
-    // EBPF_OP_EXIT pc=172 dst=r0 src=r0 offset=0 imm=0
-#line 97 "sample/sockops.c"
+    // EBPF_OP_EXIT pc=180 dst=r0 src=r0 offset=0 imm=0
+#line 103 "sample/sockops.c"
     return r0;
-#line 97 "sample/sockops.c"
+#line 103 "sample/sockops.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -820,8 +857,8 @@ static program_entry_t _programs[] = {
         connection_monitor_maps,
         2,
         connection_monitor_helpers,
-        2,
-        173,
+        3,
+        181,
         &connection_monitor_program_type_guid,
         &connection_monitor_attach_type_guid,
     },

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -711,8 +711,24 @@ static ebpf_program_data_t _ebpf_bind_program_data = {
     EBPF_PROGRAM_DATA_HEADER, &_ebpf_bind_program_info, NULL, NULL, NULL, NULL, 0, {.supports_context_header = true}};
 
 // SOCK_ADDR.
+static int
+_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
+{
+    UNREFERENCED_PARAMETER(ctx);
+    return -ENOTSUP;
+}
+
+static int
+_ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void* data, _In_ uint32_t data_size)
+{
+    UNREFERENCED_PARAMETER(ctx);
+    UNREFERENCED_PARAMETER(data);
+    UNREFERENCED_PARAMETER(data_size);
+    return -ENOTSUP;
+}
+
 static uint64_t
-_ebpf_sock_addr_get_current_pid_tgid(
+_ebpf_sock_addr_get_current_pid_tgid_implicit(
     uint64_t dummy_param1,
     uint64_t dummy_param2,
     uint64_t dummy_param3,
@@ -727,15 +743,6 @@ _ebpf_sock_addr_get_current_pid_tgid(
     UNREFERENCED_PARAMETER(dummy_param5);
     UNREFERENCED_PARAMETER(ctx);
     return 0;
-}
-
-static int
-_ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void* data, _In_ uint32_t data_size)
-{
-    UNREFERENCED_PARAMETER(ctx);
-    UNREFERENCED_PARAMETER(data);
-    UNREFERENCED_PARAMETER(data_size);
-    return -ENOTSUP;
 }
 
 static int
@@ -824,7 +831,8 @@ _ebpf_sock_addr_context_destroy(
     return;
 }
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_set_redirect_context};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {
+    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
@@ -832,7 +840,7 @@ static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function
     (uint64_t*)_ebpf_sock_addr_specific_helper_functions};
 
 static const void* _ebpf_sock_addr_global_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid,
+    (void*)_ebpf_sock_addr_get_current_pid_tgid_implicit,
     (void*)_ebpf_sock_addr_get_current_logon_id,
     (void*)_ebpf_sock_addr_is_current_admin,
     (void*)_ebpf_sock_addr_get_socket_cookie};

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -711,11 +711,22 @@ static ebpf_program_data_t _ebpf_bind_program_data = {
     EBPF_PROGRAM_DATA_HEADER, &_ebpf_bind_program_info, NULL, NULL, NULL, NULL, 0, {.supports_context_header = true}};
 
 // SOCK_ADDR.
-static int
-_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
+static uint64_t
+_ebpf_sock_addr_get_current_pid_tgid(
+    uint64_t dummy_param1,
+    uint64_t dummy_param2,
+    uint64_t dummy_param3,
+    uint64_t dummy_param4,
+    uint64_t dummy_param5,
+    _In_ const bpf_sock_addr_t* ctx)
 {
+    UNREFERENCED_PARAMETER(dummy_param1);
+    UNREFERENCED_PARAMETER(dummy_param2);
+    UNREFERENCED_PARAMETER(dummy_param3);
+    UNREFERENCED_PARAMETER(dummy_param4);
+    UNREFERENCED_PARAMETER(dummy_param5);
     UNREFERENCED_PARAMETER(ctx);
-    return -ENOTSUP;
+    return 0;
 }
 
 static int
@@ -813,8 +824,7 @@ _ebpf_sock_addr_context_destroy(
     return;
 }
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
@@ -822,6 +832,7 @@ static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function
     (uint64_t*)_ebpf_sock_addr_specific_helper_functions};
 
 static const void* _ebpf_sock_addr_global_helper_functions[] = {
+    (void*)_ebpf_sock_addr_get_current_pid_tgid,
     (void*)_ebpf_sock_addr_get_current_logon_id,
     (void*)_ebpf_sock_addr_is_current_admin,
     (void*)_ebpf_sock_addr_get_socket_cookie};
@@ -842,6 +853,31 @@ static ebpf_program_data_t _ebpf_sock_addr_program_data = {
 };
 
 // SOCK_OPS.
+static uint64_t
+_ebpf_sock_ops_get_current_pid_tgid(
+    uint64_t dummy_param1,
+    uint64_t dummy_param2,
+    uint64_t dummy_param3,
+    uint64_t dummy_param4,
+    uint64_t dummy_param5,
+    _In_ const bpf_sock_addr_t* ctx)
+{
+    UNREFERENCED_PARAMETER(dummy_param1);
+    UNREFERENCED_PARAMETER(dummy_param2);
+    UNREFERENCED_PARAMETER(dummy_param3);
+    UNREFERENCED_PARAMETER(dummy_param4);
+    UNREFERENCED_PARAMETER(dummy_param5);
+    UNREFERENCED_PARAMETER(ctx);
+    return 0;
+}
+
+static const void* _ebpf_sock_ops_global_helper_functions[] = {(void*)_ebpf_sock_ops_get_current_pid_tgid};
+
+static ebpf_helper_function_addresses_t _ebpf_sock_ops_global_helper_function_address_table = {
+    EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
+    EBPF_COUNT_OF(_ebpf_sock_ops_global_helper_functions),
+    (uint64_t*)_ebpf_sock_ops_global_helper_functions};
+
 static ebpf_result_t
 _ebpf_sock_ops_context_create(
     _In_reads_bytes_opt_(data_size_in) const uint8_t* data_in,
@@ -908,6 +944,7 @@ _ebpf_sock_ops_context_destroy(
 static ebpf_program_data_t _ebpf_sock_ops_program_data = {
     .header = EBPF_PROGRAM_DATA_HEADER,
     .program_info = &_ebpf_sock_ops_program_info,
+    .global_helper_function_addresses = &_ebpf_sock_ops_global_helper_function_address_table,
     .context_create = &_ebpf_sock_ops_context_create,
     .context_destroy = &_ebpf_sock_ops_context_destroy,
     .required_irql = DISPATCH_LEVEL,

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -189,8 +189,9 @@ TEST_CASE("xdp_context", "[netebpfext]")
             sizeof(input_context),
             (void**)&xdp_context) == 0);
 
-    bpf_xdp_adjust_head_t adjust_head = reinterpret_cast<bpf_xdp_adjust_head_t>(
-        xdp_program_data->program_type_specific_helper_function_addresses->helper_function_address[0]);
+    bpf_xdp_adjust_head_t adjust_head =
+        reinterpret_cast<bpf_xdp_adjust_head_t>(xdp_program_data->program_type_specific_helper_function_addresses
+                                                    ->helper_function_address[XDP_TEST_HELPER_ADJUST_HEAD]);
 
     // Modify the context.
     REQUIRE(adjust_head(xdp_context, 10) == 0);
@@ -372,7 +373,8 @@ netebpfext_unit_invoke_sock_addr_program(
     // Test _ebpf_sock_addr_is_current_admin global helper function.
     // If the user is not admin, then the default action is to block.
     bpf_is_current_admin_t is_current_admin = reinterpret_cast<bpf_is_current_admin_t>(
-        sock_addr_program_data->global_helper_function_addresses->helper_function_address[1]);
+        sock_addr_program_data->global_helper_function_addresses
+            ->helper_function_address[SOCK_ADDR_GLOBAL_HELPER_IS_CURRENT_ADMIN]);
     is_admin = is_current_admin(sock_addr_context);
 
     // Verify context fields match what the netebpfext helper set.

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -41,7 +41,7 @@ update_audit_map_entry(bpf_sock_addr_t* ctx)
 {
     uint64_t key = 0;
     sock_addr_audit_entry_t entry = {0};
-    entry.process_id = bpf_sock_addr_get_current_pid_tgid(ctx);
+    entry.process_id = bpf_get_current_pid_tgid();
     entry.logon_id = bpf_get_current_logon_id(ctx);
     entry.is_admin = bpf_is_current_admin(ctx);
     entry.local_port = ctx->msg_src_port;

--- a/tests/sample/sockops.c
+++ b/tests/sample/sockops.c
@@ -41,6 +41,9 @@ handle_v4(bpf_sock_ops_t* ctx, bool outbound, bool connected)
     audit_entry.tuple.remote_port = ctx->remote_port;
     audit_entry.tuple.protocol = ctx->protocol;
     audit_entry.tuple.interface_luid = ctx->interface_luid;
+    audit_entry.process_id = bpf_get_current_pid_tgid();
+    // Ignore the thread Id.
+    audit_entry.process_id >>= 32;
     audit_entry.outbound = outbound;
     audit_entry.connected = connected;
 
@@ -61,6 +64,9 @@ handle_v6(bpf_sock_ops_t* ctx, bool outbound, bool connected)
     audit_entry.tuple.remote_port = ctx->remote_port;
     audit_entry.tuple.protocol = ctx->protocol;
     audit_entry.tuple.interface_luid = ctx->interface_luid;
+    audit_entry.process_id = bpf_get_current_pid_tgid();
+    // Ignore the thread Id.
+    audit_entry.process_id >>= 32;
     audit_entry.outbound = outbound;
     audit_entry.connected = connected;
 

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -39,6 +39,7 @@ typedef struct _connection_tuple
 typedef struct _audit_entry
 {
     connection_tuple_t tuple;
+    uint64_t process_id;
     bool outbound : 1;
     bool connected : 1;
 } audit_entry_t;


### PR DESCRIPTION
## Description

This fixes #3742.
This PR overrides the global helper function `bpf_get_current_pid_tgid` in the sock_ops hook. The WFP flow established layer classify callback provides the process Id for the connection being established. This value is cached in the sock_ops context.

This PR also overrides the global helper function `bpf_get_current_pid_tgid` in the sock_addr hook but keeps the legacy `bpf_sock_addr_get_current_pid_tgid` helper for backward compatibility.

Both the overriden helpers use the implicit context feature.

## Testing

New tests added.

## Documentation

No changes needed.

## Installation

No changes needed.
