### PR TITLE
Add retry logic when scripts fail to extract a zip file

### DIFF
--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -542,23 +542,25 @@ function Initialize-NetworkInterfacesOnVMs
     }
 }
 
-function Get-ZipFileFromUrl
-{
-    param([Parameter(Mandatory=$True)][string] $Url,
-          [Parameter(Mandatory=$True)][string] $DownloadFilePath,
-          [Parameter(Mandatory=$True)][string] $OutputFileDir)
+function Get-ZipFileFromUrl {
+    param(
+        [Parameter(Mandatory=$True)][string] $Url,
+        [Parameter(Mandatory=$True)][string] $DownloadFilePath,
+        [Parameter(Mandatory=$True)][string] $OutputFileDir
+    )
 
     for ($i = 0; $i -lt 5; $i++) {
         try {
-            Write-Host "Downloading $Url to $DownloadFilePath"
+            Write-Log "Downloading $Url to $DownloadFilePath"
             Invoke-WebRequest -Uri $Url -OutFile $DownloadFilePath
 
-            Write-Host "Extracting $DownloadFilePath to $OutputFileDir"
+            Write-Log "Extracting $DownloadFilePath to $OutputFileDir"
             Expand-Archive -Path $DownloadFilePath -DestinationPath $OutputFileDir -Force
             break
         } catch {
-            Write-Log -TraceMessage "Iteration $i failed to download $Url. Removing $DownloadFilePath" -ForegroundColor Red
+            Write-Log "Iteration $i failed to download $Url. Removing $DownloadFilePath" -ForegroundColor Red
             Remove-Item -Path $DownloadFilePath -Force -ErrorAction Ignore
+            Start-Sleep -Seconds 5
         }
     }
 }
@@ -598,6 +600,7 @@ function Get-LegacyRegressionTestArtifacts
             } catch {
                 Write-Log -TraceMessage "Iteration $i failed to download $ArtifactUrl. Removing $DownloadPath" -ForegroundColor Red
                 Remove-Item -Path $DownloadPath -Force -ErrorAction Ignore
+                Start-Sleep -Seconds 5
             }
         }
 

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -597,6 +597,7 @@ function Get-LegacyRegressionTestArtifacts
 
                 # Extract the inner zip file.
                 Expand-Archive -Path "$DownloadPath\build-NativeOnlyRelease.zip" -DestinationPath $DownloadPath -Force
+                break
             } catch {
                 Write-Log -TraceMessage "Iteration $i failed to download $ArtifactUrl. Removing $DownloadPath" -ForegroundColor Red
                 Remove-Item -Path $DownloadPath -Force -ErrorAction Ignore

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -593,7 +593,7 @@ function Get-LegacyRegressionTestArtifacts
         for ($i = 0; $i -lt 5; $i++) {
             try {
                 # Download and extract the artifact.
-                Get-ZipFileFromUrl -Uri $ArtifactUrl -DownloadFilePath "$DownloadPath\artifact.zip" -OutputFileDir $DownloadPath
+                Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\artifact.zip" -OutputFileDir $DownloadPath
 
                 # Extract the inner zip file.
                 Expand-Archive -Path "$DownloadPath\build-NativeOnlyRelease.zip" -DestinationPath $DownloadPath -Force
@@ -637,7 +637,7 @@ function Get-RegressionTestArtifacts
         Remove-Item -Path $DownloadPath\Build-x64.$Configuration -Recurse -Force
     }
 
-    Get-ZipFileFromUrl -Uri $ArtifactUrl -DownloadFilePath "$DownloadPath\Build-x64.$Configuration.zip" -OutputFileDir $DownloadPath
+    Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\Build-x64.$Configuration.zip" -OutputFileDir $DownloadPath
 
     if (!(Test-Path -Path $DownloadedArtifactPath)) {
         throw ("Path ""$DownloadedArtifactPath"" not found.")
@@ -664,7 +664,7 @@ function Get-Duonic {
     $DownloadPath = "$pwd\corenet-ci"
     mkdir $DownloadPath
     Write-Host "Downloading CoreNet-CI to $DownloadPath"
-    Get-ZipFileFromUrl -Uri "https://github.com/microsoft/corenet-ci/archive/refs/heads/main.zip" -DownloadFilePath "$DownloadPath\corenet-ci.zip" -OutputFileDir $DownloadPath
+    Get-ZipFileFromUrl -Url "https://github.com/microsoft/corenet-ci/archive/refs/heads/main.zip" -DownloadFilePath "$DownloadPath\corenet-ci.zip" -OutputFileDir $DownloadPath
     Move-Item -Path "$DownloadPath\corenet-ci-main\vm-setup\duonic\*" -Destination $pwd -Force
     Move-Item -Path "$DownloadPath\corenet-ci-main\vm-setup\procdump64.exe" -Destination $pwd -Force
     Move-Item -Path "$DownloadPath\corenet-ci-main\vm-setup\notmyfault64.exe" -Destination $pwd -Force

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -546,7 +546,7 @@ function Get-ZipFileFromUrl {
     param(
         [Parameter(Mandatory=$True)][string] $Url,
         [Parameter(Mandatory=$True)][string] $DownloadFilePath,
-        [Parameter(Mandatory=$True)][string] $OutputFileDir
+        [Parameter(Mandatory=$True)][string] $OutputDir
     )
 
     for ($i = 0; $i -lt 5; $i++) {
@@ -554,8 +554,8 @@ function Get-ZipFileFromUrl {
             Write-Log "Downloading $Url to $DownloadFilePath"
             Invoke-WebRequest -Uri $Url -OutFile $DownloadFilePath
 
-            Write-Log "Extracting $DownloadFilePath to $OutputFileDir"
-            Expand-Archive -Path $DownloadFilePath -DestinationPath $OutputFileDir -Force
+            Write-Log "Extracting $DownloadFilePath to $OutputDir"
+            Expand-Archive -Path $DownloadFilePath -DestinationPath $OutputDir -Force
             break
         } catch {
             Write-Log "Iteration $i failed to download $Url. Removing $DownloadFilePath" -ForegroundColor Red
@@ -593,7 +593,7 @@ function Get-LegacyRegressionTestArtifacts
         for ($i = 0; $i -lt 5; $i++) {
             try {
                 # Download and extract the artifact.
-                Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\artifact.zip" -OutputFileDir $DownloadPath
+                Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\artifact.zip" -OutputDir $DownloadPath
 
                 # Extract the inner zip file.
                 Expand-Archive -Path "$DownloadPath\build-NativeOnlyRelease.zip" -DestinationPath $DownloadPath -Force
@@ -637,7 +637,7 @@ function Get-RegressionTestArtifacts
         Remove-Item -Path $DownloadPath\Build-x64.$Configuration -Recurse -Force
     }
 
-    Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\Build-x64.$Configuration.zip" -OutputFileDir $DownloadPath
+    Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\Build-x64.$Configuration.zip" -OutputDir $DownloadPath
 
     if (!(Test-Path -Path $DownloadedArtifactPath)) {
         throw ("Path ""$DownloadedArtifactPath"" not found.")
@@ -664,7 +664,7 @@ function Get-Duonic {
     $DownloadPath = "$pwd\corenet-ci"
     mkdir $DownloadPath
     Write-Host "Downloading CoreNet-CI to $DownloadPath"
-    Get-ZipFileFromUrl -Url "https://github.com/microsoft/corenet-ci/archive/refs/heads/main.zip" -DownloadFilePath "$DownloadPath\corenet-ci.zip" -OutputFileDir $DownloadPath
+    Get-ZipFileFromUrl -Url "https://github.com/microsoft/corenet-ci/archive/refs/heads/main.zip" -DownloadFilePath "$DownloadPath\corenet-ci.zip" -OutputDir $DownloadPath
     Move-Item -Path "$DownloadPath\corenet-ci-main\vm-setup\duonic\*" -Destination $pwd -Force
     Move-Item -Path "$DownloadPath\corenet-ci-main\vm-setup\procdump64.exe" -Destination $pwd -Force
     Move-Item -Path "$DownloadPath\corenet-ci-main\vm-setup\notmyfault64.exe" -Destination $pwd -Force

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -638,7 +638,7 @@ function Get-RegressionTestArtifacts
     }
 
     Get-ZipFileFromUrl -Url $ArtifactUrl -DownloadFilePath "$DownloadPath\Build-x64.$Configuration.zip" -OutputDir $DownloadPath
-
+    $DownloadedArtifactPath = "$DownloadPath\Build-x64 $Configuration"
     if (!(Test-Path -Path $DownloadedArtifactPath)) {
         throw ("Path ""$DownloadedArtifactPath"" not found.")
     }


### PR DESCRIPTION
## Description
Our CICD was hitting intermittent failures to extract zip files. The error codes generally indicate a corrupted file. This change adds logic to delete and re-try the download and extraction of a downloaded zip file in our test scripts to help reduce failures when this occurs.

Closes #3809

## Testing
Local execution + CICD

## Documentation
n/a

## Installation
n/a