### PR TITLE
Check for leaked ref-count when fuzzing

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -204,6 +204,19 @@ _ebpf_general_helper_function_provider_detach_client(_In_ void* provider_binding
 }
 
 _Must_inspect_result_ ebpf_result_t
+ebpf_core_initiate_pinning_table()
+{
+    return ebpf_pinning_table_allocate(&_ebpf_core_map_pinning_table);
+}
+
+void
+ebpf_core_terminate_pinning_table()
+{
+    ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
+    _ebpf_core_map_pinning_table = NULL;
+}
+
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_initiate()
 {
     ebpf_result_t return_value;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -254,7 +254,7 @@ ebpf_core_initiate()
 
     ebpf_object_tracking_initiate();
 
-    return_value = ebpf_pinning_table_allocate(&_ebpf_core_map_pinning_table);
+    return_value = ebpf_core_initiate_pinning_table();
     if (return_value != EBPF_SUCCESS) {
         goto Done;
     }
@@ -311,8 +311,7 @@ ebpf_core_terminate()
 
     ebpf_async_terminate();
 
-    ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
-    _ebpf_core_map_pinning_table = NULL;
+    ebpf_core_terminate_pinning_table();
 
     ebpf_state_terminate();
 

--- a/tests/libfuzzer/execution_context/libfuzz_harness.cpp
+++ b/tests/libfuzzer/execution_context/libfuzz_harness.cpp
@@ -436,9 +436,11 @@ class fuzz_wrapper
     ~fuzz_wrapper()
     {
         ebpf_handle_table_terminate();
+        ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
         ebpf_object_tracking_terminate();
         ebpf_epoch_synchronize();
         ebpf_object_tracking_initiate();
+        ebpf_assert(ebpf_pinning_table_allocate(&_ebpf_core_map_pinning_table) == EBPF_SUCCESS);
         ebpf_assert(ebpf_handle_table_initiate() == EBPF_SUCCESS);
     }
 

--- a/tests/libfuzzer/execution_context/libfuzz_harness.cpp
+++ b/tests/libfuzzer/execution_context/libfuzz_harness.cpp
@@ -17,6 +17,15 @@
 #include <mutex>
 #include <vector>
 
+extern "C"
+{
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_core_initiate_pinning_table();
+
+    void
+    ebpf_core_terminate_pinning_table();
+}
+
 #define REQUIRE(X)                 \
     {                              \
         bool x = (X);              \
@@ -436,11 +445,11 @@ class fuzz_wrapper
     ~fuzz_wrapper()
     {
         ebpf_handle_table_terminate();
-        ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
+        ebpf_core_terminate_pinning_table();
         ebpf_object_tracking_terminate();
         ebpf_epoch_synchronize();
         ebpf_object_tracking_initiate();
-        ebpf_assert(ebpf_pinning_table_allocate(&_ebpf_core_map_pinning_table) == EBPF_SUCCESS);
+        ebpf_assert(ebpf_core_initiate_pinning_table() == EBPF_SUCCESS);
         ebpf_assert(ebpf_handle_table_initiate() == EBPF_SUCCESS);
     }
 

--- a/tests/libfuzzer/execution_context/libfuzz_harness.cpp
+++ b/tests/libfuzzer/execution_context/libfuzz_harness.cpp
@@ -436,7 +436,9 @@ class fuzz_wrapper
     ~fuzz_wrapper()
     {
         ebpf_handle_table_terminate();
+        ebpf_object_tracking_terminate();
         ebpf_epoch_synchronize();
+        ebpf_object_tracking_initiate();
         ebpf_assert(ebpf_handle_table_initiate() == EBPF_SUCCESS);
     }
 


### PR DESCRIPTION
## Description

This pull request introduces new functionality for managing the pinning table in the eBPF core and updates the fuzzing harness to include this functionality. The most important changes include adding functions to initiate and terminate the pinning table and updating the fuzzing harness to call these new functions.

### eBPF Core Enhancements:
* Added `ebpf_core_initiate_pinning_table()` to allocate the pinning table.
* Added `ebpf_core_terminate_pinning_table()` to free the pinning table.

### Fuzzing Harness Updates:
* Declared the new pinning table functions in `libfuzz_harness.cpp`.
* Updated the `fuzz_wrapper` destructor to call `ebpf_core_terminate_pinning_table()` and `ebpf_core_initiate_pinning_table()`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
