### PR TITLE
run `api_tests` as system

### DIFF
--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -22,17 +22,17 @@ _open_ebpf_store_key(_Out_ ebpf_store_key_t* store_key)
     // Open root registry path.
     *store_key = nullptr;
 
-    // First try to open the HKLM registry key.
+    // First try to open the HKCU registry key.
     ebpf_result_t result =
-        ebpf_open_registry_key(root_registry_key_local_machine, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
+        ebpf_open_registry_key(root_registry_key_current_user, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
     if (result != ERROR_SUCCESS) {
-        // Failed to open ebpf store path in HKLM. Fall back to HKCU.
+        // Failed to open ebpf store path in HKCU. Fall back to HKLM.
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_WARNING,
             EBPF_TRACELOG_KEYWORD_BASE,
-            "_open_ebpf_store_key: Failed to open HKLM registry key. Falling back to HKCU. Error:",
+            "_open_ebpf_store_key: Failed to open HKCU registry key. Falling back to HKLM. Error:",
             result);
-        result = ebpf_open_registry_key(root_registry_key_current_user, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
+        result = ebpf_open_registry_key(root_registry_key_local_machine, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
     }
 
     EBPF_RETURN_RESULT(result);

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -22,17 +22,17 @@ _open_ebpf_store_key(_Out_ ebpf_store_key_t* store_key)
     // Open root registry path.
     *store_key = nullptr;
 
-    // First try to open the HKCU registry key.
+    // First try to open the HKLM registry key.
     ebpf_result_t result =
-        ebpf_open_registry_key(root_registry_key_current_user, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
+        ebpf_open_registry_key(root_registry_key_local_machine, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
     if (result != ERROR_SUCCESS) {
-        // Failed to open ebpf store path in HKCU. Fall back to HKLM.
+        // Failed to open ebpf store path in HKLM. Fall back to HKCU.
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_WARNING,
             EBPF_TRACELOG_KEYWORD_BASE,
-            "_open_ebpf_store_key: Failed to open HKCU registry key. Falling back to HKLM. Error:",
+            "_open_ebpf_store_key: Failed to open HKLM registry key. Falling back to HKCU. Error:",
             result);
-        result = ebpf_open_registry_key(root_registry_key_local_machine, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
+        result = ebpf_open_registry_key(root_registry_key_current_user, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
     }
 
     EBPF_RETURN_RESULT(result);

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -682,3 +682,17 @@ function Get-VCRedistributable {
     Move-Item -Path "$DownloadPath\vc_redist.x64.exe" -Destination $pwd -Force
     Remove-Item -Path $DownloadPath -Force -Recurse
 }
+
+# Download and extract PSExec to run tests as SYSTEM.
+function Get-PSExec {
+    $url = "https://download.sysinternals.com/files/PSTools.zip"
+    $DownloadPath = "$pwd\psexec"
+    mkdir $DownloadPath
+    Write-Host "Downloading PSExec from $url to $DownloadPath"
+    Invoke-WebRequest $url -OutFile "$DownloadPath\pstools.zip"
+    cd $DownloadPath
+    Expand-Archive -Path "$DownloadPath\pstools.zip" -Force
+    cd ..
+    Move-Item -Path "$DownloadPath\PSTools\PsExec64.exe" -Destination $pwd -Force
+    Remove-Item -Path $DownloadPath -Force -Recurse
+}

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -552,6 +552,7 @@ function Get-ZipFileFromUrl {
     for ($i = 0; $i -lt 5; $i++) {
         try {
             Write-Log "Downloading $Url to $DownloadFilePath"
+            $ProgressPreference = 'SilentlyContinue'
             Invoke-WebRequest -Uri $Url -OutFile $DownloadFilePath
 
             Write-Log "Extracting $DownloadFilePath to $OutputDir"
@@ -678,6 +679,7 @@ function Get-VCRedistributable {
     $DownloadPath = "$pwd\vc-redist"
     mkdir $DownloadPath
     Write-Host "Downloading Visual C++ Redistributable from $url to $DownloadPath"
+    $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $url -OutFile "$DownloadPath\vc_redist.x64.exe"
     Move-Item -Path "$DownloadPath\vc_redist.x64.exe" -Destination $pwd -Force
     Remove-Item -Path $DownloadPath -Force -Recurse
@@ -689,6 +691,7 @@ function Get-PSExec {
     $DownloadPath = "$pwd\psexec"
     mkdir $DownloadPath
     Write-Host "Downloading PSExec from $url to $DownloadPath"
+    $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest $url -OutFile "$DownloadPath\pstools.zip"
     cd $DownloadPath
     Expand-Archive -Path "$DownloadPath\pstools.zip" -Force

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -58,29 +58,29 @@ foreach ($VM in $VMList) {
 # parameter.
 if ($TestMode -eq "CI/CD") {
 
-    # Run XDP Tests.
-    Invoke-XDPTestsOnVM `
-        -Interfaces $Config.Interfaces `
-        -VMName $VMList[0].Name `
-        -TestHangTimeout $TestHangTimeout `
-        -UserModeDumpFolder $UserModeDumpFolder
+    # # Run XDP Tests.
+    # Invoke-XDPTestsOnVM `
+    #     -Interfaces $Config.Interfaces `
+    #     -VMName $VMList[0].Name `
+    #     -TestHangTimeout $TestHangTimeout `
+    #     -UserModeDumpFolder $UserModeDumpFolder
 
-    # Run Connect Redirect Tests.
-    Invoke-ConnectRedirectTestsOnVM `
-        -Interfaces $Config.Interfaces `
-        -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
-        -UserType "Administrator" `
-        -VMName $VMList[0].Name `
-        -TestHangTimeout $TestHangTimeout `
-        -UserModeDumpFolder $UserModeDumpFolder
+    # # Run Connect Redirect Tests.
+    # Invoke-ConnectRedirectTestsOnVM `
+    #     -Interfaces $Config.Interfaces `
+    #     -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
+    #     -UserType "Administrator" `
+    #     -VMName $VMList[0].Name `
+    #     -TestHangTimeout $TestHangTimeout `
+    #     -UserModeDumpFolder $UserModeDumpFolder
 
-    Invoke-ConnectRedirectTestsOnVM `
-        -Interfaces $Config.Interfaces `
-        -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
-        -UserType "StandardUser" `
-        -VMName $VMList[0].Name `
-        -TestHangTimeout $TestHangTimeout `
-        -UserModeDumpFolder $UserModeDumpFolder
+    # Invoke-ConnectRedirectTestsOnVM `
+    #     -Interfaces $Config.Interfaces `
+    #     -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
+    #     -UserType "StandardUser" `
+    #     -VMName $VMList[0].Name `
+    #     -TestHangTimeout $TestHangTimeout `
+    #     -UserModeDumpFolder $UserModeDumpFolder
 }
 
 # Stop eBPF components on test VMs.

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -16,11 +16,6 @@ param ([parameter(Mandatory = $false)][string] $AdminTarget = "TEST_VM",
 
 Push-Location $WorkingDirectory
 
-# For test execution, "Regression" and "CI/CD" have same behavior.
-if ($TestMode -eq "Regression") {
-    $TestMode = "CI/CD"
-}
-
 $AdminTestVMCredential = Get-StoredCredential -Target $AdminTarget -ErrorAction Stop
 $StandardUserTestVMCredential = Get-StoredCredential -Target $StandardUserTarget -ErrorAction Stop
 
@@ -56,31 +51,31 @@ foreach ($VM in $VMList) {
 
 # This script is used to execute the various kernel mode tests. The required behavior is selected by the $TestMode
 # parameter.
-if ($TestMode -eq "CI/CD") {
+if (($TestMode -eq "CI/CD") -or ($TestMode -eq "Regression")) {
 
-    # # Run XDP Tests.
-    # Invoke-XDPTestsOnVM `
-    #     -Interfaces $Config.Interfaces `
-    #     -VMName $VMList[0].Name `
-    #     -TestHangTimeout $TestHangTimeout `
-    #     -UserModeDumpFolder $UserModeDumpFolder
+    # Run XDP Tests.
+    Invoke-XDPTestsOnVM `
+        -Interfaces $Config.Interfaces `
+        -VMName $VMList[0].Name `
+        -TestHangTimeout $TestHangTimeout `
+        -UserModeDumpFolder $UserModeDumpFolder
 
-    # # Run Connect Redirect Tests.
-    # Invoke-ConnectRedirectTestsOnVM `
-    #     -Interfaces $Config.Interfaces `
-    #     -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
-    #     -UserType "Administrator" `
-    #     -VMName $VMList[0].Name `
-    #     -TestHangTimeout $TestHangTimeout `
-    #     -UserModeDumpFolder $UserModeDumpFolder
+    # Run Connect Redirect Tests.
+    Invoke-ConnectRedirectTestsOnVM `
+        -Interfaces $Config.Interfaces `
+        -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
+        -UserType "Administrator" `
+        -VMName $VMList[0].Name `
+        -TestHangTimeout $TestHangTimeout `
+        -UserModeDumpFolder $UserModeDumpFolder
 
-    # Invoke-ConnectRedirectTestsOnVM `
-    #     -Interfaces $Config.Interfaces `
-    #     -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
-    #     -UserType "StandardUser" `
-    #     -VMName $VMList[0].Name `
-    #     -TestHangTimeout $TestHangTimeout `
-    #     -UserModeDumpFolder $UserModeDumpFolder
+    Invoke-ConnectRedirectTestsOnVM `
+        -Interfaces $Config.Interfaces `
+        -ConnectRedirectTestConfig $Config.ConnectRedirectTest `
+        -UserType "StandardUser" `
+        -VMName $VMList[0].Name `
+        -TestHangTimeout $TestHangTimeout `
+        -UserModeDumpFolder $UserModeDumpFolder
 }
 
 # Stop eBPF components on test VMs.

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -312,17 +312,6 @@ function Install-eBPFComponents
         }
     }
 
-    # # Export program info for the sample driver as local system.
-    # Write-Log("Running 'export_program_info_sample.exe as system'...")
-    # if (Test-Path -Path "export_program_info_sample.exe") {
-    #     .\PsExec.exe -accepteula -nobanner -s "$pwd\export_program_info_sample.exe" # 2>&1 | Write-Log
-    #     if ($LASTEXITCODE -ne 0) {
-    #         throw ("Failed to run 'export_program_info_sample.exe'.");
-    #     } else {
-    #         Write-Log "'export_program_info_sample.exe' succeeded." -ForegroundColor Green
-    #     }
-    # }
-
     # Print the status of the eBPF drivers and services after installation.
     Print-eBPFComponentsStatus "Verifying the status of eBPF drivers and services after the installation..." | Out-Null
 

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -312,6 +312,17 @@ function Install-eBPFComponents
         }
     }
 
+    # # Export program info for the sample driver as local system.
+    # Write-Log("Running 'export_program_info_sample.exe as system'...")
+    # if (Test-Path -Path "export_program_info_sample.exe") {
+    #     .\PsExec.exe -accepteula -nobanner -s "$pwd\export_program_info_sample.exe" # 2>&1 | Write-Log
+    #     if ($LASTEXITCODE -ne 0) {
+    #         throw ("Failed to run 'export_program_info_sample.exe'.");
+    #     } else {
+    #         Write-Log "'export_program_info_sample.exe' succeeded." -ForegroundColor Green
+    #     }
+    # }
+
     # Print the status of the eBPF drivers and services after installation.
     Print-eBPFComponentsStatus "Verifying the status of eBPF drivers and services after the installation..." | Out-Null
 

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -312,6 +312,19 @@ function Install-eBPFComponents
         }
     }
 
+    # Export program info for the sample driver as SYSTEM.
+    Write-Log("Running 'export_program_info_sample.exe' as SYSTEM...")
+    if (Test-Path -Path "export_program_info_sample.exe") {
+        $TestCommand = "$pwd\PsExec64.exe"
+        $Arguments = "-accepteula -nobanner -s -w `"$pwd`" `"$pwd\export_program_info_sample.exe`""
+        Start-Process -NoNewWindow -Wait "$TestCommand" -ArgumentList "$Arguments"
+        if ($LASTEXITCODE -ne 0) {
+            throw ("Failed to run 'export_program_info_sample.exe as SYSTEM'.");
+        } else {
+            Write-Log "'export_program_info_sample.exe' succeeded." -ForegroundColor Green
+        }
+    }
+
     # Print the status of the eBPF drivers and services after installation.
     Print-eBPFComponentsStatus "Verifying the status of eBPF drivers and services after the installation..." | Out-Null
 

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -103,7 +103,7 @@ function Invoke-CICDTests
         "sample_ext_app.exe",
         "socket_tests.exe")
 
-    $SystemTestList = @("api_test.exe ~`"load_native_program_invalid4`"")
+    $SystemTestList = @("api_test.exe")
 
     # foreach ($Test in $TestList) {
     #     Invoke-Test -TestName $Test -VerboseLogs $VerboseLogs -Coverage $Coverage
@@ -111,7 +111,7 @@ function Invoke-CICDTests
 
     # Now run the system tests. No coverage is needed for these tests.
     foreach ($Test in $SystemTestList) {
-        $TestCommand = "PsExec64.exe /accepteula /nobanner -s -w `"$pwd.Path`" `"($pwd.Path)\unit_tests.exe`" `"-d yes`""
+        $TestCommand = "PsExec64.exe -accepteula -nobanner -s -w `"$pwd`" `"$pwd\$Test`" `"~`"load_native_program_invalid4`" -d yes`""
         # PsExec.exe /accepteula /nobanner -s -w "E:\git\github2\ebpf-for-windows-1\x64\Debug" "E:\git\github2\ebpf-for-windows-1\x64\Debug\unit_tests.exe" "-d yes"
         Invoke-Test -TestName $TestCommand -VerboseLogs $VerboseLogs -Coverage $false
     }

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -111,7 +111,7 @@ function Invoke-CICDTests
 
     # Now run the system tests. No coverage is needed for these tests.
     foreach ($Test in $SystemTestList) {
-        $TestCommand = "PsExec64.exe -accepteula -nobanner -s -w `"$pwd`" `"$pwd\$Test`" `"~`"load_native_program_invalid4`" -d yes`""
+        $TestCommand = "PsExec64.exe -accepteula -nobanner -s -w `"$pwd`" `"$pwd\$Test`" `"-d yes`""
         # PsExec.exe /accepteula /nobanner -s -w "E:\git\github2\ebpf-for-windows-1\x64\Debug" "E:\git\github2\ebpf-for-windows-1\x64\Debug\unit_tests.exe" "-d yes"
         Invoke-Test -TestName $TestCommand -VerboseLogs $VerboseLogs -Coverage $false
     }

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -103,8 +103,17 @@ function Invoke-CICDTests
         "sample_ext_app.exe",
         "socket_tests.exe")
 
-    foreach ($Test in $TestList) {
-        Invoke-Test -TestName $Test -VerboseLogs $VerboseLogs -Coverage $Coverage
+    $SystemTestList = @("api_test.exe ~`"load_native_program_invalid4`"")
+
+    # foreach ($Test in $TestList) {
+    #     Invoke-Test -TestName $Test -VerboseLogs $VerboseLogs -Coverage $Coverage
+    # }
+
+    # Now run the system tests. No coverage is needed for these tests.
+    foreach ($Test in $SystemTestList) {
+        $TestCommand = "PsExec64.exe /accepteula /nobanner -s -w `"$pwd.Path`" `"($pwd.Path)\unit_tests.exe`" `"-d yes`""
+        # PsExec.exe /accepteula /nobanner -s -w "E:\git\github2\ebpf-for-windows-1\x64\Debug" "E:\git\github2\ebpf-for-windows-1\x64\Debug\unit_tests.exe" "-d yes"
+        Invoke-Test -TestName $TestCommand -VerboseLogs $VerboseLogs -Coverage $false
     }
 
     if ($Coverage) {

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -88,7 +88,8 @@ function Invoke-CICDTests
     param([parameter(Mandatory = $true)][bool] $VerboseLogs,
           [parameter(Mandatory = $false)][bool] $Coverage = $false,
           [parameter(Mandatory = $false)][int] $TestHangTimeout = 3600,
-          [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps"
+          [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
+          [parameter(Mandatory = $true)][bool] $ExecuteSystemTests
     )
 
 
@@ -105,15 +106,16 @@ function Invoke-CICDTests
 
     $SystemTestList = @("api_test.exe")
 
-    # foreach ($Test in $TestList) {
-    #     Invoke-Test -TestName $Test -VerboseLogs $VerboseLogs -Coverage $Coverage
-    # }
+    foreach ($Test in $TestList) {
+        Invoke-Test -TestName $Test -VerboseLogs $VerboseLogs -Coverage $Coverage
+    }
 
     # Now run the system tests. No coverage is needed for these tests.
-    foreach ($Test in $SystemTestList) {
-        $TestCommand = "PsExec64.exe -accepteula -nobanner -s -w `"$pwd`" `"$pwd\$Test`" `"-d yes`""
-        # PsExec.exe /accepteula /nobanner -s -w "E:\git\github2\ebpf-for-windows-1\x64\Debug" "E:\git\github2\ebpf-for-windows-1\x64\Debug\unit_tests.exe" "-d yes"
-        Invoke-Test -TestName $TestCommand -VerboseLogs $VerboseLogs -Coverage $false
+    if ($ExecuteSystemTests) {
+        foreach ($Test in $SystemTestList) {
+            $TestCommand = "PsExec64.exe -accepteula -nobanner -s -w `"$pwd`" `"$pwd\$Test`" `"-d yes`""
+            Invoke-Test -TestName $TestCommand -VerboseLogs $VerboseLogs -Coverage $false
+        }
     }
 
     if ($Coverage) {

--- a/scripts/setup_ebpf_cicd_tests.ps1
+++ b/scripts/setup_ebpf_cicd_tests.ps1
@@ -49,6 +49,7 @@ if ($TestMode -eq "CI/CD" -or $TestMode -eq "Regression") {
 
 Get-Duonic
 Get-VCRedistributable
+Get-PSExec
 
 # Export build artifacts to the test VMs.
 Export-BuildArtifactsToVMs -VMList $VMList -ErrorAction Stop

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -53,6 +53,16 @@ function Invoke-CICDTestsOnVM
                     -Coverage $Coverage `
                     -TestHangTimeout $TestHangTimeout `
                     -UserModeDumpFolder $UserModeDumpFolder `
+                    -ExecuteSystemTests $true `
+                    2>&1 | Write-Log
+            }
+            "regression" {
+                Invoke-CICDTests `
+                    -VerboseLogs $VerboseLogs `
+                    -Coverage $Coverage `
+                    -TestHangTimeout $TestHangTimeout `
+                    -UserModeDumpFolder $UserModeDumpFolder `
+                    -ExecuteSystemTests $false `
                     2>&1 | Write-Log
             }
             "stress" {


### PR DESCRIPTION
## Description

This PR adds tests to run `api_tests` also as SYSTEM. This allows catching any ebpf store related regressions for services / apps running as SYSTEM.

## Testing

Existing CICD + new tests

## Documentation

No

## Installation

No