### PR TITLE
Run all scripts as job with timeout.

### DIFF
--- a/scripts/cleanup_ebpf_cicd_tests.ps1
+++ b/scripts/cleanup_ebpf_cicd_tests.ps1
@@ -6,54 +6,113 @@ param ([parameter(Mandatory=$false)][string] $Target = "TEST_VM",
        [parameter(Mandatory=$false)][string] $LogFileName = "TestLog.log",
        [parameter(Mandatory=$false)][string] $WorkingDirectory = $pwd.ToString(),
        [parameter(Mandatory=$false)][string] $TestExecutionJsonFileName = "test_execution.json",
-       [parameter(Mandatory=$false)][string] $SelfHostedRunnerName)
+       [parameter(Mandatory=$false)][string] $SelfHostedRunnerName = [System.Net.Dns]::GetHostName(),
+       [Parameter(Mandatory = $false)][int] $TestJobTimeout = (30*60))
 
 Push-Location $WorkingDirectory
 
 $TestVMCredential = Get-StoredCredential -Target $Target -ErrorAction Stop
 
-# Load other utility modules.
-Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName) -WarningAction SilentlyContinue
-Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($TestVMCredential.UserName, $TestVMCredential.Password, $WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
-Import-Module .\install_ebpf.psm1 -ArgumentList ($WorkingDirectory, $LogFileName) -Force -WarningAction SilentlyContinue
-
 # Read the test execution json.
 $TestExecutionConfig = Get-Content ("{0}\{1}" -f $PSScriptRoot, $TestExecutionJsonFileName) | ConvertFrom-Json
-$VMList = $TestExecutionConfig.VMMap.$SelfHostedRunnerName
 
-# Wait for all VMs to be in ready state, in case the test run caused any VM to crash.
-Wait-AllVMsToInitialize `
-    -VMList $VMList `
-    -UserName $TestVMCredential.UserName `
-    -AdminPassword $TestVMCredential.Password
+$Job = Start-Job -ScriptBlock {
+    param ([Parameter(Mandatory = $True)] [PSCredential] $TestVMCredential,
+           [Parameter(Mandatory = $true)] [PSCustomObject] $Config,
+           [Parameter(Mandatory = $true)] [string] $SelfHostedRunnerName,
+           [parameter(Mandatory = $true)] [string] $LogFileName,
+           [parameter(Mandatory = $true)] [string] $WorkingDirectory = $pwd.ToString(),
+           [parameter(Mandatory = $true)] [bool] $KmTracing
+    )
+    Push-Location $WorkingDirectory
 
-# Check if we're here after a crash (we are if c:\windows\memory.dmp exists on the VM).  If so,
-# we need to skip the stopping of the drivers as they may be in a wedged state as a result of the
-# crash.  We will be restoring the VM's 'baseline' snapshot next, so the step is redundant anyway.
-foreach ($VM in $VMList) {
-    $VMName = $VM.Name
-    $DumpFound = Invoke-Command `
-        -VMName $VMName `
-        -Credential $TestVMCredential `
-        -ScriptBlock {
-            Test-Path -Path "c:\windows\memory.dmp" -PathType leaf
+    # Load other utility modules.
+    Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName) -WarningAction SilentlyContinue
+    Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($TestVMCredential.UserName, $TestVMCredential.Password, $WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
+
+    $VMList = $Config.VMMap.$SelfHostedRunnerName
+    # Wait for all VMs to be in ready state, in case the test run caused any VM to crash.
+    Wait-AllVMsToInitialize `
+        -VMList $VMList `
+        -UserName $TestVMCredential.UserName `
+        -AdminPassword $TestVMCredential.Password
+
+    # Check if we're here after a crash (we are if c:\windows\memory.dmp exists on the VM).  If so,
+    # we need to skip the stopping of the drivers as they may be in a wedged state as a result of the
+    # crash.  We will be restoring the VM's 'baseline' snapshot next, so the step is redundant anyway.
+    foreach ($VM in $VMList) {
+        $VMName = $VM.Name
+        $DumpFound = Invoke-Command `
+            -VMName $VMName `
+            -Credential $TestVMCredential `
+            -ScriptBlock {
+                Test-Path -Path "c:\windows\memory.dmp" -PathType leaf
+            }
+
+        if ($DumpFound -eq $True) {
+            Write-Log "Post-crash reboot detected on VM $VMName"
+        } else {
+            # Stop eBPF Components on the test VM. (Un-install is not necessary.)
+            # We *MUST* be able to stop all drivers cleanly after a test.  Failure to do so indicates a fatal bug in
+            # one/some of the ebpf driver-set.
+            Stop-eBPFComponentsOnVM -VMName $VMname -ErrorAction Stop
         }
+    }
 
-    if ($DumpFound -eq $True) {
-        Write-Log "Post-crash reboot detected on VM $VMName"
-    } else {
-        # Stop eBPF Components on the test VM. (Un-install is not necessary.)
-        # We *MUST* be able to stop all drivers cleanly after a test.  Failure to do so indicates a fatal bug in
-        # one/some of the ebpf driver-set.
-        Stop-eBPFComponentsOnVM -VMName $VMname -ErrorAction Stop
+    # Import logs from VMs.
+    Import-ResultsFromVM -VMList $VMList -KmTracing $KmTracing
+
+    # Stop the VMs.
+    Stop-AllVMs -VMList $VMList
+
+    Pop-Location
+
+}  -ArgumentList (
+    $TestVMCredential,
+    $TestExecutionConfig,
+    $SelfHostedRunnerName,
+    $LogFileName,
+    $WorkingDirectory,
+    $KmTracing)
+
+# Keep track of the last received output count
+$TimeElapsed = 0
+$JobTimedOut = $false
+
+# Loop to fetch and print job output in near real-time
+while ($Job.State -eq 'Running') {
+    $JobOutput = Receive-Job -Job $job
+	$JobOutput | ForEach-Object { Write-Host $_ }
+
+    Start-Sleep -Seconds 2
+    $TimeElapsed += 2
+
+    if ($TimeElapsed -gt $TestJobTimeout) {
+        if ($Job.State -eq "Running") {
+            $VMList = $Config.VMMap.$SelfHostedRunnerName
+            # currently one VM is used per runner.
+            $TestVMName = $VMList[0].Name
+            Write-Host "Cleaning up VM $TestVMName for Kernel Tests has timed out after one hour" -ForegroundColor Yellow
+            $Timestamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
+            $CheckpointName = "Cleanup-Hang-$TestVMName-Checkpoint-$Timestamp"
+            Write-Log "Taking snapshot $CheckpointName of $TestVMName"
+            Checkpoint-VM -Name $TestVMName -SnapshotName $CheckpointName
+            $JobTimedOut = $true
+            break
+        }
     }
 }
 
-# Import logs from VMs.
-Import-ResultsFromVM -VMList $VMList -KmTracing $KmTracing
+# Print any remaining output after the job completes
+$JobOutput = Receive-Job -Job $job
+$JobOutput | ForEach-Object { Write-Host $_ }
 
-# Stop the VMs.
-Stop-AllVMs -VMList $VMList
-Restore-AllVMs -VMList $VMList
+# Clean up
+Remove-Job -Job $Job -Force
 
 Pop-Location
+
+if ($JobTimedOut) {
+    exit 1
+}
+

--- a/scripts/cleanup_ebpf_cicd_tests.ps1
+++ b/scripts/cleanup_ebpf_cicd_tests.ps1
@@ -51,11 +51,6 @@ $Job = Start-Job -ScriptBlock {
 
         if ($DumpFound -eq $True) {
             Write-Log "Post-crash reboot detected on VM $VMName"
-        } else {
-            # Stop eBPF Components on the test VM. (Un-install is not necessary.)
-            # We *MUST* be able to stop all drivers cleanly after a test.  Failure to do so indicates a fatal bug in
-            # one/some of the ebpf driver-set.
-            Stop-eBPFComponentsOnVM -VMName $VMname -ErrorAction Stop
         }
     }
 
@@ -89,7 +84,7 @@ while ($Job.State -eq 'Running') {
 
     if ($TimeElapsed -gt $TestJobTimeout) {
         if ($Job.State -eq "Running") {
-            $VMList = $Config.VMMap.$SelfHostedRunnerName
+            $VMList = $TestExecutionConfig.VMMap.$SelfHostedRunnerName
             # currently one VM is used per runner.
             $TestVMName = $VMList[0].Name
             Write-Host "Cleaning up VM $TestVMName for Kernel Tests has timed out after one hour" -ForegroundColor Yellow

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -93,6 +93,9 @@ while ($Job.State -eq 'Running') {
 
     if ($TimeElapsed -gt $TestJobTimeout) {
         if ($Job.State -eq "Running") {
+            $VMList = $Config.VMMap.$SelfHostedRunnerName
+            # currently one VM runs per runner.
+            $TestVMName = $VMList[0].Name            
             Write-Host "Running kernel tests on $TestVMName has timed out after one hour" -ForegroundColor Yellow
             $Timestamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
             $CheckpointName = "Execution-Hang-$TestVMName-Checkpoint-$Timestamp"

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -23,24 +23,18 @@ $StandardUserTestVMCredential = Get-StoredCredential -Target $StandardUserTarget
 
 # Read the test execution json.
 $Config = Get-Content ("{0}\{1}" -f $PSScriptRoot, $TestExecutionJsonFileName) | ConvertFrom-Json
-$VMList = $Config.VMMap.$SelfHostedRunnerName
-# currently one VM runs per runner.
-$TestVMName = $VMList[0].Name
 
 $Job = Start-Job -ScriptBlock {
-    param (
-           [Parameter(Mandatory = $True)][string] $TestVMName,
-           [Parameter(Mandatory = $true)] [PSCustomObject] $Config,
-           [Parameter(Mandatory = $True)] [string] $Admin,
-           [Parameter(Mandatory = $True)] [SecureString] $AdminPassword,
-           [Parameter(Mandatory = $True)] [string] $StandardUser,
-           [Parameter(Mandatory = $True)] [SecureString] $StandardUserPassword,
+    param ([Parameter(Mandatory = $True)] [PSCredential] $AdminTestVMCredential,
+           [Parameter(Mandatory = $True)] [PSCredential] $StandardUserTestVMCredential, 
+           [Parameter(Mandatory = $true)] [PSCustomObject] $Config, 
+           [Parameter(Mandatory = $true)] [string] $SelfHostedRunnerName,
            [Parameter(Mandatory = $True)] [string] $WorkingDirectory,
            [Parameter(Mandatory = $True)] [string] $LogFileName,
-           [Parameter(Mandatory = $True)][string] $TestMode,
-           [Parameter(Mandatory = $True)][string[]] $Options,
-           [Parameter(Mandatory = $True)][int] $TestHangTimeout,
-           [Parameter(Mandatory = $True)][string] $UserModeDumpFolder)
+           [Parameter(Mandatory = $True)] [string] $TestMode,
+           [Parameter(Mandatory = $True)] [string[]] $Options,
+           [Parameter(Mandatory = $True)] [int] $TestHangTimeout,
+           [Parameter(Mandatory = $True)] [string] $UserModeDumpFolder)
 
     Push-Location $WorkingDirectory
 
@@ -49,10 +43,10 @@ $Job = Start-Job -ScriptBlock {
     Import-Module $WorkingDirectory\vm_run_tests.psm1 `
         -Force `
         -ArgumentList (
-            $Admin,
-            $AdminPassword,
-            $StandardUser,
-            $StandardUserPassword,
+            $AdminTestVMCredential.UserName,
+            $AdminTestVMCredential.Password,
+            $StandardUserTestVMCredential.UserName,
+            $StandardUserTestVMCredential.Password,
             $WorkingDirectory,
             $LogFileName,
             $TestMode,
@@ -61,19 +55,23 @@ $Job = Start-Job -ScriptBlock {
             $UserModeDumpFolder) `
         -WarningAction SilentlyContinue
 
+    $VMList = $Config.VMMap.$SelfHostedRunnerName
+    # currently one VM runs per runner.
+    $TestVMName = $VMList[0].Name
+
     # Run Kernel tests on test VM.
     Write-Log "Running kernel tests on $TestVMName"
     Run-KernelTestsOnVM -VMName $TestVMName -Config $Config
 
     # Stop eBPF components on test VMs.
     Stop-eBPFComponentsOnVM -VMName $TestVMName
+
+    Pop-Location
 } -ArgumentList (
-    $TestVMName,
+    $AdminTestVMCredential,
+    $StandardUserTestVMCredential,
     $Config,
-    $AdminTestVMCredential.UserName,
-    $AdminTestVMCredential.Password,
-    $StandardUserTestVMCredential.UserName,
-    $StandardUserTestVMCredential.Password,
+    $SelfHostedRunnerName,
     $WorkingDirectory,
     $LogFileName,
     $TestMode,
@@ -82,8 +80,8 @@ $Job = Start-Job -ScriptBlock {
     $UserModeDumpFolder)
 
 # Keep track of the last received output count
-$LastCount = 0
 $TimeElapsed = 0
+$JobTimedOut = $false
 
 # Loop to fetch and print job output in near real-time
 while ($Job.State -eq 'Running') {
@@ -97,9 +95,10 @@ while ($Job.State -eq 'Running') {
         if ($Job.State -eq "Running") {
             Write-Host "Running kernel tests on $TestVMName has timed out after one hour" -ForegroundColor Yellow
             $Timestamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
-            $CheckpointName = "$TestVMName-Checkpoint-$Timestamp"
+            $CheckpointName = "Execution-Hang-$TestVMName-Checkpoint-$Timestamp"
             Write-Log "Taking snapshot $CheckpointName of $TestVMName"
             Checkpoint-VM -Name $TestVMName -SnapshotName $CheckpointName
+            $JobTimedOut = $true
             break
         }
     }
@@ -113,3 +112,7 @@ $JobOutput | ForEach-Object { Write-Host $_ }
 Remove-Job -Job $Job -Force
 
 Pop-Location
+
+if ($JobTimedOut) {
+    exit 1
+}

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -139,6 +139,7 @@ function Stop-eBPFComponents {
     $EbpfDrivers.GetEnumerator() | ForEach-Object {
         try {
             if ($_.Value.IsDriver) {
+                Write-Log "Stopping $($_.Key) driver..."
                 Stop-Service $_.Name -ErrorAction Stop 2>&1 | Write-Log
                 Write-Log "$($_.Key) driver stopped." -ForegroundColor Green
             }

--- a/scripts/setup_ebpf_cicd_tests.ps1
+++ b/scripts/setup_ebpf_cicd_tests.ps1
@@ -10,7 +10,8 @@ param ([parameter(Mandatory=$false)][string] $Target = "TEST_VM",
        [parameter(Mandatory=$false)][string] $RegressionArtifactsVersion = "",
        [parameter(Mandatory=$false)][string] $RegressionArtifactsConfiguration = "",
        [parameter(Mandatory=$false)][string] $TestExecutionJsonFileName = "test_execution.json",
-       [parameter(Mandatory=$false)][string] $SelfHostedRunnerName = [System.Net.Dns]::GetHostName())
+       [parameter(Mandatory=$false)][string] $SelfHostedRunnerName = [System.Net.Dns]::GetHostName(),
+       [Parameter(Mandatory = $false)][int] $TestJobTimeout = (30*60))
 
 Push-Location $WorkingDirectory
 
@@ -22,7 +23,7 @@ Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($TestVMCredential.User
 
 # Read the test execution json.
 $TestExecutionConfig = Get-Content ("{0}\{1}" -f $PSScriptRoot, $TestExecutionJsonFileName) | ConvertFrom-Json
-$VMList = $TestExecutionConfig.VMMap.$SelfHostedRunnerName
+$VMList = $Config.VMMap.$SelfHostedRunnerName
 
 # Delete old log files if any.
 Remove-Item "$env:TEMP\$LogFileName" -ErrorAction SilentlyContinue
@@ -31,9 +32,6 @@ foreach($VM in $VMList) {
     Remove-Item $env:TEMP\$LogFileName -ErrorAction SilentlyContinue
 }
 Remove-Item ".\TestLogs" -Recurse -Confirm:$false -ErrorAction SilentlyContinue
-
-# Get all VMs to ready state.
-Initialize-AllVMs -VMList $VMList -ErrorAction Stop
 
 if ($TestMode -eq "Regression") {
 
@@ -50,16 +48,87 @@ if ($TestMode -eq "CI/CD" -or $TestMode -eq "Regression") {
 Get-CoreNetTools
 Get-PSExec
 
-# Export build artifacts to the test VMs.
-Export-BuildArtifactsToVMs -VMList $VMList -ErrorAction Stop
+$Job = Start-Job -ScriptBlock {
+    param ([Parameter(Mandatory = $True)] [PSCredential] $TestVMCredential,
+           [Parameter(Mandatory = $true)] [PSCustomObject] $Config,
+           [Parameter(Mandatory = $true)] [string] $SelfHostedRunnerName,
+           [parameter(Mandatory = $true)] [string] $TestMode,
+           [parameter(Mandatory = $true)] [string] $LogFileName,
+           [parameter(Mandatory = $true)] [string] $WorkingDirectory = $pwd.ToString(),
+           [parameter(Mandatory = $true)] [bool] $KmTracing,
+           [parameter(Mandatory = $true)] [string] $KmTraceType
+    )
+    Push-Location $WorkingDirectory
 
-# Configure network adapters on VMs.
-Initialize-NetworkInterfacesOnVMs $VMList -ErrorAction Stop
+    # Load other utility modules.
+    Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName) -WarningAction SilentlyContinue
+    Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($TestVMCredential.UserName, $TestVMCredential.Password, $WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
 
-# Install eBPF Components on the test VM.
-foreach($VM in $VMList) {
-    $VMName = $VM.Name
-    Install-eBPFComponentsOnVM -VMName $VMname -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -ErrorAction Stop
+    $VMList = $Config.VMMap.$SelfHostedRunnerName
+
+    # Get all VMs to ready state.
+    Initialize-AllVMs -VMList $VMList -ErrorAction Stop
+
+    # Export build artifacts to the test VMs.
+    Export-BuildArtifactsToVMs -VMList $VMList -ErrorAction Stop
+
+    # Configure network adapters on VMs.
+    Initialize-NetworkInterfacesOnVMs $VMList -ErrorAction Stop
+
+    # Install eBPF Components on the test VM.
+    foreach($VM in $VMList) {
+        $VMName = $VM.Name
+        Install-eBPFComponentsOnVM -VMName $VMname -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -ErrorAction Stop
+    }
+
+    Pop-Location
+}  -ArgumentList (
+    $TestVMCredential,
+    $TestExecutionConfig,
+    $SelfHostedRunnerName,
+    $TestMode,
+    $LogFileName,
+    $WorkingDirectory,
+    $KmTracing,
+    $KmTraceType)
+
+# Keep track of the last received output count
+$TimeElapsed = 0
+$JobTimedOut = $false
+
+# Loop to fetch and print job output in near real-time
+while ($Job.State -eq 'Running') {
+    $JobOutput = Receive-Job -Job $job
+	$JobOutput | ForEach-Object { Write-Host $_ }
+
+    Start-Sleep -Seconds 2
+    $TimeElapsed += 2
+
+    if ($TimeElapsed -gt $TestJobTimeout) {
+        if ($Job.State -eq "Running") {
+            $VMList = $Config.VMMap.$SelfHostedRunnerName
+            # currently one VM is used per runner.
+            $TestVMName = $VMList[0].Name
+            Write-Host "Setting up VM $TestVMName for Kernel Tests has timed out after one hour" -ForegroundColor Yellow
+            $Timestamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
+            $CheckpointName = "Setup-Hang-$TestVMName-Checkpoint-$Timestamp"
+            Write-Log "Taking snapshot $CheckpointName of $TestVMName"
+            Checkpoint-VM -Name $TestVMName -SnapshotName $CheckpointName
+            $JobTimedOut = $true
+            break
+        }
+    }
 }
 
+# Print any remaining output after the job completes
+$JobOutput = Receive-Job -Job $job
+$JobOutput | ForEach-Object { Write-Host $_ }
+
+# Clean up
+Remove-Job -Job $Job -Force
+
 Pop-Location
+
+if ($JobTimedOut) {
+    exit 1
+}


### PR DESCRIPTION
## Description

Have the setup, execute and cleanup scripts run as a job with a timeout. Upon timeout a VM checkpoint is taken and an error is returned from the script.

This addresses #3949 by making it easier to debug the next time a hang occurs.

## Testing

CICD.

## Documentation

N/A.

## Installation

N/A.
