### PR TITLE
Short circuit printk if tracing is not enabled

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2321,6 +2321,11 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
         return -1;
     }
 
+    // If the provider is not enabled, don't bother with the rest.
+    if (!TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_PRINTK)) {
+        return 0;
+    }
+
     // Make a copy of the original format string.
     char* output = (char*)ebpf_allocate_with_tag(fmt_size + 1, EBPF_POOL_TAG_CORE);
     if (output == NULL) {


### PR DESCRIPTION
Resolves: #4034

## Description

This pull request includes an optimization to the `_ebpf_core_trace_printk` function in the `libs/execution_context/ebpf_core.c` file. The change ensures that if the trace logging provider is not enabled, the function will return early, avoiding unnecessary processing.

Optimization to trace logging:

* [`libs/execution_context/ebpf_core.c`](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R2324-R2328): Added a check to return early if the trace logging provider is not enabled, improving performance by skipping unnecessary operations.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
