### PR TITLE
Prevent double activation

### DIFF
--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -346,8 +346,16 @@ ebpf_epoch_initiate()
         }
     }
 
-    // CPU 0 is always active.
-    _ebpf_epoch_activate_cpu(0);
+    // Set the initial state for CPU 0.
+    // This code can't use _ebpf_epoch_activate_cpu as it may not running on CPU 0.
+    _ebpf_epoch_cpu_table[0].active = true;
+    ebpf_result_t result = ebpf_timed_work_queue_set_cpu_id(_ebpf_epoch_cpu_table[0].work_queue, 0);
+    if (result != EBPF_SUCCESS) {
+        return_value = result;
+        goto Error;
+    }
+
+    _ebpf_epoch_cpu_table[0].work_queue_assigned = 1;
 
     // Set the current epoch for CPU 0.
     _ebpf_epoch_cpu_table[0].current_epoch = EBPF_EPOCH_FIRST_EPOCH;

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -260,11 +260,9 @@ static _IRQL_requires_(DISPATCH_LEVEL) void _ebpf_epoch_arm_timer_if_needed(ebpf
 static void
 _ebpf_epoch_work_item_callback(_In_ cxplat_preemptible_work_item_t* preemptible_work_item, void* context);
 
-static void
-_ebpf_epoch_activate_cpu(uint32_t cpu_id);
+_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_activate_cpu(uint32_t cpu_id);
 
-static void
-_ebpf_epoch_deactivate_cpu(uint32_t cpu_id);
+_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_deactivate_cpu(uint32_t cpu_id);
 
 uint32_t
 _ebpf_epoch_next_active_cpu(uint32_t cpu_id);
@@ -1121,8 +1119,7 @@ _ebpf_epoch_work_item_callback(_In_ cxplat_preemptible_work_item_t* preemptible_
  *
  * @param[in] cpu_id CPU to add.
  */
-static void
-_ebpf_epoch_activate_cpu(uint32_t cpu_id)
+_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_activate_cpu(uint32_t cpu_id)
 {
     EBPF_LOG_ENTRY();
 
@@ -1159,10 +1156,12 @@ _ebpf_epoch_activate_cpu(uint32_t cpu_id)
  *
  * @param[in] cpu_id CPU to remove.
  */
-static void
-_ebpf_epoch_deactivate_cpu(uint32_t cpu_id)
+_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_deactivate_cpu(uint32_t cpu_id)
 {
     EBPF_LOG_ENTRY();
+    ebpf_assert(cpu_id == ebpf_get_current_cpu());
+    ebpf_assert(ebpf_list_is_empty(&_ebpf_epoch_cpu_table[cpu_id].epoch_state_list));
+    ebpf_assert(ebpf_list_is_empty(&_ebpf_epoch_cpu_table[cpu_id].free_list));
 
     EBPF_LOG_MESSAGE_UINT64(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_EPOCH, "Deactivating CPU", cpu_id);
 


### PR DESCRIPTION
Resolves: #3855

## Description

Ensure that the CPU is only activated from the current CPU and never activated from another CPU.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
