### PR TITLE
Update wdk

### DIFF
--- a/.github/workflows/check_wdk.yml
+++ b/.github/workflows/check_wdk.yml
@@ -12,6 +12,10 @@ on:
   # Allow manual triggering of the script
   workflow_dispatch:
 
+permissions:
+  contents: read  # Required by actions/checkout to fetch code.
+  issues: write # Required to create issues.
+
 jobs:
   check:
     runs-on: Windows-latest

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,10 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) eBPF for Windows contributors
+  SPDX-License-Identifier: MIT
+-->
 <packages>
-  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2454" targetFramework="native" />
 </packages>

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion>10.0.26100.2161</WDKVersion>
+    <WDKVersion>10.0.26100.2454</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion>10.0.26100.2161</WDKVersion>
+    <WDKVersion>10.0.26100.2454</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/wdk.props
+++ b/wdk.props
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright (c) Microsoft Corporation
+  Copyright (c) eBPF for Windows contributors
   SPDX-License-Identifier: MIT
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
-    <WDKVersion>10.0.26100.2161</WDKVersion>
+    <WDKVersion>10.0.26100.2454</WDKVersion>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />


### PR DESCRIPTION
Resolves: #4103

## Description

Pickup the latest WDK.
Fix permissions on the check WDK workflow.

This pull request includes updates to the permissions in the GitHub Actions workflow and upgrades to the Windows SDK and WDK versions across multiple configuration files. The most important changes are summarized below:

Permissions update in GitHub Actions workflow:

* [`.github/workflows/check_wdk.yml`](diffhunk://#diff-685871871419f1c41ce8417e0b59882ea5e4135e033d01c7dd5a1a483d047a47R15-R18): Added read permissions for contents and write permissions for issues.

SDK and WDK version upgrades:

* [`scripts/setup_build/packages.config`](diffhunk://#diff-802912bfde6b8ea411619105236cbcca7a2452e26911bc02617e5a4476da2c28L1-R13): Updated the version of various Microsoft Windows SDK and WDK packages from `10.0.26100.2161` to `10.0.26100.2454`.
* [`tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj`](diffhunk://#diff-fc796b56abadfe08981eff727a9493359dbc2084b95990a738e9b0ed83d1f885L8-R8): Updated `WDKVersion` from `10.0.26100.2161` to `10.0.26100.2454`.
* [`tools/bpf2c/templates/user_mode_bpf2c.vcxproj`](diffhunk://#diff-448d7df5def64aa8987f23fe49f3739c3d0cf62d06fd70e8fe93fbc14dae757cL8-R8): Updated `WDKVersion` from `10.0.26100.2161` to `10.0.26100.2454`.
* [`wdk.props`](diffhunk://#diff-495df965b3e771fdb5967162d00ea1db561789398bddb53465aef374a22cbd42L10-R10): Updated `WDKVersion` from `10.0.26100.2161` to `10.0.26100.2454`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
