### PR TITLE
bpf(): make union bpf_attr Linux ABI compatible

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -46,6 +46,13 @@ enum bpf_stats_type
     BPF_STATS_TYPE_UNKNOWN
 };
 
+// All types below must be ABI compatible with the Linux bpf() syscalls. This means
+// that the order, size and alignment of the types must match uapi/linux/bpf.h.
+// Constants must also match.
+//
+// Names do not have to match, but try to keep them the same as much as possible.
+// In case of conflicts prefix them with "sys_" or "SYS_".
+
 enum bpf_cmd_id
 {
     BPF_MAP_CREATE,
@@ -58,38 +65,130 @@ enum bpf_cmd_id
     BPF_OBJ_GET,
     BPF_PROG_ATTACH,
     BPF_PROG_DETACH,
+    BPF_PROG_TEST_RUN,
     BPF_PROG_GET_NEXT_ID,
     BPF_MAP_GET_NEXT_ID,
-    BPF_LINK_GET_NEXT_ID,
     BPF_PROG_GET_FD_BY_ID,
     BPF_MAP_GET_FD_BY_ID,
-    BPF_MAP_LOOKUP_AND_DELETE_ELEM,
-    BPF_LINK_GET_FD_BY_ID,
     BPF_OBJ_GET_INFO_BY_FD,
-    BPF_LINK_DETACH,
-    BPF_PROG_BIND_MAP,
-    BPF_PROG_TEST_RUN,
+    BPF_MAP_LOOKUP_AND_DELETE_ELEM = 21,
+    BPF_LINK_GET_FD_BY_ID = 30,
+    BPF_LINK_GET_NEXT_ID,
+    BPF_LINK_DETACH = 34,
+    BPF_PROG_BIND_MAP = 35,
     BPF_PROG_RUN = BPF_PROG_TEST_RUN,
 };
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(default : 4820) // reject implicit padding
+#endif
+
+/// Attributes used by BPF_MAP_CREATE.
+typedef struct
+{
+    enum bpf_map_type map_type; ///< Type of map to create.
+    uint32_t key_size;          ///< Size in bytes of keys.
+    uint32_t value_size;        ///< Size in bytes of values.
+    uint32_t max_entries;       ///< Maximum number of entries in the map.
+    uint32_t map_flags;         ///< Flags (currently 0).
+} sys_bpf_map_create_attr_t;
+
+typedef struct
+{
+    uint32_t map_fd; ///< File descriptor of map.
+    uint32_t _pad0;
+    uint64_t key;   ///< Pointer to key to look up.
+    uint64_t value; ///< Pointer to value.
+    uint64_t flags; ///< Not supported.
+} sys_bpf_map_lookup_attr_t;
+
+typedef struct
+{
+    uint32_t map_fd; ///< File descriptor of map.
+    uint32_t _pad0;
+    uint64_t key; ///< Pointer to key to delete.
+} sys_bpf_map_delete_attr_t;
+
+typedef struct
+{
+    uint32_t map_fd; ///< File descriptor of map.
+    uint32_t _pad0;
+    uint64_t key;      ///< Pointer to key to look up.
+    uint64_t next_key; ///< Pointer to next key.
+} sys_bpf_map_next_key_attr_t;
+
+typedef struct
+{
+    uint32_t start_id; ///< ID to look for an ID after. The start_id need not exist.
+    uint32_t next_id;  ///< On return, contains the next ID.
+} sys_bpf_map_next_id_attr_t;
+
+typedef struct
+{
+    enum bpf_prog_type prog_type; ///< Program type to use for loading the program.
+    uint32_t insn_cnt;            ///< Number of instructions in the array.
+    uint64_t insns;               ///< Array of instructions
+    uint64_t license;      ///< Optional pointer to a string specifying the license (currently ignored on Windows).
+    uint32_t log_level;    ///< Logging level (currently ignored on Windows).
+    uint32_t log_size;     ///< Size in bytes of the log buffer.
+    uint64_t log_buf;      ///< Pointer to a buffer in which log info can be written.
+    uint32_t kern_version; ///< Kernel version (currently ignored on Windows).
+    uint32_t prog_flags;   ///< Not supported.
+} sys_bpf_prog_load_attr_t;
+
+typedef struct
+{
+    uint32_t target_fd;               ///< eBPF target to attach/detach to/from.
+    uint32_t attach_bpf_fd;           ///< File descriptor of program to attach to.
+    enum bpf_attach_type attach_type; ///< Type of program to attach/detach to/from.
+    uint32_t attach_flags;            ///< Flags affecting the attach operation.
+} sys_bpf_prog_attach_attr_t;
+
+typedef struct
+{
+    uint32_t prog_fd;       ///< File descriptor of program to run.
+    uint32_t retval;        ///< On return, contains the return value of the program.
+    uint32_t data_size_in;  ///< Size in bytes of input data.
+    uint32_t data_size_out; ///< Size in bytes of output data.
+    uint64_t data_in;       ///< Pointer to input data.
+    uint64_t data_out;      ///< Pointer to output data.
+    uint32_t repeat;        ///< Number of times to repeat the program.
+    uint32_t duration;      ///< Duration in milliseconds to run the program.
+    uint32_t ctx_size_in;   ///< Size in bytes of input context.
+    uint32_t ctx_size_out;  ///< Size in bytes of output context.
+    uint64_t ctx_in;        ///< Pointer to input context.
+    uint64_t ctx_out;       ///< Pointer to output context.
+    uint32_t flags;         ///< Flags (currently 0).
+    uint32_t cpu;           ///< CPU to run the program on.
+    uint32_t batch_size;    ///< Number of times to run the program in a batch.
+    uint32_t _pad0;
+} sys_bpf_prog_run_attr_t;
+
+typedef struct
+{
+    uint64_t pathname; ///< Path name for pinning.
+    uint32_t bpf_fd;   ///< File descriptor referring to the program or map.
+    uint32_t flags;    ///< Not supported.
+} sys_bpf_obj_pin_attr_t;
 
 /// Attributes used by BPF_OBJ_GET_INFO_BY_FD.
 typedef struct
 {
     uint32_t bpf_fd; ///< File descriptor referring to an eBPF object.
-    uint64_t info;   ///< Pointer to memory in which to write the info obtained.
-
     /**
      * @brief On input, contains the maximum number of bytes to write into the info. On output, contains
      * the actual number of bytes written.
      */
     uint32_t info_len;
-} bpf_obj_info_attr_t;
+    uint64_t info; ///< Pointer to memory in which to write the info obtained.
+} sys_bpf_obj_info_attr_t;
 
 /// Attributes used by BPF_LINK_DETACH.
 typedef struct
 {
     uint32_t link_fd; ///< File descriptor of link to detach.
-} bpf_link_detach_attr_t;
+} sys_bpf_link_detach_attr_t;
 
 /// Attributes used by BPF_PROG_BIND_MAP.
 typedef struct
@@ -97,80 +196,41 @@ typedef struct
     uint32_t prog_fd; ///< File descriptor of program to bind map to.
     uint32_t map_fd;  ///< File descriptor of map to bind.
     uint32_t flags;   ///< Flags affecting the bind operation.
-} bpf_prog_bind_map_attr_t;
+} sys_bpf_prog_bind_map_attr_t;
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4201) // nonstandard extension used: nameless struct/union
-#endif
 /// Parameters used by the bpf() API.
 union bpf_attr
 {
     // BPF_MAP_CREATE
-    struct
-    {
-        enum bpf_map_type map_type; ///< Type of map to create.
-        uint32_t key_size;          ///< Size in bytes of keys.
-        uint32_t value_size;        ///< Size in bytes of values.
-        uint32_t max_entries;       ///< Maximum number of entries in the map.
-        uint32_t map_flags;         ///< Flags (currently 0).
-    };                              ///< Attributes used by BPF_MAP_CREATE.
+    sys_bpf_map_create_attr_t map_create; ///< Attributes used by BPF_MAP_CREATE.
 
     // BPF_MAP_LOOKUP_ELEM
     // BPF_MAP_UPDATE_ELEM
-    // BPF_MAP_DELETE_ELEM
+    sys_bpf_map_lookup_attr_t map_lookup,
+        map_update; ///< Attributes used by BPF_MAP_LOOKUP_ELEM, BPF_MAP_UPDATE_ELEM and
+
     // BPF_MAP_GET_NEXT_KEY
-    struct
-    {
-        uint32_t map_fd; ///< File descriptor of map.
-        uint64_t key;    ///< Pointer to key to look up.
-        union
-        {
-            uint64_t value;    ///< Pointer to value.
-            uint64_t next_key; ///< Pointer to next key.
-        };
-        uint64_t flags; ///< Flags (currently 0).
-    }; ///< Attributes used by BPF_MAP_LOOKUP_ELEM, BPF_MAP_UPDATE_ELEM, BPF_MAP_DELETE_ELEM, and BPF_MAP_GET_NEXT_KEY.
+    sys_bpf_map_next_key_attr_t map_get_next_key; ///< Attributes used by BPF_MAP_GET_NEXT_KEY.
+
+    // BPF_MAP_DELETE_ELEM
+    sys_bpf_map_delete_attr_t map_delete; ///< Attributes used by BPF_MAP_DELETE_ELEM.
 
     // BPF_PROG_LOAD
-    struct
-    {
-        enum bpf_prog_type prog_type; ///< Program type to use for loading the program.
-        uint64_t insns;               ///< Array of instructions
-        uint32_t insn_cnt;            ///< Number of instructions in the array.
-        uint64_t license;      ///< Optional pointer to a string specifying the license (currently ignored on Windows).
-        uint32_t log_level;    ///< Logging level (currently ignored on Windows).
-        uint64_t log_buf;      ///< Pointer to a buffer in which log info can be written.
-        uint32_t log_size;     ///< Size in bytes of the log buffer.
-        uint32_t kern_version; ///< Kernel version (currently ignored on Windows).
-    };                         ///< Attributes used by BPF_PROG_LOAD.
+    sys_bpf_prog_load_attr_t prog_load; ///< Attributes used by BPF_PROG_LOAD.
 
     // BPF_PROG_ATTACH
     // BPF_PROG_DETACH
-    struct
-    {
-        uint32_t target_fd;               ///< eBPF target to attach/detach to/from.
-        uint32_t attach_bpf_fd;           ///< File descriptor of program to attach to.
-        enum bpf_attach_type attach_type; ///< Type of program to attach/detach to/from.
-        uint32_t attach_flags;            ///< Flags affecting the attach operation.
-    };                                    ///< Attributes used by BPF_PROG_ATTACH/DETACH.
+    sys_bpf_prog_attach_attr_t prog_attach, prog_detach; ///< Attributes used by BPF_PROG_ATTACH/DETACH.
 
     // BPF_OBJ_PIN
     // BPF_OBJ_GET
-    struct
-    {
-        uint64_t pathname; ///< Path name for pinning.
-        uint32_t bpf_fd;   ///< File descriptor referring to the program or map.
-    };                     ///< Attributes used by BPF_OBJ_PIN and BPF_OBJ_GET.
+    sys_bpf_obj_pin_attr_t obj_pin, obj_get; ///< Attributes used by BPF_OBJ_PIN and BPF_OBJ_GET.
 
     // BPF_PROG_GET_NEXT_ID
     // BPF_MAP_GET_NEXT_ID
     // BPF_LINK_GET_NEXT_ID
-    struct
-    {
-        uint32_t start_id; ///< ID to look for an ID after. The start_id need not exist.
-        uint32_t next_id;  ///< On return, contains the next ID.
-    };                     ///< Attributes used by BPF_PROG_GET_NEXT_ID, BPF_MAP_GET_NEXT_ID, and BPF_LINK_GET_NEXT_ID.
+    sys_bpf_map_next_id_attr_t map_get_next_id, prog_get_next_id,
+        link_get_next_id; ///< Attributes used by BPF_PROG_GET_NEXT_ID, BPF_MAP_GET_NEXT_ID, and BPF_LINK_GET_NEXT_ID.
 
     // BPF_MAP_GET_FD_BY_ID
     uint32_t map_id; ///< ID of map for BPF_MAP_GET_FD_BY_ID to find.
@@ -182,34 +242,18 @@ union bpf_attr
     uint32_t link_id; ///< ID of link for BPF_LINK_GET_FD_BY_ID to find.
 
     // BPF_OBJ_GET_INFO_BY_FD
-    bpf_obj_info_attr_t info; ///< Attributes used by BPF_OBJ_GET_INFO_BY_FD.
+    sys_bpf_obj_info_attr_t info; ///< Attributes used by BPF_OBJ_GET_INFO_BY_FD.
 
     // BPF_LINK_DETACH
-    bpf_link_detach_attr_t link_detach; ///< Attributes used by BPF_LINK_DETACH.
+    sys_bpf_link_detach_attr_t link_detach; ///< Attributes used by BPF_LINK_DETACH.
 
     // BPF_PROG_BIND_MAP
-    bpf_prog_bind_map_attr_t prog_bind_map; ///< Attributes used by BPF_PROG_BIND_MAP.
+    sys_bpf_prog_bind_map_attr_t prog_bind_map; ///< Attributes used by BPF_PROG_BIND_MAP.
 
     // BPF_PROG_TEST_RUN
-    struct
-    {
-        uint32_t prog_fd;       ///< File descriptor of program to run.
-        uint32_t retval;        ///< On return, contains the return value of the program.
-        uint32_t data_size_in;  ///< Size in bytes of input data.
-        uint32_t data_size_out; ///< Size in bytes of output data.
-        uint64_t data_in;       ///< Pointer to input data.
-        uint64_t data_out;      ///< Pointer to output data.
-        uint32_t repeat;        ///< Number of times to repeat the program.
-        uint32_t duration;      ///< Duration in milliseconds to run the program.
-        uint32_t ctx_size_in;   ///< Size in bytes of input context.
-        uint32_t ctx_size_out;  ///< Size in bytes of output context.
-        uint64_t ctx_in;        ///< Pointer to input context.
-        uint64_t ctx_out;       ///< Pointer to output context.
-        uint32_t flags;         ///< Flags (currently 0).
-        uint32_t cpu;           ///< CPU to run the program on.
-        uint32_t batch_size;    ///< Number of times to run the program in a batch.
-    } test;                     ///< Attributes used by BPF_PROG_TEST_RUN.
+    sys_bpf_prog_run_attr_t test; ///< Attributes used by BPF_PROG_TEST_RUN.
 };
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -47,7 +47,8 @@ enum bpf_stats_type
 };
 
 // All types below must be ABI compatible with the Linux bpf() syscalls. This means
-// that the order, size and alignment of the types must match uapi/linux/bpf.h.
+// that the order, size and alignment of the types must match uapi/linux/bpf.h in
+// a tagged release of https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/.
 // Constants must also match.
 //
 // Names do not have to match, but try to keep them the same as much as possible.
@@ -100,7 +101,7 @@ typedef struct
     uint32_t _pad0;
     uint64_t key;   ///< Pointer to key to look up.
     uint64_t value; ///< Pointer to value.
-    uint64_t flags; ///< Not supported.
+    uint64_t flags; ///< Not supported, must be zero.
 } sys_bpf_map_lookup_attr_t;
 
 typedef struct
@@ -128,13 +129,13 @@ typedef struct
 {
     enum bpf_prog_type prog_type; ///< Program type to use for loading the program.
     uint32_t insn_cnt;            ///< Number of instructions in the array.
-    uint64_t insns;               ///< Array of instructions
+    uint64_t insns;               ///< Array of instructions.
     uint64_t license;      ///< Optional pointer to a string specifying the license (currently ignored on Windows).
     uint32_t log_level;    ///< Logging level (currently ignored on Windows).
     uint32_t log_size;     ///< Size in bytes of the log buffer.
     uint64_t log_buf;      ///< Pointer to a buffer in which log info can be written.
     uint32_t kern_version; ///< Kernel version (currently ignored on Windows).
-    uint32_t prog_flags;   ///< Not supported.
+    uint32_t prog_flags;   ///< Not supported, must be zero.
 } sys_bpf_prog_load_attr_t;
 
 typedef struct
@@ -169,7 +170,7 @@ typedef struct
 {
     uint64_t pathname; ///< Path name for pinning.
     uint32_t bpf_fd;   ///< File descriptor referring to the program or map.
-    uint32_t flags;    ///< Not supported.
+    uint32_t flags;    ///< Not supported, must be zero.
 } sys_bpf_obj_pin_attr_t;
 
 /// Attributes used by BPF_OBJ_GET_INFO_BY_FD.

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -6,188 +6,229 @@
 #include <windows.h>
 #include <WinError.h>
 #include <linux/bpf.h>
+#include <stdexcept>
 
-#define CHECK_SIZE(last_field_name)                                                    \
-    if (!tail_is_zero(                                                                 \
-            attr,                                                                      \
-            offsetof(union bpf_attr, last_field_name) + sizeof(attr->last_field_name), \
-            sizeof(union bpf_attr))) {                                                 \
-        return -EINVAL;                                                                \
-    }
-
-static bool
-tail_is_zero(const void* buf, unsigned int start, unsigned int end)
+template <typename T> class ExtensibleStruct
 {
-    const unsigned char* p = (const unsigned char*)buf + start;
-    const unsigned char* e = (const unsigned char*)buf + end;
+  private:
+    void* _orig;
+    size_t _orig_size;
+    T _tmp;
+    T* _p;
 
-    for (; p < e; p++) {
-        if ((*p) != 0) {
-            return false;
+    static void
+    check_tail(const void* buf, size_t start, size_t end)
+    {
+        const unsigned char* p = (const unsigned char*)buf + start;
+        const unsigned char* e = (const unsigned char*)buf + end;
+
+        for (; p < e; p++) {
+            if ((*p) != 0) {
+                throw std::runtime_error("Non-zero tail");
+            }
         }
     }
 
-    return true;
-}
+  public:
+    ExtensibleStruct(void* ptr, size_t ptr_size) : _orig(ptr)
+    {
+        if (ptr_size >= sizeof(T)) {
+            // Forward compatibility: allow a larger input as long as the
+            // unknown fields are all zero.
+            check_tail(ptr, sizeof(T), ptr_size);
+            _orig_size = 0;
+            _p = (T*)ptr;
+        } else {
+            // Backwards compatibility: allow a smaller input by implicitly zeroing all
+            // missing fields.
+            memcpy(&_tmp, ptr, ptr_size);
+            _orig_size = ptr_size;
+            _p = &_tmp;
+        }
+    }
+
+    ~ExtensibleStruct() { memcpy(_orig, &_tmp, _orig_size); }
+
+    T*
+    operator->()
+    {
+        return _p;
+    }
+
+    T*
+    operator&()
+    {
+        return _p;
+    }
+
+    T
+    operator*()
+    {
+        return *_p;
+    }
+};
 
 int
-bpf(int cmd, union bpf_attr* attr, unsigned int size)
+bpf(int cmd, union bpf_attr* p, unsigned int size)
 {
     // bpf() is ABI compatible with the Linux bpf() syscall.
     //
     // * Do not return errors via errno.
     // * Do not assume that bpf_attr has a particular size.
 
-    union bpf_attr* orig = attr;
-    union bpf_attr tmp = {};
-    int retval;
+    try {
+        switch (cmd) {
+        case BPF_LINK_DETACH: {
+            ExtensibleStruct<sys_bpf_link_detach_attr_t> attr((void*)p, (size_t)size);
+            return bpf_link_detach(attr->link_fd);
+        }
+        case BPF_LINK_GET_FD_BY_ID: {
+            ExtensibleStruct<uint32_t> link_id((void*)p, (size_t)size);
+            return bpf_link_get_fd_by_id(*link_id);
+        }
+        case BPF_LINK_GET_NEXT_ID: {
+            ExtensibleStruct<sys_bpf_map_next_id_attr_t> attr((void*)p, (size_t)size);
+            return bpf_link_get_next_id(attr->start_id, &attr->next_id);
+        }
+        case BPF_MAP_CREATE: {
+            ExtensibleStruct<sys_bpf_map_create_attr_t> attr((void*)p, (size_t)size);
+            struct bpf_map_create_opts opts = {.map_flags = attr->map_flags};
+            return bpf_map_create(attr->map_type, nullptr, attr->key_size, attr->value_size, attr->max_entries, &opts);
+        }
+        case BPF_MAP_DELETE_ELEM: {
+            ExtensibleStruct<sys_bpf_map_delete_attr_t> attr((void*)p, (size_t)size);
+            return bpf_map_delete_elem(attr->map_fd, (const void*)attr->key);
+        }
+        case BPF_MAP_GET_FD_BY_ID: {
+            ExtensibleStruct<uint32_t> map_id((void*)p, (size_t)size);
+            return bpf_map_get_fd_by_id(*map_id);
+        }
+        case BPF_MAP_GET_NEXT_ID: {
+            ExtensibleStruct<sys_bpf_map_next_id_attr_t> attr((void*)p, (size_t)size);
+            return bpf_map_get_next_id(attr->start_id, &attr->next_id);
+        }
+        case BPF_MAP_GET_NEXT_KEY: {
+            ExtensibleStruct<sys_bpf_map_next_key_attr_t> attr((void*)p, (size_t)size);
+            return bpf_map_get_next_key(attr->map_fd, (const void*)attr->key, (void*)attr->next_key);
+        }
+        case BPF_MAP_LOOKUP_ELEM: {
+            ExtensibleStruct<sys_bpf_map_lookup_attr_t> attr((void*)p, (size_t)size);
 
-    if (size > sizeof(tmp)) {
-        // Forward compatibility: allow a larger input as long as the
-        // unknown fields are all zero.
-        if (!tail_is_zero(attr, sizeof(tmp), size)) {
+            if (attr->flags != 0) {
+                return -EINVAL;
+            }
+
+            return bpf_map_lookup_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+        }
+        case BPF_MAP_LOOKUP_AND_DELETE_ELEM: {
+            ExtensibleStruct<sys_bpf_map_lookup_attr_t> attr((void*)p, (size_t)size);
+
+            if (attr->flags != 0) {
+                return -EINVAL;
+            }
+
+            return bpf_map_lookup_and_delete_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+        }
+        case BPF_MAP_UPDATE_ELEM: {
+            ExtensibleStruct<sys_bpf_map_lookup_attr_t> attr((void*)p, (size_t)size);
+            return bpf_map_update_elem(attr->map_fd, (const void*)attr->key, (const void*)attr->value, attr->flags);
+        }
+        case BPF_OBJ_GET: {
+            ExtensibleStruct<sys_bpf_obj_pin_attr_t> attr((void*)p, (size_t)size);
+            if (attr->bpf_fd != 0 || attr->flags != 0) {
+                return -EINVAL;
+            }
+            return bpf_obj_get((const char*)attr->pathname);
+        }
+        case BPF_PROG_ATTACH: {
+            ExtensibleStruct<sys_bpf_prog_attach_attr_t> attr((void*)p, (size_t)size);
+            return bpf_prog_attach(attr->attach_bpf_fd, attr->target_fd, attr->attach_type, attr->attach_flags);
+        }
+        case BPF_PROG_DETACH: {
+            ExtensibleStruct<sys_bpf_prog_attach_attr_t> attr((void*)p, (size_t)size);
+            return bpf_prog_detach(attr->target_fd, attr->attach_type);
+        }
+        case BPF_OBJ_GET_INFO_BY_FD: {
+            ExtensibleStruct<sys_bpf_obj_info_attr_t> attr((void*)p, (size_t)size);
+            return bpf_obj_get_info_by_fd(attr->bpf_fd, (void*)attr->info, &attr->info_len);
+        }
+        case BPF_OBJ_PIN: {
+            ExtensibleStruct<sys_bpf_obj_pin_attr_t> attr((void*)p, (size_t)size);
+
+            if (attr->flags != 0) {
+                return -EINVAL;
+            }
+
+            return bpf_obj_pin(attr->bpf_fd, (const char*)attr->pathname);
+        }
+        case BPF_PROG_BIND_MAP: {
+            ExtensibleStruct<sys_bpf_prog_bind_map_attr_t> attr((void*)p, (size_t)size);
+            struct bpf_prog_bind_opts opts = {sizeof(struct bpf_prog_bind_opts), attr->flags};
+            return bpf_prog_bind_map(attr->prog_fd, attr->map_fd, &opts);
+        }
+        case BPF_PROG_GET_FD_BY_ID: {
+            ExtensibleStruct<uint32_t> prog_id((void*)p, (size_t)size);
+            return bpf_prog_get_fd_by_id(*prog_id);
+        }
+        case BPF_PROG_GET_NEXT_ID: {
+            ExtensibleStruct<sys_bpf_map_next_id_attr_t> attr((void*)p, (size_t)size);
+            return bpf_prog_get_next_id(attr->start_id, &attr->next_id);
+        }
+        case BPF_PROG_LOAD: {
+            ExtensibleStruct<sys_bpf_prog_load_attr_t> attr((void*)p, (size_t)size);
+
+            if (attr->prog_flags != 0) {
+                return -EINVAL;
+            }
+
+            struct bpf_prog_load_opts opts = {
+                .kern_version = attr->kern_version, .log_size = attr->log_size, .log_buf = (char*)attr->log_buf};
+            return bpf_prog_load(
+                attr->prog_type,
+                nullptr,
+                (const char*)attr->license,
+                (const struct bpf_insn*)attr->insns,
+                attr->insn_cnt,
+                &opts);
+        }
+        case BPF_PROG_TEST_RUN: {
+            ExtensibleStruct<sys_bpf_prog_run_attr_t> attr((void*)p, (size_t)size);
+
+            if (attr->_pad0 != 0) {
+                return -EINVAL;
+            }
+
+            bpf_test_run_opts test_run_opts = {
+                .sz = sizeof(bpf_test_run_opts),
+                .data_in = (void*)attr->data_in,
+                .data_out = (void*)attr->data_out,
+                .data_size_in = attr->data_size_in,
+                .data_size_out = attr->data_size_out,
+                .ctx_in = (void*)attr->ctx_in,
+                .ctx_out = (void*)attr->ctx_out,
+                .ctx_size_in = attr->ctx_size_in,
+                .ctx_size_out = attr->ctx_size_out,
+                .repeat = (int)(attr->repeat),
+                .flags = attr->flags,
+                .cpu = attr->cpu,
+                .batch_size = attr->batch_size,
+            };
+
+            int retval = bpf_prog_test_run_opts(attr->prog_fd, &test_run_opts);
+            if (retval == 0) {
+                attr->data_size_out = test_run_opts.data_size_out;
+                attr->ctx_size_out = test_run_opts.ctx_size_out;
+                attr->retval = test_run_opts.retval;
+                attr->duration = test_run_opts.duration;
+            }
+
+            return retval;
+        }
+        default:
+            SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
             return -EINVAL;
         }
-    } else {
-        // Backwards compatibility: allow a smaller input by implicitly zeroing all
-        // missing fields.
-        memcpy(&tmp, attr, size);
-        attr = &tmp;
-    }
-
-    switch (cmd) {
-    case BPF_LINK_DETACH:
-        CHECK_SIZE(link_detach.link_fd);
-        retval = bpf_link_detach(attr->link_detach.link_fd);
-        break;
-    case BPF_LINK_GET_FD_BY_ID:
-        CHECK_SIZE(link_id);
-        retval = bpf_link_get_fd_by_id(attr->link_id);
-        break;
-    case BPF_LINK_GET_NEXT_ID:
-        CHECK_SIZE(next_id);
-        retval = bpf_link_get_next_id(attr->start_id, &attr->next_id);
-        break;
-    case BPF_MAP_CREATE: {
-        CHECK_SIZE(map_flags);
-        struct bpf_map_create_opts opts = {.map_flags = attr->map_flags};
-        retval = bpf_map_create(attr->map_type, nullptr, attr->key_size, attr->value_size, attr->max_entries, &opts);
-        break;
-    }
-    case BPF_MAP_DELETE_ELEM:
-        CHECK_SIZE(key);
-        retval = bpf_map_delete_elem(attr->map_fd, (const void*)attr->key);
-        break;
-    case BPF_MAP_GET_FD_BY_ID:
-        CHECK_SIZE(map_id);
-        retval = bpf_map_get_fd_by_id(attr->map_id);
-        break;
-    case BPF_MAP_GET_NEXT_ID:
-        CHECK_SIZE(next_id);
-        retval = bpf_map_get_next_id(attr->start_id, &attr->next_id);
-        break;
-    case BPF_MAP_GET_NEXT_KEY:
-        CHECK_SIZE(next_key);
-        retval = bpf_map_get_next_key(attr->map_fd, (const void*)attr->key, (void*)attr->next_key);
-        break;
-    case BPF_MAP_LOOKUP_ELEM:
-        CHECK_SIZE(value);
-        retval = bpf_map_lookup_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
-        break;
-    case BPF_MAP_LOOKUP_AND_DELETE_ELEM:
-        CHECK_SIZE(value);
-        retval = bpf_map_lookup_and_delete_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
-        break;
-    case BPF_MAP_UPDATE_ELEM:
-        CHECK_SIZE(flags);
-        retval = bpf_map_update_elem(attr->map_fd, (const void*)attr->key, (const void*)attr->value, attr->flags);
-        break;
-    case BPF_OBJ_GET:
-        CHECK_SIZE(bpf_fd);
-        if (attr->bpf_fd != 0) {
-            retval = -EINVAL;
-            break;
-        }
-        retval = bpf_obj_get((const char*)attr->pathname);
-        break;
-    case BPF_PROG_ATTACH: {
-        CHECK_SIZE(attach_flags);
-        retval = bpf_prog_attach(attr->attach_bpf_fd, attr->target_fd, attr->attach_type, attr->attach_flags);
-        break;
-    }
-    case BPF_PROG_DETACH: {
-        CHECK_SIZE(attach_type);
-        retval = bpf_prog_detach(attr->target_fd, attr->attach_type);
-        break;
-    }
-    case BPF_OBJ_GET_INFO_BY_FD:
-        CHECK_SIZE(info.info_len);
-        retval = bpf_obj_get_info_by_fd(attr->info.bpf_fd, (void*)attr->info.info, &attr->info.info_len);
-        break;
-    case BPF_OBJ_PIN:
-        CHECK_SIZE(bpf_fd);
-        retval = bpf_obj_pin(attr->bpf_fd, (const char*)attr->pathname);
-        break;
-    case BPF_PROG_BIND_MAP: {
-        CHECK_SIZE(prog_bind_map.flags);
-        struct bpf_prog_bind_opts opts = {sizeof(struct bpf_prog_bind_opts), attr->prog_bind_map.flags};
-        retval = bpf_prog_bind_map(attr->prog_bind_map.prog_fd, attr->prog_bind_map.map_fd, &opts);
-        break;
-    }
-    case BPF_PROG_GET_FD_BY_ID:
-        CHECK_SIZE(prog_id);
-        retval = bpf_prog_get_fd_by_id(attr->prog_id);
-        break;
-    case BPF_PROG_GET_NEXT_ID:
-        CHECK_SIZE(next_id);
-        retval = bpf_prog_get_next_id(attr->start_id, &attr->next_id);
-        break;
-    case BPF_PROG_LOAD: {
-        CHECK_SIZE(kern_version);
-        struct bpf_prog_load_opts opts = {
-            .kern_version = attr->kern_version, .log_size = attr->log_size, .log_buf = (char*)attr->log_buf};
-        retval = bpf_prog_load(
-            attr->prog_type,
-            nullptr,
-            (const char*)attr->license,
-            (const struct bpf_insn*)attr->insns,
-            attr->insn_cnt,
-            &opts);
-        break;
-    }
-    case BPF_PROG_TEST_RUN: {
-        bpf_test_run_opts test_run_opts = {
-            .sz = sizeof(bpf_test_run_opts),
-            .data_in = (void*)attr->test.data_in,
-            .data_out = (void*)attr->test.data_out,
-            .data_size_in = attr->test.data_size_in,
-            .data_size_out = attr->test.data_size_out,
-            .ctx_in = (void*)attr->test.ctx_in,
-            .ctx_out = (void*)attr->test.ctx_out,
-            .ctx_size_in = attr->test.ctx_size_in,
-            .ctx_size_out = attr->test.ctx_size_out,
-            .repeat = (int)(attr->test.repeat),
-            .flags = attr->test.flags,
-            .cpu = attr->test.cpu,
-            .batch_size = attr->test.batch_size,
-        };
-        retval = bpf_prog_test_run_opts(attr->test.prog_fd, &test_run_opts);
-        if (retval == 0) {
-            attr->test.data_size_out = test_run_opts.data_size_out;
-            attr->test.ctx_size_out = test_run_opts.ctx_size_out;
-            attr->test.retval = test_run_opts.retval;
-            attr->test.duration = test_run_opts.duration;
-        }
-        break;
-    }
-    default:
-        SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+    } catch (...) {
         return -EINVAL;
     }
-
-    if (attr != orig) {
-        memcpy(orig, attr, size);
-    }
-
-    return retval;
 }

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -14,14 +14,14 @@ template <typename T> class ExtensibleStruct
   private:
     void* _source;
     size_t _copy_size;
-    T _tmp;
-    T* _ptr;
+    T _temporary;
+    T* _pointer;
 
     static void
-    check_tail(_In_reads_bytes_(end) const void* buf, size_t start, size_t end)
+    check_tail(_In_reads_bytes_(end) const void* buffer, size_t start, size_t end)
     {
-        const unsigned char* p = (const unsigned char*)buf + start;
-        const unsigned char* e = (const unsigned char*)buf + end;
+        const unsigned char* p = (const unsigned char*)buffer + start;
+        const unsigned char* e = (const unsigned char*)buffer + end;
 
         for (; p < e; p++) {
             if ((*p) != 0) {
@@ -31,46 +31,46 @@ template <typename T> class ExtensibleStruct
     }
 
   public:
-    ExtensibleStruct(_In_reads_bytes_(ptr_size) void* ptr, size_t ptr_size) : _source(ptr)
+    ExtensibleStruct(_In_reads_bytes_(size) void* pointer, size_t size) : _source(pointer)
     {
-        if (ptr_size >= sizeof(T)) {
+        if (size >= sizeof(T)) {
             // Forward compatibility: allow a larger input as long as the
             // unknown fields are all zero.
-            check_tail(ptr, sizeof(T), ptr_size);
+            check_tail(pointer, sizeof(T), size);
             _copy_size = 0;
-            _ptr = (T*)ptr;
+            _pointer = (T*)pointer;
         } else {
             // Backwards compatibility: allow a smaller input by implicitly zeroing all
             // missing fields.
-            memcpy(&_tmp, ptr, ptr_size);
-            _copy_size = ptr_size;
-            _ptr = &_tmp;
+            memcpy(&_temporary, pointer, size);
+            _copy_size = size;
+            _pointer = &_temporary;
         }
     }
 
-    ~ExtensibleStruct() { memcpy(_source, &_tmp, _copy_size); }
+    ~ExtensibleStruct() { memcpy(_source, &_temporary, _copy_size); }
 
     T*
     operator->()
     {
-        return _ptr;
+        return _pointer;
     }
 
     T*
     operator&()
     {
-        return _ptr;
+        return _pointer;
     }
 
     T
     operator*()
     {
-        return *_ptr;
+        return *_pointer;
     }
 };
 
 int
-bpf(int cmd, union bpf_attr* p, unsigned int size)
+bpf(int cmd, union bpf_attr* attr, unsigned int size)
 {
     // bpf() is ABI compatible with the Linux bpf() syscall.
     //
@@ -80,147 +80,171 @@ bpf(int cmd, union bpf_attr* p, unsigned int size)
     try {
         switch (cmd) {
         case BPF_LINK_DETACH: {
-            ExtensibleStruct<sys_bpf_link_detach_attr_t> attr((void*)p, (size_t)size);
-            return bpf_link_detach(attr->link_fd);
+            ExtensibleStruct<sys_bpf_link_detach_attr_t> detach_attr((void*)attr, (size_t)size);
+            return bpf_link_detach(detach_attr->link_fd);
         }
         case BPF_LINK_GET_FD_BY_ID: {
-            ExtensibleStruct<uint32_t> link_id((void*)p, (size_t)size);
+            ExtensibleStruct<uint32_t> link_id((void*)attr, (size_t)size);
             return bpf_link_get_fd_by_id(*link_id);
         }
         case BPF_LINK_GET_NEXT_ID: {
-            ExtensibleStruct<sys_bpf_map_next_id_attr_t> attr((void*)p, (size_t)size);
-            return bpf_link_get_next_id(attr->start_id, &attr->next_id);
+            ExtensibleStruct<sys_bpf_map_next_id_attr_t> next_id_attr((void*)attr, (size_t)size);
+            return bpf_link_get_next_id(next_id_attr->start_id, &next_id_attr->next_id);
         }
         case BPF_MAP_CREATE: {
-            ExtensibleStruct<sys_bpf_map_create_attr_t> attr((void*)p, (size_t)size);
-            struct bpf_map_create_opts opts = {.map_flags = attr->map_flags};
-            return bpf_map_create(attr->map_type, nullptr, attr->key_size, attr->value_size, attr->max_entries, &opts);
+            ExtensibleStruct<sys_bpf_map_create_attr_t> map_create_attr((void*)attr, (size_t)size);
+            struct bpf_map_create_opts opts = {.map_flags = map_create_attr->map_flags};
+            return bpf_map_create(
+                map_create_attr->map_type,
+                nullptr,
+                map_create_attr->key_size,
+                map_create_attr->value_size,
+                map_create_attr->max_entries,
+                &opts);
         }
         case BPF_MAP_DELETE_ELEM: {
-            ExtensibleStruct<sys_bpf_map_delete_attr_t> attr((void*)p, (size_t)size);
-            return bpf_map_delete_elem(attr->map_fd, (const void*)attr->key);
+            ExtensibleStruct<sys_bpf_map_delete_attr_t> map_delete_attr((void*)attr, (size_t)size);
+            return bpf_map_delete_elem(map_delete_attr->map_fd, (const void*)map_delete_attr->key);
         }
         case BPF_MAP_GET_FD_BY_ID: {
-            ExtensibleStruct<uint32_t> map_id((void*)p, (size_t)size);
+            ExtensibleStruct<uint32_t> map_id((void*)attr, (size_t)size);
             return bpf_map_get_fd_by_id(*map_id);
         }
         case BPF_MAP_GET_NEXT_ID: {
-            ExtensibleStruct<sys_bpf_map_next_id_attr_t> attr((void*)p, (size_t)size);
-            return bpf_map_get_next_id(attr->start_id, &attr->next_id);
+            ExtensibleStruct<sys_bpf_map_next_id_attr_t> next_id_attr((void*)attr, (size_t)size);
+            return bpf_map_get_next_id(next_id_attr->start_id, &next_id_attr->next_id);
         }
         case BPF_MAP_GET_NEXT_KEY: {
-            ExtensibleStruct<sys_bpf_map_next_key_attr_t> attr((void*)p, (size_t)size);
-            return bpf_map_get_next_key(attr->map_fd, (const void*)attr->key, (void*)attr->next_key);
+            ExtensibleStruct<sys_bpf_map_next_key_attr_t> next_key_attr((void*)attr, (size_t)size);
+            return bpf_map_get_next_key(
+                next_key_attr->map_fd, (const void*)next_key_attr->key, (void*)next_key_attr->next_key);
         }
         case BPF_MAP_LOOKUP_ELEM: {
-            ExtensibleStruct<sys_bpf_map_lookup_attr_t> attr((void*)p, (size_t)size);
+            ExtensibleStruct<sys_bpf_map_lookup_attr_t> lookup_elem_attr((void*)attr, (size_t)size);
 
-            if (attr->flags != 0) {
+            if (lookup_elem_attr->flags != 0) {
                 return -EINVAL;
             }
 
-            return bpf_map_lookup_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+            return bpf_map_lookup_elem(
+                lookup_elem_attr->map_fd, (const void*)lookup_elem_attr->key, (void*)lookup_elem_attr->value);
         }
         case BPF_MAP_LOOKUP_AND_DELETE_ELEM: {
-            ExtensibleStruct<sys_bpf_map_lookup_attr_t> attr((void*)p, (size_t)size);
+            ExtensibleStruct<sys_bpf_map_lookup_attr_t> lookup_and_delete_attr((void*)attr, (size_t)size);
 
-            if (attr->flags != 0) {
+            if (lookup_and_delete_attr->flags != 0) {
                 return -EINVAL;
             }
 
-            return bpf_map_lookup_and_delete_elem(attr->map_fd, (const void*)attr->key, (void*)attr->value);
+            return bpf_map_lookup_and_delete_elem(
+                lookup_and_delete_attr->map_fd,
+                (const void*)lookup_and_delete_attr->key,
+                (void*)lookup_and_delete_attr->value);
         }
         case BPF_MAP_UPDATE_ELEM: {
-            ExtensibleStruct<sys_bpf_map_lookup_attr_t> attr((void*)p, (size_t)size);
-            return bpf_map_update_elem(attr->map_fd, (const void*)attr->key, (const void*)attr->value, attr->flags);
+            ExtensibleStruct<sys_bpf_map_lookup_attr_t> update_elem_attr((void*)attr, (size_t)size);
+            return bpf_map_update_elem(
+                update_elem_attr->map_fd,
+                (const void*)update_elem_attr->key,
+                (const void*)update_elem_attr->value,
+                update_elem_attr->flags);
         }
         case BPF_OBJ_GET: {
-            ExtensibleStruct<sys_bpf_obj_pin_attr_t> attr((void*)p, (size_t)size);
-            if (attr->bpf_fd != 0 || attr->flags != 0) {
+            ExtensibleStruct<sys_bpf_obj_pin_attr_t> obj_get_attr((void*)attr, (size_t)size);
+            if (obj_get_attr->bpf_fd != 0 || obj_get_attr->flags != 0) {
                 return -EINVAL;
             }
-            return bpf_obj_get((const char*)attr->pathname);
+            return bpf_obj_get((const char*)obj_get_attr->pathname);
         }
         case BPF_PROG_ATTACH: {
-            ExtensibleStruct<sys_bpf_prog_attach_attr_t> attr((void*)p, (size_t)size);
-            return bpf_prog_attach(attr->attach_bpf_fd, attr->target_fd, attr->attach_type, attr->attach_flags);
+            ExtensibleStruct<sys_bpf_prog_attach_attr_t> prog_attach_attr((void*)attr, (size_t)size);
+            return bpf_prog_attach(
+                prog_attach_attr->attach_bpf_fd,
+                prog_attach_attr->target_fd,
+                prog_attach_attr->attach_type,
+                prog_attach_attr->attach_flags);
         }
         case BPF_PROG_DETACH: {
-            ExtensibleStruct<sys_bpf_prog_attach_attr_t> attr((void*)p, (size_t)size);
-            return bpf_prog_detach(attr->target_fd, attr->attach_type);
+            ExtensibleStruct<sys_bpf_prog_attach_attr_t> prog_detach_attr((void*)attr, (size_t)size);
+            return bpf_prog_detach(prog_detach_attr->target_fd, prog_detach_attr->attach_type);
         }
         case BPF_OBJ_GET_INFO_BY_FD: {
-            ExtensibleStruct<sys_bpf_obj_info_attr_t> attr((void*)p, (size_t)size);
-            return bpf_obj_get_info_by_fd(attr->bpf_fd, (void*)attr->info, &attr->info_len);
+            ExtensibleStruct<sys_bpf_obj_info_attr_t> info_by_fd_attr((void*)attr, (size_t)size);
+            return bpf_obj_get_info_by_fd(
+                info_by_fd_attr->bpf_fd, (void*)info_by_fd_attr->info, &info_by_fd_attr->info_len);
         }
         case BPF_OBJ_PIN: {
-            ExtensibleStruct<sys_bpf_obj_pin_attr_t> attr((void*)p, (size_t)size);
+            ExtensibleStruct<sys_bpf_obj_pin_attr_t> obj_pin_attr((void*)attr, (size_t)size);
 
-            if (attr->flags != 0) {
+            if (obj_pin_attr->flags != 0) {
                 return -EINVAL;
             }
 
-            return bpf_obj_pin(attr->bpf_fd, (const char*)attr->pathname);
+            return bpf_obj_pin(obj_pin_attr->bpf_fd, (const char*)obj_pin_attr->pathname);
         }
         case BPF_PROG_BIND_MAP: {
-            ExtensibleStruct<sys_bpf_prog_bind_map_attr_t> attr((void*)p, (size_t)size);
-            struct bpf_prog_bind_opts opts = {sizeof(struct bpf_prog_bind_opts), attr->flags};
-            return bpf_prog_bind_map(attr->prog_fd, attr->map_fd, &opts);
+            ExtensibleStruct<sys_bpf_prog_bind_map_attr_t> bind_map_attr((void*)attr, (size_t)size);
+            struct bpf_prog_bind_opts opts = {sizeof(struct bpf_prog_bind_opts), bind_map_attr->flags};
+            return bpf_prog_bind_map(bind_map_attr->prog_fd, bind_map_attr->map_fd, &opts);
         }
         case BPF_PROG_GET_FD_BY_ID: {
-            ExtensibleStruct<uint32_t> prog_id((void*)p, (size_t)size);
+            ExtensibleStruct<uint32_t> prog_id((void*)attr, (size_t)size);
             return bpf_prog_get_fd_by_id(*prog_id);
         }
         case BPF_PROG_GET_NEXT_ID: {
-            ExtensibleStruct<sys_bpf_map_next_id_attr_t> attr((void*)p, (size_t)size);
-            return bpf_prog_get_next_id(attr->start_id, &attr->next_id);
+            ExtensibleStruct<sys_bpf_map_next_id_attr_t> next_id_attr((void*)attr, (size_t)size);
+            return bpf_prog_get_next_id(next_id_attr->start_id, &next_id_attr->next_id);
         }
         case BPF_PROG_LOAD: {
-            ExtensibleStruct<sys_bpf_prog_load_attr_t> attr((void*)p, (size_t)size);
+            ExtensibleStruct<sys_bpf_prog_load_attr_t> prog_load_attr((void*)attr, (size_t)size);
 
-            if (attr->prog_flags != 0) {
+            if (prog_load_attr->prog_flags != 0) {
                 return -EINVAL;
             }
 
             struct bpf_prog_load_opts opts = {
-                .kern_version = attr->kern_version, .log_size = attr->log_size, .log_buf = (char*)attr->log_buf};
+                .kern_version = prog_load_attr->kern_version,
+                .log_size = prog_load_attr->log_size,
+                .log_buf = (char*)prog_load_attr->log_buf,
+            };
+
             return bpf_prog_load(
-                attr->prog_type,
+                prog_load_attr->prog_type,
                 nullptr,
-                (const char*)attr->license,
-                (const struct bpf_insn*)attr->insns,
-                attr->insn_cnt,
+                (const char*)prog_load_attr->license,
+                (const struct bpf_insn*)prog_load_attr->insns,
+                prog_load_attr->insn_cnt,
                 &opts);
         }
         case BPF_PROG_TEST_RUN: {
-            ExtensibleStruct<sys_bpf_prog_run_attr_t> attr((void*)p, (size_t)size);
+            ExtensibleStruct<sys_bpf_prog_run_attr_t> prog_run((void*)attr, (size_t)size);
 
-            if (attr->_pad0 != 0) {
+            if (prog_run->_pad0 != 0) {
                 return -EINVAL;
             }
 
             bpf_test_run_opts test_run_opts = {
                 .sz = sizeof(bpf_test_run_opts),
-                .data_in = (void*)attr->data_in,
-                .data_out = (void*)attr->data_out,
-                .data_size_in = attr->data_size_in,
-                .data_size_out = attr->data_size_out,
-                .ctx_in = (void*)attr->ctx_in,
-                .ctx_out = (void*)attr->ctx_out,
-                .ctx_size_in = attr->ctx_size_in,
-                .ctx_size_out = attr->ctx_size_out,
-                .repeat = (int)(attr->repeat),
-                .flags = attr->flags,
-                .cpu = attr->cpu,
-                .batch_size = attr->batch_size,
+                .data_in = (void*)prog_run->data_in,
+                .data_out = (void*)prog_run->data_out,
+                .data_size_in = prog_run->data_size_in,
+                .data_size_out = prog_run->data_size_out,
+                .ctx_in = (void*)prog_run->ctx_in,
+                .ctx_out = (void*)prog_run->ctx_out,
+                .ctx_size_in = prog_run->ctx_size_in,
+                .ctx_size_out = prog_run->ctx_size_out,
+                .repeat = (int)(prog_run->repeat),
+                .flags = prog_run->flags,
+                .cpu = prog_run->cpu,
+                .batch_size = prog_run->batch_size,
             };
 
-            int retval = bpf_prog_test_run_opts(attr->prog_fd, &test_run_opts);
+            int retval = bpf_prog_test_run_opts(prog_run->prog_fd, &test_run_opts);
             if (retval == 0) {
-                attr->data_size_out = test_run_opts.data_size_out;
-                attr->ctx_size_out = test_run_opts.ctx_size_out;
-                attr->retval = test_run_opts.retval;
-                attr->duration = test_run_opts.duration;
+                prog_run->data_size_out = test_run_opts.data_size_out;
+                prog_run->ctx_size_out = test_run_opts.ctx_size_out;
+                prog_run->retval = test_run_opts.retval;
+                prog_run->duration = test_run_opts.duration;
             }
 
             return retval;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2161,7 +2161,7 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     // Now enumerate the IDs.
     memset(&attr, 0, sizeof(attr));
     REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) == 0);
-    uint32_t id1 = attr.next_id;
+    uint32_t id1 = attr.link_get_next_id.next_id;
 
     memset(&attr, 0, sizeof(attr));
     attr.link_id = id1;
@@ -2169,7 +2169,7 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     REQUIRE(fd1 >= 0);
 
     REQUIRE(bpf(BPF_LINK_GET_NEXT_ID, &attr, sizeof(attr)) == 0);
-    uint32_t id2 = attr.next_id;
+    uint32_t id2 = attr.link_get_next_id.next_id;
 
     memset(&attr, 0, sizeof(attr));
     attr.link_id = id2;
@@ -2202,15 +2202,15 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
 
     // Pin the detached link.
     memset(&attr, 0, sizeof(attr));
-    attr.bpf_fd = fd1;
-    attr.pathname = (uintptr_t) "MyPath";
+    attr.obj_pin.bpf_fd = fd1;
+    attr.obj_pin.pathname = (uintptr_t) "MyPath";
     REQUIRE(bpf(BPF_OBJ_PIN, &attr, sizeof(attr)) == 0);
 
     // Verify that bpf_fd must be 0 when calling BPF_OBJ_GET.
     REQUIRE(bpf(BPF_OBJ_GET, &attr, sizeof(attr)) == -EINVAL);
 
     // Retrieve a new fd from the pin path.
-    attr.bpf_fd = 0;
+    attr.obj_pin.bpf_fd = 0;
     fd_t fd3 = bpf(BPF_OBJ_GET, &attr, sizeof(attr));
     REQUIRE(fd3 > 0);
 
@@ -2862,14 +2862,14 @@ TEST_CASE("bpf() backwards compatibility", "[libbpf]")
     } tmp = {};
     union bpf_attr* attr = &tmp.attr;
 
-    attr->map_type = BPF_MAP_TYPE_ARRAY;
-    attr->key_size = sizeof(uint32_t);
-    attr->value_size = sizeof(uint32_t);
-    attr->max_entries = 2;
-    attr->map_flags = 0;
+    attr->map_create.map_type = BPF_MAP_TYPE_ARRAY;
+    attr->map_create.key_size = sizeof(uint32_t);
+    attr->map_create.value_size = sizeof(uint32_t);
+    attr->map_create.max_entries = 2;
+    attr->map_create.map_flags = 0;
 
     // Truncate bpf_attr before map_flags.
-    int map_fd = bpf(BPF_MAP_CREATE, attr, offsetof(union bpf_attr, map_flags));
+    int map_fd = bpf(BPF_MAP_CREATE, attr, offsetof(union bpf_attr, map_create.map_flags));
     REQUIRE(map_fd > 0);
     Platform::_close(map_fd);
 
@@ -2900,9 +2900,9 @@ TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf]")
 
     // Load and verify the eBPF program.
     union bpf_attr attr = {};
-    attr.prog_type = BPF_PROG_TYPE_SAMPLE;
-    attr.insns = (uintptr_t)instructions;
-    attr.insn_cnt = _countof(instructions);
+    attr.prog_load.prog_type = BPF_PROG_TYPE_SAMPLE;
+    attr.prog_load.insns = (uintptr_t)instructions;
+    attr.prog_load.insn_cnt = _countof(instructions);
     int program_fd = bpf(BPF_PROG_LOAD, &attr, sizeof(attr));
     REQUIRE(program_fd >= 0);
 
@@ -2919,9 +2919,9 @@ TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf]")
 
     // Verify we can enumerate the program id.
     memset(&attr, 0, sizeof(attr));
-    attr.start_id = 0;
+    attr.prog_get_next_id.start_id = 0;
     REQUIRE(bpf(BPF_PROG_GET_NEXT_ID, &attr, sizeof(attr)) == 0);
-    REQUIRE(attr.next_id == program_info.id);
+    REQUIRE(attr.prog_get_next_id.next_id == program_info.id);
 
     // Verify we can convert the program id to an fd.
     memset(&attr, 0, sizeof(attr));
@@ -2932,11 +2932,11 @@ TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf]")
 
     // Create a map.
     memset(&attr, 0, sizeof(attr));
-    attr.map_type = BPF_MAP_TYPE_ARRAY;
-    attr.key_size = sizeof(uint32_t);
-    attr.value_size = sizeof(uint32_t);
-    attr.max_entries = 2;
-    attr.map_flags = 0;
+    attr.map_create.map_type = BPF_MAP_TYPE_ARRAY;
+    attr.map_create.key_size = sizeof(uint32_t);
+    attr.map_create.value_size = sizeof(uint32_t);
+    attr.map_create.max_entries = 2;
+    attr.map_create.map_flags = 0;
     int map_fd = bpf(BPF_MAP_CREATE, &attr, sizeof(attr));
     REQUIRE(map_fd > 0);
 
@@ -2951,9 +2951,9 @@ TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf]")
 
     // Verify we can enumerate the map id.
     memset(&attr, 0, sizeof(attr));
-    attr.start_id = 0;
+    attr.map_get_next_id.start_id = 0;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_ID, &attr, sizeof(attr)) == 0);
-    REQUIRE(attr.next_id == map_id);
+    REQUIRE(attr.map_get_next_id.next_id == map_id);
 
     // Verify we can convert the map id to an fd.
     memset(&attr, 0, sizeof(attr));
@@ -2996,31 +2996,31 @@ TEST_CASE("BPF_PROG_ATTACH", "[libbpf]")
 
     // Verify we can't attach the program using an attach type that doesn't work with this API.
     memset(&attr, 0, sizeof(attr));
-    attr.attach_bpf_fd = program_fd;
-    attr.target_fd = program_fd;
-    attr.attach_flags = 0;
-    attr.attach_type = BPF_ATTACH_TYPE_SAMPLE;
+    attr.prog_attach.attach_bpf_fd = program_fd;
+    attr.prog_attach.target_fd = program_fd;
+    attr.prog_attach.attach_flags = 0;
+    attr.prog_attach.attach_type = BPF_ATTACH_TYPE_SAMPLE;
     REQUIRE(bpf(BPF_PROG_ATTACH, &attr, sizeof(attr)) == -ENOTSUP);
 
     // Verify we can attach the program.
     memset(&attr, 0, sizeof(attr));
-    attr.attach_bpf_fd = program_fd;
+    attr.prog_attach.attach_bpf_fd = program_fd;
     // TODO (issue #1028): Currently the target_fd is treated as a compartment id.
-    attr.target_fd = program_fd;
-    attr.attach_flags = 0;
-    attr.attach_type = BPF_CGROUP_INET4_CONNECT;
+    attr.prog_attach.target_fd = program_fd;
+    attr.prog_attach.attach_flags = 0;
+    attr.prog_attach.attach_type = BPF_CGROUP_INET4_CONNECT;
     REQUIRE(bpf(BPF_PROG_ATTACH, &attr, sizeof(attr)) == 0);
 
     // Verify we can detach the program.
     memset(&attr, 0, sizeof(attr));
-    attr.target_fd = program_fd;
-    attr.attach_type = BPF_CGROUP_INET4_CONNECT;
+    attr.prog_detach.target_fd = program_fd;
+    attr.prog_detach.attach_type = BPF_CGROUP_INET4_CONNECT;
     REQUIRE(bpf(BPF_PROG_DETACH, &attr, sizeof(attr)) == 0);
 
     // Verify we can't detach the program using a type that doesn't work with this API.
     memset(&attr, 0, sizeof(attr));
-    attr.target_fd = program_fd;
-    attr.attach_type = BPF_ATTACH_TYPE_SAMPLE;
+    attr.prog_detach.target_fd = program_fd;
+    attr.prog_detach.attach_type = BPF_ATTACH_TYPE_SAMPLE;
     REQUIRE(bpf(BPF_PROG_DETACH, &attr, sizeof(attr)) == -ENOTSUP);
 }
 #endif
@@ -3035,11 +3035,11 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
 
     // Create a hash map.
     union bpf_attr attr = {};
-    attr.map_type = BPF_MAP_TYPE_HASH;
-    attr.key_size = sizeof(uint32_t);
-    attr.value_size = sizeof(uint32_t);
-    attr.max_entries = 3;
-    attr.map_flags = 0;
+    attr.map_create.map_type = BPF_MAP_TYPE_HASH;
+    attr.map_create.key_size = sizeof(uint32_t);
+    attr.map_create.value_size = sizeof(uint32_t);
+    attr.map_create.max_entries = 3;
+    attr.map_create.map_flags = 0;
     int map_fd = bpf(BPF_MAP_CREATE, &attr, sizeof(attr));
     REQUIRE(map_fd > 0);
 
@@ -3047,51 +3047,51 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     uint64_t value = 12345;
     uint32_t key = 42;
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
-    attr.value = (uintptr_t)&value;
-    attr.flags = 0;
+    attr.map_update.map_fd = map_fd;
+    attr.map_update.key = (uintptr_t)&key;
+    attr.map_update.value = (uintptr_t)&value;
+    attr.map_update.flags = 0;
     REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
 
     // Look up the entry.
     value = 0;
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
-    attr.value = (uintptr_t)&value;
+    attr.map_lookup.map_fd = map_fd;
+    attr.map_lookup.key = (uintptr_t)&key;
+    attr.map_lookup.value = (uintptr_t)&value;
     REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
     REQUIRE(value == 12345);
 
     // Enumerate the entry.
     uint32_t next_key;
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = 0;
-    attr.next_key = (uintptr_t)&next_key;
+    attr.map_get_next_key.map_fd = map_fd;
+    attr.map_get_next_key.key = 0;
+    attr.map_get_next_key.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     REQUIRE(next_key == key);
 
     // Verify the entry is the last entry.
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
-    attr.next_key = (uintptr_t)&next_key;
+    attr.map_get_next_key.map_fd = map_fd;
+    attr.map_get_next_key.key = (uintptr_t)&key;
+    attr.map_get_next_key.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
     REQUIRE(errno == ENOENT);
 
     // Delete the entry.
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
+    attr.map_delete.map_fd = map_fd;
+    attr.map_delete.key = (uintptr_t)&key;
     REQUIRE(bpf(BPF_MAP_DELETE_ELEM, &attr, sizeof(attr)) == 0);
 
     // Look up and delete the entry.
     memset(&attr, 0, sizeof(attr));
     value = 0;
     key = 42;
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
-    attr.value = (uintptr_t)&value;
+    attr.map_lookup.map_fd = map_fd;
+    attr.map_lookup.key = (uintptr_t)&key;
+    attr.map_lookup.value = (uintptr_t)&value;
 
     // Add the element back to the entry after the previous test entry deletion.
     bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr));
@@ -3103,9 +3103,9 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
 
     // Verify that no entries exist.
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = 0;
-    attr.next_key = (uintptr_t)&next_key;
+    attr.map_get_next_key.map_fd = map_fd;
+    attr.map_get_next_key.key = 0;
+    attr.map_get_next_key.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
     REQUIRE(errno == ENOENT);
 
@@ -3114,26 +3114,26 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     for (key = 100; key < 400; key += 100) {
         value = 0;
         memset(&attr, 0, sizeof(attr));
-        attr.map_fd = map_fd;
-        attr.key = (uintptr_t)&key;
-        attr.value = (uintptr_t)&value;
+        attr.map_update.map_fd = map_fd;
+        attr.map_update.key = (uintptr_t)&key;
+        attr.map_update.value = (uintptr_t)&value;
         REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
     }
 
     // Look up the first key in the map, so we can check that it's returned later.
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = NULL;
-    attr.next_key = (uintptr_t)&next_key;
+    attr.map_get_next_key.map_fd = map_fd;
+    attr.map_get_next_key.key = NULL;
+    attr.map_get_next_key.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     uint64_t first_key = next_key;
 
     // Look up a key that is not present in the map, and check that the first key is returned.
     key = 123;
     memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
-    attr.next_key = (uintptr_t)&next_key;
+    attr.map_get_next_key.map_fd = map_fd;
+    attr.map_get_next_key.key = (uintptr_t)&key;
+    attr.map_get_next_key.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     REQUIRE(next_key == first_key);
 
@@ -3555,10 +3555,10 @@ _test_maps_batch(bpf_map_type map_type)
 
     // Create a hash map.
     union bpf_attr attr = {};
-    attr.map_type = map_type;
-    attr.key_size = sizeof(uint32_t);
-    attr.value_size = sizeof(uint64_t);
-    attr.max_entries = 1024 * 1024;
+    attr.map_create.map_type = map_type;
+    attr.map_create.key_size = sizeof(uint32_t);
+    attr.map_create.value_size = sizeof(uint64_t);
+    attr.map_create.max_entries = 1024 * 1024;
 
     fd_t map_fd = bpf(BPF_MAP_CREATE, &attr, sizeof(attr));
     REQUIRE(map_fd > 0);


### PR DESCRIPTION
At this point we also take the first steps to fixing the existing ABI incompatibility. On the Linux side, care was taken to avoid most padding in bpf_attr. By forcing the compiler to refuse implicit padding we get a good heuristic for fields in the incorrect order.

These changes mean that union bpf_attr in linux/bpf.h is not source compatible with the Linux header anymore. It's not possible to be source compatible and ABI compatible at the same time because we're already using Linux type names with ABI incompatible definitions. For example BPF_OBJ_NAME_LEN differs, and the order of fields in struct bpf_prog_info, etc. also does not match.

Change the definition of union bpf_attr to be more convenient to work with. This allows refactoring the macro magic used to check for forwards and backwards compatibility into a class, which ends up a lot less error prone.

Updates #3729