### PR TITLE
Improve ringbuffer performance

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4266,15 +4266,22 @@ _ebpf_ring_buffer_map_async_query_completion(_Inout_ void* completion_context) N
                 break;
             }
 
-            int callback_result = subscription->sample_callback(
-                subscription->sample_callback_context,
-                const_cast<void*>(reinterpret_cast<const void*>(record->data)),
-                record->header.length - EBPF_OFFSET_OF(ebpf_ring_buffer_record_t, data));
-            if (callback_result != 0) {
-                break;
+            while (ebpf_ring_buffer_record_is_locked(record)) {
+                // The record is being written to by the producer.
+                // Wait for the producer to finish writing.
+                YieldProcessor();
             }
 
-            consumer += record->header.length;
+            if (!ebpf_ring_buffer_record_is_discarded(record)) {
+                int callback_result = subscription->sample_callback(
+                    subscription->sample_callback_context,
+                    const_cast<void*>(reinterpret_cast<const void*>(record->data)),
+                    ebpf_ring_buffer_record_size(record) - EBPF_OFFSET_OF(ebpf_ring_buffer_record_t, data));
+                if (callback_result != 0) {
+                    break;
+                }
+            }
+            consumer += ebpf_ring_buffer_record_size(record);
         }
     }
 

--- a/libs/runtime/ebpf_ring_buffer.h
+++ b/libs/runtime/ebpf_ring_buffer.h
@@ -38,6 +38,7 @@ ebpf_ring_buffer_destroy(_Frees_ptr_opt_ ebpf_ring_buffer_t* ring_buffer);
  * @retval EBPF_SUCCESS Successfully wrote record ring buffer.
  * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
  */
+EBPF_INLINE_HINT
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_output(_Inout_ ebpf_ring_buffer_t* ring_buffer, _In_reads_bytes_(length) uint8_t* data, size_t length);
 


### PR DESCRIPTION
## Description

This pull request includes significant changes to the eBPF ring buffer implementation, focusing on improving synchronization, memory management, and adding new functionality. The most important changes include the introduction of spin locks for better concurrency control, a new flag-based system for record states, and the addition of a stress test for the ring buffer.

### Synchronization and Memory Management Improvements:
* [`libs/runtime/ebpf_ring_buffer.c`](diffhunk://#diff-bf6e569a8d57eb9f398cbd998dfea55358d269dc4128cc699ba3587e0064e441L11-L84): Introduced `cxplat_spin_lock_t` for both producer and consumer locks, replacing the previous `ebpf_lock_t`. This change improves concurrency control by using spin locks, which are more efficient in high-contention scenarios.
* [`libs/runtime/ebpf_ring_buffer.c`](diffhunk://#diff-bf6e569a8d57eb9f398cbd998dfea55358d269dc4128cc699ba3587e0064e441L228-R244): Modified the `ebpf_ring_buffer_reserve` and `ebpf_ring_buffer_output` functions to use a new flag-based system for record states, ensuring better synchronization and memory management. [[1]](diffhunk://#diff-bf6e569a8d57eb9f398cbd998dfea55358d269dc4128cc699ba3587e0064e441L228-R244) [[2]](diffhunk://#diff-bf6e569a8d57eb9f398cbd998dfea55358d269dc4128cc699ba3587e0064e441L138-R149)

### New Flag-Based System for Record States:
* [`libs/shared/ebpf_ring_buffer_record.h`](diffhunk://#diff-6c5e261ed21be7330c8111d45946332410815b76b90cdfcb7996e92b000d0db0R8-R19): Introduced new flags `EBPF_RING_BUFFER_RECORD_FLAG_LOCKED` and `EBPF_RING_BUFFER_RECORD_FLAG_DISCARDED` to manage the state of records in the ring buffer. This change simplifies the handling of record states and improves code readability. [[1]](diffhunk://#diff-6c5e261ed21be7330c8111d45946332410815b76b90cdfcb7996e92b000d0db0R8-R19) [[2]](diffhunk://#diff-6c5e261ed21be7330c8111d45946332410815b76b90cdfcb7996e92b000d0db0R42-R60)

### Additional Functionality:
* [`libs/runtime/unit/platform_unit_test.cpp`](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6R1149-R1248): Added a new stress test case `ring_buffer_stress` to evaluate the performance and reliability of the ring buffer under high load conditions. This test helps ensure the robustness of the ring buffer implementation.

### Other Notable Changes:
* [`libs/api/ebpf_api.cpp`](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeR4269-R4284): Added a loop to wait for the producer to finish writing if the record is locked, ensuring data consistency.
* [`external/usersim`](diffhunk://#diff-4ae78540d77e146774e537be8c7888b0e96d803c98c06760e4e8775833905812L1-R1): Updated the submodule commit reference to point to the latest commit.

## Testing

CI/CD + dedicated stress test

## Documentation

No.

## Installation

No.
