### PR TITLE
Fix AV in netebpfext

### DIFF
--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -991,14 +991,15 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_blocked_contexts
 
 #pragma warning(suppress : 6001) /* entry and list entry are non-null */
         RemoveEntryList(&entry->list_entry);
+        uint64_t transport_endpoint_handle = entry->transport_endpoint_handle;
+        BOOLEAN result =
+            RtlDeleteElementGenericTableAvl(&_net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_table, entry);
+        ebpf_assert(result);
         NET_EBPF_EXT_LOG_MESSAGE_UINT64(
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "_net_ebpf_ext_purge_block_connect_contexts: Delete",
-            entry->transport_endpoint_handle);
-        BOOLEAN result =
-            RtlDeleteElementGenericTableAvl(&_net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_table, entry);
-        ebpf_assert(result);
+            transport_endpoint_handle);
         _net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_count--;
     }
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -995,12 +995,13 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_blocked_contexts
         BOOLEAN result =
             RtlDeleteElementGenericTableAvl(&_net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_table, entry);
         ebpf_assert(result);
+        entry = NULL;
+        _net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_count--;
         NET_EBPF_EXT_LOG_MESSAGE_UINT64(
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "_net_ebpf_ext_purge_block_connect_contexts: Delete",
             transport_endpoint_handle);
-        _net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_count--;
     }
 
     // Free entries from low-memory list.

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -991,15 +991,15 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_blocked_contexts
 
 #pragma warning(suppress : 6001) /* entry and list entry are non-null */
         RemoveEntryList(&entry->list_entry);
-        BOOLEAN result =
-            RtlDeleteElementGenericTableAvl(&_net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_table, entry);
-        ebpf_assert(result);
-        _net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_count--;
         NET_EBPF_EXT_LOG_MESSAGE_UINT64(
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "_net_ebpf_ext_purge_block_connect_contexts: Delete",
             entry->transport_endpoint_handle);
+        BOOLEAN result =
+            RtlDeleteElementGenericTableAvl(&_net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_table, entry);
+        ebpf_assert(result);
+        _net_ebpf_ext_sock_addr_blocked_contexts.blocked_context_count--;
     }
 
     // Free entries from low-memory list.


### PR DESCRIPTION
## Description

Fix an AV in netebpfext. In `_net_ebpf_ext_purge_blocked_connect_contexts()`, `connection_context` entry is accessed after it has been freed.

## Testing

Existing CICD.

## Documentation

No

## Installation

No
