### PR TITLE
Prefere static_cast over reinterpret_cast

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -431,7 +431,7 @@ load_byte_code(
     } catch (std::runtime_error& err) {
         auto message = err.what();
         auto message_length = strlen(message) + 1;
-        char* error = reinterpret_cast<char*>(ebpf_allocate(message_length + 1));
+        char* error = static_cast<char*>(ebpf_allocate(message_length + 1));
         if (error) {
             strcpy_s(error, message_length, message);
         }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -520,7 +520,7 @@ _ebpf_map_lookup_element_batch_helper(
     size_t key_size = 0;
     size_t value_size = 0;
 
-    const uint8_t* previous_key = reinterpret_cast<const uint8_t*>(in_batch);
+    const uint8_t* previous_key = static_cast<const uint8_t*>(in_batch);
 
     ebpf_assert(keys);
     ebpf_assert(values);
@@ -947,8 +947,8 @@ ebpf_map_update_element_batch(
     if ((type == BPF_MAP_TYPE_PROG_ARRAY) || (type == BPF_MAP_TYPE_HASH_OF_MAPS) ||
         (type == BPF_MAP_TYPE_ARRAY_OF_MAPS)) {
         for (size_t index = 0; index < input_count; index++) {
-            fd_t fd = reinterpret_cast<const fd_t*>(values)[index];
-            const uint8_t* key = reinterpret_cast<const uint8_t*>(keys) + index * key_size;
+            fd_t fd = static_cast<const fd_t*>(values)[index];
+            const uint8_t* key = static_cast<const uint8_t*>(keys) + index * key_size;
             ebpf_handle_t handle = ebpf_handle_invalid;
             // If the fd is valid, resolve it to a handle, else pass ebpf_handle_invalid to the IOCTL.
             if (fd != ebpf_fd_invalid) {
@@ -1450,8 +1450,8 @@ ebpf_program_query_info(
 
     size_t file_name_length = reply->section_name_offset - reply->file_name_offset;
     size_t section_name_length = reply->header.length - reply->section_name_offset;
-    char* local_file_name = reinterpret_cast<char*>(ebpf_allocate(file_name_length + 1));
-    char* local_section_name = reinterpret_cast<char*>(ebpf_allocate(section_name_length + 1));
+    char* local_file_name = static_cast<char*>(ebpf_allocate(file_name_length + 1));
+    char* local_section_name = static_cast<char*>(ebpf_allocate(section_name_length + 1));
 
     if (!local_file_name || !local_section_name) {
         ebpf_free(local_file_name);
@@ -4188,8 +4188,7 @@ _ebpf_ring_buffer_map_async_query_completion(_Inout_ void* completion_context) N
     EBPF_LOG_ENTRY();
     ebpf_assert(completion_context);
 
-    ebpf_ring_buffer_subscription_t* subscription =
-        reinterpret_cast<ebpf_ring_buffer_subscription_t*>(completion_context);
+    ebpf_ring_buffer_subscription_t* subscription = static_cast<ebpf_ring_buffer_subscription_t*>(completion_context);
 
     size_t consumer = 0;
     size_t producer = 0;

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -125,7 +125,7 @@ bpf_object__open_mem(const void* buffer, size_t buffer_size, const struct bpf_ob
     struct bpf_object* object = nullptr;
     const char* error_message;
     ebpf_result_t result = ebpf_object_open_memory(
-        reinterpret_cast<const uint8_t*>(buffer),
+        static_cast<const uint8_t*>(buffer),
         buffer_size,
         ((opts) ? opts->object_name : nullptr),
         ((opts) ? opts->pin_root_path : nullptr),

--- a/tests/bpf2c_plugin/bpf2c_test.cpp
+++ b/tests/bpf2c_plugin/bpf2c_test.cpp
@@ -34,7 +34,7 @@ _memfrob(uint64_t a, uint64_t b, uint64_t c, uint64_t d, uint64_t e)
     UNREFERENCED_PARAMETER(d);
     UNREFERENCED_PARAMETER(e);
 
-    uint8_t* p = reinterpret_cast<uint8_t*>(a);
+    uint8_t* p = static_cast<uint8_t*>(a);
     for (uint64_t i = 0; i < b; i++) {
         p[i] ^= 42;
     }
@@ -70,7 +70,7 @@ _strcmp_ext(uint64_t a, uint64_t b, uint64_t c, uint64_t d, uint64_t e)
     UNREFERENCED_PARAMETER(c);
     UNREFERENCED_PARAMETER(d);
     UNREFERENCED_PARAMETER(e);
-    return strcmp(reinterpret_cast<char*>(a), reinterpret_cast<char*>(b));
+    return strcmp(static_cast<char*>(a), static_cast<char*>(b));
 }
 
 static uint64_t
@@ -167,8 +167,8 @@ main(int argc, char** argv)
                 return -1;
             } else {
                 helper_function_entries[j].address =
-                    reinterpret_cast<helper_function_t>(_helper_functions[helper_function_entries[j].helper_id]);
-                if (helper_function_entries[j].address == reinterpret_cast<helper_function_t>(_unwind)) {
+                    static_cast<helper_function_t>(_helper_functions[helper_function_entries[j].helper_id]);
+                if (helper_function_entries[j].address == static_cast<helper_function_t>(_unwind)) {
                     helper_function_entries[j].tail_call = true;
                 }
             }

--- a/tests/bpf2c_tests/bpf_test.cpp
+++ b/tests/bpf2c_tests/bpf_test.cpp
@@ -68,8 +68,8 @@ main(int argc, char** argv)
                 return -1;
             } else {
                 helper_function_entries[j].address =
-                    reinterpret_cast<helper_function_t>(helper_functions[helper_function_entries[j].helper_id]);
-                if (helper_function_entries[j].address == reinterpret_cast<helper_function_t>(unwind)) {
+                    static_cast<helper_function_t>(helper_functions[helper_function_entries[j].helper_id]);
+                if (helper_function_entries[j].address == static_cast<helper_function_t>(unwind)) {
                     helper_function_entries[j].tail_call = true;
                 }
             }

--- a/tests/bpf2c_tests/raw_bpf.cpp
+++ b/tests/bpf2c_tests/raw_bpf.cpp
@@ -144,7 +144,7 @@ run_ubpf_jit_test(const std::string& data_file)
     char* error = nullptr;
     ubpf_vm* vm = prepare_ubpf_vm(instructions);
     size_t code_size = UBPF_CODE_SIZE;
-    uint8_t* code = reinterpret_cast<uint8_t*>(VirtualAlloc2(
+    uint8_t* code = static_cast<uint8_t*>(VirtualAlloc2(
         GetCurrentProcess(), nullptr, code_size, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE, nullptr, 0));
     REQUIRE(code != nullptr);
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -185,13 +185,13 @@ typedef class _ip_packet
         if (_address_family == AF_INET) {
             (ip_addresses == nullptr) ? set_ipv4_addresses(&_test_ipv4_addrs.source, &_test_ipv4_addrs.destination)
                                       : set_ipv4_addresses(
-                                            &(reinterpret_cast<const _ipv4_address_pair*>(ip_addresses))->source,
-                                            &(reinterpret_cast<const _ipv4_address_pair*>(ip_addresses))->destination);
+                                            &(static_cast<const _ipv4_address_pair*>(ip_addresses))->source,
+                                            &(static_cast<const _ipv4_address_pair*>(ip_addresses))->destination);
         } else {
             (ip_addresses == nullptr) ? set_ipv6_addresses(&_test_ipv6_addrs.source, &_test_ipv6_addrs.destination)
                                       : set_ipv6_addresses(
-                                            &(reinterpret_cast<const _ipv6_address_pair*>(ip_addresses))->source,
-                                            &(reinterpret_cast<const _ipv6_address_pair*>(ip_addresses))->destination);
+                                            &(static_cast<const _ipv6_address_pair*>(ip_addresses))->source,
+                                            &(static_cast<const _ipv6_address_pair*>(ip_addresses))->destination);
         }
     }
     uint8_t*
@@ -305,16 +305,16 @@ typedef class _ip_in_ip_packet : public ip_packet_t
             (inner_ip_addresses == nullptr)
                 ? set_inner_ipv4_addresses(&_test2_ipv4_addrs.source, &_test2_ipv4_addrs.destination)
                 : set_inner_ipv4_addresses(
-                      &(reinterpret_cast<const _ipv4_address_pair*>(inner_ip_addresses))->source,
-                      &(reinterpret_cast<const _ipv4_address_pair*>(inner_ip_addresses))->destination);
+                      &(static_cast<const _ipv4_address_pair*>(inner_ip_addresses))->source,
+                      &(static_cast<const _ipv4_address_pair*>(inner_ip_addresses))->destination);
         } else {
             _packet.resize(_packet.size() + sizeof(ebpf::IPV6_HEADER));
 
             (inner_ip_addresses == nullptr)
                 ? set_inner_ipv6_addresses(&_test2_ipv6_addrs.source, &_test2_ipv6_addrs.destination)
                 : set_inner_ipv6_addresses(
-                      &(reinterpret_cast<const _ipv6_address_pair*>(inner_ip_addresses))->source,
-                      &(reinterpret_cast<const _ipv6_address_pair*>(inner_ip_addresses))->destination);
+                      &(static_cast<const _ipv6_address_pair*>(inner_ip_addresses))->source,
+                      &(static_cast<const _ipv6_address_pair*>(inner_ip_addresses))->destination);
         }
     }
 
@@ -632,7 +632,7 @@ emulate_bind(std::function<ebpf_result_t(void*, uint32_t*)>& invoke, uint64_t pi
     ctx->app_id_end = (uint8_t*)(app_id.c_str()) + app_id.size();
     ctx->process_id = pid;
     ctx->operation = BIND_OPERATION_BIND;
-    REQUIRE(invoke(reinterpret_cast<void*>(ctx), &result) == EBPF_SUCCESS);
+    REQUIRE(invoke(static_cast<void*>(ctx), &result) == EBPF_SUCCESS);
     return static_cast<bind_action_t>(result);
 }
 
@@ -1776,7 +1776,7 @@ _xdp_reflect_packet_test(ebpf_execution_type_t execution_type, ADDRESS_FAMILY ad
     REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_TX);
 
-    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
+    ebpf::ETHERNET_HEADER* ethernet_header = static_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
     REQUIRE(memcmp(ethernet_header->Destination, _test_source_mac.data(), sizeof(ethernet_header->Destination)) == 0);
     REQUIRE(memcmp(ethernet_header->Source, _test_destination_mac.data(), sizeof(ethernet_header->Source)) == 0);
 
@@ -1830,7 +1830,7 @@ _xdp_encap_reflect_packet_test(ebpf_execution_type_t execution_type, ADDRESS_FAM
     REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_TX);
 
-    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
+    ebpf::ETHERNET_HEADER* ethernet_header = static_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
     REQUIRE(memcmp(ethernet_header->Destination, _test_source_mac.data(), sizeof(ethernet_header->Destination)) == 0);
     REQUIRE(memcmp(ethernet_header->Source, _test_destination_mac.data(), sizeof(ethernet_header->Source)) == 0);
 
@@ -1963,7 +1963,7 @@ _xdp_decapsulate_permit_packet_test(ebpf_execution_type_t execution_type, ADDRES
     REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_PASS);
 
-    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
+    ebpf::ETHERNET_HEADER* ethernet_header = static_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
 
     if (address_family == AF_INET) {
         ebpf::IPV4_HEADER* ipv4_header = reinterpret_cast<ebpf::IPV4_HEADER*>(ethernet_header + 1);
@@ -2522,7 +2522,7 @@ TEST_CASE("ebpf_program_load_bytes-name-gen", "[end-to-end]")
         program_type,
         nullptr,
         EBPF_EXECUTION_ANY,
-        reinterpret_cast<const ebpf_inst*>(instructions),
+        static_cast<const ebpf_inst*>(instructions),
         insn_cnt,
         nullptr,
         0,

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -291,7 +291,7 @@ typedef class _single_instance_hook : public _hook_helper
         _Out_ void** provider_binding_context,
         _Out_ const void** provider_dispatch)
     {
-        auto hook = reinterpret_cast<_single_instance_hook*>(provider_context);
+        auto hook = static_cast<_single_instance_hook*>(provider_context);
 
         if (hook->client_binding_context != nullptr) {
             // Can't attach a single-instance provider to a second client.
@@ -310,7 +310,7 @@ typedef class _single_instance_hook : public _hook_helper
     static NTSTATUS
     provider_detach_client_callback(_Inout_ void* provider_binding_context)
     {
-        auto hook = reinterpret_cast<_single_instance_hook*>(provider_binding_context);
+        auto hook = static_cast<_single_instance_hook*>(provider_binding_context);
         hook->client_binding_context = nullptr;
         hook->client_data = nullptr;
         hook->client_dispatch_table = nullptr;
@@ -437,7 +437,7 @@ _xdp_context_create(
     ebpf_result_t retval = EBPF_FAILED;
     *context = nullptr;
 
-    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
+    xdp_md_t* xdp_context = static_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
     if (xdp_context == nullptr) {
         goto Done;
     }
@@ -475,9 +475,9 @@ _xdp_context_destroy(
         return;
     }
 
-    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(context);
-    uint8_t* data = reinterpret_cast<uint8_t*>(xdp_context->data);
-    uint8_t* data_end = reinterpret_cast<uint8_t*>(xdp_context->data_end);
+    xdp_md_t* xdp_context = static_cast<xdp_md_t*>(context);
+    uint8_t* data = static_cast<uint8_t*>(xdp_context->data);
+    uint8_t* data_end = static_cast<uint8_t*>(xdp_context->data_end);
     size_t data_length = data_end - data;
     if (data_length <= *data_size_out) {
         memmove(data_out, data, data_length);
@@ -618,8 +618,7 @@ _sample_test_context_create(
         goto Done;
     }
 
-    context_header =
-        reinterpret_cast<sample_program_context_header_t*>(malloc(sizeof(sample_program_context_header_t)));
+    context_header = static_cast<sample_program_context_header_t*>(malloc(sizeof(sample_program_context_header_t)));
     if (!context_header) {
         goto Done;
     }
@@ -781,7 +780,7 @@ _ebpf_sock_addr_context_create(
     ebpf_result_t retval;
     *context = nullptr;
 
-    bpf_sock_addr_t* sock_addr_context = reinterpret_cast<bpf_sock_addr_t*>(ebpf_allocate(sizeof(bpf_sock_addr_t)));
+    bpf_sock_addr_t* sock_addr_context = static_cast<bpf_sock_addr_t*>(ebpf_allocate(sizeof(bpf_sock_addr_t)));
     if (sock_addr_context == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -818,7 +817,7 @@ _ebpf_sock_addr_context_destroy(
         return;
     }
 
-    bpf_sock_addr_t* sock_addr_context = reinterpret_cast<bpf_sock_addr_t*>(context);
+    bpf_sock_addr_t* sock_addr_context = static_cast<bpf_sock_addr_t*>(context);
     if (context_out && *context_size_out >= sizeof(bpf_sock_addr_t)) {
         bpf_sock_addr_t* provided_context = (bpf_sock_addr_t*)context_out;
         *provided_context = *sock_addr_context;
@@ -900,7 +899,7 @@ _ebpf_sock_ops_context_create(
     ebpf_result_t retval;
     *context = nullptr;
 
-    bpf_sock_ops_t* sock_ops_context = reinterpret_cast<bpf_sock_ops_t*>(ebpf_allocate(sizeof(bpf_sock_ops_t)));
+    bpf_sock_ops_t* sock_ops_context = static_cast<bpf_sock_ops_t*>(ebpf_allocate(sizeof(bpf_sock_ops_t)));
     if (sock_ops_context == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -937,7 +936,7 @@ _ebpf_sock_ops_context_destroy(
         return;
     }
 
-    bpf_sock_ops_t* sock_ops_context = reinterpret_cast<bpf_sock_ops_t*>(context);
+    bpf_sock_ops_t* sock_ops_context = static_cast<bpf_sock_ops_t*>(context);
     if (context_out && *context_size_out >= sizeof(bpf_sock_ops_t)) {
         bpf_sock_ops_t* provided_context = (bpf_sock_ops_t*)context_out;
         *provided_context = *sock_ops_context;
@@ -1052,7 +1051,7 @@ typedef class _program_info_provider
         _Out_ void** provider_binding_context,
         _Out_ const void** provider_dispatch)
     {
-        auto hook = reinterpret_cast<_program_info_provider*>(provider_context);
+        auto hook = static_cast<_program_info_provider*>(provider_context);
         UNREFERENCED_PARAMETER(nmr_binding_handle);
         UNREFERENCED_PARAMETER(client_dispatch);
         UNREFERENCED_PARAMETER(client_binding_context);
@@ -1066,7 +1065,7 @@ typedef class _program_info_provider
     static NTSTATUS
     provider_detach_client_callback(_Inout_ void* provider_binding_context)
     {
-        auto hook = reinterpret_cast<_program_info_provider*>(provider_binding_context);
+        auto hook = static_cast<_program_info_provider*>(provider_binding_context);
         UNREFERENCED_PARAMETER(hook);
 
         // There should be no in-progress calls to any client functions,

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -306,7 +306,7 @@ static void
 _complete_overlapped(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result)
 {
     UNREFERENCED_PARAMETER(output_buffer_length);
-    auto overlapped = reinterpret_cast<OVERLAPPED*>(context);
+    auto overlapped = static_cast<OVERLAPPED*>(context);
 
     // Copy the output buffer to the user buffer.
     if (overlapped) {
@@ -463,7 +463,7 @@ GlueDeviceIoControl(
     UNREFERENCED_PARAMETER(io_control_code);
 
     ebpf_result_t result;
-    const ebpf_operation_header_t* user_request = reinterpret_cast<decltype(user_request)>(input_buffer);
+    const ebpf_operation_header_t* user_request = static_cast<decltype(user_request)>(input_buffer);
     ebpf_operation_header_t* user_reply = nullptr;
     *bytes_returned = 0;
     auto request_id = user_request->id;
@@ -499,7 +499,7 @@ GlueDeviceIoControl(
     }
 
     if (minimum_reply_size > 0) {
-        user_reply = reinterpret_cast<decltype(user_reply)>(output_buffer);
+        user_reply = static_cast<decltype(user_reply)>(output_buffer);
         if (!user_reply) {
             result = EBPF_INVALID_ARGUMENT;
             goto Fail;

--- a/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
@@ -176,16 +176,16 @@ class fuzz_wrapper
         ebpf_program_parameters_t params{
             type,
             type,
-            {reinterpret_cast<uint8_t*>(program_name.data()), program_name.size()},
-            {reinterpret_cast<uint8_t*>(section.data()), section.size()},
-            {reinterpret_cast<uint8_t*>(file.data()), file.size()},
+            {static_cast<uint8_t*>(program_name.data()), program_name.size()},
+            {static_cast<uint8_t*>(section.data()), section.size()},
+            {static_cast<uint8_t*>(file.data()), file.size()},
             EBPF_CODE_JIT};
 
         if (ebpf_program_create_and_initialize(&params, &program_handle) == EBPF_SUCCESS) {
             handles.push_back(program_handle);
         }
         for (const auto& [name, def] : _map_definitions) {
-            cxplat_utf8_string_t utf8_name{reinterpret_cast<uint8_t*>(const_cast<char*>(name.data())), name.size()};
+            cxplat_utf8_string_t utf8_name{static_cast<uint8_t*>(const_cast<char*>(name.data())), name.size()};
             ebpf_handle_t handle;
             if (ebpf_core_create_map(&utf8_name, &def, ebpf_handle_invalid, &handle) == EBPF_SUCCESS) {
                 handles.push_back(handle);

--- a/tests/libfuzzer/execution_context/libfuzz_harness.cpp
+++ b/tests/libfuzzer/execution_context/libfuzz_harness.cpp
@@ -184,9 +184,9 @@ class fuzz_wrapper
             ebpf_program_parameters_t params{
                 type,
                 type,
-                {reinterpret_cast<uint8_t*>(name.data()), name.size()},
-                {reinterpret_cast<uint8_t*>(section.data()), section.size()},
-                {reinterpret_cast<uint8_t*>(file.data()), file.size()},
+                {static_cast<uint8_t*>(name.data()), name.size()},
+                {static_cast<uint8_t*>(section.data()), section.size()},
+                {static_cast<uint8_t*>(file.data()), file.size()},
                 EBPF_CODE_JIT};
             ebpf_handle_t handle;
             if (ebpf_program_create_and_initialize(&params, &handle) == EBPF_SUCCESS) {
@@ -194,7 +194,7 @@ class fuzz_wrapper
             }
         }
         for (const auto& [name, def] : _map_definitions) {
-            cxplat_utf8_string_t utf8_name{reinterpret_cast<uint8_t*>(const_cast<char*>(name.data())), name.size()};
+            cxplat_utf8_string_t utf8_name{static_cast<uint8_t*>(const_cast<char*>(name.data())), name.size()};
             ebpf_handle_t handle;
             if (ebpf_core_create_map(&utf8_name, &def, ebpf_handle_invalid, &handle) == EBPF_SUCCESS) {
                 handles.push_back(handle);
@@ -236,10 +236,10 @@ fuzz_ioctl(std::vector<uint8_t>& random_buffer)
     }
 
     // Use first 2 bytes of random buffer to determine reply buffer length.
-    reply_buffer_length = reinterpret_cast<uint16_t*>(random_buffer.data())[0];
+    reply_buffer_length = static_cast<uint16_t*>(random_buffer.data())[0];
     reply.resize(reply_buffer_length);
 
-    auto header = reinterpret_cast<ebpf_operation_header_t*>(random_buffer.data());
+    auto header = static_cast<ebpf_operation_header_t*>(random_buffer.data());
     auto operation_id = header->id;
     header->length = static_cast<uint16_t>(random_buffer.size());
 

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -131,7 +131,7 @@ ring_buffer_test_event_context_t::unsubscribe()
 int
 ring_buffer_test_event_handler(_Inout_ void* ctx, _In_opt_ const void* data, size_t size)
 {
-    ring_buffer_test_event_context_t* event_context = reinterpret_cast<ring_buffer_test_event_context_t*>(ctx);
+    ring_buffer_test_event_context_t* event_context = static_cast<ring_buffer_test_event_context_t*>(ctx);
 
     if ((data == nullptr) || (size == 0)) {
         // eBPF ring buffer invokes callback with NULL data indicating that the subscription is canceled.
@@ -151,7 +151,7 @@ ring_buffer_test_event_handler(_Inout_ void* ctx, _In_opt_ const void* data, siz
         return 0;
     }
 
-    std::vector<char> event_record(reinterpret_cast<const char*>(data), reinterpret_cast<const char*>(data) + size);
+    std::vector<char> event_record(static_cast<const char*>(data), static_cast<const char*>(data) + size);
 
     // Check if indicated event record matches an entry in the context records
     // that has not been matched yet.

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -152,7 +152,7 @@ _client_socket::post_async_receive(bool error_expected)
     int error = 0;
     int wsaerr = 0;
 
-    WSABUF wsa_recv_buffer{static_cast<unsigned long>(recv_buffer.size()), reinterpret_cast<char*>(recv_buffer.data())};
+    WSABUF wsa_recv_buffer{static_cast<unsigned long>(recv_buffer.size()), static_cast<char*>(recv_buffer.data())};
 
     // Create an event handle and set up the overlapped structure.
     overlapped.hEvent = WSACreateEvent();
@@ -251,7 +251,7 @@ _datagram_client_socket::send_message_to_remote_host(
 
     // Send a message to the remote host using the sender socket.
     std::vector<char> send_buffer(message, message + strlen(message));
-    WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), reinterpret_cast<char*>(send_buffer.data())};
+    WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), static_cast<char*>(send_buffer.data())};
     uint32_t bytes_sent = 0;
     uint32_t send_flags = 0;
     error = WSASendTo(
@@ -471,7 +471,7 @@ _datagram_server_socket::post_async_receive()
 {
     int error = 0;
 
-    WSABUF wsa_recv_buffer{static_cast<unsigned long>(recv_buffer.size()), reinterpret_cast<char*>(recv_buffer.data())};
+    WSABUF wsa_recv_buffer{static_cast<unsigned long>(recv_buffer.size()), static_cast<char*>(recv_buffer.data())};
 
     // Create an event handle and set up the overlapped structure.
     overlapped.hEvent = WSACreateEvent();
@@ -512,7 +512,7 @@ _datagram_server_socket::send_async_response(_In_z_ const char* message)
 
     // Send a response to the sender.
     std::vector<char> send_buffer(message, message + strlen(message));
-    WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), reinterpret_cast<char*>(send_buffer.data())};
+    WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), static_cast<char*>(send_buffer.data())};
     uint32_t bytes_sent = 0;
     uint32_t send_flags = 0;
     error = WSASendTo(
@@ -617,7 +617,7 @@ _stream_server_socket::post_async_receive()
 {
     initialize_accept_socket();
 
-    WSABUF wsa_recv_buffer{static_cast<unsigned long>(recv_buffer.size()), reinterpret_cast<char*>(recv_buffer.data())};
+    WSABUF wsa_recv_buffer{static_cast<unsigned long>(recv_buffer.size()), static_cast<char*>(recv_buffer.data())};
 
     // Create an event handle and set up the overlapped structure.
     overlapped.hEvent = WSACreateEvent();
@@ -647,7 +647,7 @@ _stream_server_socket::send_async_response(_In_z_ const char* message)
 {
     // Send a message to the remote host using the sender socket.
     std::vector<char> send_buffer(message, message + strlen(message));
-    WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), reinterpret_cast<char*>(send_buffer.data())};
+    WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), static_cast<char*>(send_buffer.data())};
     uint32_t bytes_sent = 0;
     overlapped.hEvent = WSACreateEvent();
     int32_t error = WSASend(

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -152,12 +152,12 @@ _netebpf_ext_helper::_program_info_client_attach_provider(
     _Inout_ void* client_context,
     _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
 {
-    auto& helper = *reinterpret_cast<_netebpf_ext_helper*>(client_context);
+    auto& helper = *static_cast<_netebpf_ext_helper*>(client_context);
     auto client_binding_context = std::make_unique<program_info_provider_t>();
     client_binding_context->module_id = *provider_registration_instance->ModuleId;
     client_binding_context->parent = &helper;
     client_binding_context->program_data =
-        reinterpret_cast<const ebpf_program_data_t*>(provider_registration_instance->NpiSpecificCharacteristics);
+        static_cast<const ebpf_program_data_t*>(provider_registration_instance->NpiSpecificCharacteristics);
 
     NTSTATUS status = NmrClientAttachProvider(
         nmr_binding_handle,
@@ -194,7 +194,7 @@ _netebpf_ext_helper::_hook_client_attach_provider(
 {
     UNREFERENCED_PARAMETER(provider_registration_instance);
     const void* provider_dispatch_table;
-    auto base_client_context = reinterpret_cast<netebpfext_helper_base_client_context_t*>(client_context);
+    auto base_client_context = static_cast<netebpfext_helper_base_client_context_t*>(client_context);
     if (base_client_context == nullptr) {
         return STATUS_INVALID_PARAMETER;
     }

--- a/tests/stress/km/stress_tests_km.cpp
+++ b/tests/stress/km/stress_tests_km.cpp
@@ -1189,7 +1189,7 @@ _invoke_mt_bindmonitor_tail_call_thread_function(thread_context& context)
             socket_handle = WSASocket(remote_endpoint.ss_family, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, 0);
             REQUIRE(socket_handle != INVALID_SOCKET);
 
-            INETADDR_SETANY(reinterpret_cast<PSOCKADDR>(&remote_endpoint));
+            INETADDR_SETANY(static_cast<PSOCKADDR>(&remote_endpoint));
             SS_PORT(&remote_endpoint) = htons(remote_port);
 
             // Forcefully bind to the same port in use using socket option SO_REUSEADDR.

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -3398,7 +3398,7 @@ emulate_bind_tail_call(std::function<ebpf_result_t(void*, uint32_t*)>& invoke, u
     ctx->process_id = pid;
     ctx->operation = BIND_OPERATION_BIND;
 
-    REQUIRE(invoke(reinterpret_cast<void*>(ctx), &result) == EBPF_SUCCESS);
+    REQUIRE(invoke(static_cast<void*>(ctx), &result) == EBPF_SUCCESS);
 
     return static_cast<bind_action_t>(result);
 }


### PR DESCRIPTION
## Description

This pull request focuses on converting `reinterpret_cast` to `static_cast` for better type safety and readability across multiple files. The changes are primarily in the `libs/api` and `tests` directories.

### Type Safety Improvements:

* [`libs/api/Verifier.cpp`](diffhunk://#diff-c7cabf550a3d7ec7f53d5aaf8ea0e8a77d949e886b3c0f492ebd75228756b40fL434-R434): Changed `reinterpret_cast` to `static_cast` in the `load_byte_code` function for error message allocation.
* [`libs/api/ebpf_api.cpp`](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL523-R523): Replaced `reinterpret_cast` with `static_cast` in several functions including `_ebpf_map_lookup_element_batch_helper`, `ebpf_map_update_element_batch`, `ebpf_program_query_info`, and `_ebpf_ring_buffer_map_async_query_completion`. [[1]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL523-R523) [[2]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL950-R951) [[3]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1453-R1454) [[4]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL4191-R4191)
* [`libs/api/libbpf_object.cpp`](diffhunk://#diff-91af4554cf2831a775b4de416aff1ab4fc022732599494f6328a0c4fd46bdad4L128-R128): Updated `bpf_object__open_mem` to use `static_cast` instead of `reinterpret_cast`.

### Test Code Enhancements:

* [`tests/bpf2c_plugin/bpf2c_test.cpp`](diffhunk://#diff-5745a28e355e7502d8455020a1047c95af4bc8d3e9772752558682e827c30a4cL37-R37): Converted `reinterpret_cast` to `static_cast` in functions like `_memfrob`, `_strcmp_ext`, and `main`. [[1]](diffhunk://#diff-5745a28e355e7502d8455020a1047c95af4bc8d3e9772752558682e827c30a4cL37-R37) [[2]](diffhunk://#diff-5745a28e355e7502d8455020a1047c95af4bc8d3e9772752558682e827c30a4cL73-R73) [[3]](diffhunk://#diff-5745a28e355e7502d8455020a1047c95af4bc8d3e9772752558682e827c30a4cL170-R171)
* [`tests/bpf2c_tests/bpf_test.cpp`](diffhunk://#diff-16cd2e817a6812ec72703fd5cee13cfd69f34c27a6880067c1fc1723101b67daL71-R72): Updated `main` function to use `static_cast` for helper function entries.
* [`tests/bpf2c_tests/raw_bpf.cpp`](diffhunk://#diff-d590dc22b21b3d2ad3e943623809a5f165244bffc37fd575ce63027aa11a970aL147-R147): Changed `reinterpret_cast` to `static_cast` in `run_ubpf_jit_test`.
* [`tests/end_to_end/end_to_end.cpp`](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL188-R194): Replaced `reinterpret_cast` with `static_cast` in multiple functions including `typedef class _ip_packet`, `typedef class _ip_in_ip_packet`, `emulate_bind`, `_xdp_reflect_packet_test`, `_xdp_encap_reflect_packet_test`, `_xdp_decapsulate_permit_packet_test`, and `TEST_CASE("ebpf_program_load_bytes-name-gen", "[end-to-end]")`. [[1]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL188-R194) [[2]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL308-R317) [[3]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL635-R635) [[4]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL1779-R1779) [[5]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL1833-R1833) [[6]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL1966-R1966) [[7]](diffhunk://#diff-f9ee921992a589d5643886350a4641e33e7902b7643a4983110219db80e660eeL2525-R2525)
* [`tests/end_to_end/helpers.h`](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL294-R294): Updated various functions to use `static_cast` instead of `reinterpret_cast` for better type safety. [[1]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL294-R294) [[2]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL313-R313) [[3]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL440-R440) [[4]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL478-R480) [[5]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL621-R621) [[6]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL784-R783) [[7]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL821-R820) [[8]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL903-R902) [[9]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL940-R939) [[10]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL1055-R1054) [[11]](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL1069-R1068)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
