### PR TITLE
Tag ELF files with platform specific section

### DIFF
--- a/include/bpf_helpers_platform.h
+++ b/include/bpf_helpers_platform.h
@@ -7,12 +7,17 @@
  * @brief This file contains platform specific defines used by eBPF programs.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // For eBPF programs, struct bpf_map means struct _ebpf_map_definition_in_file,
 // since they use inner_map_idx and pass pointers to such structures to the various
 // map APIs.
 #define bpf_map _ebpf_map_definition_in_file
+
+#if !defined(_MSC_VER)
+const bool __ebpf_for_windows_tag __attribute__((section(".ebpf_for_windows"))) = true;
+#endif
 
 // Type aliases used by libbpf headers.
 typedef int32_t __s32;


### PR DESCRIPTION
Compiling against Windows eBPF headers produces object files which are not easily distinguishable from object files compiled against Linux headers. This is a problem for cross-platform tooling which wishes to inspect the contents of an ELF.

Emit a section .ebpf_for_windows with the contents 0x01 into ELFs compiled against the windows headers.

Updates #3956