### PR TITLE
Avoid raising and lowering the IRQL if not needed

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1181,6 +1181,7 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, size_t partition, _Inout
 
     ebpf_lru_key_state_t key_state = _get_key_state(map, partition, entry);
     ebpf_lock_state_t state = 0;
+    bool is_preemptible = ebpf_is_preemptible();
 
     switch (key_state) {
     case EBPF_LRU_KEY_UNINITIALIZED:
@@ -1193,7 +1194,12 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, size_t partition, _Inout
         return;
     }
 
-    state = ebpf_lock_lock(&map->partitions[partition].lock);
+    if (!is_preemptible) {
+        ebpf_lock_lock_at_dispatch(&map->partitions[partition].lock);
+    } else {
+        state = ebpf_lock_lock(&map->partitions[partition].lock);
+    }
+
     lock_held = true;
 
     key_state = _get_key_state(map, partition, entry);
@@ -1224,7 +1230,11 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, size_t partition, _Inout
     _merge_hot_into_cold_list_if_needed(map, partition);
 
     if (lock_held) {
-        ebpf_lock_unlock(&map->partitions[partition].lock, state);
+        if (!is_preemptible) {
+            ebpf_lock_unlock_at_dispatch(&map->partitions[partition].lock);
+        } else {
+            ebpf_lock_unlock(&map->partitions[partition].lock, state);
+        }
     }
 }
 

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -52,6 +52,18 @@ _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVE
     KeReleaseSpinLock(lock, state);
 }
 
+_Requires_lock_not_held_(*lock) _Acquires_lock_(*lock) _IRQL_requires_max_(DISPATCH_LEVEL)
+    _IRQL_requires_(DISPATCH_LEVEL) void ebpf_lock_lock_at_dispatch(_Inout_ ebpf_lock_t* lock)
+{
+    KeAcquireSpinLockAtDpcLevel(lock);
+}
+
+_Requires_lock_held_(*lock) _Releases_lock_(*lock)
+    _IRQL_requires_(DISPATCH_LEVEL) void ebpf_lock_unlock_at_dispatch(_Inout_ ebpf_lock_t* lock)
+{
+    KeReleaseSpinLockFromDpcLevel(lock);
+}
+
 bool
 ebpf_is_preemptible()
 {

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -224,6 +224,22 @@ extern "C"
         _Inout_ ebpf_lock_t* lock, _IRQL_restores_ ebpf_lock_state_t state);
 
     /**
+     * @brief Acquire exclusive access to the lock.
+     * @param[in, out] lock Pointer to memory location that contains the lock.
+     * @returns The previous lock_state required for unlock.
+     */
+    _Requires_lock_not_held_(*lock) _Acquires_lock_(*lock) _IRQL_requires_(DISPATCH_LEVEL)
+        _IRQL_requires_max_(DISPATCH_LEVEL) void ebpf_lock_lock_at_dispatch(_Inout_ ebpf_lock_t* lock);
+
+    /**
+     * @brief Release exclusive access to the lock.
+     * @param[in, out] lock Pointer to memory location that contains the lock.
+     * @param[in] state The state returned from ebpf_lock_lock.
+     */
+    _Requires_lock_held_(*lock) _Releases_lock_(*lock)
+        _IRQL_requires_(DISPATCH_LEVEL) void ebpf_lock_unlock_at_dispatch(_Inout_ ebpf_lock_t* lock);
+
+    /**
      * @brief Raise the IRQL to new_irql.
      *
      * @param[in] new_irql The new IRQL.


### PR DESCRIPTION
## Description

This pull request introduces changes to enhance the locking mechanisms in the eBPF platform by adding new functions for acquiring and releasing locks at dispatch level. The key updates include the introduction of new lock functions and modifications to existing functions to utilize these new mechanisms.

### Enhancements to locking mechanisms:

* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deR55-R66): Added new functions `ebpf_lock_lock_at_dispatch` and `ebpf_lock_unlock_at_dispatch` for acquiring and releasing locks at dispatch level.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R226-R241): Declared the new functions `ebpf_lock_lock_at_dispatch` and `ebpf_lock_unlock_at_dispatch` to provide their prototypes for external linkage.

### Modifications to existing functions:

* [`libs/execution_context/ebpf_maps.c`](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cR1184): Updated the `_insert_into_hot_list` function to use the new dispatch level lock functions when the system is not preemptible. [[1]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cR1184) [[2]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cR1197-R1202) [[3]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cR1233-R1239)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
