### PR TITLE
Switch to v0.11.0 of BPF performance

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -222,7 +222,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
         cd ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.0.6/build-Release-windows-2022.zip -OutFile bpf_performance.zip
+        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.11.0/build-Release-windows-2022.zip -OutFile bpf_performance.zip
 
     - name: Extract artifacts to build path
       if: steps.skip_check.outputs.should_skip != 'true' && inputs.download_demo_repository == true && matrix.configurations != 'FuzzerDebug'


### PR DESCRIPTION
## Description

This pull request includes an update to the `reusable-build.yml` workflow file. The most important change is updating the URL for downloading the `bpf_performance` build artifact to a newer version.

Workflow update:

* [`.github/workflows/reusable-build.yml`](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L225-R225): Updated the URL in the `Invoke-WebRequest` command to download `bpf_performance` version 0.11.0 instead of version 0.0.6.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
