### PR TITLE
Add support for cache aligned epoch memory and switch maps to use it

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -984,7 +984,7 @@ _create_hash_map_internal(
     ebpf_core_map_t* local_map = NULL;
     *map = NULL;
 
-    local_map = ebpf_epoch_allocate_with_tag(map_struct_size, EBPF_POOL_TAG_MAP);
+    local_map = ebpf_epoch_allocate_cache_aligned_with_tag(map_struct_size, EBPF_POOL_TAG_MAP);
     if (local_map == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -1022,7 +1022,7 @@ Done:
         if (local_map && local_map->data) {
             ebpf_hash_table_destroy((ebpf_hash_table_t*)local_map->data);
         }
-        ebpf_epoch_free(local_map);
+        ebpf_epoch_free_cache_aligned(local_map);
         local_map = NULL;
     }
     return retval;
@@ -1044,7 +1044,7 @@ static void
 _delete_hash_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 {
     ebpf_hash_table_destroy((ebpf_hash_table_t*)map->data);
-    ebpf_epoch_free(map);
+    ebpf_epoch_free_cache_aligned(map);
 }
 
 static void
@@ -1404,7 +1404,7 @@ Exit:
         if (lru_map && lru_map->core_map.data) {
             ebpf_hash_table_destroy((ebpf_hash_table_t*)lru_map->core_map.data);
         }
-        ebpf_epoch_free(lru_map);
+        ebpf_epoch_free_cache_aligned(lru_map);
         lru_map = NULL;
     }
 
@@ -1416,7 +1416,7 @@ _delete_lru_hash_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 {
     ebpf_core_lru_map_t* lru_map = EBPF_FROM_FIELD(ebpf_core_lru_map_t, core_map, map);
     ebpf_hash_table_destroy((ebpf_hash_table_t*)lru_map->core_map.data);
-    ebpf_epoch_free(map);
+    ebpf_epoch_free_cache_aligned(map);
 }
 
 static ebpf_result_t

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -178,6 +178,9 @@ typedef struct _ebpf_epoch_allocation_header
     ebpf_epoch_allocation_type_t entry_type; ///< Type of entry.
 } ebpf_epoch_allocation_header_t;
 
+static_assert(
+    sizeof(ebpf_epoch_allocation_header_t) < EBPF_CACHE_LINE_SIZE, "Header size must be less than cache line");
+
 /**
  * @brief This structure is used as a place holder when a custom action needs
  * to be performed on epoch end. Typically this is releasing memory that can't

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -58,6 +58,15 @@ extern "C"
     _Must_inspect_result_ _Ret_writes_maybenull_(size) void* ebpf_epoch_allocate(size_t size);
 
     /**
+     * @brief Allocate cache aligned memory under epoch control.
+     * @param[in] size Size of memory to allocate
+     * @param[in] tag Pool tag to use.
+     * @returns Pointer to memory block allocated, or null on failure.
+     */
+    _Must_inspect_result_
+        _Ret_writes_maybenull_(size) void* ebpf_epoch_allocate_cache_aligned_with_tag(size_t size, uint32_t tag);
+
+    /**
      * @brief Allocate memory under epoch control with tag.
      * @param[in] size Size of memory to allocate
      * @param[in] tag Pool tag to use.
@@ -72,6 +81,13 @@ extern "C"
      */
     void
     ebpf_epoch_free(_Frees_ptr_opt_ void* memory);
+
+    /**
+     * @brief Free memory under epoch control.
+     * @param[in] memory Allocation to be freed once epoch ends.
+     */
+    void
+    ebpf_epoch_free_cache_aligned(_Frees_ptr_opt_ void* memory);
 
     /**
      * @brief Wait for the current epoch to end.

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -531,6 +531,21 @@ TEST_CASE("epoch_test_single_epoch", "[platform]")
     ebpf_epoch_synchronize();
 }
 
+TEST_CASE("epoch_test_single_epoch_cache_aligned", "[platform]")
+{
+    _test_helper test_helper;
+    test_helper.initialize();
+
+    ebpf_epoch_scope_t epoch_scope;
+    void* memory = ebpf_epoch_allocate_cache_aligned_with_tag(10, 0);
+    if (memory) {
+        memset(memory, 0, 10);
+    }
+    ebpf_epoch_free_cache_aligned(memory);
+    epoch_scope.exit();
+    ebpf_epoch_synchronize();
+}
+
 TEST_CASE("epoch_test_two_threads", "[platform]")
 {
     _test_helper test_helper;

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -541,6 +541,8 @@ TEST_CASE("epoch_test_single_epoch_cache_aligned", "[platform]")
     if (memory) {
         memset(memory, 0, 10);
     }
+
+    REQUIRE(memory == EBPF_CACHE_ALIGN_POINTER(memory));
     ebpf_epoch_free_cache_aligned(memory);
     epoch_scope.exit();
     ebpf_epoch_synchronize();

--- a/libs/shared/ebpf_shared_framework.h
+++ b/libs/shared/ebpf_shared_framework.h
@@ -74,6 +74,12 @@ ebpf_free(_Frees_ptr_opt_ void* pointer)
     cxplat_free(pointer, CXPLAT_POOL_FLAG_NON_PAGED, 0);
 }
 
+__forceinline void
+ebpf_free_cache_aligned(_Frees_ptr_opt_ void* pointer)
+{
+    cxplat_free(pointer, (cxplat_pool_flags_t)(CXPLAT_POOL_FLAG_NON_PAGED | CXPLAT_POOL_FLAG_CACHE_ALIGNED), 0);
+}
+
 #define ebpf_reallocate cxplat_reallocate
 
 /**
@@ -86,6 +92,13 @@ __forceinline __drv_allocatesMem(Mem) _Must_inspect_result_
     _Ret_writes_maybenull_(size) void* ebpf_allocate_with_tag(size_t size, uint32_t tag)
 {
     return cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, size, tag);
+}
+
+__forceinline __drv_allocatesMem(Mem) _Must_inspect_result_
+    _Ret_writes_maybenull_(size) void* ebpf_allocate_cache_aligned_with_tag(size_t size, uint32_t tag)
+{
+    return cxplat_allocate(
+        (cxplat_pool_flags_t)(CXPLAT_POOL_FLAG_NON_PAGED | CXPLAT_POOL_FLAG_CACHE_ALIGNED), size, tag);
 }
 
 #define ebpf_safe_size_t_add(augend, addend, result) \


### PR DESCRIPTION
## Description

This pull request introduces cache-aligned memory allocation and deallocation functions to improve performance in the `ebpf_epoch` module. The main changes include adding new functions for cache-aligned memory operations and updating existing code to use these new functions.

### Cache-aligned memory allocation and deallocation:

* Added `ebpf_epoch_allocate_cache_aligned_with_tag` and `ebpf_epoch_free_cache_aligned` functions to handle cache-aligned memory operations. (`libs/runtime/ebpf_epoch.c`, `libs/runtime/ebpf_epoch.h`) [[1]](diffhunk://#diff-94ff44c39b70c06d386f9ecf50e23a03d48426267b588073db7e54b55a31c59dR459-R473) [[2]](diffhunk://#diff-94ff44c39b70c06d386f9ecf50e23a03d48426267b588073db7e54b55a31c59dR492-R509) [[3]](diffhunk://#diff-b2fcc909c78ebd178827ba44c049750e5352ec24c1b0459f96721ac3304a5829R60-R68) [[4]](diffhunk://#diff-b2fcc909c78ebd178827ba44c049750e5352ec24c1b0459f96721ac3304a5829R85-R91)
* Updated `_create_hash_map_internal`, `_delete_hash_map`, `_create_lru_hash_map`, and `_delete_lru_hash_map` to use the new cache-aligned allocation and free functions. (`libs/execution_context/ebpf_maps.c`) [[1]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL987-R987) [[2]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1025-R1025) [[3]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1047-R1047) [[4]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1407-R1407) [[5]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1419-R1419)
* Added a new allocation type `EBPF_EPOCH_ALLOCATION_MEMORY_CACHE_ALIGNED` to the `ebpf_epoch_allocation_type` enum. (`libs/runtime/ebpf_epoch.c`)
* Added a new test case `epoch_test_single_epoch_cache_aligned` to verify the cache-aligned memory operations. (`libs/runtime/unit/platform_unit_test.cpp`)

### Shared framework updates:

* Added `ebpf_allocate_cache_aligned_with_tag` and `ebpf_free_cache_aligned` functions to the shared framework for cache-aligned memory operations. (`libs/shared/ebpf_shared_framework.h`) [[1]](diffhunk://#diff-e23e20856d4f0764786ee92e6b717a1677e2432682a680c4fce8bea0845c7a09R77-R82) [[2]](diffhunk://#diff-e23e20856d4f0764786ee92e6b717a1677e2432682a680c4fce8bea0845c7a09R97-R103)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
