### PR TITLE
Switch to group affinity to work correctly on systems with > 64 CPUs

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2389,7 +2389,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     ebpf_result_t result;
     uint32_t return_value = 0;
     uint8_t old_irql = 0;
-    uintptr_t old_thread_affinity;
+    GROUP_AFFINITY old_thread_affinity;
     size_t batch_size = options->batch_size ? options->batch_size : 1024;
     ebpf_execution_context_state_t execution_context_state = {0};
     ebpf_epoch_state_t epoch_state = {0};
@@ -2400,7 +2400,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     void* program_context = NULL;
     bool supports_context_header;
 
-    result = ebpf_set_current_thread_affinity((uintptr_t)1 << options->cpu, &old_thread_affinity);
+    result = ebpf_set_current_thread_cpu_affinity(options->cpu, &old_thread_affinity);
     if (result != EBPF_SUCCESS) {
         goto Done;
     }
@@ -2501,7 +2501,7 @@ Done:
     }
 
     if (thread_affinity_set) {
-        ebpf_restore_current_thread_affinity(old_thread_affinity);
+        ebpf_restore_current_thread_cpu_affinity(&old_thread_affinity);
     }
 
     context->completion_callback(

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -414,7 +414,7 @@ ebpf_set_current_thread_cpu_affinity(uint32_t cpu_index, _Out_ GROUP_AFFINITY* o
     }
 
     new_affinity.Group = processor.Group;
-    new_affinity.Mask = (ULONG_PTR)1 << processor.Number;
+    new_affinity.Mask = AFFINITY_MASK(processor.Number);
 
     KeSetSystemGroupAffinityThread(&new_affinity, old_cpu_affinity);
 

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -52,12 +52,6 @@ _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVE
     KeReleaseSpinLock(lock, state);
 }
 
-void
-ebpf_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask)
-{
-    KeRevertToUserAffinityThreadEx(old_thread_affinity_mask);
-}
-
 bool
 ebpf_is_preemptible()
 {
@@ -68,7 +62,11 @@ ebpf_is_preemptible()
 uint32_t
 ebpf_get_current_cpu()
 {
-    return KeGetCurrentProcessorNumberEx(NULL);
+    PROCESSOR_NUMBER processor_number;
+
+    KeGetCurrentProcessorNumberEx(&processor_number);
+
+    return KeGetProcessorIndexFromNumber(&processor_number);
 }
 
 uint64_t
@@ -397,43 +395,36 @@ ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask)
+ebpf_set_current_thread_cpu_affinity(uint32_t cpu_index, _Out_ GROUP_AFFINITY* old_cpu_affinity)
 {
     if (KeGetCurrentIrql() >= DISPATCH_LEVEL) {
         return EBPF_OPERATION_NOT_SUPPORTED;
     }
 
-    KAFFINITY old_affinity = KeSetSystemAffinityThreadEx(new_thread_affinity_mask);
-    *old_thread_affinity_mask = old_affinity;
-    return EBPF_SUCCESS;
-}
-
-_Must_inspect_result_ ebpf_result_t
-ebpf_allocate_non_preemptible_work_item(
-    _Outptr_ KDPC** dpc,
-    uint32_t cpu_id,
-    _In_ PKDEFERRED_ROUTINE work_item_routine,
-    _Inout_opt_ void* work_item_context)
-{
-    *dpc = ebpf_allocate(sizeof(KDPC));
-    if (*dpc == NULL) {
-        return EBPF_NO_MEMORY;
+    if (cpu_index >= ebpf_get_cpu_count()) {
+        return EBPF_INVALID_ARGUMENT;
     }
 
-    KeInitializeDpc(*dpc, work_item_routine, work_item_context);
-    KeSetTargetProcessorDpc(*dpc, (uint8_t)cpu_id);
+    PROCESSOR_NUMBER processor;
+    GROUP_AFFINITY new_affinity = {0};
+
+    NTSTATUS status = KeGetProcessorNumberFromIndex(cpu_index, &processor);
+    if (!NT_SUCCESS(status)) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    new_affinity.Group = processor.Group;
+    new_affinity.Mask = (ULONG_PTR)1 << processor.Number;
+
+    KeSetSystemGroupAffinityThread(&new_affinity, old_cpu_affinity);
+
     return EBPF_SUCCESS;
 }
 
 void
-ebpf_free_non_preemptible_work_item(_In_opt_ _Frees_ptr_opt_ KDPC* dpc)
+ebpf_restore_current_thread_cpu_affinity(_In_ GROUP_AFFINITY* old_cpu_affinity)
 {
-    if (!dpc) {
-        return;
-    }
-
-    KeRemoveQueueDpc(dpc);
-    ebpf_free(dpc);
+    KeRevertToUserGroupAffinityThread(old_cpu_affinity);
 }
 
 typedef struct _ebpf_timer_work_item

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -272,33 +272,6 @@ extern "C"
     ebpf_get_current_thread_id();
 
     /**
-     * @brief Create a non-preemptible work item.
-     *
-     * @param[out] work_item Pointer to memory that will contain the pointer to
-     *  the non-preemptible work item on success.
-     * @param[in] cpu_id Associate the work item with this CPU.
-     * @param[in] work_item_routine Routine to execute as a work item.
-     * @param[in, out] work_item_context Context to pass to the routine.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
-     *  work item.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_allocate_non_preemptible_work_item(
-        _Outptr_ KDPC** work_item,
-        uint32_t cpu_id,
-        _In_ PKDEFERRED_ROUTINE work_item_routine,
-        _Inout_opt_ void* work_item_context);
-
-    /**
-     * @brief Free a non-preemptible work item.
-     *
-     * @param[in] work_item Pointer to the work item to free.
-     */
-    void
-    ebpf_free_non_preemptible_work_item(_In_opt_ _Frees_ptr_opt_ KDPC* work_item);
-
-    /**
      * @brief Create a preemptible work item.
      *
      * @param[out] work_item Pointer to memory that will contain the pointer to
@@ -662,11 +635,24 @@ extern "C"
     uint64_t
     ebpf_query_time_since_boot(bool include_suspended_time);
 
+    /**
+     * @brief Affinitize the current thread to a specific CPU by index and return the old affinity.
+     *
+     * @param[in] cpu_index The index of the CPU to affinitize to.
+     * @param[out] old_cpu_affinity The old CPU affinity.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT The CPU index is invalid.
+     */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask);
+    ebpf_set_current_thread_cpu_affinity(uint32_t cpu_index, _Out_ GROUP_AFFINITY* old_cpu_affinity);
 
+    /**
+     * @brief Restore the CPU affinity of the current thread to the previous affinity.
+     *
+     * @param[in] old_cpu_affinity The previous CPU affinity.
+     */
     void
-    ebpf_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask);
+    ebpf_restore_current_thread_cpu_affinity(_In_ GROUP_AFFINITY* old_cpu_affinity);
 
     typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -29,6 +29,10 @@ extern "C"
 #define EBPF_INLINE_HINT
 #endif
 
+#if !defined(AFFINITY_MASK)
+#define AFFINITY_MASK(n) ((ULONG_PTR)1 << (n))
+#endif
+
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
     {                                         \
         ((uint8_t*)(x)), sizeof((x)) - 1      \

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -30,7 +30,7 @@ extern "C"
 #endif
 
 #if !defined(AFFINITY_MASK)
-#define AFFINITY_MASK(n) ((ULONG_PTR)1 << (n))
+#define AFFINITY_MASK(n) ((ULONG_PTR)(1) << (n))
 #endif
 
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -76,19 +76,18 @@ typedef class _emulate_dpc
   public:
     _emulate_dpc(uint32_t cpu_id)
     {
-        uintptr_t new_thread_affinity_mask = 1ull << cpu_id;
-        ebpf_assert_success(ebpf_set_current_thread_affinity(new_thread_affinity_mask, &old_thread_affinity_mask));
+        ebpf_assert_success(ebpf_set_current_thread_cpu_affinity(cpu_id, &old_thread_affinity_mask));
         KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
     }
     ~_emulate_dpc()
     {
         KeLowerIrql(old_irql);
 
-        ebpf_restore_current_thread_affinity(old_thread_affinity_mask);
+        ebpf_restore_current_thread_cpu_affinity(&old_thread_affinity_mask);
     }
 
   private:
-    uintptr_t old_thread_affinity_mask;
+    GROUP_AFFINITY old_thread_affinity_mask;
     KIRQL old_irql;
 
 } emulate_dpc_t;


### PR DESCRIPTION
Resolves: #3868

## Description

This pull request focuses on refactoring the thread affinity handling in the eBPF platform code. The primary changes involve replacing the old thread affinity mechanism with a more robust CPU affinity system using `GROUP_AFFINITY`. Additionally, some unused functions were removed to clean up the codebase.

### Refactoring thread affinity handling:

* [`libs/execution_context/ebpf_program.c`](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2392-R2392): Replaced `ebpf_set_current_thread_affinity` with `ebpf_set_current_thread_cpu_affinity` and updated the type of `old_thread_affinity` to `GROUP_AFFINITY`. [[1]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2392-R2392) [[2]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2403-R2403) [[3]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2504-R2504)
* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL400-R427): Updated `ebpf_set_current_thread_affinity` to `ebpf_set_current_thread_cpu_affinity` and changed the type of `old_thread_affinity_mask` to `GROUP_AFFINITY`.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R638-R655): Added new function declarations for setting and restoring CPU affinity using `GROUP_AFFINITY`.

### Code cleanup:

* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL55-L60): Removed the `ebpf_restore_current_thread_affinity` function.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7L274-L300): Removed declarations for non-preemptible work item functions.

### Tests and examples:

* [`libs/runtime/unit/platform_unit_test.cpp`](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6L575-R594): Updated test cases to use the new `ebpf_set_current_thread_cpu_affinity` function.
* [`tests/end_to_end/helpers.h`](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL79-R90): Modified the `emulate_dpc` class to use `GROUP_AFFINITY` for thread affinity.

### Submodule update:

* [`external/usersim`](diffhunk://#diff-4ae78540d77e146774e537be8c7888b0e96d803c98c06760e4e8775833905812L1-R1): Updated the submodule commit reference.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
