### PR TITLE
Remove workaround for test failure

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2199,12 +2199,6 @@ _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
     ebpf_result_t retval;
     uint8_t* value;
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return NULL;
-    }
-
     retval = ebpf_map_find_entry(map, 0, key, sizeof(&value), (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
     if (retval != EBPF_SUCCESS) {
         return NULL;
@@ -2216,22 +2210,12 @@ _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 static int64_t
 _ebpf_core_map_update_element(ebpf_map_t* map, const uint8_t* key, const uint8_t* value, uint64_t flags)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
     return -ebpf_map_update_entry(map, 0, key, 0, value, flags, EBPF_MAP_FLAG_HELPER);
 }
 
 static int64_t
 _ebpf_core_map_delete_element(ebpf_map_t* map, const uint8_t* key)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
     return -ebpf_map_delete_entry(map, 0, key, EBPF_MAP_FLAG_HELPER);
 }
 
@@ -2240,11 +2224,6 @@ _ebpf_core_map_find_and_delete_element(_Inout_ ebpf_map_t* map, _In_ const uint8
 {
     ebpf_result_t retval;
     uint8_t* value;
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return NULL;
-    }
     retval = ebpf_map_find_entry(
         map, 0, key, sizeof(&value), (uint8_t*)&value, EBPF_MAP_FLAG_HELPER | EBPF_MAP_FIND_FLAG_DELETE);
     if (retval != EBPF_SUCCESS) {
@@ -2257,12 +2236,6 @@ _ebpf_core_map_find_and_delete_element(_Inout_ ebpf_map_t* map, _In_ const uint8
 static int64_t
 _ebpf_core_tail_call(void* context, ebpf_map_t* map, uint32_t index)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
-
     // Get program from map[index].
     ebpf_program_t* callee = ebpf_map_get_program_from_entry(map, sizeof(index), (uint8_t*)&index);
     if (callee == NULL) {
@@ -2510,12 +2483,6 @@ static int
 _ebpf_core_ring_buffer_output(
     _Inout_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
-
     // This function implements bpf_ringbuf_output helper function, which returns negative error in case of failure.
     UNREFERENCED_PARAMETER(flags);
     return -ebpf_ring_buffer_map_output(map, data, length);
@@ -2524,33 +2491,18 @@ _ebpf_core_ring_buffer_output(
 static int
 _ebpf_core_map_push_elem(_Inout_ ebpf_map_t* map, _In_ const uint8_t* value, uint64_t flags)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
     return -ebpf_map_push_entry(map, 0, value, (int)flags | EBPF_MAP_FLAG_HELPER);
 }
 
 static int
 _ebpf_core_map_pop_elem(_Inout_ ebpf_map_t* map, _Out_ uint8_t* value)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
     return -ebpf_map_pop_entry(map, 0, value, EBPF_MAP_FLAG_HELPER);
 }
 
 static int
 _ebpf_core_map_peek_elem(_Inout_ ebpf_map_t* map, _Out_ uint8_t* value)
 {
-    // Workadound for bug (https://github.com/microsoft/ebpf-for-windows/issues/4017) in bpf2c_fuzzer that crashes with
-    // null map pointer. Remove when fixed.
-    if (map == NULL) {
-        return -EBPF_INVALID_ARGUMENT;
-    }
     return -ebpf_map_peek_entry(map, 0, value, EBPF_MAP_FLAG_HELPER);
 }
 

--- a/tests/libfuzzer/include/fuzz_helper_function.hpp
+++ b/tests/libfuzzer/include/fuzz_helper_function.hpp
@@ -221,7 +221,10 @@ template <typename context_type> class fuzz_helper_function
             }
             case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS:
                 // Put the PROG_ARRAY map pointer into the argument.
-                argument[arg_count] = (uint64_t)get_prog_array_map();
+                argument[arg_count] = (uint64_t)get_map(BPF_MAP_TYPE_PROG_ARRAY);
+                if (argument[arg_count] == 0) {
+                    return -1;
+                }
                 break;
             case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE: {
                 // Put the supplied data into the argument.
@@ -434,12 +437,6 @@ template <typename context_type> class fuzz_helper_function
         return maps.contains(type) ? maps[type] : nullptr;
     }
 
-    _Ret_maybenull_ ebpf_map_t*
-    get_prog_array_map()
-    {
-        return prog_array_map;
-    }
-
     // Generic helper prototypes.
     typedef uint64_t (*function0_t)();
     typedef uint64_t (*function1_t)(uint64_t r1);
@@ -554,7 +551,6 @@ template <typename context_type> class fuzz_helper_function
   private:
     GUID provider_guid;
     std::map<ebpf_map_type_t, ebpf_map_t*> maps;
-    ebpf_map_t* prog_array_map = nullptr;
     NPI_CLIENT_CHARACTERISTICS program_information_client_characteristics;
     HANDLE program_information_nmr_handle;
     const ebpf_program_data_t* program_data;


### PR DESCRIPTION
Resolves: #4017

## Description

This pull request removes workarounds that were previously added to handle a bug in the `bpf2c_fuzzer` which caused crashes with null map pointers. These workarounds are no longer necessary as the bug has been fixed.

Key changes:

* Removed null map pointer checks in `_ebpf_core_map_find_element`, `_ebpf_core_map_update_element`, `_ebpf_core_map_delete_element`, `_ebpf_core_map_find_and_delete_element`, `_ebpf_core_tail_call`, `_ebpf_core_ring_buffer_output`, `_ebpf_core_map_push_elem`, `_ebpf_core_map_pop_elem`, and `_ebpf_core_map_peek_elem` functions in `libs/execution_context/ebpf_core.c`. [[1]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2202-L2207) [[2]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2219-L2234) [[3]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2243-L2247) [[4]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2260-L2265) [[5]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2513-L2518) [[6]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2527-L2553)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
