### PR TITLE
Uninstall ebpf by product id

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -3,6 +3,7 @@
 Copyright (c) eBPF for Windows contributors
 SPDX-License-Identifier: MIT
 -->
+<!-- Product version must remain the same for the life of the product. Do not change it. -->
 <?define ProductVersion="022C44B5-8969-4B75-8DB0-73F98B1BD7DC"?>
 <?define UpgradeCode="B6BCACB1-C872-4159-ABCB-43A50668056C"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:ui="http://schemas.microsoft.com/wix/UIExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">

--- a/scripts/setup-ebpf.ps1
+++ b/scripts/setup-ebpf.ps1
@@ -35,8 +35,8 @@ $VcRedistPath = Join-Path $WorkingDirectory "vc_redist.x64.exe"
 Push-Location $WorkingDirectory
 
 if ($Uninstall) {
-    # Uninstall the MSI package.
-    $arguments = "/x $MsiPath /qn /norestart /l*v msi-uninstall.log"
+    # Uninstall the MSI package using the MSI product code. Product code from: installer\Product.wxs
+    $arguments = "/x {022C44B5-8969-4B75-8DB0-73F98B1BD7DC} /qn /norestart /l*v msi-uninstall.log"
     Write-Host("Uninstalling eBPF MSI package at 'msiexec.exe $arguments'...")
     $process = Start-Process -FilePath msiexec.exe -ArgumentList $arguments -Wait -PassThru
     if ($process.ExitCode -eq 0) {


### PR DESCRIPTION
Resolves: #3760

## Description

This pull request includes a change to the `scripts/setup-ebpf.ps1` file to improve the uninstallation process of the eBPF MSI package. The most important change is the modification of the uninstallation command to use the MSI product code directly.

Improvements to uninstallation process:

* [`scripts/setup-ebpf.ps1`](diffhunk://#diff-6980b71c60f1fdf381b6bfb4fc4ed1f05d1a402be4f41bb919a3df808888c808L38-R39): Changed the uninstallation command to use the MSI product code `{022C44B5-8969-4B75-8DB0-73F98B1BD7DC}` instead of the MSI path, ensuring a more reliable uninstallation process.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
