### PR TITLE
Remove netperf on azure upload attempt as azure VMs have been retired

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -640,19 +640,6 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-  upload_netperf_results_azure_2022:
-    needs: netperf
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/upload-perf-results.yml
-    with:
-      name: upload_netperf_results_azure_2022
-      result_artifact: netperf_azure_2022_x64
-      platform: Azure Windows 2022
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
   upload_netperf_results_lab_2022:
     needs: netperf
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Description

This pull request involves changes to the continuous integration and deployment workflow configuration in the `.github/workflows/cicd.yml` file. The primary change is the removal of a specific job related to uploading performance results to Azure.

Changes to CI/CD workflow:

* Removed the `upload_netperf_results_azure_2022` job, which included configurations for uploading performance results to Azure for Windows 2022 platform.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
