### PR TITLE
Backwards compatible fixes to bpf() syscall emulation

### DIFF
--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -3,6 +3,8 @@
 #include "bpf.h"
 #include "libbpf.h"
 
+#include <windows.h>
+#include <WinError.h>
 #include <linux/bpf.h>
 
 #define CHECK_SIZE(last_field_name)                                                         \
@@ -122,6 +124,7 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
         return retval;
     }
     default:
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
         return -EINVAL;
     }
 }

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -7,13 +7,16 @@
 
 #define CHECK_SIZE(last_field_name)                                                         \
     if (size < offsetof(union bpf_attr, last_field_name) + sizeof(attr->last_field_name)) { \
-        errno = EINVAL;                                                                     \
-        return -1;                                                                          \
+        return -EINVAL;                                                                     \
     }
 
 int
 bpf(int cmd, union bpf_attr* attr, unsigned int size)
 {
+    // bpf() is ABI compatible with the Linux bpf() syscall.
+    //
+    // * Do not return errors via errno.
+
     switch (cmd) {
     case BPF_LINK_DETACH:
         CHECK_SIZE(link_detach.link_fd);
@@ -53,8 +56,7 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
     case BPF_OBJ_GET:
         CHECK_SIZE(bpf_fd);
         if (attr->bpf_fd != 0) {
-            errno = EINVAL;
-            return -1;
+            return -EINVAL;
         }
         return bpf_obj_get((const char*)attr->pathname);
     case BPF_PROG_ATTACH: {
@@ -120,7 +122,6 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
         return retval;
     }
     default:
-        errno = EINVAL;
-        return -1;
+        return -EINVAL;
     }
 }

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -7,10 +7,28 @@
 #include <WinError.h>
 #include <linux/bpf.h>
 
-#define CHECK_SIZE(last_field_name)                                                         \
-    if (size < offsetof(union bpf_attr, last_field_name) + sizeof(attr->last_field_name)) { \
-        return -EINVAL;                                                                     \
+#define CHECK_SIZE(last_field_name)                                                    \
+    if (!tail_is_zero(                                                                 \
+            attr,                                                                      \
+            offsetof(union bpf_attr, last_field_name) + sizeof(attr->last_field_name), \
+            sizeof(union bpf_attr))) {                                                 \
+        return -EINVAL;                                                                \
     }
+
+static bool
+tail_is_zero(const void* buf, unsigned int start, unsigned int end)
+{
+    const unsigned char* p = (const unsigned char*)buf + start;
+    const unsigned char* e = (const unsigned char*)buf + end;
+
+    for (; p < e; p++) {
+        if ((*p) != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 int
 bpf(int cmd, union bpf_attr* attr, unsigned int size)
@@ -18,85 +36,124 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
     // bpf() is ABI compatible with the Linux bpf() syscall.
     //
     // * Do not return errors via errno.
+    // * Do not assume that bpf_attr has a particular size.
+
+    union bpf_attr* orig = attr;
+    union bpf_attr tmp = {};
+    int retval;
+
+    if (size > sizeof(tmp)) {
+        // Forward compatibility: allow a larger input as long as the
+        // unknown fields are all zero.
+        if (!tail_is_zero(attr, sizeof(tmp), size)) {
+            return -EINVAL;
+        }
+    } else {
+        // Backwards compatibility: allow a smaller input by implicitly zeroing all
+        // missing fields.
+        memcpy(&tmp, attr, size);
+        attr = &tmp;
+    }
 
     switch (cmd) {
     case BPF_LINK_DETACH:
         CHECK_SIZE(link_detach.link_fd);
-        return bpf_link_detach(attr->link_detach.link_fd);
+        retval = bpf_link_detach(attr->link_detach.link_fd);
+        break;
     case BPF_LINK_GET_FD_BY_ID:
         CHECK_SIZE(link_id);
-        return bpf_link_get_fd_by_id(attr->link_id);
+        retval = bpf_link_get_fd_by_id(attr->link_id);
+        break;
     case BPF_LINK_GET_NEXT_ID:
         CHECK_SIZE(next_id);
-        return bpf_link_get_next_id(attr->start_id, &attr->next_id);
+        retval = bpf_link_get_next_id(attr->start_id, &attr->next_id);
+        break;
     case BPF_MAP_CREATE: {
         CHECK_SIZE(map_flags);
         struct bpf_map_create_opts opts = {.map_flags = attr->map_flags};
-        return bpf_map_create(attr->map_type, nullptr, attr->key_size, attr->value_size, attr->max_entries, &opts);
+        retval = bpf_map_create(attr->map_type, nullptr, attr->key_size, attr->value_size, attr->max_entries, &opts);
+        break;
     }
     case BPF_MAP_DELETE_ELEM:
         CHECK_SIZE(key);
-        return bpf_map_delete_elem(attr->map_fd, (const void*)attr->key);
+        retval = bpf_map_delete_elem(attr->map_fd, (const void*)attr->key);
+        break;
     case BPF_MAP_GET_FD_BY_ID:
         CHECK_SIZE(map_id);
-        return bpf_map_get_fd_by_id(attr->map_id);
+        retval = bpf_map_get_fd_by_id(attr->map_id);
+        break;
     case BPF_MAP_GET_NEXT_ID:
         CHECK_SIZE(next_id);
-        return bpf_map_get_next_id(attr->start_id, &attr->next_id);
+        retval = bpf_map_get_next_id(attr->start_id, &attr->next_id);
+        break;
     case BPF_MAP_GET_NEXT_KEY:
         CHECK_SIZE(next_key);
-        return bpf_map_get_next_key(attr->map_fd, (const void*)attr->key, (void*)attr->next_key);
+        retval = bpf_map_get_next_key(attr->map_fd, (const void*)attr->key, (void*)attr->next_key);
+        break;
     case BPF_MAP_LOOKUP_ELEM:
         CHECK_SIZE(value);
-        return bpf_map_lookup_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+        retval = bpf_map_lookup_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+        break;
     case BPF_MAP_LOOKUP_AND_DELETE_ELEM:
         CHECK_SIZE(value);
-        return bpf_map_lookup_and_delete_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+        retval = bpf_map_lookup_and_delete_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+        break;
     case BPF_MAP_UPDATE_ELEM:
         CHECK_SIZE(flags);
-        return bpf_map_update_elem(attr->map_fd, (const void*)attr->key, (const void*)attr->value, attr->flags);
+        retval = bpf_map_update_elem(attr->map_fd, (const void*)attr->key, (const void*)attr->value, attr->flags);
+        break;
     case BPF_OBJ_GET:
         CHECK_SIZE(bpf_fd);
         if (attr->bpf_fd != 0) {
-            return -EINVAL;
+            retval = -EINVAL;
+            break;
         }
-        return bpf_obj_get((const char*)attr->pathname);
+        retval = bpf_obj_get((const char*)attr->pathname);
+        break;
     case BPF_PROG_ATTACH: {
         CHECK_SIZE(attach_flags);
-        return bpf_prog_attach(attr->attach_bpf_fd, attr->target_fd, attr->attach_type, attr->attach_flags);
+        retval = bpf_prog_attach(attr->attach_bpf_fd, attr->target_fd, attr->attach_type, attr->attach_flags);
+        break;
     }
     case BPF_PROG_DETACH: {
         CHECK_SIZE(attach_type);
-        return bpf_prog_detach(attr->target_fd, attr->attach_type);
+        retval = bpf_prog_detach(attr->target_fd, attr->attach_type);
+        break;
     }
     case BPF_OBJ_GET_INFO_BY_FD:
         CHECK_SIZE(info.info_len);
-        return bpf_obj_get_info_by_fd(attr->info.bpf_fd, (void*)attr->info.info, &attr->info.info_len);
+        retval = bpf_obj_get_info_by_fd(attr->info.bpf_fd, (void*)attr->info.info, &attr->info.info_len);
+        break;
     case BPF_OBJ_PIN:
         CHECK_SIZE(bpf_fd);
-        return bpf_obj_pin(attr->bpf_fd, (const char*)attr->pathname);
+        retval = bpf_obj_pin(attr->bpf_fd, (const char*)attr->pathname);
+        break;
     case BPF_PROG_BIND_MAP: {
         CHECK_SIZE(prog_bind_map.flags);
         struct bpf_prog_bind_opts opts = {sizeof(struct bpf_prog_bind_opts), attr->prog_bind_map.flags};
-        return bpf_prog_bind_map(attr->prog_bind_map.prog_fd, attr->prog_bind_map.map_fd, &opts);
+        retval = bpf_prog_bind_map(attr->prog_bind_map.prog_fd, attr->prog_bind_map.map_fd, &opts);
+        break;
     }
     case BPF_PROG_GET_FD_BY_ID:
         CHECK_SIZE(prog_id);
-        return bpf_prog_get_fd_by_id(attr->prog_id);
+        retval = bpf_prog_get_fd_by_id(attr->prog_id);
+        break;
     case BPF_PROG_GET_NEXT_ID:
         CHECK_SIZE(next_id);
-        return bpf_prog_get_next_id(attr->start_id, &attr->next_id);
+        retval = bpf_prog_get_next_id(attr->start_id, &attr->next_id);
+        break;
     case BPF_PROG_LOAD: {
         CHECK_SIZE(kern_version);
         struct bpf_prog_load_opts opts = {
             .kern_version = attr->kern_version, .log_size = attr->log_size, .log_buf = (char*)attr->log_buf};
-        return bpf_prog_load(
+        retval = bpf_prog_load(
             attr->prog_type,
             nullptr,
             (const char*)attr->license,
             (const struct bpf_insn*)attr->insns,
             attr->insn_cnt,
             &opts);
+        break;
     }
     case BPF_PROG_TEST_RUN: {
         bpf_test_run_opts test_run_opts = {
@@ -114,17 +171,23 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
             .cpu = attr->test.cpu,
             .batch_size = attr->test.batch_size,
         };
-        int retval = bpf_prog_test_run_opts(attr->test.prog_fd, &test_run_opts);
+        retval = bpf_prog_test_run_opts(attr->test.prog_fd, &test_run_opts);
         if (retval == 0) {
             attr->test.data_size_out = test_run_opts.data_size_out;
             attr->test.ctx_size_out = test_run_opts.ctx_size_out;
             attr->test.retval = test_run_opts.retval;
             attr->test.duration = test_run_opts.duration;
         }
-        return retval;
+        break;
     }
     default:
         SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
         return -EINVAL;
     }
+
+    if (attr != orig) {
+        memcpy(orig, attr, size);
+    }
+
+    return retval;
 }

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -165,6 +165,10 @@ ebpf_result_to_errno(ebpf_result_t result)
         error = ENOSPC;
         break;
 
+    case EBPF_ACCESS_DENIED:
+        error = EPERM;
+        break;
+
     default:
         error = EOTHER;
         break;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2136,13 +2136,11 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     // Verify the enumeration is empty.
     union bpf_attr attr;
     memset(&attr, 0, sizeof(attr));
-    REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) < 0);
-    REQUIRE(errno == ENOENT);
+    REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) == -ENOENT);
 
     memset(&attr, 0, sizeof(attr));
     attr.link_id = EBPF_ID_NONE;
-    REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) < 0);
-    REQUIRE(errno == ENOENT);
+    REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) == -ENOENT);
 
     // Load and attach some programs.
     program_load_attach_helper_t sample_helper;
@@ -2170,8 +2168,7 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     fd_t fd2 = bpf(BPF_LINK_GET_FD_BY_ID, &attr, sizeof(attr));
     REQUIRE(fd2 >= 0);
 
-    REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) < 0);
-    REQUIRE(errno == ENOENT);
+    REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) == -ENOENT);
 
     // Get info on the first link.
     memset(&attr, 0, sizeof(attr));
@@ -2202,8 +2199,7 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     REQUIRE(bpf(BPF_OBJ_PIN, &attr, sizeof(attr)) == 0);
 
     // Verify that bpf_fd must be 0 when calling BPF_OBJ_GET.
-    REQUIRE(bpf(BPF_OBJ_GET, &attr, sizeof(attr)) < 0);
-    REQUIRE(errno == EINVAL);
+    REQUIRE(bpf(BPF_OBJ_GET, &attr, sizeof(attr)) == -EINVAL);
 
     // Retrieve a new fd from the pin path.
     attr.bpf_fd = 0;
@@ -2219,8 +2215,7 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     REQUIRE(info.id == id1);
 
     // And for completeness, try an invalid bpf() call.
-    REQUIRE(bpf(-1, &attr, sizeof(attr)) < 0);
-    REQUIRE(errno == EINVAL);
+    REQUIRE(bpf(-1, &attr, sizeof(attr)) == -EINVAL);
 
     // Unpin the link.
     REQUIRE(ebpf_object_unpin("MyPath") == EBPF_SUCCESS);


### PR DESCRIPTION
bpf(): do not return errors via errno

    The Linux ABI returns all syscall errors via the function return value, not
    via errno.

    Fixes https://github.com/microsoft/ebpf-for-windows/issues/3749

Allow detecting if bpf() command is not implemented

    Use SetLastError to indicate to callers that a bpf() command is not 
    implemented. This avoids polluting the bpf() return value with platform
    specific error returns while still allowing detection of this important
    case.

Add forwards and backwards compatibility to bpf() emulation

    On Linux, bpf() accepts a bpf_attr which is larger than what the syscall
    expects, as long as the unknown fields are all 0. It also accepts a bpf_attr
    which is smaller than what it expects, by assuming that all missing fields
    are zero.

    This allows forwards and backwards compatilibity between old and new 
    versions of both the Linux kernel and user space tooling.

    Implement a similar scheme for the bpf() emulation.

Return EPERM from bpf() if user is not privileged

    On Linux, bpf() returns EPERM if the user doesn't have CAP_BPF. Return the
    same error when the user isn't able to open the device handle.
