### PR TITLE
Export functions necessary for ebpf-go port

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -109,6 +109,8 @@ EXPORTS
     ebpf_api_close_handle
     ebpf_api_get_pinned_map_info
     ebpf_api_map_info_free
+    ebpf_close_fd
+    ebpf_dup_fd
     ebpf_enumerate_programs
     ebpf_enumerate_sections = ebpf_enumerate_programs
     ebpf_free_programs

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -133,7 +133,7 @@ EXPORTS
     ebpf_object_unpin
     ebpf_program_attach
     ebpf_program_attach_by_fd
-    ebpf_program_attach_fds
+    ebpf_program_attach_by_fds
     ebpf_program_query_info
     ebpf_ring_buffer_map_write
     ebpf_store_delete_program_information

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -117,6 +117,10 @@ EXPORTS
     ebpf_free_sections = ebpf_free_programs
     ebpf_free_string
     ebpf_get_attach_type_name
+    ebpf_get_bpf_program_type
+    ebpf_get_bpf_attach_type
+    ebpf_get_ebpf_program_type
+    ebpf_get_ebpf_attach_type
     ebpf_get_next_pinned_object_path
     ebpf_get_next_pinned_program_path
     ebpf_get_program_info_from_verifier

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -133,7 +133,7 @@ EXPORTS
     ebpf_object_unpin
     ebpf_program_attach
     ebpf_program_attach_by_fd
-    ebpf_program_attach_as_fd
+    ebpf_program_attach_fds
     ebpf_program_query_info
     ebpf_ring_buffer_map_write
     ebpf_store_delete_program_information

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -117,10 +117,10 @@ EXPORTS
     ebpf_free_sections = ebpf_free_programs
     ebpf_free_string
     ebpf_get_attach_type_name
-    ebpf_get_bpf_program_type
     ebpf_get_bpf_attach_type
-    ebpf_get_ebpf_program_type
+    ebpf_get_bpf_program_type
     ebpf_get_ebpf_attach_type
+    ebpf_get_ebpf_program_type
     ebpf_get_next_pinned_object_path
     ebpf_get_next_pinned_program_path
     ebpf_get_program_info_from_verifier
@@ -149,5 +149,5 @@ EXPORTS
     libbpf_num_possible_cpus
     libbpf_prog_type_by_name
     libbpf_strerror
-    ring_buffer__new
     ring_buffer__free
+    ring_buffer__new

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -110,7 +110,7 @@ EXPORTS
     ebpf_api_get_pinned_map_info
     ebpf_api_map_info_free
     ebpf_close_fd
-    ebpf_dup_fd
+    ebpf_duplicate_fd
     ebpf_enumerate_programs
     ebpf_enumerate_sections = ebpf_enumerate_programs
     ebpf_free_programs

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -129,6 +129,7 @@ EXPORTS
     ebpf_object_unpin
     ebpf_program_attach
     ebpf_program_attach_by_fd
+    ebpf_program_attach_as_fd
     ebpf_program_query_info
     ebpf_ring_buffer_map_write
     ebpf_store_delete_program_information

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -423,6 +423,8 @@ extern "C"
      * the link as a file descriptor.
      *
      * @see ebpf_program_attach_by_fd
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_attach_fds(

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -419,6 +419,20 @@ extern "C"
         _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
+     * @brief Attach an eBPF program by program file descriptor and return
+     * the link as a file descriptor.
+     *
+     * @see ebpf_program_attach_by_fd
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_program_attach_as_fd(
+        fd_t program_fd,
+        _In_opt_ const ebpf_attach_type_t* attach_type,
+        _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+        size_t attach_parameters_size,
+        _Out_ fd_t* link) EBPF_NO_EXCEPT;
+
+    /**
      * @brief Detach an eBPF program from an attach point represented by
      *  the bpf_link structure.
      *

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -474,6 +474,17 @@ extern "C"
     ebpf_close_fd(fd_t fd) EBPF_NO_EXCEPT;
 
     /**
+     * @brief Duplicate a file descriptor.
+     *
+     * @param [in] fd File descriptor to be duplicated.
+     * @param [out] dup Duplicated file descriptor.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_dup_fd(fd_t fd, _Out_ fd_t* dup) EBPF_NO_EXCEPT;
+
+    /**
      * @brief Get eBPF program type and expected attach type by name.
      *
      * @param[in] name Name, as if it were a section name in an ELF file.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -639,12 +639,14 @@ extern "C"
     /**
      * @brief Get eBPF attach type for the specified BPF attach type.
      *
-     * @param[in] program_type BPF attach type.
+     * @param[in] bpf_attach_type BPF attach type.
+     * @param[out] ebpf_attach_type eBPF attach type or GUID_NULL.
      *
-     * @returns Pointer to eBPF attach type, or NULL if not found.
+     * @returns EBPF_INVALID_ARGUMENT if attach type is unknown, EBPF_SUCCESS otherwise.
      */
-    _Ret_maybenull_ const ebpf_attach_type_t*
-    ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) EBPF_NO_EXCEPT;
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type, _Out_ ebpf_attach_type_t* ebpf_attach_type)
+        EBPF_NO_EXCEPT;
 
     /**
      * @brief Get BPF program type for the specified eBPF program type.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -624,6 +624,46 @@ extern "C"
     ebpf_ring_buffer_map_write(
         fd_t ring_buffer_map_fd, _In_reads_bytes_(data_length) const void* data, size_t data_length) EBPF_NO_EXCEPT;
 
+    /**
+     * @brief Get eBPF program type for the specified bpf program type.
+     *
+     * @param[in] program_type Bpf program type.
+     *
+     * @returns Pointer to eBPF program type, or NULL if not found.
+     */
+    _Ret_maybenull_ const ebpf_program_type_t*
+    ebpf_get_ebpf_program_type(bpf_prog_type_t bpf_program_type) EBPF_NO_EXCEPT;
+
+    /**
+     * @brief Get eBPF attach type for the specified bpf attach type.
+     *
+     * @param[in] program_type Bpf attach type.
+     *
+     * @returns Pointer to eBPF attach type, or NULL if not found.
+     */
+    _Ret_maybenull_ const ebpf_attach_type_t*
+    ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) EBPF_NO_EXCEPT;
+
+    /**
+     * @brief Get bpf program type for the specified eBPF program type.
+     *
+     * @param[in] program_type eBPF program type GUID.
+     *
+     * @returns Bpf program type, or BPF_PROG_TYPE_UNSPEC if not found.
+     */
+    bpf_prog_type_t
+    ebpf_get_bpf_program_type(_In_ const ebpf_program_type_t* program_type) EBPF_NO_EXCEPT;
+
+    /**
+     * @brief Get bpf attach type for the specified eBPF attach type.
+     *
+     * @param[in] attach_type eBPF attach type GUID.
+     *
+     * @returns Bpf attach type, or BPF_ATTACH_TYPE_UNSPEC if not found.
+     */
+    bpf_attach_type_t
+    ebpf_get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) EBPF_NO_EXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -642,7 +642,8 @@ extern "C"
      * @param[in] bpf_attach_type BPF attach type.
      * @param[out] ebpf_attach_type eBPF attach type or GUID_NULL.
      *
-     * @returns EBPF_INVALID_ARGUMENT if attach type is unknown, EBPF_SUCCESS otherwise.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT The attach type is unknown.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type, _Out_ ebpf_attach_type_t* ebpf_attach_type)

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -427,7 +427,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_program_attach_fds(
+    ebpf_program_attach_by_fds(
         fd_t program_fd,
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -498,7 +498,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_dup_fd(fd_t fd, _Out_ fd_t* dup) EBPF_NO_EXCEPT;
+    ebpf_duplicate_fd(fd_t fd, _Out_ fd_t* dup) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get eBPF program type and expected attach type by name.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -425,7 +425,7 @@ extern "C"
      * @see ebpf_program_attach_by_fd
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_program_attach_as_fd(
+    ebpf_program_attach_fds(
         fd_t program_fd,
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -625,9 +625,9 @@ extern "C"
         fd_t ring_buffer_map_fd, _In_reads_bytes_(data_length) const void* data, size_t data_length) EBPF_NO_EXCEPT;
 
     /**
-     * @brief Get eBPF program type for the specified bpf program type.
+     * @brief Get eBPF program type for the specified BPF program type.
      *
-     * @param[in] program_type Bpf program type.
+     * @param[in] program_type BPF program type.
      *
      * @returns Pointer to eBPF program type, or NULL if not found.
      */
@@ -635,9 +635,9 @@ extern "C"
     ebpf_get_ebpf_program_type(bpf_prog_type_t bpf_program_type) EBPF_NO_EXCEPT;
 
     /**
-     * @brief Get eBPF attach type for the specified bpf attach type.
+     * @brief Get eBPF attach type for the specified BPF attach type.
      *
-     * @param[in] program_type Bpf attach type.
+     * @param[in] program_type BPF attach type.
      *
      * @returns Pointer to eBPF attach type, or NULL if not found.
      */
@@ -645,21 +645,21 @@ extern "C"
     ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) EBPF_NO_EXCEPT;
 
     /**
-     * @brief Get bpf program type for the specified eBPF program type.
+     * @brief Get BPF program type for the specified eBPF program type.
      *
      * @param[in] program_type eBPF program type GUID.
      *
-     * @returns Bpf program type, or BPF_PROG_TYPE_UNSPEC if not found.
+     * @returns BPF program type, or BPF_PROG_TYPE_UNSPEC if not found.
      */
     bpf_prog_type_t
     ebpf_get_bpf_program_type(_In_ const ebpf_program_type_t* program_type) EBPF_NO_EXCEPT;
 
     /**
-     * @brief Get bpf attach type for the specified eBPF attach type.
+     * @brief Get BPF attach type for the specified eBPF attach type.
      *
      * @param[in] attach_type eBPF attach type GUID.
      *
-     * @returns Bpf attach type, or BPF_ATTACH_TYPE_UNSPEC if not found.
+     * @returns BPF attach type, or BPF_ATTACH_TYPE_UNSPEC if not found.
      */
     bpf_attach_type_t
     ebpf_get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) EBPF_NO_EXCEPT;

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -713,6 +713,16 @@ ebpf_program_load_bytes(
 #endif
 
 /**
+ * @brief Get eBPF attach type for the specified bpf attach type.
+ *
+ * @param[in] program_type Bpf attach type.
+ *
+ * @returns Pointer to eBPF attach type, or NULL if not found.
+ */
+_Ret_maybenull_ const ebpf_attach_type_t*
+get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept;
+
+/**
  * @brief Initialize the eBPF library's thread local storage.
  */
 void

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -713,46 +713,6 @@ ebpf_program_load_bytes(
 #endif
 
 /**
- * @brief Get eBPF program type for the specified bpf program type.
- *
- * @param[in] program_type Bpf program type.
- *
- * @returns Pointer to eBPF program type, or NULL if not found.
- */
-_Ret_maybenull_ const ebpf_program_type_t*
-ebpf_get_ebpf_program_type(bpf_prog_type_t bpf_program_type) noexcept;
-
-/**
- * @brief Get eBPF attach type for the specified bpf attach type.
- *
- * @param[in] program_type Bpf attach type.
- *
- * @returns Pointer to eBPF attach type, or NULL if not found.
- */
-_Ret_maybenull_ const ebpf_attach_type_t*
-get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept;
-
-/**
- * @brief Get bpf program type for the specified eBPF program type.
- *
- * @param[in] program_type eBPF program type GUID.
- *
- * @returns Bpf program type, or BPF_PROG_TYPE_UNSPEC if not found.
- */
-bpf_prog_type_t
-get_bpf_program_type(_In_ const ebpf_program_type_t* program_type) noexcept;
-
-/**
- * @brief Get bpf attach type for the specified eBPF attach type.
- *
- * @param[in] attach_type eBPF attach type GUID.
- *
- * @returns Bpf attach type, or BPF_ATTACH_TYPE_UNSPEC if not found.
- */
-bpf_attach_type_t
-get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept;
-
-/**
  * @brief Initialize the eBPF library's thread local storage.
  */
 void

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1656,7 +1656,7 @@ ebpf_program_attach(
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_program_attach_as_fd(
+ebpf_program_attach_fds(
     fd_t program_fd,
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
@@ -1699,7 +1699,7 @@ ebpf_program_attach_by_fd(
     }
 
     ebpf_result_t result =
-        ebpf_program_attach_as_fd(program_fd, attach_type, attach_parameters, attach_parameters_size, &new_link->fd);
+        ebpf_program_attach_fds(program_fd, attach_type, attach_parameters, attach_parameters_size, &new_link->fd);
     if (result != EBPF_SUCCESS) {
         ebpf_free(new_link);
         EBPF_RETURN_RESULT(result);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1491,7 +1491,7 @@ static ebpf_result_t
 _link_ebpf_program(
     ebpf_handle_t program_handle,
     _In_ const ebpf_attach_type_t* attach_type,
-    _Outptr_ ebpf_link_t** link,
+    _Out_ ebpf_handle_t* link,
     _In_reads_bytes_opt_(attach_parameter_size) uint8_t* attach_parameter,
     size_t attach_parameter_size) NO_EXCEPT_TRY
 {
@@ -1500,19 +1500,9 @@ _link_ebpf_program(
     ebpf_operation_link_program_request_t* request;
     ebpf_operation_link_program_reply_t reply;
     ebpf_result_t result = EBPF_SUCCESS;
-    bool attached = false;
 
     ebpf_assert(attach_type);
-    ebpf_assert(link);
     ebpf_assert(attach_parameter || !attach_parameter_size);
-
-    *link = nullptr;
-    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate(sizeof(ebpf_link_t));
-    if (new_link == nullptr) {
-        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
-    }
-    new_link->handle = ebpf_handle_invalid;
-    new_link->fd = ebpf_fd_invalid;
 
     try {
         size_t buffer_size = offsetof(ebpf_operation_link_program_request_t, data) + attach_parameter_size;
@@ -1529,35 +1519,17 @@ _link_ebpf_program(
 
         result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer, reply));
         if (result != EBPF_SUCCESS) {
-            goto Exit;
+            EBPF_RETURN_RESULT(result);
         }
         ebpf_assert(reply.header.id == ebpf_operation_id_t::EBPF_OPERATION_LINK_PROGRAM);
-        attached = true;
 
-        new_link->handle = reply.link_handle;
-        new_link->fd = _create_file_descriptor_for_handle(new_link->handle);
-        if (new_link->fd == ebpf_fd_invalid) {
-            result = EBPF_NO_MEMORY;
-        } else {
-            *link = new_link;
-            new_link = nullptr;
-        }
+        *link = reply.link_handle;
+        EBPF_RETURN_RESULT(EBPF_SUCCESS);
     } catch (const std::bad_alloc&) {
-        result = EBPF_NO_MEMORY;
-        goto Exit;
+        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     } catch (...) {
-        result = EBPF_FAILED;
-        goto Exit;
+        EBPF_RETURN_RESULT(EBPF_FAILED);
     }
-
-Exit:
-    if (new_link != nullptr) {
-        if (attached) {
-            ebpf_assert_success(ebpf_link_detach(new_link));
-        }
-        ebpf_link_close(new_link);
-    }
-    EBPF_RETURN_RESULT(result);
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
@@ -1610,6 +1582,50 @@ ebpf_detach_link_by_fd(fd_t fd) NO_EXCEPT_TRY
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
+_ebpf_program_attach(
+    ebpf_handle_t program_handle,
+    _In_opt_ const ebpf_program_t* program,
+    _In_opt_ const ebpf_attach_type_t* attach_type,
+    _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+    size_t attach_parameters_size,
+    _Out_ ebpf_handle_t* link_handle,
+    _Out_opt_ fd_t* link_fd) NO_EXCEPT_TRY
+{
+    EBPF_LOG_ENTRY();
+    ebpf_assert(attach_parameters || !attach_parameters_size);
+    ebpf_assert(link_handle);
+
+    *link_handle = ebpf_handle_invalid;
+
+    if (attach_type == nullptr) {
+        // Unspecified attach_type is allowed only if we can find an ebpf_program_t.
+        if (program == nullptr || IsEqualGUID(program->attach_type, GUID_NULL)) {
+            EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
+        }
+
+        attach_type = &program->attach_type;
+    }
+
+    ebpf_result_t result = _link_ebpf_program(
+        program_handle, attach_type, link_handle, (uint8_t*)attach_parameters, attach_parameters_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    if (link_fd != nullptr) {
+        *link_fd = _create_file_descriptor_for_handle(*link_handle);
+        if (*link_fd == ebpf_fd_invalid) {
+            Platform::CloseHandle(*link_handle);
+            *link_handle = ebpf_handle_invalid;
+            EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
+        }
+    }
+
+    EBPF_RETURN_RESULT(EBPF_SUCCESS);
+}
+CATCH_NO_MEMORY_EBPF_RESULT
+
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_attach(
     _In_ const struct bpf_program* program,
     _In_opt_ const ebpf_attach_type_t* attach_type,
@@ -1618,32 +1634,51 @@ ebpf_program_attach(
     _Outptr_ struct bpf_link** link) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
-    ebpf_result_t result = EBPF_SUCCESS;
-    const ebpf_attach_type_t* program_attach_type;
 
     ebpf_assert(program);
-    ebpf_assert(link);
-    ebpf_assert(attach_parameters || !attach_params_size);
-    if (IsEqualGUID(program->attach_type, GUID_NULL)) {
-        if (attach_type == nullptr) {
-            result = EBPF_INVALID_ARGUMENT;
-            goto Exit;
-        } else {
-            program_attach_type = attach_type;
-        }
-    } else {
-        program_attach_type = &program->attach_type;
-    }
-    if (program->handle == ebpf_handle_invalid) {
-        result = EBPF_INVALID_ARGUMENT;
-        goto Exit;
+
+    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate(sizeof(ebpf_link_t));
+    if (new_link == nullptr) {
+        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
 
-    result =
-        _link_ebpf_program(program->handle, program_attach_type, link, (uint8_t*)attach_parameters, attach_params_size);
+    ebpf_result_t result = _ebpf_program_attach(
+        program->handle, program, attach_type, attach_parameters, attach_params_size, &new_link->handle, &new_link->fd);
 
-Exit:
+    if (result != EBPF_SUCCESS) {
+        ebpf_free(new_link);
+        EBPF_RETURN_RESULT(result);
+    }
+
+    *link = new_link;
     EBPF_RETURN_RESULT(result);
+}
+CATCH_NO_MEMORY_EBPF_RESULT
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_program_attach_as_fd(
+    fd_t program_fd,
+    _In_opt_ const ebpf_attach_type_t* attach_type,
+    _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+    size_t attach_parameters_size,
+    _Out_ fd_t* link) NO_EXCEPT_TRY
+{
+    EBPF_LOG_ENTRY();
+    ebpf_assert(link);
+
+    ebpf_handle_t program_handle = _get_handle_from_file_descriptor(program_fd);
+    if (program_handle == ebpf_handle_invalid) {
+        EBPF_RETURN_RESULT(EBPF_INVALID_FD);
+    }
+
+    ebpf_program_t* program = nullptr;
+    if (attach_type == nullptr) {
+        program = _get_ebpf_program_from_handle(program_handle);
+    }
+
+    ebpf_handle_t link_handle;
+    EBPF_RETURN_RESULT(_ebpf_program_attach(
+        program_handle, program, attach_type, attach_parameters, attach_parameters_size, &link_handle, link));
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
@@ -1656,27 +1691,23 @@ ebpf_program_attach_by_fd(
     _Outptr_ struct bpf_link** link) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
-    ebpf_assert(attach_parameters || !attach_parameters_size);
     ebpf_assert(link);
-    *link = nullptr;
 
-    ebpf_handle_t program_handle = _get_handle_from_file_descriptor(program_fd);
-    if (program_handle == ebpf_handle_invalid) {
-        EBPF_RETURN_RESULT(EBPF_INVALID_FD);
+    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate(sizeof(ebpf_link_t));
+    if (new_link == nullptr) {
+        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
 
-    if (attach_type == nullptr) {
-        // Unspecified attach_type is allowed only if we can find an ebpf_program_t.
-        ebpf_program_t* program = _get_ebpf_program_from_handle(program_handle);
-        if (program == nullptr) {
-            EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
-        }
-
-        EBPF_RETURN_RESULT(ebpf_program_attach(program, attach_type, attach_parameters, attach_parameters_size, link));
+    ebpf_result_t result =
+        ebpf_program_attach_as_fd(program_fd, attach_type, attach_parameters, attach_parameters_size, &new_link->fd);
+    if (result != EBPF_SUCCESS) {
+        ebpf_free(new_link);
+        EBPF_RETURN_RESULT(result);
     }
 
-    EBPF_RETURN_RESULT(
-        _link_ebpf_program(program_handle, attach_type, link, (uint8_t*)attach_parameters, attach_parameters_size));
+    new_link->handle = _get_handle_from_file_descriptor(new_link->fd);
+    *link = new_link;
+    EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1809,7 +1809,7 @@ ebpf_close_fd(fd_t fd) noexcept
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_dup_fd(fd_t fd, _Out_ fd_t* dup) noexcept
+ebpf_duplicate_fd(fd_t fd, _Out_ fd_t* dup) noexcept
 {
     EBPF_LOG_ENTRY();
 

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1766,6 +1766,35 @@ ebpf_api_close_handle(ebpf_handle_t handle) NO_EXCEPT_TRY
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
+ebpf_close_fd(fd_t fd) noexcept
+{
+    EBPF_LOG_ENTRY();
+
+    if (Platform::_close(fd) == -1) {
+        EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(errno));
+    }
+
+    EBPF_RETURN_RESULT(EBPF_SUCCESS);
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_dup_fd(fd_t fd, _Out_ fd_t* dup) noexcept
+{
+    EBPF_LOG_ENTRY();
+
+    ebpf_assert(dup);
+
+    int retval = Platform::_dup(fd);
+    *dup = retval;
+
+    if (retval == -1) {
+        EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(errno));
+    }
+
+    EBPF_RETURN_RESULT(EBPF_SUCCESS);
+}
+
+_Must_inspect_result_ ebpf_result_t
 ebpf_api_get_pinned_map_info(
     _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) NO_EXCEPT_TRY
 {

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1656,7 +1656,7 @@ ebpf_program_attach(
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_program_attach_fds(
+ebpf_program_attach_by_fds(
     fd_t program_fd,
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
@@ -1699,7 +1699,7 @@ ebpf_program_attach_by_fd(
     }
 
     ebpf_result_t result =
-        ebpf_program_attach_fds(program_fd, attach_type, attach_parameters, attach_parameters_size, &new_link->fd);
+        ebpf_program_attach_by_fds(program_fd, attach_type, attach_parameters, attach_parameters_size, &new_link->fd);
     if (result != EBPF_SUCCESS) {
         ebpf_free(new_link);
         EBPF_RETURN_RESULT(result);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1491,7 +1491,7 @@ static ebpf_result_t
 _link_ebpf_program(
     ebpf_handle_t program_handle,
     _In_ const ebpf_attach_type_t* attach_type,
-    _Out_ ebpf_handle_t* link,
+    _Out_ ebpf_handle_t* link_handle,
     _In_reads_bytes_opt_(attach_parameter_size) uint8_t* attach_parameter,
     size_t attach_parameter_size) NO_EXCEPT_TRY
 {
@@ -1523,7 +1523,7 @@ _link_ebpf_program(
         }
         ebpf_assert(reply.header.id == ebpf_operation_id_t::EBPF_OPERATION_LINK_PROGRAM);
 
-        *link = reply.link_handle;
+        *link_handle = reply.link_handle;
         EBPF_RETURN_RESULT(EBPF_SUCCESS);
     } catch (const std::bad_alloc&) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -260,7 +260,7 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
 
     if (_does_attach_type_support_attachable_fd(type) && (flags == 0)) {
         result = ebpf_program_attach_by_fd(
-            prog_fd, ebpf_get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), &link);
+            prog_fd, get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), &link);
     } else {
         result = EBPF_OPERATION_NOT_SUPPORTED;
     }
@@ -280,7 +280,7 @@ int
 bpf_prog_detach2(int prog_fd, int attachable_fd, enum bpf_attach_type type)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(type);
+    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(type);
     if (attach_type == nullptr) {
         result = EBPF_INVALID_ARGUMENT;
         return libbpf_result_err(result);
@@ -485,7 +485,7 @@ bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_atta
     if (program->object->loaded) {
         return libbpf_err(-EBUSY);
     }
-    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(type);
+    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(type);
     if (attach_type != nullptr) {
         program->attach_type = *attach_type;
     }
@@ -710,7 +710,7 @@ libbpf_bpf_attach_type_str(enum bpf_attach_type t)
     if (t == BPF_ATTACH_TYPE_UNSPEC) {
         return "unspec";
     }
-    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(t);
+    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(t);
     return (attach_type == nullptr) ? nullptr : ebpf_get_attach_type_name(attach_type);
 }
 

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -260,7 +260,7 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
 
     if (_does_attach_type_support_attachable_fd(type) && (flags == 0)) {
         result = ebpf_program_attach_by_fd(
-            prog_fd, get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), &link);
+            prog_fd, ebpf_get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), &link);
     } else {
         result = EBPF_OPERATION_NOT_SUPPORTED;
     }
@@ -280,7 +280,7 @@ int
 bpf_prog_detach2(int prog_fd, int attachable_fd, enum bpf_attach_type type)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(type);
+    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(type);
     if (attach_type == nullptr) {
         result = EBPF_INVALID_ARGUMENT;
         return libbpf_result_err(result);
@@ -476,7 +476,7 @@ bpf_object__unpin_programs(struct bpf_object* obj, const char* path)
 enum bpf_attach_type
 bpf_program__get_expected_attach_type(const struct bpf_program* program)
 {
-    return get_bpf_attach_type(&program->attach_type);
+    return ebpf_get_bpf_attach_type(&program->attach_type);
 }
 
 int
@@ -485,7 +485,7 @@ bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_atta
     if (program->object->loaded) {
         return libbpf_err(-EBUSY);
     }
-    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(type);
+    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(type);
     if (attach_type != nullptr) {
         program->attach_type = *attach_type;
     }
@@ -496,7 +496,7 @@ bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_atta
 enum bpf_prog_type
 bpf_program__type(const struct bpf_program* program)
 {
-    return get_bpf_program_type(&program->program_type);
+    return ebpf_get_bpf_program_type(&program->program_type);
 }
 
 int
@@ -710,7 +710,7 @@ libbpf_bpf_attach_type_str(enum bpf_attach_type t)
     if (t == BPF_ATTACH_TYPE_UNSPEC) {
         return "unspec";
     }
-    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(t);
+    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(t);
     return (attach_type == nullptr) ? nullptr : ebpf_get_attach_type_name(attach_type);
 }
 

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -316,7 +316,7 @@ get_ebpf_program_type(bpf_prog_type_t bpf_program_type)
 }
 
 _Ret_maybenull_ const ebpf_attach_type_t*
-get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept
+ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept
 {
     _load_ebpf_provider_data();
 
@@ -330,7 +330,7 @@ get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept
 }
 
 bpf_prog_type_t
-get_bpf_program_type(_In_ const ebpf_program_type_t* ebpf_program_type) noexcept
+ebpf_get_bpf_program_type(_In_ const ebpf_program_type_t* ebpf_program_type) noexcept
 {
     _load_ebpf_provider_data();
 
@@ -344,7 +344,7 @@ get_bpf_program_type(_In_ const ebpf_program_type_t* ebpf_program_type) noexcept
 }
 
 bpf_attach_type_t
-get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept
+ebpf_get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept
 {
     _load_ebpf_provider_data();
 

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -25,6 +25,10 @@
 
 #define GET_PROGRAM_INFO_REPLY_BUFFER_SIZE 4096
 
+#ifndef GUID_NULL
+const GUID GUID_NULL = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
+#endif
+
 static thread_local ebpf_handle_t _program_under_verification = ebpf_handle_invalid;
 
 extern bool use_ebpf_store;
@@ -316,7 +320,7 @@ get_ebpf_program_type(bpf_prog_type_t bpf_program_type)
 }
 
 _Ret_maybenull_ const ebpf_attach_type_t*
-ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept
+get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept
 {
     _load_ebpf_provider_data();
 
@@ -327,6 +331,19 @@ ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type) noexcept
     }
 
     return nullptr;
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_get_ebpf_attach_type(bpf_attach_type_t bpf_attach_type, _Out_ ebpf_attach_type_t* ebpf_attach_type) noexcept
+{
+    const ebpf_attach_type_t* result = get_ebpf_attach_type(bpf_attach_type);
+    if (result == nullptr) {
+        *ebpf_attach_type = GUID_NULL;
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    *ebpf_attach_type = *result;
+    return EBPF_SUCCESS;
 }
 
 bpf_prog_type_t

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -11,6 +11,7 @@
 #endif
 
 std::function<decltype(_close)> close_handler;
+std::function<decltype(_dup)> dup_handler;
 std::function<decltype(CancelIoEx)> cancel_io_ex_handler;
 std::function<decltype(CloseHandle)> close_handle_handler;
 std::function<decltype(CreateFileW)> create_file_handler;
@@ -112,6 +113,12 @@ int
 _close(int file_handle)
 {
     return close_handler(file_handle);
+}
+
+int
+_dup(int file_handle)
+{
+    return dup_handler(file_handle);
 }
 
 bool

--- a/libs/thunk/mock/mock.h
+++ b/libs/thunk/mock/mock.h
@@ -13,6 +13,7 @@ uint32_t
 _delete_service(SC_HANDLE service_handle);
 
 extern std::function<decltype(_close)> close_handler;
+extern std::function<decltype(_dup)> dup_handler;
 extern std::function<decltype(CancelIoEx)> cancel_io_ex_handler;
 extern std::function<decltype(CloseHandle)> close_handle_handler;
 extern std::function<decltype(CreateFileW)> create_file_handler;

--- a/libs/thunk/platform.h
+++ b/libs/thunk/platform.h
@@ -54,6 +54,9 @@ _get_osfhandle(int file_descriptor);
 int
 _close(int file_descriptor);
 
+int
+_dup(int file_descriptor);
+
 bool
 _is_native_program(_In_z_ const char* file_name);
 

--- a/libs/thunk/windows/platform.cpp
+++ b/libs/thunk/windows/platform.cpp
@@ -131,6 +131,13 @@ _close(int file_descriptor)
     return ::_close(file_descriptor);
 }
 
+int
+_dup(int file_descriptor)
+{
+    _invalid_parameter_suppression suppress;
+    return ::_dup(file_descriptor);
+}
+
 bool
 _is_native_program(_In_z_ const char* file_name)
 {

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -549,6 +549,8 @@ TEST_CASE("hash_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_H
 
 TEST_CASE("duplicate_fd", "")
 {
+    _disable_crt_report_hook disable_hook;
+
     fd_t map_fd1 = bpf_map_create(BPF_MAP_TYPE_ARRAY, "map", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
     REQUIRE(map_fd1 > 0);
 

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -547,7 +547,7 @@ _test_nested_maps(bpf_map_type type)
 TEST_CASE("array_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
 TEST_CASE("hash_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
 
-TEST_CASE("dup_fd", "")
+TEST_CASE("duplicate_fd", "")
 {
     fd_t map_fd1 = bpf_map_create(BPF_MAP_TYPE_ARRAY, "map", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
     REQUIRE(map_fd1 > 0);
@@ -557,7 +557,7 @@ TEST_CASE("dup_fd", "")
     REQUIRE(bpf_map_update_elem(map_fd1, &key, &value, 0) == 0);
 
     fd_t map_fd2;
-    REQUIRE(ebpf_dup_fd(map_fd1, &map_fd2) == EBPF_SUCCESS);
+    REQUIRE(ebpf_duplicate_fd(map_fd1, &map_fd2) == EBPF_SUCCESS);
     REQUIRE(map_fd2 > 0);
 
     REQUIRE(bpf_map_lookup_elem(map_fd2, &key, &value) == 0);

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -547,6 +547,30 @@ _test_nested_maps(bpf_map_type type)
 TEST_CASE("array_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
 TEST_CASE("hash_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
 
+TEST_CASE("dup_fd", "")
+{
+    fd_t map_fd1 = bpf_map_create(BPF_MAP_TYPE_ARRAY, "map", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(map_fd1 > 0);
+
+    uint32_t key = 0;
+    uint32_t value = 1;
+    REQUIRE(bpf_map_update_elem(map_fd1, &key, &value, 0) == 0);
+
+    fd_t map_fd2;
+    REQUIRE(ebpf_dup_fd(map_fd1, &map_fd2) == EBPF_SUCCESS);
+    REQUIRE(map_fd2 > 0);
+
+    REQUIRE(bpf_map_lookup_elem(map_fd2, &key, &value) == 0);
+    REQUIRE(value == 1);
+
+    REQUIRE(ebpf_close_fd(map_fd2) == EBPF_SUCCESS);
+    REQUIRE(ebpf_close_fd(map_fd2) == EBPF_FAILED);
+    REQUIRE(bpf_map_lookup_elem(map_fd2, &key, &value) == -EBADF);
+    REQUIRE(bpf_map_lookup_elem(map_fd1, &key, &value) == 0);
+
+    REQUIRE(ebpf_close_fd(map_fd1) == EBPF_SUCCESS);
+}
+
 void
 tailcall_load_test(_In_z_ const char* file_name)
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2005,7 +2005,7 @@ ebpf_program_attach_fds_test(ebpf_execution_type_t execution_type)
     REQUIRE(result == 0);
 
     fd_t link_fd;
-    REQUIRE(ebpf_program_attach_fds(program_fd, &EBPF_ATTACH_TYPE_SAMPLE, nullptr, 0, &link_fd) == EBPF_SUCCESS);
+    REQUIRE(ebpf_program_attach_by_fds(program_fd, &EBPF_ATTACH_TYPE_SAMPLE, nullptr, 0, &link_fd) == EBPF_SUCCESS);
     REQUIRE(link_fd > 0);
     REQUIRE(ebpf_close_fd(link_fd) == EBPF_SUCCESS);
 
@@ -2013,10 +2013,10 @@ ebpf_program_attach_fds_test(ebpf_execution_type_t execution_type)
 }
 
 #if !defined(CONFIG_BPF_JIT_DISABLED)
-TEST_CASE("ebpf_program_attach_fds-jit", "[end_to_end]") { ebpf_program_attach_fds_test(EBPF_EXECUTION_JIT); }
+TEST_CASE("ebpf_program_attach_by_fds-jit", "[end_to_end]") { ebpf_program_attach_fds_test(EBPF_EXECUTION_JIT); }
 #endif
 
-TEST_CASE("ebpf_program_attach_fds-native", "[end_to_end]") { ebpf_program_attach_fds_test(EBPF_EXECUTION_NATIVE); }
+TEST_CASE("ebpf_program_attach_by_fds-native", "[end_to_end]") { ebpf_program_attach_fds_test(EBPF_EXECUTION_NATIVE); }
 
 TEST_CASE("create_map", "[end_to_end]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1978,6 +1978,46 @@ TEST_CASE("implicit_explicit_detach", "[end_to_end]")
 }
 #endif
 
+static void
+ebpf_program_attach_as_fd_test(ebpf_execution_type_t execution_type)
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE) ? SAMPLE_PATH "test_sample_ebpf_um.dll"
+                                                                      : SAMPLE_PATH "test_sample_ebpf.o";
+    const char* error_message = nullptr;
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    bpf_object_ptr unique_object;
+    fd_t program_fd;
+    int result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, execution_type, &unique_object, &program_fd, &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+
+    fd_t link_fd;
+    REQUIRE(ebpf_program_attach_as_fd(program_fd, &EBPF_ATTACH_TYPE_SAMPLE, nullptr, 0, &link_fd) == EBPF_SUCCESS);
+    REQUIRE(link_fd > 0);
+    REQUIRE(ebpf_close_fd(link_fd) == EBPF_SUCCESS);
+
+    bpf_object__close(unique_object.release());
+}
+
+#if !defined(CONFIG_BPF_JIT_DISABLED)
+TEST_CASE("ebpf_program_attach_as_fd-jit", "[end_to_end]") { ebpf_program_attach_as_fd_test(EBPF_EXECUTION_JIT); }
+#endif
+
+TEST_CASE("ebpf_program_attach_as_fd-native", "[end_to_end]") { ebpf_program_attach_as_fd_test(EBPF_EXECUTION_NATIVE); }
+
 TEST_CASE("create_map", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -3183,36 +3183,36 @@ TEST_CASE("ebpf_get_program_type_name invalid types", "[end-to-end]")
     REQUIRE(name2 == nullptr);
 }
 
-TEST_CASE("get_ebpf_attach_type", "[end_to_end]")
+TEST_CASE("ebpf_get_ebpf_attach_type", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
 
     // First test a valid input.
-    const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(BPF_ATTACH_TYPE_BIND);
+    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(BPF_ATTACH_TYPE_BIND);
     REQUIRE(attach_type != nullptr);
 
     REQUIRE(IsEqualGUID(*attach_type, EBPF_ATTACH_TYPE_BIND) != 0);
 
     // Try with invalid bpf attach type.
-    REQUIRE(get_ebpf_attach_type((bpf_attach_type_t)BPF_ATTACH_TYPE_INVALID) == nullptr);
+    REQUIRE(ebpf_get_ebpf_attach_type((bpf_attach_type_t)BPF_ATTACH_TYPE_INVALID) == nullptr);
 }
 
-TEST_CASE("get_bpf_program_type", "[end_to_end]")
+TEST_CASE("ebpf_get_bpf_program_type", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
 
     // First test a valid input.
-    REQUIRE(get_bpf_program_type(&EBPF_PROGRAM_TYPE_SAMPLE) == BPF_PROG_TYPE_SAMPLE);
+    REQUIRE(ebpf_get_bpf_program_type(&EBPF_PROGRAM_TYPE_SAMPLE) == BPF_PROG_TYPE_SAMPLE);
 
     // Try with EBPF_PROGRAM_TYPE_UNSPECIFIED.
-    REQUIRE(get_bpf_program_type(&EBPF_PROGRAM_TYPE_UNSPECIFIED) == BPF_PROG_TYPE_UNSPEC);
+    REQUIRE(ebpf_get_bpf_program_type(&EBPF_PROGRAM_TYPE_UNSPECIFIED) == BPF_PROG_TYPE_UNSPEC);
 
     // Try with invalid program type.
     GUID invalid_program_type;
     REQUIRE(UuidCreate(&invalid_program_type) == RPC_S_OK);
-    REQUIRE(get_bpf_program_type(&invalid_program_type) == BPF_PROG_TYPE_UNSPEC);
+    REQUIRE(ebpf_get_bpf_program_type(&invalid_program_type) == BPF_PROG_TYPE_UNSPEC);
 }
 
 TEST_CASE("ebpf_get_ebpf_program_type", "[end_to_end]")
@@ -3235,21 +3235,21 @@ TEST_CASE("ebpf_get_ebpf_program_type", "[end_to_end]")
     REQUIRE(program_type == nullptr);
 }
 
-TEST_CASE("get_bpf_attach_type", "[end_to_end]")
+TEST_CASE("ebpf_get_bpf_attach_type", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
 
     // Try with EBPF_ATTACH_TYPE_SAMPLE.
-    REQUIRE(get_bpf_attach_type(&EBPF_ATTACH_TYPE_SAMPLE) == BPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(ebpf_get_bpf_attach_type(&EBPF_ATTACH_TYPE_SAMPLE) == BPF_ATTACH_TYPE_SAMPLE);
 
     // Try with EBPF_ATTACH_TYPE_UNSPECIFIED.
-    REQUIRE(get_bpf_attach_type(&EBPF_ATTACH_TYPE_UNSPECIFIED) == BPF_ATTACH_TYPE_UNSPEC);
+    REQUIRE(ebpf_get_bpf_attach_type(&EBPF_ATTACH_TYPE_UNSPECIFIED) == BPF_ATTACH_TYPE_UNSPEC);
 
     // Try with invalid attach type.
     GUID invalid_attach_type;
     REQUIRE(UuidCreate(&invalid_attach_type) == RPC_S_OK);
-    REQUIRE(get_bpf_attach_type(&invalid_attach_type) == BPF_ATTACH_TYPE_UNSPEC);
+    REQUIRE(ebpf_get_bpf_attach_type(&invalid_attach_type) == BPF_ATTACH_TYPE_UNSPEC);
 }
 
 TEST_CASE("test_ebpf_object_set_execution_type", "[end_to_end]")

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1979,7 +1979,7 @@ TEST_CASE("implicit_explicit_detach", "[end_to_end]")
 #endif
 
 static void
-ebpf_program_attach_as_fd_test(ebpf_execution_type_t execution_type)
+ebpf_program_attach_fds_test(ebpf_execution_type_t execution_type)
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
@@ -2005,7 +2005,7 @@ ebpf_program_attach_as_fd_test(ebpf_execution_type_t execution_type)
     REQUIRE(result == 0);
 
     fd_t link_fd;
-    REQUIRE(ebpf_program_attach_as_fd(program_fd, &EBPF_ATTACH_TYPE_SAMPLE, nullptr, 0, &link_fd) == EBPF_SUCCESS);
+    REQUIRE(ebpf_program_attach_fds(program_fd, &EBPF_ATTACH_TYPE_SAMPLE, nullptr, 0, &link_fd) == EBPF_SUCCESS);
     REQUIRE(link_fd > 0);
     REQUIRE(ebpf_close_fd(link_fd) == EBPF_SUCCESS);
 
@@ -2013,10 +2013,10 @@ ebpf_program_attach_as_fd_test(ebpf_execution_type_t execution_type)
 }
 
 #if !defined(CONFIG_BPF_JIT_DISABLED)
-TEST_CASE("ebpf_program_attach_as_fd-jit", "[end_to_end]") { ebpf_program_attach_as_fd_test(EBPF_EXECUTION_JIT); }
+TEST_CASE("ebpf_program_attach_fds-jit", "[end_to_end]") { ebpf_program_attach_fds_test(EBPF_EXECUTION_JIT); }
 #endif
 
-TEST_CASE("ebpf_program_attach_as_fd-native", "[end_to_end]") { ebpf_program_attach_as_fd_test(EBPF_EXECUTION_NATIVE); }
+TEST_CASE("ebpf_program_attach_fds-native", "[end_to_end]") { ebpf_program_attach_fds_test(EBPF_EXECUTION_NATIVE); }
 
 TEST_CASE("create_map", "[end_to_end]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -3189,13 +3189,14 @@ TEST_CASE("ebpf_get_ebpf_attach_type", "[end_to_end]")
     test_helper.initialize();
 
     // First test a valid input.
-    const ebpf_attach_type_t* attach_type = ebpf_get_ebpf_attach_type(BPF_ATTACH_TYPE_BIND);
-    REQUIRE(attach_type != nullptr);
+    ebpf_attach_type_t attach_type;
+    REQUIRE(ebpf_get_ebpf_attach_type(BPF_ATTACH_TYPE_BIND, &attach_type) == EBPF_SUCCESS);
 
-    REQUIRE(IsEqualGUID(*attach_type, EBPF_ATTACH_TYPE_BIND) != 0);
+    REQUIRE(IsEqualGUID(attach_type, EBPF_ATTACH_TYPE_BIND) != 0);
 
     // Try with invalid bpf attach type.
-    REQUIRE(ebpf_get_ebpf_attach_type((bpf_attach_type_t)BPF_ATTACH_TYPE_INVALID) == nullptr);
+    REQUIRE(
+        ebpf_get_ebpf_attach_type((bpf_attach_type_t)BPF_ATTACH_TYPE_INVALID, &attach_type) == EBPF_INVALID_ARGUMENT);
 }
 
 TEST_CASE("ebpf_get_bpf_program_type", "[end_to_end]")

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -43,7 +43,7 @@ typedef struct _bind_context_header
     sample_program_context_t* ctx = &header.context;
 
 bpf_attach_type_t
-get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept;
+ebpf_get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept;
 
 typedef struct _ebpf_free_memory
 {
@@ -143,7 +143,7 @@ typedef class _single_instance_hook : public _hook_helper
     {
         attach_provider_data.header = EBPF_ATTACH_PROVIDER_DATA_HEADER;
         attach_provider_data.supported_program_type = program_type;
-        attach_provider_data.bpf_attach_type = get_bpf_attach_type(&attach_type);
+        attach_provider_data.bpf_attach_type = ebpf_get_bpf_attach_type(&attach_type);
         this->attach_type = attach_type;
         attach_provider_data.link_type = link_type;
         module_id.Guid = attach_type;

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -13,6 +13,7 @@
 #include "ebpf_result.h"
 
 #include <windows.h>
+#include <crtdbg.h>
 #include <future>
 #include <set>
 
@@ -56,3 +57,22 @@ ring_buffer_test_event_handler(_Inout_ void* ctx, _In_opt_ const void* data, siz
 void
 ring_buffer_api_test_helper(
     fd_t ring_buffer_map, std::vector<std::vector<char>>& expected_records, std::function<void(int)> generate_event);
+
+class _disable_crt_report_hook
+{
+  public:
+    _disable_crt_report_hook() { previous_hook = _CrtSetReportHook(_ignore_report_hook); }
+    ~_disable_crt_report_hook() { _CrtSetReportHook(previous_hook); }
+
+  private:
+    static int
+    _ignore_report_hook(int reportType, char* message, int* returnValue)
+    {
+        UNREFERENCED_PARAMETER(reportType);
+        UNREFERENCED_PARAMETER(message);
+        // Don't show the debug window.
+        *returnValue = 0;
+        return TRUE;
+    }
+    _CRT_REPORT_HOOK previous_hook;
+};


### PR DESCRIPTION
This PR exports various functions required to make the ebpf-go port work. They fall into the following categories:

* Functions dealing with the osfhandle machinery. There is no easy / reliable way to access the correct ucrt function from Go without re-exporting.
* Functions which mirror existing functionality but return fd_t in some fashion, instead of operating on libbpf objects. This is necessary because the library has different semantics than libbpf.
* Functions to translate between GUID and libbpf enums. These are necessary because the data types in the Go library can not accommodate GUIDs. Hence we need use enums and transparently map to GUID.

Commit messages below
---

Export ebpf_close_fd and ebpf_dup_fd

    Export functions used to manipulate fd_t. This makes the use of the UCRT
    _get_osfhandle an implementation detail which is abstracted away from users
    of ebpfapi.dll. This also makes it easier to use the API via run-time
    dynamic linking.

Allow attaching a link as an fd

    Add a function which returns the link as an fd when attaching a program. The
    existing functions are re-jigged to reduce code duplication.

Export functions to translate between GUID and enums

    Allow users to resolve libbpf style enums to Windows GUIDs and vice versa.

