### PR TITLE
Speedup walking the free-list

### DIFF
--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -613,6 +613,8 @@ _ebpf_epoch_release_free_list(_Inout_ ebpf_epoch_cpu_entry_t* cpu_entry, int64_t
         header = CONTAINING_RECORD(entry, ebpf_epoch_allocation_header_t, list_entry);
         if (header->freed_epoch <= released_epoch) {
             ebpf_list_remove_entry(entry);
+            // Prefetch the next entry that will be removed after the current one.
+            _mm_prefetch((char*)entry->Flink->Flink, _MM_HINT_T0);
             switch (header->entry_type) {
             case EBPF_EPOCH_ALLOCATION_MEMORY:
                 ebpf_free(header);

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -613,8 +613,7 @@ _ebpf_epoch_release_free_list(_Inout_ ebpf_epoch_cpu_entry_t* cpu_entry, int64_t
         header = CONTAINING_RECORD(entry, ebpf_epoch_allocation_header_t, list_entry);
         if (header->freed_epoch <= released_epoch) {
             ebpf_list_remove_entry(entry);
-            // Prefetch the next entry that will be removed after the current one.
-            _mm_prefetch((char*)entry->Flink->Flink, _MM_HINT_T0);
+            PrefetchForWrite(entry->Flink->Flink);
             switch (header->entry_type) {
             case EBPF_EPOCH_ALLOCATION_MEMORY:
                 ebpf_free(header);

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -828,10 +828,7 @@ ebpf_hash_table_find(_In_ const ebpf_hash_table_t* hash_table, _In_ const uint8_
         goto Done;
     }
 
-#if defined(_M_X64)
-    // Prefetch the data on the assumption that it will be used by the caller soon.
-    _mm_prefetch((const char*)data, _MM_HINT_T0);
-#endif
+    PrefetchForWrite(data);
 
     *value = data;
     if (hash_table->notification_callback) {


### PR DESCRIPTION
## Description

This pull request includes an optimization to the `_ebpf_epoch_release_free_list` function in the `libs/runtime/ebpf_epoch.c` file. The change involves prefetching the next entry to be removed, which can improve performance by reducing cache misses.

Performance optimization:

* [`libs/runtime/ebpf_epoch.c`](diffhunk://#diff-94ff44c39b70c06d386f9ecf50e23a03d48426267b588073db7e54b55a31c59dR616-R617): Added a prefetch instruction to the `_ebpf_epoch_release_free_list` function to prefetch the next entry that will be removed after the current one. This aims to improve performance by reducing cache misses.

## Testing

CI/CD

## Documentation

No.

## Installation

No.


Before:
```
Timestamp,Test,Average Duration (ns),CPU 0 Duration (ns),CPU 1 Duration (ns),CPU 2 Duration (ns),CPU 3 Duration (ns),CPU 4 Duration (ns),CPU 5 Duration (ns),CPU 6 Duration (ns),CPU 7 Duration (ns)
2024-11-22T19:11:34-0800,BPF_MAP_TYPE_HASH read,30,33,29,29,27,29,29,32,32
2024-11-22T19:11:34-0800,BPF_MAP_TYPE_HASH update,711,717,705,709,713,718,714,710,704
2024-11-22T19:11:42-0800,BPF_MAP_TYPE_HASH update and read,88,504,32,28,31,30,32,28,26
2024-11-22T19:11:47-0800,BPF_MAP_TYPE_HASH replace,772,779,771,769,783,763,774,777,766
2024-11-22T19:11:55-0800,BPF_MAP_TYPE_HASH_OF_MAPS read,70,70,72,76,66,72,71,67,70
2024-11-22T19:11:56-0800,BPF_MAP_TYPE_HASH_OF_MAPS update,920,917,915,919,924,919,925,924,924
```

After:
```
Timestamp,Test,Average Duration (ns),CPU 0 Duration (ns),CPU 1 Duration (ns),CPU 2 Duration (ns),CPU 3 Duration (ns),CPU 4 Duration (ns),CPU 5 Duration (ns),CPU 6 Duration (ns),CPU 7 Duration (ns)
2024-11-22T19:12:42-0800,BPF_MAP_TYPE_HASH read,30,31,29,31,26,32,32,30,30
2024-11-22T19:12:43-0800,BPF_MAP_TYPE_HASH update,639,643,637,644,646,634,638,631,644
2024-11-22T19:12:49-0800,BPF_MAP_TYPE_HASH update and read,83,463,28,29,29,30,29,30,28
2024-11-22T19:12:54-0800,BPF_MAP_TYPE_HASH replace,685,684,683,686,689,685,692,682,681
2024-11-22T19:13:01-0800,BPF_MAP_TYPE_HASH_OF_MAPS read,64,65,60,60,69,68,60,70,64
2024-11-22T19:13:02-0800,BPF_MAP_TYPE_HASH_OF_MAPS update,821,820,823,819,813,823,818,829,827
```