### PR TITLE
Don't attempt to cross-compile native images

### DIFF
--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -244,7 +244,7 @@
       <BuildInParallel>true</BuildInParallel>
     </CustomBuild>
   </ItemGroup>
-  <ItemGroup Condition="'$(Analysis)'=='' And '$(Configuration)'!='FuzzerDebug'">
+  <ItemGroup Condition="'$(Analysis)'=='' And '$(Configuration)'!='FuzzerDebug' And '$(Platform)'=='$(HostPlatform)'">
     <!-- Build BPF programs that pass verification and build native images for them. -->
     <CustomBuild Include="*.c">
       <FileType>CppCode</FileType>
@@ -276,7 +276,7 @@
        configuration. As a result of that, the eBPF store cannot be populated for sample program types and hence bpf2c cannot convert
        the sample program types to native images (as it needs program information for offline verification).
   -->
-  <ItemGroup Condition="'$(Configuration)'!='FuzzerDebug'">
+  <ItemGroup Condition="'$(Configuration)'!='FuzzerDebug' And '$(Platform)'=='$(HostPlatform)'">
     <CustomBuild Include="undocked\*.c">
       <FileType>CppCode</FileType>
       <Command>
@@ -345,7 +345,7 @@
     </CustomBuild>
   </ItemGroup>
   <!-- Build BPF programs that pass verification and build native images for them but require custom program type. -->
-  <ItemGroup Condition="'$(Analysis)'=='' And '$(Configuration)'!='FuzzerDebug'">
+  <ItemGroup Condition="'$(Analysis)'=='' And '$(Configuration)'!='FuzzerDebug' And '$(Platform)'=='$(HostPlatform)'">
     <CustomBuild Include="custom_program_type\*.c">
       <FileType>CppCode</FileType>
       <Command>


### PR DESCRIPTION
## Description

This pull request includes updates to the `tests/sample/sample.vcxproj` file to ensure that custom build steps are only executed when the platform matches the host platform. This change improves the build configuration by adding an additional condition to the `ItemGroup` elements.

Build configuration improvements:

* [`tests/sample/sample.vcxproj`](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L247-R247): Added condition to check if `'$(Platform)'=='$(HostPlatform)'` in multiple `ItemGroup` elements to ensure custom build steps are only executed when the platform matches the host platform. [[1]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L247-R247) [[2]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L279-R279) [[3]](diffhunk://#diff-129f72ff74c074bbf70bb526469ee820be00f3fbea35315b3f0d6bda2e4b1375L348-R348)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
