### PR TITLE
expand stack to 16KB for sock_addr hook.

### DIFF
--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -4,7 +4,7 @@
 #include "ebpf_extension_uuids.h"
 #include "net_ebpf_ext_hook_provider.h"
 
-#define NET_EBPF_EXT_STACK_EXPANSION_SIZE 1024 * 4
+#define NET_EBPF_EXT_STACK_EXPANSION_SIZE 1024 * 16
 
 typedef struct _net_ebpf_ext_hook_client_rundown
 {


### PR DESCRIPTION
## Description
_Describe the purpose of and changes within this Pull Request._
The socket hook takes a lot of stack as the WFP redirect code seems to require a lot of stack. If the eBPF program attached to a socket hook invokes further helper functions that allocate memory, the stack can grow too big and sometimes cause double fault. So increasing the stack expansion limit to 16KB.

## Testing
_Do any existing tests cover this change? Are new tests needed?_
CICD is sufficient for this.

## Documentation
_Is there any documentation impact for this change?_
No.

## Installation
_Is there any installer impact for this change?_
No.