### PR TITLE
Add code to assert closer to failure

### DIFF
--- a/libs/runtime/ebpf_async.c
+++ b/libs/runtime/ebpf_async.c
@@ -23,6 +23,7 @@ ebpf_async_initiate()
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(ebpf_handle_t),
         .value_size = sizeof(ebpf_async_tracker_t),
+        .assert_key_present = true,
     };
 
     EBPF_RETURN_RESULT(ebpf_hash_table_create(&_ebpf_async_tracker_table, &options));

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -65,6 +65,7 @@ extern "C"
         void* notification_context;     //< Context to pass to notification functions.
         ebpf_hash_table_notification_function
             notification_callback; //< Function to call when value storage is allocated or freed.
+        bool assert_key_present;   // Assert that the key is present in the hash table when calling find or delete.
     } ebpf_hash_table_creation_options_t;
 
     /**

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -381,7 +381,7 @@ TEST_CASE("hash_table_stress_test", "[platform]")
         .key_size = sizeof(uint32_t),
         .value_size = sizeof(uint64_t),
         .minimum_bucket_count = static_cast<size_t>(worker_threads) * static_cast<size_t>(key_count),
-    };
+        .assert_key_present = true};
     REQUIRE(ebpf_hash_table_create(&table, &options) == EBPF_SUCCESS);
     auto worker = [table, iterations, key_count, load_factor, &cpu_id]() {
         uint32_t next_key = 0;


### PR DESCRIPTION
## Description

This pull request introduces a new feature to assert the presence of keys in the eBPF hash table. The main changes include adding an assertion flag to the hash table creation options and updating the hash table operations to respect this flag. This was added to assert closer to a failure in the async tracker code.

### Enhancements to eBPF Hash Table:

* [`libs/runtime/ebpf_async.c`](diffhunk://#diff-6d10848231dd966c376b0e0afc6ac1540f3f0b70827e71de5e6817ae0b7b12f1R26): Added `assert_key_present` to `ebpf_hash_table_creation_options_t` to enable key presence assertions.
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR62-R65): Introduced a `flags` structure in `_ebpf_hash_table` to include `assert_key_is_present` for asserting key presence during find or delete operations.
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR826-R827): Updated `ebpf_hash_table_find` to assert if the key should be present but isn't.
* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR892-R895): Modified `ebpf_hash_table_delete` to assert if the key should be present but isn't.
* [`libs/runtime/ebpf_hash_table.h`](diffhunk://#diff-f1989d71f868f217839f62cf184adc9960ec5f45fab4056bfcc85a76052d88e6R68): Added `assert_key_present` to `ebpf_hash_table_creation_options_t` to support the new assertion feature.
* [`libs/runtime/unit/platform_unit_test.cpp`](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6L384-R384): Updated the hash table stress test to set `assert_key_present` to true.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
