### PR TITLE
Change clang version to 18.1.8 in formatting script.

### DIFF
--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -55,7 +55,7 @@ Style Guide
 ### Automated Formatting with `clang-format`
 
 For all C/C++ files (`*.c`, `*.cpp` and `*.h`), we use `clang-format` (specifically
-version ```17.0.3```) to apply our code formatting rules. After modifying C/C++ files and
+version ```18.1.8```) to apply our code formatting rules. After modifying C/C++ files and
 before merging, be sure to run:
 
 ```sh

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -214,7 +214,7 @@ On a defender machine with [eBPF installed](#installing-ebpf-for-windows), do th
 1. Install and set up a DNS server.
 1. Make sure that either test signing was enabled as discussed in
    [Installing eBPF for Windows](#installing-ebpf-for-windows), or the kernel debugger (KD) is attached and running.
-1. Install [clang](https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/LLVM-17.0.3-win64.exe)
+1. Install [clang](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe)
    if not already installed on the defender machine.
 1. Copy `droppacket.c` and `ebpf.h` to a folder (such as `c:\test`).
 

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -174,7 +174,7 @@ check_clang-format()
         cf="clang-format"
     fi
 
-    local required_cfver='17.0.3'
+    local required_cfver='18.1.8'
     # shellcheck disable=SC2155
     local cfver=$(${cf} --version | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
     check_version "${required_cfver}" "${cfver}"

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -250,7 +250,7 @@ function check_clang-format()
     # Windows does not have a clang-format-7 executable
 
 
-    $required_cfver='17.0.3'
+    $required_cfver='18.1.8'
 
     try {
        $cfver=(( Invoke-Expression "clang-format --version" 2> $null ) -split " ")[2]

--- a/scripts/generate-commitid.ps1
+++ b/scripts/generate-commitid.ps1
@@ -14,5 +14,5 @@ if (Test-Path $file_name) {
 }
 if ($old_commit_id -ne $commit_id) {
     Write-Output "Commit ID changed, regenerating $file_name"
-    $new_content | out-file -FilePath $file_name
+    $new_content | out-file -FilePath $file_name -Encoding Ascii
 }


### PR DESCRIPTION
## Description

This fixes #4133 and #4134.
The changes update the clang version in the code format scripts to point to 18.1.8. It also changes the script to generate the git_commit_id.h file to use ascii encoding.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
Existing tests cover this change. No new tests are needed.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.
