### PR TITLE
Watchdog timer

### DIFF
--- a/scripts/Run-Self-Hosted-Runner-Test.ps1
+++ b/scripts/Run-Self-Hosted-Runner-Test.ps1
@@ -74,6 +74,34 @@ function GetDriveFreeSpaceGB
     return $FreeSpaceGB
 }
 
+$timer = $null
+
+function StartWatchDogTimer
+{
+    param(
+        [Parameter(Mandatory = $true)] [string] $ActionOnTimeout,
+        [Parameter(Mandatory = $false)] [int] $Timeout = 3600
+    )
+    $timer = New-Object System.Timers.Timer
+    $timer.Interval = $Timeout * 1000 # Convert seconds to milliseconds.
+    $timer.AutoReset = $false
+
+    $timer.add_Elapsed({
+        Write-Log "Watchdog timer expired. Killing the test process."
+        & $ActionOnTimeout
+    })
+
+    $timer.Start()
+}
+
+function StopWatchDogTimer
+{
+    if ($timer -ne $null) {
+        $timer.Stop()
+        $timer.Dispose()
+    }
+}
+
 if ($VerbosePreference -eq 'Continue') {
     Write-Log "Command               : $TestCommand"
     Write-Log "Arguments             : $TestArguments"
@@ -138,6 +166,8 @@ if ($VerbosePreference -eq 'Continue') {
     }
     Write-Log "`n"
 }
+
+StartWatchDogTimer -ActionOnTimeout "$NotMyFaultBinaryPath /crash" -Timeout ($TestHangTimeout * 1.1)
 
 # Get the available free space before test start (useful in investigating dump file creation failures)
 try {
@@ -279,3 +309,5 @@ if (-not $WaitResult) {
         ThrowWithErrorMessage -ErrorMessage $ErrorMessage
     }
 }
+
+StopWatchDogTimer


### PR DESCRIPTION
## Description

Add backup mechanism to always generate a crash-dump.
This pull request introduces a watchdog timer mechanism to the `Run-Self-Hosted-Runner-Test.ps1` script to handle test hangs more effectively. The main changes include adding functions to start and stop the timer, and integrating the timer with the test execution flow.

### Watchdog Timer Implementation:

* Added `StartWatchDogTimer` function to initialize and start a timer that triggers a specified action on timeout. (`scripts/Run-Self-Hosted-Runner-Test.ps1`)
* Added `StopWatchDogTimer` function to stop and dispose of the timer. (`scripts/Run-Self-Hosted-Runner-Test.ps1`)

### Integration with Test Execution Flow:

* Integrated `StartWatchDogTimer` to trigger a crash process if the test hangs for longer than the specified timeout. (`scripts/Run-Self-Hosted-Runner-Test.ps1`)
* Added `StopWatchDogTimer` call to ensure the timer is stopped after the test execution completes. (`scripts/Run-Self-Hosted-Runner-Test.ps1`)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
