### PR TITLE
Switch to fuzzing main branch

### DIFF
--- a/.onefuzz/OneFuzzConfig.json
+++ b/.onefuzz/OneFuzzConfig.json
@@ -6,7 +6,7 @@
       "JobNotificationEmail": "edgeosebpf@microsoft.com",
       "Skip": false,
       "TargetBuildBranches": [
-        "feature/security_fix"
+        "main"
       ],
       "Fuzzer": {
         "$type": "libfuzzer",
@@ -83,7 +83,7 @@
       "JobNotificationEmail": "edgeosebpf@microsoft.com",
       "Skip": false,
       "TargetBuildBranches": [
-        "feature/security_fix"
+        "main"
       ],
       "Fuzzer": {
         "$type": "libfuzzer",
@@ -160,7 +160,7 @@
       "JobNotificationEmail": "edgeosebpf@microsoft.com",
       "Skip": false,
       "TargetBuildBranches": [
-        "feature/security_fix"
+        "main"
       ],
       "Fuzzer": {
         "$type": "libfuzzer",
@@ -237,7 +237,7 @@
       "JobNotificationEmail": "edgeosebpf@microsoft.com",
       "Skip": false,
       "TargetBuildBranches": [
-        "feature/security_fix"
+        "main"
       ],
       "Fuzzer": {
         "$type": "libfuzzer",
@@ -314,7 +314,7 @@
       "JobNotificationEmail": "edgeosebpf@microsoft.com",
       "Skip": false,
       "TargetBuildBranches": [
-        "feature/security_fix"
+        "main"
       ],
       "Fuzzer": {
         "$type": "libfuzzer",


### PR DESCRIPTION
## Description

This pull request updates the `TargetBuildBranches` field in the `.onefuzz/OneFuzzConfig.json` file to change the target branch from `feature/security_fix` to `main`.

Configuration updates:

* [`.onefuzz/OneFuzzConfig.json`](diffhunk://#diff-68617b12f58cdcc9c85a499fa6ad5771fa2f572c9ca06bb5470b1e6b3c4e8226L9-R9): Changed the `TargetBuildBranches` field from `feature/security_fix` to `main` in multiple instances. [[1]](diffhunk://#diff-68617b12f58cdcc9c85a499fa6ad5771fa2f572c9ca06bb5470b1e6b3c4e8226L9-R9) [[2]](diffhunk://#diff-68617b12f58cdcc9c85a499fa6ad5771fa2f572c9ca06bb5470b1e6b3c4e8226L86-R86) [[3]](diffhunk://#diff-68617b12f58cdcc9c85a499fa6ad5771fa2f572c9ca06bb5470b1e6b3c4e8226L163-R163) [[4]](diffhunk://#diff-68617b12f58cdcc9c85a499fa6ad5771fa2f572c9ca06bb5470b1e6b3c4e8226L240-R240) [[5]](diffhunk://#diff-68617b12f58cdcc9c85a499fa6ad5771fa2f572c9ca06bb5470b1e6b3c4e8226L317-R317)

## Testing

N/A

## Documentation

N/A

## Installation

N/A
