### PR TITLE
Add and remove CPU from epoch computation on active and idle

### DIFF
--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -905,6 +905,13 @@ _ebpf_epoch_messenger_propose_release_epoch(
     for (ebpf_list_entry_t* entry = cpu_entry->epoch_state_list.Flink; entry != &cpu_entry->epoch_state_list;
          entry = entry->Flink) {
         epoch_state = CONTAINING_RECORD(entry, ebpf_epoch_state_t, epoch_list_entry);
+        if (epoch_state->epoch == EBPF_EPOCH_UNKNOWN_EPOCH) {
+            ebpf_assert(cpu_entry->current_epoch != EBPF_EPOCH_UNKNOWN_EPOCH);
+            // Assume the thread is in the previous epoch. This is safe because the CPU was not active when the thread
+            // entered the epoch and the epoch doesn't advance while CPUs are activating.
+            epoch_state->epoch = cpu_entry->current_epoch - 1;
+        }
+
         minimum_epoch = min(minimum_epoch, epoch_state->epoch);
     }
 

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -14,7 +14,7 @@ extern "C"
     typedef struct _ebpf_epoch_state
     {
         LIST_ENTRY epoch_list_entry; /// List entry for the epoch list.
-        uint64_t epoch;              /// The epoch when this entry was added to the list.
+        int64_t epoch;               /// The epoch when this entry was added to the list.
         uint32_t cpu_id;             /// The CPU on which this entry was added to the list.
         KIRQL irql_at_enter;         /// The IRQL when this entry was added to the list.
     } ebpf_epoch_state_t;

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -49,6 +49,17 @@ extern "C"
         _In_ void* context);
 
     /**
+     * @brief Set the CPU ID for the timed work queue.
+     *
+     * @param[in,out] work_queue Work queue to set the CPU ID for.
+     * @param[in] cpu_id Which CPU to run the work queue on.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT The CPU ID is invalid.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_timed_work_queue_set_cpu_id(_Inout_ ebpf_timed_work_queue_t* work_queue, uint32_t cpu_id);
+
+    /**
      * @brief Destroy a timed work queue.
      *
      * @param[in] work_queue The timed work queue to destroy.

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -680,12 +680,6 @@ struct scoped_cpu_affinity
     bool affinity_set = false;
 };
 
-struct scoped_usersim_override
-{
-    scoped_usersim_override() { usersim_set_affinity_and_priority_override(0); }
-    ~scoped_usersim_override() { usersim_clear_affinity_and_priority_override(); }
-};
-
 /**
  * @brief This function executes as a test script to verify epoch behavior. Various scripts are used to test different
  * scenarios.
@@ -711,9 +705,6 @@ _run_epoch_test_script(const std::vector<std::string>& script)
         std::vector<work_item_ptr> work_items;
         // Start on CPU 0 as default.
         scoped_cpu_affinity affinity_scope(0);
-
-        // Prevent usersim from interfering with the test.
-        scoped_usersim_override usersim_override;
 
         typedef std::variant<std::function<void()>, std::function<void(size_t)>, std::function<void(size_t, bool)>>
             step_t;


### PR DESCRIPTION
## Description

Restore the changes reverted by https://github.com/microsoft/ebpf-for-windows/commit/205802b082b5727974d9a76bfd43fe69cb1ff8ff and fix a bug that was causing use after free (the for loop for computing oldest epoch was malformed resulting in a no-op).

Note: This is intentionally three or more commits:
1. Restore the reverted code (including the bug).
2. Fix the bug.
3. PR feedback and addition of new tests.

## Testing

CI/CD + 24 hour run of api_test.exe (previously failing after 2 hours).

## Documentation

Yes, in the files.

## Installation

No.
