### PR TITLE
Update usersim

### DIFF
--- a/tests/performance/performance_measure.h
+++ b/tests/performance/performance_measure.h
@@ -55,7 +55,6 @@ template <typename T> class _performance_measure
         for (uint32_t i = 0; i < cpu_count; i++) {
             threads.emplace_back(std::thread([i, this, &ready_count] {
                 uint32_t local_cpu_id = i;
-                usersim_set_affinity_and_priority_override(local_cpu_id);
                 uintptr_t thread_mask = local_cpu_id;
                 thread_mask = static_cast<uintptr_t>(1) << thread_mask;
                 SetThreadAffinityMask(GetCurrentThread(), thread_mask);
@@ -76,8 +75,6 @@ template <typename T> class _performance_measure
                         if (!preemptible) {
                             KeLowerIrql(old_irql);
                         }
-                        usersim_clear_affinity_and_priority_override();
-                        usersim_set_affinity_and_priority_override(local_cpu_id);
                         if (!preemptible) {
                             old_irql = KeRaiseIrqlToDpcLevel();
                         }
@@ -94,7 +91,6 @@ template <typename T> class _performance_measure
                 if (!preemptible) {
                     KeLowerIrql(old_irql);
                 }
-                usersim_clear_affinity_and_priority_override();
             }));
         }
         // Wait for threads to spin up.


### PR DESCRIPTION
## Description

Pickup latest usersim.
This pull request includes updates to the `external/usersim` submodule and modifications to the `performance_measure` class in the `tests/performance/performance_measure.h` file to remove calls to `usersim_set_affinity_and_priority_override` and `usersim_clear_affinity_and_priority_override`.

Submodule update:

* [`external/usersim`](diffhunk://#diff-4ae78540d77e146774e537be8c7888b0e96d803c98c06760e4e8775833905812L1-R1): Updated the submodule commit reference to the latest commit.

Performance measure class changes:

* [`tests/performance/performance_measure.h`](diffhunk://#diff-6e1c63471f95341747ca3035dea06743c29dfc4d69d82ab32de810358a96e664L58): Removed the call to `usersim_set_affinity_and_priority_override` in the thread initialization loop.
* [`tests/performance/performance_measure.h`](diffhunk://#diff-6e1c63471f95341747ca3035dea06743c29dfc4d69d82ab32de810358a96e664L79-L80): Removed the calls to `usersim_clear_affinity_and_priority_override` and `usersim_set_affinity_and_priority_override` within the thread execution logic. [[1]](diffhunk://#diff-6e1c63471f95341747ca3035dea06743c29dfc4d69d82ab32de810358a96e664L79-L80) [[2]](diffhunk://#diff-6e1c63471f95341747ca3035dea06743c29dfc4d69d82ab32de810358a96e664L97)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
