### PR TITLE
Fix incorrect platform reference in kernel_mode_bpf2c.vcxproj

### DIFF
--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -16,13 +16,13 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|ARM">
+    <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
-      <Platform>ARM</Platform>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM">
+    <ProjectConfiguration Include="Release|ARM64">
       <Configuration>Release</Configuration>
-      <Platform>ARM</Platform>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
## Description

This pull request includes changes to the project configuration for ARM64 support.

Project configuration updates:
* [`tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj`](diffhunk://#diff-fc796b56abadfe08981eff727a9493359dbc2084b95990a738e9b0ed83d1f885L19-R25): Updated project configurations to replace ARM with ARM64 for both Debug and Release configurations.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
