### PR TITLE
Add support for unseeded integer hashing in hash-table

### DIFF
--- a/libs/runtime/ebpf_async.c
+++ b/libs/runtime/ebpf_async.c
@@ -23,6 +23,7 @@ ebpf_async_initiate()
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(ebpf_handle_t),
         .value_size = sizeof(ebpf_async_tracker_t),
+        .use_unseeded_integer_hashing = true,
     };
 
     EBPF_RETURN_RESULT(ebpf_hash_table_create(&_ebpf_async_tracker_table, &options));

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -64,7 +64,9 @@ extern "C"
         size_t supplemental_value_size; //< Size of supplemental value to store in each entry - defaults to 0.
         void* notification_context;     //< Context to pass to notification functions.
         ebpf_hash_table_notification_function
-            notification_callback; //< Function to call when value storage is allocated or freed.
+            notification_callback;         //< Function to call when value storage is allocated or freed.
+        bool use_unseeded_integer_hashing; //< Use unseeded integer hashing for this key. Key must be an integer of size
+                                           // 1, 2, 4, or 8 bytes.
     } ebpf_hash_table_creation_options_t;
 
     /**

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -153,6 +153,7 @@ ebpf_object_tracking_initiate()
         .value_size = sizeof(ebpf_id_entry_t),
         .max_entries = EBPF_HASH_TABLE_NO_LIMIT,
         .minimum_bucket_count = 1024,
+        .use_unseeded_integer_hashing = true,
     };
 
     memset(_ebpf_object_reference_history, 0, sizeof(_ebpf_object_reference_history));

--- a/libs/runtime/ebpf_state.c
+++ b/libs/runtime/ebpf_state.c
@@ -46,6 +46,7 @@ ebpf_state_initiate()
         .key_size = sizeof(uint64_t),
         .value_size = sizeof(ebpf_state_entry_t),
         .minimum_bucket_count = ebpf_get_cpu_count(),
+        .use_unseeded_integer_hashing = true,
     };
 
     return_value = ebpf_hash_table_create(&_ebpf_state_thread_table, &options);


### PR DESCRIPTION
## Description

This pull request introduces changes to the eBPF runtime to add support for unseeded integer hashing in hash tables. The most important changes include adding new hash functions for integer keys, updating the hash table creation options, and modifying the hash table's bucket index computation to use the new hash functions.

### Enhancements to Hash Table Functionality:

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR160-R181): Added new functions `_ebpf_integer_hash_function_32bit` and `_ebpf_integer_hash_function_64bit` for hashing 32-bit and 64-bit integer keys, respectively. Updated `_ebpf_hash_table_compute_bucket_index` to use these functions when `use_integer_hashing` is enabled. [[1]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR160-R181) [[2]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR315-R332)

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR71-R73): Added a new field `use_integer_hashing` to the `struct _ebpf_hash_table` to indicate whether integer hashing should be used.

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR735): Modified `ebpf_hash_table_create` to initialize the `use_integer_hashing` field based on the creation options.

### Updates to Hash Table Creation Options:

* [`libs/runtime/ebpf_hash_table.h`](diffhunk://#diff-f1989d71f868f217839f62cf184adc9960ec5f45fab4056bfcc85a76052d88e6R68-R69): Added a new field `use_unseeded_integer_hashing` to `ebpf_hash_table_creation_options_t` to specify whether unseeded integer hashing should be used for the hash table.

### Application of New Hashing Option:

* [`libs/runtime/ebpf_async.c`](diffhunk://#diff-6d10848231dd966c376b0e0afc6ac1540f3f0b70827e71de5e6817ae0b7b12f1R26): Enabled `use_unseeded_integer_hashing` in the `ebpf_async_initiate` function.
* [`libs/runtime/ebpf_object.c`](diffhunk://#diff-fe5b083e271468dbec2f7fc1b1027ab10a3b5d322b639df79609133d6c0f5f32R156): Enabled `use_unseeded_integer_hashing` in the `ebpf_object_tracking_initiate` function.
* [`libs/runtime/ebpf_state.c`](diffhunk://#diff-6fb4b762167b2f2a18d877d6abd281734ecb6ea39ba2e295119c02158f3d044cR49): Enabled `use_unseeded_integer_hashing` in the `ebpf_state_initiate` function.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
