### PR TITLE
bpf(): return ENOENT when looking up out-of-bounds index in array

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -476,7 +476,7 @@ _find_array_map_entry(
     key_value = *(uint32_t*)key;
 
     if (key_value >= map->ebpf_map_definition.max_entries) {
-        return EBPF_INVALID_ARGUMENT;
+        return EBPF_OBJECT_NOT_FOUND;
     }
 
     *data = &map->data[key_value * map->ebpf_map_definition.value_size];

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -846,7 +846,7 @@ TEST_CASE("libbpf map", "[libbpf]")
 
     int result = bpf_map_lookup_elem(map_fd, &index, &value);
     REQUIRE(result < 0);
-    REQUIRE(errno == EINVAL);
+    REQUIRE(errno == ENOENT);
 
     // Wrong fd type.
     int program_fd = bpf_program__fd(const_cast<const bpf_program*>(program));


### PR DESCRIPTION
Looking up an index which is larger than an array's length currently results in EINVAL. This doesn't match what Linux does, which is to return ENOENT.

Change the behaviour to return ENOENT instead.