### PR TITLE
Add ebpf_version()

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -130,6 +130,7 @@ EXPORTS
     ebpf_store_delete_section_information
     ebpf_store_update_program_information_array
     ebpf_store_update_section_information
+    ebpf_version
     libbpf_attach_type_by_name
     libbpf_bpf_attach_type_str
     libbpf_bpf_link_type_str

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -31,6 +31,13 @@ extern "C"
     struct bpf_link;
 
     /**
+     * @brief Query the version of the eBPF runtime.
+     * @returns A version in the form Major.Minor.Revision. The returned string is only valid while the DLL is loaded.
+     */
+    const char*
+    ebpf_version() EBPF_NO_EXCEPT;
+
+    /**
      * @brief Query info about an eBPF program.
      * @param[in] fd File descriptor of an eBPF program.
      * @param[out] execution_type On success, contains the execution type.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -15,6 +15,7 @@
 #include "ebpf_serialize.h"
 #include "ebpf_shared_framework.h"
 #include "ebpf_tracelog.h"
+#include "ebpf_version.h"
 #include "hash.h"
 #pragma warning(push)
 #pragma warning(disable : 4200) // Zero-sized array in struct/union
@@ -246,6 +247,12 @@ ebpf_api_terminate() noexcept
     clean_up_rpc_binding();
 #endif
     ebpf_trace_terminate();
+}
+
+const char*
+ebpf_version() noexcept
+{
+    return EBPF_VERSION;
 }
 
 static ebpf_result_t

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -9,6 +9,7 @@
 #include "catch_wrapper.hpp"
 #include "common_tests.h"
 #include "ebpf_structs.h"
+#include "ebpf_version.h"
 #include "misc_helper.h"
 #include "native_helper.hpp"
 #include "program_helper.h"
@@ -103,6 +104,8 @@ static _Success_(return == 0) int _program_load_helper(
     *object = new_object;
     return 0;
 }
+
+TEST_CASE("ebpf_version", "") { REQUIRE(strcmp(ebpf_version(), EBPF_VERSION) == 0); }
 
 static void
 _test_program_load(


### PR DESCRIPTION
Export a function which allows retrieving the version string of the runtime. ebpf-go uses this information in its own testsuite to be able to assert that certain features are working given the necessary minimum version.
