### PR TITLE
[netebpfext] Add per-provider WFP handles to avoid improper use from parallel invocations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,8 +19,7 @@
 	url = https://github.com/trailofbits/pe-parse.git
 [submodule "external/usersim"]
 	path = external/usersim
-	url = https://github.com/matthewige/usersim.git
-	branch = user/maige/add_wfp_apis
+	url = https://github.com/microsoft/usersim.git
 [submodule "tests/external/kissfft"]
 	path = tests/external/kissfft
 	url = https://github.com/mborgerding/kissfft

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,8 @@
 	url = https://github.com/trailofbits/pe-parse.git
 [submodule "external/usersim"]
 	path = external/usersim
-	url = https://github.com/microsoft/usersim.git
+	url = https://github.com/matthewige/usersim.git
+	branch = user/maige/add_wfp_apis
 [submodule "tests/external/kissfft"]
 	path = tests/external/kissfft
 	url = https://github.com/mborgerding/kissfft

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -383,7 +383,7 @@ net_ebpf_extension_delete_wfp_filters(
     NET_EBPF_EXT_LOG_ENTRY();
     NTSTATUS status = STATUS_SUCCESS;
 
-    if (!wfp_engine_handle) {
+    if (wfp_engine_handle == NULL) {
         NET_EBPF_EXT_LOG_MESSAGE(
             NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "WFP engine handle is NULL");
     } else {
@@ -426,7 +426,7 @@ net_ebpf_extension_add_wfp_filters(
 
     NET_EBPF_EXT_LOG_ENTRY();
 
-    if (!wfp_engine_handle) {
+    if (wfp_engine_handle == NULL) {
         NET_EBPF_EXT_LOG_MESSAGE(
             NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "WFP engine handle is NULL");
         result = EBPF_INVALID_ARGUMENT;
@@ -663,9 +663,9 @@ net_ebpf_ext_uninitialize_ndis_handles()
 }
 
 NTSTATUS
-net_ebpf_extension_open_wfp_engine_handle(HANDLE* wfp_engine_handle)
+net_ebpf_extension_open_wfp_engine_handle(_Out_ HANDLE* wfp_engine_handle)
 {
-    if (!wfp_engine_handle) {
+    if (wfp_engine_handle == NULL) {
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -673,9 +673,9 @@ net_ebpf_extension_open_wfp_engine_handle(HANDLE* wfp_engine_handle)
 }
 
 NTSTATUS
-net_ebpf_extension_close_wfp_engine_handle(HANDLE wfp_engine_handle)
+net_ebpf_extension_close_wfp_engine_handle(_In_ HANDLE wfp_engine_handle)
 {
-    if (!wfp_engine_handle) {
+    if (wfp_engine_handle == NULL) {
         return STATUS_INVALID_PARAMETER;
     }
 

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -806,10 +806,10 @@ net_ebpf_extension_uninitialize_wfp_components(void)
 
         // Clean up the sub layers.
         for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_sublayers); index++) {
-            status = FwpmSubLayerDeleteByKey0(_fwp_engine_handle, _net_ebpf_ext_sublayers[index].sublayer_guid);
+            status = FwpmSubLayerDeleteByKey(_fwp_engine_handle, _net_ebpf_ext_sublayers[index].sublayer_guid);
             if (!NT_SUCCESS(status) && !WFP_ERROR(status, SUBLAYER_NOT_FOUND)) {
                 NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmSubLayerDeleteByKey0", status);
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmSubLayerDeleteByKey", status);
             }
         }
 

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -225,7 +225,7 @@ static net_ebpf_ext_wfp_callout_state_t _net_ebpf_ext_wfp_callout_states[] = {
     }};
 
 // WFP globals
-static EX_SPIN_LOCK _fwp_engine_lock = 0;
+static EX_SPIN_LOCK _fwp_engine_lock = {0};
 _Guarded_by_(_fwp_engine_lock) static HANDLE _fwp_engine_handle;
 
 //

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -553,9 +553,6 @@ _net_ebpf_ext_register_wfp_callout(_Inout_ net_ebpf_ext_wfp_callout_state_t* cal
     callout_register_state.flags = 0;
 
     status = FwpsCalloutRegister(device_object, &callout_register_state, &callout_state->assigned_callout_id);
-    if (WFP_ERROR(status, ALREADY_EXISTS)) {
-        status = STATUS_SUCCESS;
-    }
     if (!NT_SUCCESS(status)) {
         NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(
             NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
@@ -576,9 +573,6 @@ _net_ebpf_ext_register_wfp_callout(_Inout_ net_ebpf_ext_wfp_callout_state_t* cal
     callout_add_state.applicableLayer = *callout_state->layer_guid;
 
     status = FwpmCalloutAdd(_fwp_engine_handle, &callout_add_state, NULL, NULL);
-    if (WFP_ERROR(status, ALREADY_EXISTS)) {
-        status = STATUS_SUCCESS;
-    }
     if (!NT_SUCCESS(status)) {
         NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(
             NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
@@ -699,9 +693,6 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
     ebpf_wfp_provider.displayData.description = L"Windows Networking eBPF Extension";
     ebpf_wfp_provider.providerKey = EBPF_WFP_PROVIDER;
     status = FwpmProviderAdd(_fwp_engine_handle, &ebpf_wfp_provider, NULL);
-    if (WFP_ERROR(status, ALREADY_EXISTS)) {
-        status = STATUS_SUCCESS;
-    }
     NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmProviderAdd", status);
 
     // Add all the sub layers.
@@ -716,9 +707,6 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
         ebpf_hook_sub_layer.weight = _net_ebpf_ext_sublayers[index].weight;
 
         status = FwpmSubLayerAdd(_fwp_engine_handle, &ebpf_hook_sub_layer, NULL);
-        if (WFP_ERROR(status, ALREADY_EXISTS)) {
-            status = STATUS_SUCCESS;
-        }
         NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmSubLayerAdd", status);
     }
 

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -140,17 +140,21 @@ typedef struct _net_ebpf_extension_wfp_filter_context
     bool context_deleting : 1; ///< True if all the clients have been detached and the context is being deleted.
     bool wildcard : 1;         ///< True if the filter context is for wildcard filters.
     bool initialized : 1;      ///< True if the filter context has been successfully initialized.
+    HANDLE wfp_engine_handle;  ///< WFP engine handle.
 } net_ebpf_extension_wfp_filter_context_t;
 
-#define CLEAN_UP_FILTER_CONTEXT(filter_context)            \
-    if ((filter_context) != NULL) {                        \
-        if ((filter_context)->filter_ids != NULL) {        \
-            ExFreePool((filter_context)->filter_ids);      \
-        }                                                  \
-        if ((filter_context)->client_contexts != NULL) {   \
-            ExFreePool((filter_context)->client_contexts); \
-        }                                                  \
-        ExFreePool((filter_context));                      \
+#define CLEAN_UP_FILTER_CONTEXT(filter_context)                                              \
+    if ((filter_context) != NULL) {                                                          \
+        if ((filter_context)->filter_ids != NULL) {                                          \
+            ExFreePool((filter_context)->filter_ids);                                        \
+        }                                                                                    \
+        if ((filter_context)->client_contexts != NULL) {                                     \
+            ExFreePool((filter_context)->client_contexts);                                   \
+        }                                                                                    \
+        if ((filter_context)->wfp_engine_handle != NULL) {                                   \
+            net_ebpf_extension_close_wfp_engine_handle((filter_context)->wfp_engine_handle); \
+        }                                                                                    \
+        ExFreePool((filter_context));                                                        \
     }
 
 #define REFERENCE_FILTER_CONTEXT(filter_context)                  \

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -143,18 +143,18 @@ typedef struct _net_ebpf_extension_wfp_filter_context
     HANDLE wfp_engine_handle;  ///< WFP engine handle.
 } net_ebpf_extension_wfp_filter_context_t;
 
-#define CLEAN_UP_FILTER_CONTEXT(filter_context)                                              \
-    if ((filter_context) != NULL) {                                                          \
-        if ((filter_context)->filter_ids != NULL) {                                          \
-            ExFreePool((filter_context)->filter_ids);                                        \
-        }                                                                                    \
-        if ((filter_context)->client_contexts != NULL) {                                     \
-            ExFreePool((filter_context)->client_contexts);                                   \
-        }                                                                                    \
-        if ((filter_context)->wfp_engine_handle != NULL) {                                   \
-            net_ebpf_extension_close_wfp_engine_handle((filter_context)->wfp_engine_handle); \
-        }                                                                                    \
-        ExFreePool((filter_context));                                                        \
+#define CLEAN_UP_FILTER_CONTEXT(filter_context)                   \
+    if ((filter_context) != NULL) {                               \
+        if ((filter_context)->filter_ids != NULL) {               \
+            ExFreePool((filter_context)->filter_ids);             \
+        }                                                         \
+        if ((filter_context)->client_contexts != NULL) {          \
+            ExFreePool((filter_context)->client_contexts);        \
+        }                                                         \
+        if ((filter_context)->wfp_engine_handle != NULL) {        \
+            FwpmEngineClose((filter_context)->wfp_engine_handle); \
+        }                                                         \
+        ExFreePool((filter_context));                             \
     }
 
 #define REFERENCE_FILTER_CONTEXT(filter_context)                  \
@@ -380,9 +380,3 @@ ebpf_result_t
 net_ebpf_ext_add_client_context(
     _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context,
     _In_ const struct _net_ebpf_extension_hook_client* hook_client);
-
-NTSTATUS
-net_ebpf_extension_open_wfp_engine_handle(_Out_ HANDLE* wfp_engine_handle);
-
-NTSTATUS
-net_ebpf_extension_close_wfp_engine_handle(_In_ HANDLE wfp_engine_handle);

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -27,10 +27,10 @@
 
 // Note: The maximum number of clients that can attach per-hook in multi-attach case has been currently capped to
 // a constant value to keep the implementation simple. Keeping the max limit constant allows allocating the memory
-// required for creating a copy of list of clients on the stack itself. In the future, if there is a need to increase this
-// maximum count, the value can be simply increased as long as the required memory can still be allocated on stack. If
-// the required memory becomes too large, we may need to switch to a different design to handle this. One option is to
-// use epoch based memory management for the list of clients. This eliminates the need to create a copy of programs
+// required for creating a copy of list of clients on the stack itself. In the future, if there is a need to increase
+// this maximum count, the value can be simply increased as long as the required memory can still be allocated on stack.
+// If the required memory becomes too large, we may need to switch to a different design to handle this. One option is
+// to use epoch based memory management for the list of clients. This eliminates the need to create a copy of programs
 // per-invocation. Another option can be to always invoke the programs while holding the socket context lock, but that
 // comes with a side effect of every program invocation now happening at DISPATCH_LEVEL.
 #define NET_EBPF_EXT_MAX_CLIENTS_PER_HOOK_MULTI_ATTACH 16
@@ -247,6 +247,7 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
 /**
  * @brief Add WFP filters with specified conditions at specified layers.
  *
+ * @param[in] wfp_filter_handle The WFP filter handle used to add the filters.
  * @param[in] filter_count Count of filters to be added.
  * @param[in] parameters Filter parameters.
  * @param[in] condition_count Count of filter conditions.
@@ -259,6 +260,7 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
  */
 _Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_add_wfp_filters(
+    _In_ HANDLE wfp_engine_handle,
     uint32_t filter_count,
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
     uint32_t condition_count,
@@ -269,12 +271,15 @@ net_ebpf_extension_add_wfp_filters(
 /**
  * @brief Deletes WFP filters with specified filter IDs.
  *
+ * @param[in] wfp_filter_handle The WFP filter handle used to delete the filters.
  * @param[in]  filter_count Count of filters to be added.
  * @param[in]  filter_ids ID of the filter being deleted.
  */
 void
 net_ebpf_extension_delete_wfp_filters(
-    uint32_t filter_count, _Frees_ptr_ _In_count_(filter_count) net_ebpf_ext_wfp_filter_id_t* filter_ids);
+    _In_ HANDLE wfp_engine_handle,
+    uint32_t filter_count,
+    _Frees_ptr_ _In_count_(filter_count) net_ebpf_ext_wfp_filter_id_t* filter_ids);
 
 // eBPF WFP Provider GUID.
 // ddb851f5-841a-4b77-8a46-bb7063e9f162
@@ -371,3 +376,9 @@ ebpf_result_t
 net_ebpf_ext_add_client_context(
     _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context,
     _In_ const struct _net_ebpf_extension_hook_client* hook_client);
+
+NTSTATUS
+net_ebpf_extension_open_wfp_engine_handle(HANDLE* wfp_engine_handle);
+
+NTSTATUS
+net_ebpf_extension_close_wfp_engine_handle(HANDLE wfp_engine_handle);

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -378,7 +378,7 @@ net_ebpf_ext_add_client_context(
     _In_ const struct _net_ebpf_extension_hook_client* hook_client);
 
 NTSTATUS
-net_ebpf_extension_open_wfp_engine_handle(HANDLE* wfp_engine_handle);
+net_ebpf_extension_open_wfp_engine_handle(_Out_ HANDLE* wfp_engine_handle);
 
 NTSTATUS
-net_ebpf_extension_close_wfp_engine_handle(HANDLE wfp_engine_handle);
+net_ebpf_extension_close_wfp_engine_handle(_In_ HANDLE wfp_engine_handle);

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -19,8 +19,6 @@ typedef struct _bind_context_header
 // WFP filter related globals for bind hook.
 //
 
-static HANDLE _net_ebpf_extension_bind_wfp_engine_handle = NULL;
-
 const net_ebpf_extension_wfp_filter_parameters_t _net_ebpf_extension_bind_wfp_filter_parameters[] = {
     {&FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4,
      NULL, // Default sublayer.
@@ -123,7 +121,7 @@ _net_ebpf_ext_bind_create_filter_context(
 
     // Add WFP filters at appropriate layers and set the hook NPI client as the filter's raw context.
     result = net_ebpf_extension_add_wfp_filters(
-        _net_ebpf_extension_bind_wfp_engine_handle,
+        local_filter_context->wfp_engine_handle,
         EBPF_COUNT_OF(_net_ebpf_extension_bind_wfp_filter_parameters),
         _net_ebpf_extension_bind_wfp_filter_parameters,
         0,
@@ -155,7 +153,7 @@ _net_ebpf_ext_bind_delete_filter_context(
 
     // Delete the WFP filters.
     net_ebpf_extension_delete_wfp_filters(
-        _net_ebpf_extension_bind_wfp_engine_handle, filter_context->filter_ids_count, filter_context->filter_ids);
+        filter_context->wfp_engine_handle, filter_context->filter_ids_count, filter_context->filter_ids);
     net_ebpf_extension_wfp_filter_context_cleanup((net_ebpf_extension_wfp_filter_context_t*)filter_context);
 
 Exit:
@@ -208,16 +206,6 @@ net_ebpf_ext_bind_register_providers()
         goto Exit;
     }
 
-    status = net_ebpf_extension_open_wfp_engine_handle(&_net_ebpf_extension_bind_wfp_engine_handle);
-    if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            NET_EBPF_EXT_TRACELOG_KEYWORD_BIND,
-            "net_ebpf_ext_bind::net_ebpf_extension_open_fwp_engine_handle",
-            status);
-        goto Exit;
-    }
-
 Exit:
     if (!NT_SUCCESS(status)) {
         net_ebpf_ext_bind_unregister_providers();
@@ -235,11 +223,6 @@ net_ebpf_ext_bind_unregister_providers()
     if (_ebpf_bind_program_info_provider_context != NULL) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_bind_program_info_provider_context);
         _ebpf_bind_program_info_provider_context = NULL;
-    }
-    if (_net_ebpf_extension_bind_wfp_engine_handle != NULL) {
-        if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_bind_wfp_engine_handle))) {
-            _net_ebpf_extension_bind_wfp_engine_handle = NULL;
-        }
     }
 }
 

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -228,15 +228,15 @@ Exit:
 void
 net_ebpf_ext_bind_unregister_providers()
 {
-    if (_ebpf_bind_hook_provider_context) {
+    if (_ebpf_bind_hook_provider_context != NULL) {
         net_ebpf_extension_hook_provider_unregister(_ebpf_bind_hook_provider_context);
         _ebpf_bind_hook_provider_context = NULL;
     }
-    if (_ebpf_bind_program_info_provider_context) {
+    if (_ebpf_bind_program_info_provider_context != NULL) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_bind_program_info_provider_context);
         _ebpf_bind_program_info_provider_context = NULL;
     }
-    if (_net_ebpf_extension_bind_wfp_engine_handle) {
+    if (_net_ebpf_extension_bind_wfp_engine_handle != NULL) {
         if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_bind_wfp_engine_handle))) {
             _net_ebpf_extension_bind_wfp_engine_handle = NULL;
         }

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1299,7 +1299,7 @@ net_ebpf_ext_sock_addr_unregister_providers()
             _ebpf_sock_addr_hook_provider_context[i] = NULL;
         }
     }
-    if (_ebpf_sock_addr_program_info_provider_context) {
+    if (_ebpf_sock_addr_program_info_provider_context != NULL) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_sock_addr_program_info_provider_context);
         _ebpf_sock_addr_program_info_provider_context = NULL;
     }
@@ -1307,7 +1307,7 @@ net_ebpf_ext_sock_addr_unregister_providers()
     _net_ebpf_ext_uninitialize_blocked_connection_contexts();
     _net_ebpf_sock_addr_clean_up_security_descriptor();
 
-    if (_net_ebpf_extension_sock_addr_wfp_engine_handle) {
+    if (_net_ebpf_extension_sock_addr_wfp_engine_handle != NULL) {
         if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_sock_addr_wfp_engine_handle))) {
             _net_ebpf_extension_sock_addr_wfp_engine_handle = NULL;
         }

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -260,8 +260,6 @@ static SECURITY_DESCRIPTOR* _net_ebpf_ext_security_descriptor_admin = NULL;
 static ACL* _net_ebpf_ext_dacl_admin = NULL;
 static GENERIC_MAPPING _net_ebpf_ext_generic_mapping = {0};
 
-static HANDLE _net_ebpf_extension_sock_addr_wfp_engine_handle = NULL;
-
 static bool
 _net_ebpf_extension_sock_addr_process_verdict(_Inout_ void* program_context, int program_verdict);
 
@@ -692,7 +690,7 @@ _net_ebpf_extension_sock_addr_create_filter_context(
     // Add a single WFP filter at the WFP layer corresponding to the hook type, and set the hook NPI client as the
     // filter's raw context.
     result = net_ebpf_extension_add_wfp_filters(
-        _net_ebpf_extension_sock_addr_wfp_engine_handle,
+        local_filter_context->base.wfp_engine_handle,
         filter_parameters_array->count, // filter_count
         filter_parameters_array->filter_parameters,
         (compartment_id == UNSPECIFIED_COMPARTMENT_ID) ? 0 : 1,
@@ -724,7 +722,7 @@ _net_ebpf_extension_sock_addr_delete_filter_context(
     sock_addr_filter_context = (net_ebpf_extension_sock_addr_wfp_filter_context_t*)filter_context;
 
     net_ebpf_extension_delete_wfp_filters(
-        _net_ebpf_extension_sock_addr_wfp_engine_handle, filter_context->filter_ids_count, filter_context->filter_ids);
+        filter_context->wfp_engine_handle, filter_context->filter_ids_count, filter_context->filter_ids);
     if (sock_addr_filter_context->redirect_handle != NULL) {
         FwpsRedirectHandleDestroy(sock_addr_filter_context->redirect_handle);
     }
@@ -1271,15 +1269,6 @@ net_ebpf_ext_sock_addr_register_providers()
         }
     }
 
-    status = net_ebpf_extension_open_wfp_engine_handle(&_net_ebpf_extension_sock_addr_wfp_engine_handle);
-    if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-            "net_ebpf_ext_sock_addr::net_ebpf_extension_open_wfp_engine_handle failed.",
-            status);
-    }
-
 Exit:
     if (!NT_SUCCESS(status)) {
         if (blocked_connection_contexts_initialized) {
@@ -1306,12 +1295,6 @@ net_ebpf_ext_sock_addr_unregister_providers()
 
     _net_ebpf_ext_uninitialize_blocked_connection_contexts();
     _net_ebpf_sock_addr_clean_up_security_descriptor();
-
-    if (_net_ebpf_extension_sock_addr_wfp_engine_handle != NULL) {
-        if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_sock_addr_wfp_engine_handle))) {
-            _net_ebpf_extension_sock_addr_wfp_engine_handle = NULL;
-        }
-    }
 }
 
 typedef enum _net_ebpf_extension_sock_addr_connection_direction

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -368,15 +368,15 @@ Exit:
 void
 net_ebpf_ext_sock_ops_unregister_providers()
 {
-    if (_ebpf_sock_ops_hook_provider_context) {
+    if (_ebpf_sock_ops_hook_provider_context != NULL) {
         net_ebpf_extension_hook_provider_unregister(_ebpf_sock_ops_hook_provider_context);
         _ebpf_sock_ops_hook_provider_context = NULL;
     }
-    if (_ebpf_sock_ops_program_info_provider_context) {
+    if (_ebpf_sock_ops_program_info_provider_context != NULL) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_sock_ops_program_info_provider_context);
         _ebpf_sock_ops_program_info_provider_context = NULL;
     }
-    if (_net_ebpf_extension_sock_ops_wfp_engine_handle) {
+    if (_net_ebpf_extension_sock_ops_wfp_engine_handle != NULL) {
         if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_sock_ops_wfp_engine_handle))) {
             _net_ebpf_extension_sock_ops_wfp_engine_handle = NULL;
         }

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -65,8 +65,6 @@ typedef struct _net_ebpf_extension_sock_ops_wfp_filter_context
         flow_context_list; ///< List of flow contexts associated with WFP flows.
 } net_ebpf_extension_sock_ops_wfp_filter_context_t;
 
-static HANDLE _net_ebpf_extension_sock_ops_wfp_engine_handle = NULL;
-
 //
 // SOCK_OPS Global helper function implementation.
 //
@@ -188,7 +186,7 @@ _net_ebpf_extension_sock_ops_create_filter_context(
     // Add WFP filters at appropriate layers and set the hook NPI client as the filter's raw context.
     filter_count = NET_EBPF_SOCK_OPS_FILTER_COUNT;
     result = net_ebpf_extension_add_wfp_filters(
-        _net_ebpf_extension_sock_ops_wfp_engine_handle,
+        local_filter_context->base.wfp_engine_handle,
         filter_count,
         _net_ebpf_extension_sock_ops_wfp_filter_parameters,
         (compartment_id == UNSPECIFIED_COMPARTMENT_ID) ? 0 : 1,
@@ -261,7 +259,7 @@ _net_ebpf_extension_sock_ops_delete_filter_context(
 
     InitializeListHead(&local_list_head);
     net_ebpf_extension_delete_wfp_filters(
-        _net_ebpf_extension_sock_ops_wfp_engine_handle,
+        filter_context->wfp_engine_handle,
         local_filter_context->base.filter_ids_count,
         local_filter_context->base.filter_ids);
 
@@ -348,16 +346,6 @@ net_ebpf_ext_sock_ops_register_providers()
         goto Exit;
     }
 
-    status = net_ebpf_extension_open_wfp_engine_handle(&_net_ebpf_extension_sock_ops_wfp_engine_handle);
-    if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS,
-            "net_ebpf_ext_sock_opts::net_ebpf_extension_wfp_engine_open failed.",
-            status);
-        goto Exit;
-    }
-
 Exit:
     if (!NT_SUCCESS(status)) {
         net_ebpf_ext_sock_ops_unregister_providers();
@@ -375,11 +363,6 @@ net_ebpf_ext_sock_ops_unregister_providers()
     if (_ebpf_sock_ops_program_info_provider_context != NULL) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_sock_ops_program_info_provider_context);
         _ebpf_sock_ops_program_info_provider_context = NULL;
-    }
-    if (_net_ebpf_extension_sock_ops_wfp_engine_handle != NULL) {
-        if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_sock_ops_wfp_engine_handle))) {
-            _net_ebpf_extension_sock_ops_wfp_engine_handle = NULL;
-        }
     }
 }
 

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -9,6 +9,8 @@
 #include "ebpf_shared_framework.h"
 #include "net_ebpf_ext_xdp.h"
 
+static HANDLE _net_ebpf_extension_xdp_wfp_engine_handle = NULL;
+
 //
 // Utility functions.
 //
@@ -167,6 +169,7 @@ _net_ebpf_extension_xdp_create_filter_context(
     // Add WFP filters at appropriate layers and set the hook NPI client as the filter's raw context.
     filter_count = NET_EBPF_XDP_FILTER_COUNT;
     result = net_ebpf_extension_add_wfp_filters(
+        _net_ebpf_extension_xdp_wfp_engine_handle,
         filter_count,
         _net_ebpf_extension_xdp_wfp_filter_parameters,
         (if_index == 0) ? 0 : 1,
@@ -242,7 +245,9 @@ _net_ebpf_extension_xdp_delete_filter_context(
     xdp_filter_context = (net_ebpf_extension_xdp_wfp_filter_context_t*)filter_context;
 
     net_ebpf_extension_delete_wfp_filters(
-        xdp_filter_context->base.filter_ids_count, xdp_filter_context->base.filter_ids);
+        _net_ebpf_extension_xdp_wfp_engine_handle,
+        xdp_filter_context->base.filter_ids_count,
+        xdp_filter_context->base.filter_ids);
     net_ebpf_extension_wfp_filter_context_cleanup((net_ebpf_extension_wfp_filter_context_t*)xdp_filter_context);
 
 Exit:
@@ -293,6 +298,16 @@ net_ebpf_ext_xdp_register_providers()
         goto Exit;
     }
 
+    status = net_ebpf_extension_open_wfp_engine_handle(&_net_ebpf_extension_xdp_wfp_engine_handle);
+    if (!NT_SUCCESS(status)) {
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_XDP,
+            "net_ebpf_ext_xdp::net_ebpf_extension_open_wfp_engine_handle failed.",
+            status);
+        goto Exit;
+    }
+
 Exit:
     if (!NT_SUCCESS(status)) {
         net_ebpf_ext_xdp_unregister_providers();
@@ -310,6 +325,11 @@ net_ebpf_ext_xdp_unregister_providers()
     if (_ebpf_xdp_test_program_info_provider_context) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_xdp_test_program_info_provider_context);
         _ebpf_xdp_test_program_info_provider_context = NULL;
+    }
+    if (_net_ebpf_extension_xdp_wfp_engine_handle) {
+        if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_xdp_wfp_engine_handle))) {
+            _net_ebpf_extension_xdp_wfp_engine_handle = NULL;
+        }
     }
 }
 

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -318,15 +318,15 @@ Exit:
 void
 net_ebpf_ext_xdp_unregister_providers()
 {
-    if (_ebpf_xdp_test_hook_provider_context) {
+    if (_ebpf_xdp_test_hook_provider_context != NULL) {
         net_ebpf_extension_hook_provider_unregister(_ebpf_xdp_test_hook_provider_context);
         _ebpf_xdp_test_hook_provider_context = NULL;
     }
-    if (_ebpf_xdp_test_program_info_provider_context) {
+    if (_ebpf_xdp_test_program_info_provider_context != NULL) {
         net_ebpf_extension_program_info_provider_unregister(_ebpf_xdp_test_program_info_provider_context);
         _ebpf_xdp_test_program_info_provider_context = NULL;
     }
-    if (_net_ebpf_extension_xdp_wfp_engine_handle) {
+    if (_net_ebpf_extension_xdp_wfp_engine_handle != NULL) {
         if (NT_SUCCESS(net_ebpf_extension_close_wfp_engine_handle(_net_ebpf_extension_xdp_wfp_engine_handle))) {
             _net_ebpf_extension_xdp_wfp_engine_handle = NULL;
         }

--- a/netebpfext/sys/netebpfext_platform.h
+++ b/netebpfext/sys/netebpfext_platform.h
@@ -9,3 +9,5 @@
 #pragma warning(disable : 4201) // unnamed struct/union
 #include <fwpsk.h>
 #pragma warning(pop)
+
+#define WFP_ERROR(status, error) ((status) == (STATUS_FWP_##error))

--- a/netebpfext/user/netebpfext_platform.h
+++ b/netebpfext/user/netebpfext_platform.h
@@ -4,3 +4,5 @@
 #pragma once
 
 #include "usersim/../../src/net_platform.h"
+
+#define WFP_ERROR(status, error) ((status) == (FWP_E_##error))


### PR DESCRIPTION
## Description
Issue:
Our KM stress tests revealed an issue in our netebpfext code. There is a single global WFP handle, but multiple threads could use this at the same time (such as two programs attaching in parallel), leading to errors in the WFP APIs.

Fix:
- Add per-provider handles
- Make all WFP engine handles use static sessions (this allows a separate WFP handle to access the same objects, such as the sublayer/callouts)
- Add proper cleanup logic to remove all WFP objects

Closes https://github.com/microsoft/ebpf-for-windows/issues/3607

## Testing
Existing tests validate this functionality.

## Documentation
None.

## Installation
None.