### PR TITLE
Checkout C files as UTF-8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,7 @@
 
 # Mark generated corpus files as binary.
 **/corpus/**        -text
+
+# Ensure that all compilable files are checked out as UTF-8
+*.c* text encoding=utf-8
+*.h* text encoding=utf-8


### PR DESCRIPTION
Resolves:
https://github.com/microsoft/ebpf-for-windows/issues/3944

## Description

This pull request includes a small change to the `.gitattributes` file to ensure that all compilable files are checked out as UTF-8.

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR19-R22): Added rules to ensure that all `.c` and `.h` files are checked out as UTF-8.

## Testing

Tested by [@dynamic-i ](https://github.com/dynamic-i)

## Documentation

N/A

## Installation

N/A
