### PR TITLE
Switch to cxplat_get_current_processor_number

### DIFF
--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
@@ -207,8 +207,8 @@
     <FilesToPackage Include="$(TargetPath)" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\external\usersim\cxplat\src\cxplat_winkernel\cxplat_winkernel.vcxproj">
-      <Project>{1ebe3966-7dc4-49b4-b840-3d33d63415ec}</Project>
+    <ProjectReference Include="..\..\external\usersim\cxplat\src\cxplat_winuser\cxplat_winuser.vcxproj">
+      <Project>{f2ca70ab-af9a-47d1-9da9-94d5ab573ac2}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\external\usersim\src\usersim.vcxproj">
       <Project>{030a7ac6-14dc-45cf-af34-891057ab1402}</Project>

--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj.filters
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj.filters
@@ -35,4 +35,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="$(SolutionDir)resource\ebpf_resource.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -62,11 +62,7 @@ ebpf_is_preemptible()
 uint32_t
 ebpf_get_current_cpu()
 {
-    PROCESSOR_NUMBER processor_number;
-
-    KeGetCurrentProcessorNumberEx(&processor_number);
-
-    return KeGetProcessorIndexFromNumber(&processor_number);
+    return cxplat_get_current_processor_number();
 }
 
 uint64_t

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -264,6 +264,7 @@ extern "C"
      *   running on. Only valid if ebpf_is_preemptible() == true.
      * @retval Zero based index of CPUs.
      */
+    EBPF_INLINE_HINT
     uint32_t
     ebpf_get_current_cpu();
 


### PR DESCRIPTION
## Description

This pull request includes several changes to the `libs/runtime/ebpf_platform` files and an update to the `external/usersim` submodule. The most important changes involve modifying the `ebpf_get_current_cpu` function to use a different method for retrieving the current processor number and adding an inline hint to the function declaration.

Changes to `ebpf_get_current_cpu` function:

* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL65-R65): Modified the `ebpf_get_current_cpu` function to use `cxplat_get_current_processor_number` instead of `KeGetCurrentProcessorNumberEx` and `KeGetProcessorIndexFromNumber`.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R267): Added `EBPF_INLINE_HINT` to the `ebpf_get_current_cpu` function declaration.

Submodule update:

* [`external/usersim`](diffhunk://#diff-4ae78540d77e146774e537be8c7888b0e96d803c98c06760e4e8775833905812L1-R1): Updated submodule commit to `177182f08eb59f516f41f17e7d53a433e93100d9`.

## Testing

CI/CD

Reduces unbatched invoke from 37ns -> 22ns.

## Documentation

No.

## Installation

No.
