### PR TITLE
Always use clang from Visual Studio folder

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,9 @@
   <PropertyGroup Condition="'$(Fuzzer)'!='True' And '$(Configuration)'!='FuzzerDebug'">
     <SpectreMitigation>Spectre</SpectreMitigation>
   </PropertyGroup>
+  <PropertyGroup>
+    <ClangExec>"$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe"</ClangExec>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -172,7 +172,7 @@
     <CustomBuild Include="*.c">
       <FileType>CppCode</FileType>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c %(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c %(Filename).c -o $(OutputPath)%(Filename).o
         pushd $(OutDir)
         powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -FileName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(KernelConfiguration) -KernelMode $true
         powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -FileName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $false
@@ -203,7 +203,7 @@
     <CustomBuild Include="undocked\*.c">
       <FileType>CppCode</FileType>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -I. -I../../undocked/tests/sample/ext/inc -c undocked\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -I. -I../../undocked/tests/sample/ext/inc -c undocked\%(Filename).c -o $(OutputPath)%(Filename).o
         pushd $(OutDir)
         powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -FileName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(KernelConfiguration) -KernelMode $true
         powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -FileName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $false
@@ -218,9 +218,9 @@
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
     <CustomBuild Include="unsafe\*.c">
       <FileType>CppCode</FileType>
-      <Command>clang $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command>$(ClangExec) $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
@@ -228,9 +228,9 @@
   <ItemGroup Condition="'$(Configuration)'=='NativeOnlyDebug'">
     <CustomBuild Include="unsafe\*.c">
       <FileType>CppCode</FileType>
-      <Command>clang $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command>$(ClangExec) $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
@@ -238,9 +238,9 @@
   <ItemGroup Condition="'$(Configuration)'=='FuzzerDebug'">
     <CustomBuild Include="unsafe\*.c">
       <FileType>CppCode</FileType>
-      <Command>clang $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command>$(ClangExec) $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
@@ -248,9 +248,9 @@
   <ItemGroup Condition="'$(Configuration)'=='Release'">
     <CustomBuild Include="unsafe\*.c">
       <FileType>CppCode</FileType>
-      <Command>clang $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command>$(ClangExec) $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
       <BuildInParallel>true</BuildInParallel>
@@ -259,9 +259,9 @@
   <ItemGroup Condition="'$(Configuration)'=='NativeOnlyRelease'">
     <CustomBuild Include="unsafe\*.c">
       <FileType>CppCode</FileType>
-      <Command>clang $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command>$(ClangExec) $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
       <BuildInParallel>true</BuildInParallel>
@@ -272,7 +272,7 @@
     <CustomBuild Include="custom_program_type\*.c">
       <FileType>CppCode</FileType>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c custom_program_type\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c custom_program_type\%(Filename).c -o $(OutputPath)%(Filename).o
         pushd $(SolutionDir)\scripts
         powershell -NonInteractive -ExecutionPolicy Unrestricted .\build_custom_sample_programs.ps1 -FileName %(Filename) -FilePath $(OutDir) -IncludePath $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelConfiguration $(KernelConfiguration)
         popd


### PR DESCRIPTION
## Description

This pull request introduces changes to streamline the build process by centralizing the Clang executable definition. The main changes include adding a new property for the Clang executable path and updating various build commands to use this new property.

### Build Process Improvements:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR36-R38): Added a new property `ClangExec` to define the path to the Clang executable.

* [`tests/sample/sample.vcxproj`](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L175-R175): Updated multiple build commands to use the new `ClangExec` property instead of hardcoding the `clang` executable path. This change affects several custom build steps across different configurations, including `Debug`, `NativeOnlyDebug`, `FuzzerDebug`, and `Release`. [[1]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L175-R175) [[2]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L206-R206) [[3]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L221-R253) [[4]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L262-R264) [[5]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L275-R275)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
