### PR TITLE
Check if test process failed to start.

### DIFF
--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -157,6 +157,10 @@ function Process-TestCompletion
           [Parameter(Mandatory = $false)] [int] $TestHangTimeout = (10*60), # 10 minutes default timeout.
           [Parameter(Mandatory = $false)] [bool] $NeedKernelDump = $true)
 
+    if ($TestProcess -eq $null) {
+        ThrowWithErrorMessage -ErrorMessage "*** ERROR *** Test $TestCommand failed to start."
+    }
+
     # Use Wait-Process for the process to terminate or timeout.
     # See https://stackoverflow.com/a/23797762
     Wait-Process -InputObject $TestProcess -Timeout $TestHangTimeout -ErrorAction SilentlyContinue
@@ -359,14 +363,12 @@ function Invoke-XDPTest
     Push-Location $WorkingDirectory
 
     Write-Log "Executing $XDPTestName with remote address: $RemoteIPV4Address"
-    $TestRunScript = ".\Run-Self-Hosted-Runner-Test.ps1"
     $TestCommand = ".\xdp_tests.exe"
     $TestArguments = "$XDPTestName --remote-ip $RemoteIPV4Address"
     $TestProcess = Start-Process -FilePath $TestCommand -ArgumentList $TestArguments -PassThru -NoNewWindow
     Process-TestCompletion -TestProcess $TestProcess -TestCommand $TestCommand
 
     Write-Log "Executing $XDPTestName with remote address: $RemoteIPV6Address"
-    $TestRunScript = ".\Run-Self-Hosted-Runner-Test.ps1"
     $TestCommand = ".\xdp_tests.exe"
     $TestArguments = "$XDPTestName --remote-ip $RemoteIPV6Address"
     $TestProcess = Start-Process -FilePath $TestCommand -ArgumentList $TestArguments -PassThru -NoNewWindow
@@ -395,7 +397,6 @@ function Invoke-ConnectRedirectTest
 
     Push-Location $WorkingDirectory
 
-    $TestRunScript = ".\Run-Self-Hosted-Runner-Test.ps1"
     $TestCommand = ".\connect_redirect_tests.exe"
 
     ## First run the test with both v4 and v6 programs attached.
@@ -471,7 +472,7 @@ function Invoke-CICDStressTests
 
     $LASTEXITCODE = 0
 
-    $TestCommand = "ebpf_stress_tests_km"
+    $TestCommand = ".\ebpf_stress_tests_km"
     $TestArguments = " "
     if ($RestartExtension -eq $false) {
         $TestArguments = "-tt=8 -td=5"

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -472,7 +472,7 @@ function Invoke-CICDStressTests
 
     $LASTEXITCODE = 0
 
-    $TestCommand = ".\ebpf_stress_tests_km"
+    $TestCommand = ".\ebpf_stress_tests_km.exe"
     $TestArguments = " "
     if ($RestartExtension -eq $false) {
         $TestArguments = "-tt=8 -td=5"


### PR DESCRIPTION
## Description
This change fixes #4114 by specifying the full path to the multi-thread tests. This change also handles the case where the test process failed to start.

## Testing

Existing CICD is adequate.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.