### PR TITLE
handle timeout on driver stop.

### DIFF
--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -59,12 +59,22 @@ $Job = Start-Job -ScriptBlock {
     # currently one VM runs per runner.
     $TestVMName = $VMList[0].Name
 
-    # Run Kernel tests on test VM.
-    Write-Log "Running kernel tests on $TestVMName"
-    Run-KernelTestsOnVM -VMName $TestVMName -Config $Config
+    try {
+        # Run Kernel tests on test VM.
+        Write-Log "Running kernel tests on $TestVMName"
+        Run-KernelTestsOnVM -VMName $TestVMName -Config $Config
 
-    # Stop eBPF components on test VMs.
-    Stop-eBPFComponentsOnVM -VMName $TestVMName
+        # Stop eBPF components on test VMs.
+        Stop-eBPFComponentsOnVM -VMName $TestVMName
+    } catch [System.Management.Automation.RemoteException] {
+        # Next, generate kernel dump.
+        Write-Log $_.Exception.Message
+        Write-Log $_.ScriptStackTrace
+        if ($_.CategoryInfo.Reason -eq "TimeoutException") {
+            Generate-KernelDumpOnVM($TestVMName)
+        }
+    }
+
 
     Pop-Location
 } -ArgumentList (


### PR DESCRIPTION
## Description

This change induces a bugcheck on the test VM if stopping a driver at the end of the tests takes more than 60 seconds.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CICD scripts updated.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.