### PR TITLE
Don't abort program if next_key is NULL in ebpf_map_get_next_key()

### DIFF
--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -415,7 +415,7 @@ ebpf_map_lookup_and_delete_element_batch(
  * @retval EBPF_NO_MORE_KEYS previous_key was the last key.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void* next_key) noexcept;
+ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_opt_ void* next_key) noexcept;
 
 /**
  * @brief Detach a link given a file descriptor.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1128,7 +1128,7 @@ Exit:
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void* next_key) NO_EXCEPT_TRY
+ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_opt_ void* next_key) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1142,7 +1142,10 @@ ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void
     uint32_t type;
     ebpf_handle_t map_handle = ebpf_handle_invalid;
 
-    ebpf_assert(next_key);
+    if (next_key == NULL) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
 
     map_handle = _get_handle_from_file_descriptor(map_fd);
     if (map_handle == ebpf_handle_invalid) {

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1005,6 +1005,11 @@ TEST_CASE("libbpf map", "[libbpf]")
     REQUIRE(result < 0);
     REQUIRE(errno == EINVAL);
 
+    // next_key is NULL.
+    result = bpf_map_get_next_key(map_fd, NULL, NULL);
+    REQUIRE(result < 0);
+    REQUIRE(errno == EINVAL);
+
     bpf_object__close(object);
 }
 #endif


### PR DESCRIPTION
On Linux it is valid to pass NULL as next_key for queue type maps, since that map type doesn't really have a key. Return EINVAL instead of aborting the process via an assert.
