### PR TITLE
bpf(): allow creating nested maps

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -92,7 +92,8 @@ typedef struct
     uint32_t key_size;          ///< Size in bytes of keys.
     uint32_t value_size;        ///< Size in bytes of values.
     uint32_t max_entries;       ///< Maximum number of entries in the map.
-    uint32_t map_flags;         ///< Flags (currently 0).
+    uint32_t map_flags;         ///< Not supported, must be zero.
+    uint32_t inner_map_fd;      ///< File descriptor of inner map.
 } sys_bpf_map_create_attr_t;
 
 typedef struct

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -93,7 +93,12 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
         }
         case BPF_MAP_CREATE: {
             ExtensibleStruct<sys_bpf_map_create_attr_t> map_create_attr((void*)attr, (size_t)size);
-            struct bpf_map_create_opts opts = {.map_flags = map_create_attr->map_flags};
+
+            struct bpf_map_create_opts opts = {
+                .inner_map_fd = map_create_attr->inner_map_fd,
+                .map_flags = map_create_attr->map_flags,
+            };
+
             return bpf_map_create(
                 map_create_attr->map_type,
                 nullptr,

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2978,6 +2978,17 @@ TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf]")
     attr.prog_bind_map.flags = 0;
     REQUIRE(bpf(BPF_PROG_BIND_MAP, &attr, sizeof(attr)) == 0);
 
+    // Verify we can create a nested map.
+    attr.map_create = {};
+    attr.map_create.map_type = BPF_MAP_TYPE_ARRAY_OF_MAPS;
+    attr.map_create.key_size = 4;
+    attr.map_create.value_size = 4;
+    attr.map_create.max_entries = 1;
+    attr.map_create.inner_map_fd = map_fd;
+    int nested_map_fd = bpf(BPF_MAP_CREATE, &attr, sizeof(attr.map_create));
+    REQUIRE(nested_map_fd >= 0);
+    Platform::_close(nested_map_fd);
+
     // Release our own references on the map and program.
     Platform::_close(map_fd);
     Platform::_close(program_fd);


### PR DESCRIPTION
Add support for creating nested maps via the bpf() syscall wrapper.
