### PR TITLE
Fix incorrect path to downloaded script

### DIFF
--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -102,7 +102,7 @@ jobs:
         export PGUSER=$(cat ${{github.workspace}}/PGUSER)
         export PGPORT=$(cat ${{github.workspace}}/PGPORT)
         export PGDATABASE=$(cat ${{github.workspace}}/PGDATABASE)
-        psql -f ./scripts/check_perf_results.sql -v platform='${{inputs.platform}}' --csv > ${{github.workspace}}/results/regression_results.csv
+        psql -f ./check_perf_results.sql -v platform='${{inputs.platform}}' --csv > ${{github.workspace}}/results/regression_results.csv
 
     - name: Upload regression results
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882


### PR DESCRIPTION
## Description

This pull request includes a small change to the `.github/workflows/upload-perf-results.yml` file. The change updates the path to the `check_perf_results.sql` script to ensure it is correctly located.

* [`.github/workflows/upload-perf-results.yml`](diffhunk://#diff-88e0670dc528bb3547c4ca7dfeca2c6f0d0c345cb778802a3eb7d9f2db4be040L105-R105): Updated the path to the `check_perf_results.sql` script from `./scripts/check_perf_results.sql` to `./check_perf_results.sql`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
