### PR TITLE
Always count entries on debug builds

### DIFF
--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -758,7 +758,13 @@ ebpf_hash_table_create(_Out_ ebpf_hash_table_t** hash_table, _In_ const ebpf_has
     table->entry_count = 0;
     table->seed = ebpf_random_uint32();
     table->extract = options->extract_function;
+#if defined(NDEBUG)
     table->max_entry_count = options->max_entries;
+#else
+    // If debug mode, treat EBPF_HASH_TABLE_NO_LIMIT as -1 to ensure that entries are counted.
+    table->max_entry_count = options->max_entries == EBPF_HASH_TABLE_NO_LIMIT ? -1 : options->max_entries;
+#endif
+
     table->supplemental_value_size = options->supplemental_value_size;
     table->notification_context = options->notification_context;
     table->notification_callback = options->notification_callback;


### PR DESCRIPTION
## Description

This pull request includes a change to the `ebpf_hash_table_create` function in the `libs/runtime/ebpf_hash_table.c` file. The change introduces different behavior for the `max_entry_count` field based on whether the code is compiled in debug mode or not.

* [`libs/runtime/ebpf_hash_table.c`](diffhunk://#diff-6c24a75cf729f18fc4eb4459a9eb23a3561b8192157748b256c40db9abc47c2aR761-R767): Added a conditional compilation block to set `max_entry_count` to `-1` if `EBPF_HASH_TABLE_NO_LIMIT` is specified and the code is compiled in debug mode. In non-debug mode, it retains the original behavior.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
