### PR TITLE
Switch to latest ebpf-verifier and fix GSL issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,7 +76,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/ZH:SHA_256 /we4062 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(SolutionDir)external\ebpf-verifier\build\packages\boost\lib\native\include;$(OutDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(SolutionDir)external\ebpf-verifier\build\packages\boost\lib\native\include;$(SolutionDir)external\ebpf-verifier\build\_deps\gsl-src\include;$(OutDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <CETCompat Condition="'$(Platform)'=='x64'">true</CETCompat>

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -29,6 +29,7 @@
 #include <complex>
 #include <condition_variable>
 #include <fstream>
+#include <iostream>
 #include <mutex>
 #include <numeric>
 #include <sddl.h>


### PR DESCRIPTION
## Description

This pull request includes a small change to the `external/ebpf-verifier` submodule. The change updates the submodule commit to a new version.

* [`external/ebpf-verifier`](diffhunk://#diff-0f47f98c433f156a9980e12abb7595d356ac1690a2e6ddbc3d51f7a4f0c7621eL1-R1): Updated the submodule commit to `257897c60be7d7ac35ed993794d95b6a9f4c7573` from `07a6da07d721ca80ee43ae02d1ce0b2f51f8b1fd`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
