### PR TITLE
Don't attempt to resolve local calls as helper functions calls

### DIFF
--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -39,7 +39,8 @@ _resolve_helper_functions(
     // Build a table to map [1, MAXUINT32] -> [0,63]
     for (size_t index = 0; index < instruction_count; index++) {
         ebpf_inst& instruction = instructions[index];
-        if (instruction.opcode != INST_OP_CALL) {
+        // Check if this is an CALL instruction with instruction source as 0 (helper function).
+        if (!(instruction.opcode == INST_OP_CALL && instruction.src == 0)) {
             continue;
         }
         helper_id_to_address[instruction.imm] = {0};


### PR DESCRIPTION
## Description

Fix a minor issue where bpf2bpf offsets are resolved as helper function ids.

This pull request includes a change to the `_resolve_helper_functions` method in the `libs/service/api_service.cpp` file. The change improves the logic for identifying CALL instructions that are helper functions.

### Improvements to instruction identification:

* [`libs/service/api_service.cpp`](diffhunk://#diff-4b05db47f30b730880202628e554484a25835ea2ef9c897e50dbfabe67538b85L42-R43): Modified the condition to check if an instruction is a CALL instruction with the instruction source as 0 (helper function).

## Testing

CI/CD

## Documentation

No.

## Installation

No.
