### PR TITLE
Return ENOENT from bpf_obj_get when no pinned object exists

### DIFF
--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -83,8 +83,8 @@ int
 bpf_obj_get(const char* pathname)
 {
     fd_t fd = -1;
-    libbpf_result_err(ebpf_object_get(pathname, &fd)); // set the errno
-    return fd;
+    int result = libbpf_result_err(ebpf_object_get(pathname, &fd));
+    return result ? result : fd;
 }
 
 struct bpf_object*

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1381,9 +1381,9 @@ TEST_CASE("map_pinning_test", "[end_to_end]")
         bpf_map__unpin(bpf_object__find_map_by_name(unique_object.get(), "limits_map"), limit_maps_name.c_str()) ==
         EBPF_SUCCESS);
 
-    REQUIRE(bpf_obj_get(limit_maps_name.c_str()) == ebpf_fd_invalid);
+    REQUIRE(bpf_obj_get(limit_maps_name.c_str()) == -ENOENT);
 
-    REQUIRE(bpf_obj_get(process_maps_name.c_str()) == ebpf_fd_invalid);
+    REQUIRE(bpf_obj_get(process_maps_name.c_str()) == -ENOENT);
 
     bpf_object__close(unique_object.release());
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -600,7 +600,7 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
     REQUIRE(obj_fd != ebpf_fd_invalid);
     REQUIRE(errno == EEXIST);
     obj_fd = bpf_obj_get(bad_pin_path);
-    REQUIRE(obj_fd == ebpf_fd_invalid);
+    REQUIRE(obj_fd == -ENOENT);
     REQUIRE(errno == ENOENT);
 
     result = bpf_program__unpin(program, pin_path);


### PR DESCRIPTION
The current implementation of bpf_obj_get doesn't follow libbpf semantics, because it always returns -1 on error, instead of returning the negative error number.

This is especially noticeable when trying to open a non-existant object, which should return -ENOENT.

See https://github.com/libbpf/libbpf/blob/caa17bdcbfc58e68eaf4d017c058e6577606bf56/src/bpf.c#L625-L626
