### PR TITLE
Wrap platform specific code in approriate #defines

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2312,9 +2312,9 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
 
     if ((*p == 0) && (arg_count == specifier_count)) {
         va_list arg_list;
-        __va_start(&arg_list, arg_count);
+        va_start(arg_list, arg_count);
         bytes_written = ebpf_platform_printk(output, arg_list);
-        __va_end(&arg_list);
+        va_end(arg_list);
     }
 
     ebpf_free(output);

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <set>
 
+#if !defined(CONFIG_BPF_JIT_DISABLED)
 typedef struct _free_trampoline_table
 {
     void
@@ -28,6 +29,7 @@ typedef struct _free_trampoline_table
 } free_trampoline_table_t;
 
 typedef std::unique_ptr<ebpf_trampoline_table_t, free_trampoline_table_t> ebpf_trampoline_table_ptr;
+#endif
 
 typedef class _ebpf_async_wrapper
 {
@@ -755,6 +757,7 @@ test_function()
     return TEST_FUNCTION_RETURN;
 }
 
+#if !defined(CONFIG_BPF_JIT_DISABLED)
 TEST_CASE("program", "[execution_context]")
 {
     // single_instance_hook_t call ebpapi functions, which requires calling ebpf_api_initiate/ebpf_api_terminate.
@@ -931,6 +934,7 @@ TEST_CASE("program", "[execution_context]")
 
     ebpf_free_trampoline_table(table.release());
 }
+#endif
 
 TEST_CASE("name size", "[execution_context]")
 {

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -11,7 +11,7 @@ static uint32_t _ebpf_platform_maximum_processor_count = 0;
 
 static bool _ebpf_platform_is_cxplat_initialized = false;
 
-bool ebpf_processor_supports_sse42 = true;
+bool ebpf_processor_supports_sse42 = false;
 
 _Ret_range_(>, 0) uint32_t ebpf_get_cpu_count() { return _ebpf_platform_maximum_processor_count; }
 
@@ -525,10 +525,12 @@ ebpf_platform_initiate()
     ebpf_result_t result = ebpf_result_from_cxplat_status(cxplat_initialize());
     _ebpf_platform_is_cxplat_initialized = (result == EBPF_SUCCESS);
     ebpf_initialize_cpu_count();
+#if defined(_M_X64)
     // Check if processor supports SSE4.2
     int cpu_info[4] = {0};
     __cpuid(cpu_info, CPU_INFO_PROCESSOR_INFO_FUNCTION);
     ebpf_processor_supports_sse42 = (cpu_info[CPU_INFO_SSE42_BYTE_OFFSET] & (1 << CPU_INFO_SSE32_BIT_OFFSET)) != 0;
+#endif
 
     return result;
 }

--- a/libs/runtime/ebpf_random.c
+++ b/libs/runtime/ebpf_random.c
@@ -88,7 +88,9 @@ ebpf_random_initiate()
         return EBPF_NO_MEMORY;
     }
     for (uint32_t i = 0; i < cpu_count; i++) {
-        uint32_t seed = (uint32_t)__rdtsc();
+        LARGE_INTEGER time;
+        KeQueryPerformanceCounter(&time);
+        uint32_t seed = time.LowPart;
         ebpf_random_state_t* state = &_ebpf_random_number_generator_state[i];
         init_mt19937_genrand(state, seed);
     }

--- a/libs/runtime/ebpf_trampoline.c
+++ b/libs/runtime/ebpf_trampoline.c
@@ -74,7 +74,7 @@ ebpf_update_trampoline_table(
     _In_ const ebpf_helper_function_addresses_t* helper_function_addresses)
 {
     EBPF_LOG_ENTRY();
-#if defined(_AMD64_)
+#if defined(_M_X64)
 
     size_t function_count = helper_function_addresses->helper_function_count;
     ebpf_trampoline_entry_t* local_entries;
@@ -130,9 +130,11 @@ ebpf_update_trampoline_table(
 Exit:
     return_value = ebpf_protect_memory(trampoline_table->memory_descriptor, EBPF_PAGE_PROTECT_READ_EXECUTE);
     EBPF_RETURN_RESULT(return_value);
-#elif
+#else
     UNREFERENCED_PARAMETER(trampoline_table);
-    UNREFERENCED_PARAMETER(dispatch_table);
+    UNREFERENCED_PARAMETER(helper_function_count);
+    UNREFERENCED_PARAMETER(helper_function_ids);
+    UNREFERENCED_PARAMETER(helper_function_addresses);
     EBPF_RETURN_RESULT(EBPF_OPERATION_NOT_SUPPORTED);
 #endif
 }

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -610,6 +610,7 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
 
 static auto provider_function = []() { return EBPF_SUCCESS; };
 
+#if !defined(CONFIG_BPF_JIT_DISABLED)
 TEST_CASE("trampoline_test", "[platform]")
 {
     _test_helper test_helper;
@@ -659,6 +660,7 @@ TEST_CASE("trampoline_test", "[platform]")
     REQUIRE(test_function() == EBPF_OBJECT_ALREADY_EXISTS);
     ebpf_free_trampoline_table(table.release());
 }
+#endif
 
 struct ebpf_security_descriptor_t_free
 {

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -91,7 +91,7 @@ static uint64_t _ebpf_file_descriptor_counter = 0;
 _Guarded_by_(_fd_to_handle_mutex) static std::map<fd_t, ebpf_handle_t> _fd_to_handle_map;
 
 static std::mutex _service_path_to_context_mutex;
-static uint32_t _ebpf_service_handle_counter = 0;
+static volatile int64_t _ebpf_service_handle_counter = 0;
 _Guarded_by_(
     _service_path_to_context_mutex) static std::map<std::wstring, service_context_t*> _service_path_to_context_map;
 
@@ -623,7 +623,7 @@ _Requires_lock_not_held_(_service_path_to_context_mutex) uint32_t Glue_create_se
 
         std::unique_lock lock(_service_path_to_context_mutex);
         _service_path_to_context_map.insert(std::pair<std::wstring, service_context_t*>(service_path, context));
-        context->handle = InterlockedIncrement64((int64_t*)&_ebpf_service_handle_counter);
+        context->handle = InterlockedIncrement64(&_ebpf_service_handle_counter);
 
         *service_handle = (SC_HANDLE)context->handle;
     } catch (...) {


### PR DESCRIPTION
## Description

This pull request includes several changes focused on improving compatibility and conditional compilation for different architectures, as well as enhancing the initialization and testing processes. The most important changes include updating function calls, adding conditional compilation guards, and modifying initialization procedures.

### Compatibility and Conditional Compilation:

* [`libs/execution_context/ebpf_core.c`](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2315-R2317): Updated `va_start` and `va_end` function calls to standard versions. (`[libs/execution_context/ebpf_core.cL2315-R2317](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2315-R2317)`)
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL8-R8): Added conditional compilation for SSE4.2 support and `_M_X64` architecture in multiple functions. (`[[1]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL8-R8)`, `[[2]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aL159-R159)`, `[[3]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR186)`, `[[4]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR314-R322)`, `[[5]](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR831-R834)`)
* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL14-R14): Changed the default value of `ebpf_processor_supports_sse42` to `false` and added conditional checks for SSE4.2 support during initialization. (`[[1]](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL14-R14)`, `[[2]](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deR528-R533)`)
* [`libs/runtime/ebpf_trampoline.c`](diffhunk://#diff-9a9c4c2aaa1573d327ecb9f7aebb0a474e0d3e409404c2d0a785b41de95b39e0L77-R77): Updated conditional compilation guards for `_M_X64` architecture. (`[[1]](diffhunk://#diff-9a9c4c2aaa1573d327ecb9f7aebb0a474e0d3e409404c2d0a785b41de95b39e0L77-R77)`, `[[2]](diffhunk://#diff-9a9c4c2aaa1573d327ecb9f7aebb0a474e0d3e409404c2d0a785b41de95b39e0L133-R137)`)

### Initialization and Testing:

* [`libs/runtime/ebpf_random.c`](diffhunk://#diff-352cd3d48909d53c2bb800778d29262ee7653bcc2aa0318f5f0cbe0ae8be52ecL91-R93): Modified the seed initialization in `ebpf_random_initiate()` to use `KeQueryPerformanceCounter` instead of `__rdtsc()`. (`[libs/runtime/ebpf_random.cL91-R93](diffhunk://#diff-352cd3d48909d53c2bb800778d29262ee7653bcc2aa0318f5f0cbe0ae8be52ecL91-R93)`)
* [`libs/execution_context/unit/execution_context_unit_test.cpp`](diffhunk://#diff-d6816dfe8bc2c8c368029c7ec3ff325f3d468fdb841e1554643b64fe0bed8cb5R19): Added conditional compilation guards around tests to disable them when `CONFIG_BPF_JIT_DISABLED` is defined. (`[[1]](diffhunk://#diff-d6816dfe8bc2c8c368029c7ec3ff325f3d468fdb841e1554643b64fe0bed8cb5R19)`, `[[2]](diffhunk://#diff-d6816dfe8bc2c8c368029c7ec3ff325f3d468fdb841e1554643b64fe0bed8cb5R32)`, `[[3]](diffhunk://#diff-d6816dfe8bc2c8c368029c7ec3ff325f3d468fdb841e1554643b64fe0bed8cb5R760)`, `[[4]](diffhunk://#diff-d6816dfe8bc2c8c368029c7ec3ff325f3d468fdb841e1554643b64fe0bed8cb5R937)`)
* [`libs/runtime/unit/platform_unit_test.cpp`](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6R613): Added conditional compilation guards around trampoline tests to disable them when `CONFIG_BPF_JIT_DISABLED` is defined. (`[[1]](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6R613)`, `[[2]](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6R663)`)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
