### PR TITLE
Avoid unneeded atomic operations

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1598,7 +1598,6 @@ _update_hash_map_entry_with_handle(
     ebpf_map_option_t option)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    size_t entry_count = 0;
 
     // The 'map' and 'key' arguments cannot be NULL due to caller's prior validations.
     ebpf_assert(map != NULL && key != NULL);
@@ -1634,8 +1633,6 @@ _update_hash_map_entry_with_handle(
     }
 
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&object_map->lock);
-
-    entry_count = ebpf_hash_table_key_count((ebpf_hash_table_t*)map->data);
 
     uint8_t* old_value = NULL;
     ebpf_result_t found_result = ebpf_hash_table_find((ebpf_hash_table_t*)map->data, key, &old_value);


### PR DESCRIPTION
## Description

This pull request includes several changes to the `libs/runtime/ebpf_hash_table.c` and `libs/execution_context/ebpf_maps.c` files to improve the handling of entry counts in hash tables. The main changes involve ensuring that entry counts are only managed when a maximum entry count is enforced.

### Improvements to entry count handling:

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL58-R59): Modified the `struct _ebpf_hash_table` to ensure `entry_count` is only valid if `max_entry_count` is not `EBPF_HASH_TABLE_NO_LIMIT`.
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR372-R378): Updated `_ebpf_hash_table_bucket_insert` to increment `entry_count` only if `max_entry_count` is enforced and to handle out-of-space errors accordingly. [[1]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR372-R378) [[2]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR419-R423)
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR490-R492): Adjusted `_ebpf_hash_table_bucket_delete` to decrement `entry_count` only if `max_entry_count` is enforced.
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR975-R988): Enhanced `ebpf_hash_table_key_count` to return `entry_count` if `max_entry_count` is enforced, otherwise count the keys in the hash table.

### Code cleanup:

* [`libs/execution_context/ebpf_maps.c`](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1601): Removed the unused `entry_count` variable from `_update_hash_map_entry_with_handle`. [[1]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1601) [[2]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1638-L1639)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
