### PR TITLE
Enforce memory ordering in RCU aware hash-table

### DIFF
--- a/libs/runtime/ebpf_interlocked.c
+++ b/libs/runtime/ebpf_interlocked.c
@@ -64,6 +64,30 @@ ebpf_interlocked_decrement_int64(_Inout_ volatile int64_t* addend)
 }
 
 int32_t
+ebpf_interlocked_increment_int32_no_fence(_Inout_ volatile int32_t* addend)
+{
+    return InterlockedIncrementNoFence((volatile long*)addend);
+}
+
+int32_t
+ebpf_interlocked_decrement_int32_no_fence(_Inout_ volatile int32_t* addend)
+{
+    return InterlockedDecrementNoFence((volatile long*)addend);
+}
+
+int64_t
+ebpf_interlocked_increment_int64_no_fence(_Inout_ volatile int64_t* addend)
+{
+    return InterlockedIncrementNoFence64(addend);
+}
+
+int64_t
+ebpf_interlocked_decrement_int64_no_fence(_Inout_ volatile int64_t* addend)
+{
+    return InterlockedDecrementNoFence64(addend);
+}
+
+int32_t
 ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, int32_t exchange, int32_t comparand)
 {
     return InterlockedCompareExchange((long volatile*)destination, exchange, comparand);

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -390,6 +390,46 @@ extern "C"
     ebpf_interlocked_decrement_int64(_Inout_ volatile int64_t* addend);
 
     /**
+     * @brief Atomically increase the value of addend by 1 and return the new
+     *  value.
+     *
+     * @param[in, out] addend Value to increase by 1.
+     * @return The new value.
+     */
+    int32_t
+    ebpf_interlocked_increment_int32_no_fence(_Inout_ volatile int32_t* addend);
+
+    /**
+     * @brief Atomically decrease the value of addend by 1 and return the new
+     *  value.
+     *
+     * @param[in, out] addend Value to decrease by 1.
+     * @return The new value.
+     */
+    int32_t
+    ebpf_interlocked_decrement_int32_no_fence(_Inout_ volatile int32_t* addend);
+
+    /**
+     * @brief Atomically increase the value of addend by 1 and return the new
+     *  value.
+     *
+     * @param[in, out] addend Value to increase by 1.
+     * @return The new value.
+     */
+    int64_t
+    ebpf_interlocked_increment_int64_no_fence(_Inout_ volatile int64_t* addend);
+
+    /**
+     * @brief Atomically decrease the value of addend by 1 and return the new
+     *  value.
+     *
+     * @param[in, out] addend Value to increase by 1.
+     * @return The new value.
+     */
+    int64_t
+    ebpf_interlocked_decrement_int64_no_fence(_Inout_ volatile int64_t* addend);
+
+    /**
      * @brief Performs an atomic operation that compares the input value pointed
      *  to by destination with the value of comparand and replaces it with
      *  exchange.


### PR DESCRIPTION
## Description

This pull request includes several changes to the `ebpf_hash_table` implementation to improve memory ordering and atomic operations. The most important changes are the introduction of helper functions for reading and writing hash table buckets, and the replacement of existing atomic operations with their "no fence" variants.

Memory ordering improvements:

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR343-R369): Added `_ebpf_hash_table_get_bucket` and `_ebpf_hash_table_set_bucket` helper functions to ensure correct memory ordering when accessing hash table buckets.

Atomic operations updates:

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL373-R400): Replaced `ebpf_interlocked_increment_int64` and `ebpf_interlocked_decrement_int64` with `ebpf_interlocked_increment_int64_no_fence` and `ebpf_interlocked_decrement_int64_no_fence` in various functions. [[1]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL373-R400) [[2]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL421-R448) [[3]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL491-R518)
* [`libs/runtime/ebpf_interlocked.c`](diffhunk://#diff-82c988c5aba05183bc1095af8c20c57e25d8ba2ed9fcb0b9ee16ec25bf33533bR66-R89): Added new functions `ebpf_interlocked_increment_int32_no_fence`, `ebpf_interlocked_decrement_int32_no_fence`, `ebpf_interlocked_increment_int64_no_fence`, and `ebpf_interlocked_decrement_int64_no_fence`.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R392-R431): Declared the new "no fence" atomic operations.

Code refactoring:

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL600-R627): Updated multiple functions to use the new `_ebpf_hash_table_get_bucket` and `_ebpf_hash_table_set_bucket` helper functions for accessing hash table buckets. [[1]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL600-R627) [[2]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL656-R683) [[3]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL780-R807) [[4]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL886-R913) [[5]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL1011-R1038) [[6]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL1060-R1087)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
