### PR TITLE
Add `/allpdata` linker flag for all ebpf kernel driver component functions to facilitate fbt like functionality

### DIFF
--- a/ebpfcore/EbpfCore.vcxproj
+++ b/ebpfcore/EbpfCore.vcxproj
@@ -164,6 +164,7 @@
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/allpdata %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>

--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
@@ -118,6 +118,7 @@
   <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -189,6 +190,7 @@
       <AdditionalDependencies>usersim.lib;uuid.lib;bcrypt.lib;legacy_stdio_definitions.lib;ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>ntdll.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>/allpdata %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>

--- a/netebpfext/sys/netebpfext.vcxproj
+++ b/netebpfext/sys/netebpfext.vcxproj
@@ -163,6 +163,7 @@
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/allpdata %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>


### PR DESCRIPTION
## Description

* Add `/allpdata` linker flag for all kernel drivers to enable dtrace function boundary tracing (fbt) for all functions.
* Disable incremental linking for `EbpfCore_Usersim` project since this conflicts with `/allpdata`.
* Resolve #3856.

**Note:** fbt instrumentation uses unwind information from the pdata image section to get information about function prologue and epilogues; this is sometime unavailable for leaf functions not calling any imported API since they may not have unwind information, hence, `/allpdata` forces this information to be generated for all functions.

## Testing

* Validated fbt probes for ebfcore are enumerated using dtrace (eg. `dtrace -ln "fbt:ebpfcore::"`).
* Compared change in image size to baseline, confirming no change in release builds:

| Image                 | Baseline <br>Size (bytes) | `/allpdata` <br>Size (bytes) | Change <br> (bytes) |
| :----------------- | :---------: | :---------: | :--------: |
| **`EbpfCore.sys`**    |
| &nbsp;&nbsp;&nbsp;&nbsp; Debug               |  623,568  |  624,624   | +1,056   |
| &nbsp;&nbsp;&nbsp;&nbsp; Release               | 302,328 | 302,328 | 0 |
| &nbsp;&nbsp;&nbsp;&nbsp; NativeOnly         | 282,184 | 282,184 | 0 |
| **`netebpfext.sys`**  | | | |
| &nbsp;&nbsp;&nbsp;&nbsp; Debug  | 240,824   | 241,336   | +512      |
| &nbsp;&nbsp;&nbsp;&nbsp; Release | 138,584 | 138,584 | 0 |
| &nbsp;&nbsp;&nbsp;&nbsp; NativeOnly         | 138,584 | 138,584 | 0 |

## Documentation

* None

## Installation

* None
