### PR TITLE
Set the freed_epoch to current_epoch, not 0

### DIFF
--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -58,7 +58,7 @@
 
 #define EBPF_EPOCH_FAIL_FAST(REASON, ASSERTION) \
     if (!(ASSERTION)) {                         \
-        ebpf_assert(!#ASSERTION);               \
+        ebpf_assert(#ASSERTION);                \
         __fastfail(REASON);                     \
     }
 
@@ -827,7 +827,7 @@ _ebpf_epoch_messenger_propose_release_epoch(
                 ebpf_epoch_allocation_header_t* header =
                     CONTAINING_RECORD(entry, ebpf_epoch_allocation_header_t, list_entry);
                 ebpf_assert(header->freed_epoch == EBPF_EPOCH_UNKNOWN_EPOCH);
-                header->freed_epoch = cpu_entry->current_epoch;
+                header->freed_epoch = message->message.propose_epoch.current_epoch;
             }
         }
 


### PR DESCRIPTION
## Description

This pull request includes two changes to the `libs/runtime/ebpf_epoch.c` file that address assertion behavior and epoch handling in the eBPF runtime.

Assertion behavior update:

* Modified the `EBPF_EPOCH_FAIL_FAST` macro to correctly pass the assertion string to `ebpf_assert`. (`libs/runtime/ebpf_epoch.c`)

Epoch handling update:

* Updated the `_ebpf_epoch_messenger_propose_release_epoch` function to use `message->message.propose_epoch.current_epoch` instead of `cpu_entry->current_epoch` for setting the `freed_epoch` field. (`libs/runtime/ebpf_epoch.c`)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
