### PR TITLE
Switch WIX installer project to current wix version

### DIFF
--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <ProductVersion>3.10</ProductVersion>
+    <ProductVersion>3.14</ProductVersion>
     <ProjectGuid>fe9b26cd-e885-4881-90d7-a096131c5c4a</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>ebpf-for-windows</OutputName>


### PR DESCRIPTION
## Description

This pull request includes a minor update to the `installer/ebpf-for-windows.wixproj` file. The change involves updating the `ProductVersion` property to reflect a new version number.

* [`installer/ebpf-for-windows.wixproj`](diffhunk://#diff-4462afcae70dc1060039e3e56938f7583048ef6f0cf3fe709a32a406958b6297L11-R11): Updated `ProductVersion` from `3.10` to `3.14`.

## Testing

CI/CD

## Documentation

No.

## Installation

Yes. Support for 3.14 installer features (like ARM64)
