### PR TITLE
Switch to more performant API

### DIFF
--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -59,16 +59,6 @@ ebpf_is_preemptible()
     return irql < DISPATCH_LEVEL;
 }
 
-uint32_t
-ebpf_get_current_cpu()
-{
-    PROCESSOR_NUMBER processor_number;
-
-    KeGetCurrentProcessorNumberEx(&processor_number);
-
-    return KeGetProcessorIndexFromNumber(&processor_number);
-}
-
 uint64_t
 ebpf_get_current_thread_id()
 {

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -264,6 +264,7 @@ extern "C"
      *   running on. Only valid if ebpf_is_preemptible() == true.
      * @retval Zero based index of CPUs.
      */
+    EBPF_INLINE_HINT
     uint32_t
     ebpf_get_current_cpu();
 

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -262,3 +262,9 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t
 
     return EBPF_SUCCESS;
 }
+
+uint32_t
+ebpf_get_current_cpu()
+{
+    return KeGetCurrentProcessorIndex();
+}

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -281,3 +281,13 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t
     NTSTATUS status = usersim_platform_get_authentication_id(authentication_id);
     return ntstatus_to_ebpf_result(status);
 }
+
+uint32_t
+ebpf_get_current_cpu()
+{
+    PROCESSOR_NUMBER processor_number;
+
+    KeGetCurrentProcessorNumberEx(&processor_number);
+
+    return KeGetProcessorIndexFromNumber(&processor_number);
+}


### PR DESCRIPTION
## Description

This pull request includes changes to the `ebpf_get_current_cpu` function across several files in the `libs/runtime` directory. The main goal is to refactor and reintroduce the function with inline hints and platform-specific implementations.

Refactoring `ebpf_get_current_cpu` function:

* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL62-L71): Removed the `ebpf_get_current_cpu` function.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R267): Added an inline hint to the `ebpf_get_current_cpu` function declaration.

Platform-specific implementations:

* [`libs/runtime/kernel/ebpf_platform_kernel.c`](diffhunk://#diff-86ad2329b975e7c7a873e33a2f2e00ed7130fdf4ddbe4e08b49470a746c4cba6R265-R270): Added the `ebpf_get_current_cpu` function implementation using `KeGetCurrentProcessorIndex`.
* [`libs/runtime/user/ebpf_platform_user.cpp`](diffhunk://#diff-20b5fd970c548fe85017a765358e1c10c4c66e68ecee00954927a767bbe9a70eR284-R293): Added the `ebpf_get_current_cpu` function implementation using `KeGetCurrentProcessorNumberEx` and `KeGetProcessorIndexFromNumber`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
