### PR TITLE
Use volatile write when writing to user buffer

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2109,7 +2109,8 @@ ebpf_program_get_info(
                     EBPF_RETURN_RESULT(EBPF_INVALID_POINTER);
                 } else {
                     ebpf_map_t* map = program->maps[i];
-                    map_ids[i] = ebpf_map_get_id(map);
+                    // Volatile user mode pointer.
+                    WriteNoFence((volatile long*)&map_ids[i], ebpf_map_get_id(map));
                 }
             }
         } __except (EXCEPTION_EXECUTE_HANDLER) {


### PR DESCRIPTION
## Description

This pull request includes a change to the `ebpf_program_get_info` function in the `libs/execution_context/ebpf_program.c` file. The change ensures that the `map_ids` array is updated using a volatile user mode pointer to prevent potential issues with compiler optimizations.

* [`libs/execution_context/ebpf_program.c`](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2112-R2113): Modified the `ebpf_program_get_info` function to use `WriteNoFence` for updating the `map_ids` array, ensuring proper handling of volatile user mode pointers.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
