### PR TITLE
netsh ebpf show verif should verify all sections

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -636,13 +636,13 @@ ebpf_api_elf_disassemble_section(
 static uint32_t
 _ebpf_api_elf_verify_program_from_stream(
     std::istream& stream,
-    const char* stream_name,
-    const char* section_name,
-    const char* program_name,
+    _In_z_ const char* stream_name,
+    _In_opt_z_ const char* section_name, // Section name, or null to look in all sections.
+    _In_opt_z_ const char* program_name, // Program name, or null to use the first program.
     ebpf_verification_verbosity_t verbosity,
-    const char** report,
-    const char** error_message,
-    ebpf_api_verifier_stats_t* stats) noexcept
+    _Outptr_result_maybenull_z_ const char** report,
+    _Outptr_result_maybenull_z_ const char** error_message,
+    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
 {
     std::ostringstream error;
     std::ostringstream output;
@@ -661,7 +661,8 @@ _ebpf_api_elf_verify_program_from_stream(
         if (!stream) {
             throw std::runtime_error(std::string("No such file or directory opening ") + stream_name);
         }
-        auto raw_programs = read_elf(stream, stream_name, section_name, verifier_options, platform);
+        auto raw_programs =
+            read_elf(stream, stream_name, (section_name != nullptr ? section_name : ""), verifier_options, platform);
         std::optional<raw_program> found_program;
         for (auto& program : raw_programs) {
             if ((program_name == nullptr) || (program.function_name == program_name)) {
@@ -768,7 +769,6 @@ static _Success_(return == 0) uint32_t _verify_program_from_string(
     ebpf_clear_thread_local_storage();
 
     set_global_program_and_attach_type(program_type, nullptr);
-    _verification_in_progress_helper helper;
     return _ebpf_api_elf_verify_program_from_stream(
         stream, name, section_name, program_name, verbosity, report, error_message, stats);
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4133,8 +4133,11 @@ ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) NO_EXCE
     ebpf_assert(program_type);
 
     try {
-        const EbpfProgramType& type = get_program_type_windows(*program_type);
-        EBPF_RETURN_POINTER(const char*, type.name.c_str());
+        const EbpfProgramType* type = get_program_type_windows(*program_type);
+        if (type == nullptr) {
+            EBPF_RETURN_POINTER(const char*, nullptr);
+        }
+        EBPF_RETURN_POINTER(const char*, type->name.c_str());
     } catch (...) {
         return nullptr;
     }

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -120,19 +120,20 @@ query_map_definition(
 }
 
 void
-set_global_program_and_attach_type(const ebpf_program_type_t* program_type, const ebpf_attach_type_t* attach_type)
+set_global_program_and_attach_type(
+    _In_opt_ const ebpf_program_type_t* program_type, _In_opt_ const ebpf_attach_type_t* attach_type)
 {
     _global_program_type = program_type;
     _global_attach_type = attach_type;
 }
 
-const ebpf_program_type_t*
+_Ret_maybenull_ const ebpf_program_type_t*
 get_global_program_type()
 {
     return _global_program_type;
 }
 
-const ebpf_attach_type_t*
+_Ret_maybenull_ const ebpf_attach_type_t*
 get_global_attach_type()
 {
     return _global_attach_type;
@@ -170,6 +171,8 @@ ebpf_verify_program(
     _In_ const ebpf_verifier_options_t& options,
     _Out_ ebpf_api_verifier_stats_t* stats)
 {
+    _verification_in_progress_helper helper;
+
     stats->total_unreachable = 0;
     stats->total_warnings = 0;
     stats->max_loop_count = 0;

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -216,18 +216,6 @@ get_global_program_type();
 _Ret_maybenull_ const ebpf_attach_type_t*
 get_global_attach_type();
 
-void
-set_verification_in_progress(bool value);
-
-bool
-get_verification_in_progress();
-
-struct _verification_in_progress_helper
-{
-    _verification_in_progress_helper() { set_verification_in_progress(true); }
-    ~_verification_in_progress_helper() { set_verification_in_progress(false); }
-};
-
 /**
  * @brief Save handle to program being verified in thread-local storage.
  *

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -207,12 +207,13 @@ query_map_definition(
     _Out_ ebpf_id_t* inner_map_id) noexcept;
 
 void
-set_global_program_and_attach_type(const ebpf_program_type_t* program_type, const ebpf_attach_type_t* attach_type);
+set_global_program_and_attach_type(
+    _In_opt_ const ebpf_program_type_t* program_type, _In_opt_ const ebpf_attach_type_t* attach_type);
 
-const ebpf_program_type_t*
+_Ret_maybenull_ const ebpf_program_type_t*
 get_global_program_type();
 
-const ebpf_attach_type_t*
+_Ret_maybenull_ const ebpf_attach_type_t*
 get_global_attach_type();
 
 void

--- a/libs/api_common/windows_platform_common.hpp
+++ b/libs/api_common/windows_platform_common.hpp
@@ -14,7 +14,7 @@ is_helper_usable_windows(int32_t n);
 EbpfMapType
 get_map_type_windows(uint32_t platform_specific_type);
 
-const EbpfProgramType&
+_Ret_maybenull_ const EbpfProgramType*
 get_program_type_windows(const GUID& program_type);
 
 EbpfProgramType

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -243,18 +243,6 @@ _verify_program(
     const char* report;
     const char* error_message;
     ebpf_api_verifier_stats_t stats;
-#if 0
-    ebpf_program_type_t program_type = *program_type_input;
-
-    ebpf_program_type_t program_type_zero = {0};
-    if (memcmp(&program_type, &program_type_zero, sizeof(ebpf_program_type_t)) == 0) {
-        ebpf_attach_type_t attach_type;
-        if (ebpf_get_program_type_by_name(section.c_str(), &program_type, &attach_type) != EBPF_SUCCESS) {
-            std::cerr << "\nProgram type for section " << section.c_str() << " not found." << std::endl;
-            return ERROR_SUPPRESS_OUTPUT;
-        }
-    }
-#endif
 
     unsigned long status = ebpf_api_elf_verify_program_from_file(
         filename.c_str(),

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -232,6 +232,58 @@ handle_ebpf_show_sections(
     return NO_ERROR;
 }
 
+static unsigned long
+_verify_program(
+    std::string filename,                             // Name of file in which the program appears.
+    std::string section,                              // Name of section in which the program appears.
+    std::string program_name,                         // Name of program.
+    _In_opt_ const ebpf_program_type_t* program_type, // Program type.
+    ebpf_verification_verbosity_t verbosity)          // Verbosity.
+{
+    const char* report;
+    const char* error_message;
+    ebpf_api_verifier_stats_t stats;
+#if 0
+    ebpf_program_type_t program_type = *program_type_input;
+
+    ebpf_program_type_t program_type_zero = {0};
+    if (memcmp(&program_type, &program_type_zero, sizeof(ebpf_program_type_t)) == 0) {
+        ebpf_attach_type_t attach_type;
+        if (ebpf_get_program_type_by_name(section.c_str(), &program_type, &attach_type) != EBPF_SUCCESS) {
+            std::cerr << "\nProgram type for section " << section.c_str() << " not found." << std::endl;
+            return ERROR_SUPPRESS_OUTPUT;
+        }
+    }
+#endif
+
+    unsigned long status = ebpf_api_elf_verify_program_from_file(
+        filename.c_str(),
+        !section.empty() ? section.c_str() : nullptr,
+        !program_name.empty() ? program_name.c_str() : nullptr,
+        program_type,
+        verbosity,
+        &report,
+        &error_message,
+        &stats);
+    if (status == ERROR_SUCCESS) {
+        std::cout << report;
+        std::cout << "\nProgram terminates within " << stats.max_loop_count << " loop iterations\n";
+        ebpf_free_string(report);
+        return NO_ERROR;
+    } else {
+        if (error_message) {
+            std::cerr << error_message << std::endl;
+        }
+        if (report) {
+            std::cerr << "\nVerification report:\n" << report;
+            std::cerr << stats.total_warnings << " errors\n\n";
+        }
+        ebpf_free_string(error_message);
+        ebpf_free_string(report);
+        return ERROR_SUPPRESS_OUTPUT;
+    }
+}
+
 // The following function uses windows specific type as an input to match
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
@@ -272,9 +324,9 @@ handle_ebpf_show_verification(
     std::string section = "";      // Use the first code section by default.
     std::string program_name = ""; // Use the first program name by default.
     std::string type_name = "";
-    ebpf_program_type_t program_type;
+    ebpf_program_type_t program_type_guid = {0};
+    ebpf_program_type_t* program_type = nullptr;
     ebpf_attach_type_t attach_type;
-    bool program_type_found = false;
 
     for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc); i++) {
         switch (tag_type[i]) {
@@ -292,10 +344,10 @@ handle_ebpf_show_verification(
         }
         case TYPE_INDEX: {
             type_name = down_cast_from_wstring(std::wstring(argv[current_index + i]));
-            if (ebpf_get_program_type_by_name(type_name.c_str(), &program_type, &attach_type) != EBPF_SUCCESS) {
+            if (ebpf_get_program_type_by_name(type_name.c_str(), &program_type_guid, &attach_type) != EBPF_SUCCESS) {
                 status = ERROR_INVALID_PARAMETER;
             } else {
-                program_type_found = true;
+                program_type = &program_type_guid;
             }
             break;
         }
@@ -316,39 +368,6 @@ handle_ebpf_show_verification(
         return status;
     }
 
-    const char* report;
-    const char* error_message;
-    ebpf_api_verifier_stats_t stats;
-
-    if (section == "") {
-        // If no section name was provided, fetch the first section name.
-        ebpf_api_program_info_t* program_data = nullptr;
-        ebpf_result_t result =
-            ebpf_enumerate_programs(filename.c_str(), level == VL_VERBOSE, &program_data, &error_message);
-        if (result != ERROR_SUCCESS || program_data == nullptr) {
-            if (error_message) {
-                std::cerr << error_message << std::endl;
-            } else {
-                std::cerr << "\nNo section(s) found" << std::endl;
-            }
-            ebpf_free_string(error_message);
-            ebpf_free_programs(program_data);
-            return ERROR_SUPPRESS_OUTPUT;
-        }
-
-        section = program_data->section_name;
-        program_name = program_data->program_name;
-        ebpf_free_string(error_message);
-        ebpf_free_programs(program_data);
-    }
-
-    if (!program_type_found) {
-        if (ebpf_get_program_type_by_name(section.c_str(), &program_type, &attach_type) != EBPF_SUCCESS) {
-            std::cerr << "\nProgram type for section " << section.c_str() << " not found." << std::endl;
-            return ERROR_SUPPRESS_OUTPUT;
-        }
-    }
-
     ebpf_verification_verbosity_t verbosity = EBPF_VERIFICATION_VERBOSITY_NORMAL;
     switch (level) {
     case VL_NORMAL:
@@ -366,30 +385,40 @@ handle_ebpf_show_verification(
         break;
     }
 
-    status = ebpf_api_elf_verify_program_from_file(
-        filename.c_str(),
-        !section.empty() ? section.c_str() : nullptr,
-        !program_name.empty() ? program_name.c_str() : nullptr,
-        &program_type,
-        verbosity,
-        &report,
-        &error_message,
-        &stats);
-    if (status == ERROR_SUCCESS) {
-        std::cout << report;
-        std::cout << "\nProgram terminates within " << stats.max_loop_count << " loop iterations\n";
-        ebpf_free_string(report);
-        return NO_ERROR;
-    } else {
+    ebpf_api_program_info_t* program_data = nullptr;
+    const char* error_message;
+    ebpf_result_t result = ebpf_enumerate_programs(
+        filename.c_str(), verbosity == EBPF_VERIFICATION_VERBOSITY_VERBOSE, &program_data, &error_message);
+    if (result != ERROR_SUCCESS || program_data == nullptr) {
         if (error_message) {
             std::cerr << error_message << std::endl;
-        }
-        if (report) {
-            std::cerr << "\nVerification report:\n" << report;
-            std::cerr << stats.total_warnings << " errors\n\n";
+        } else {
+            std::cerr << "\nNo section(s) found" << std::endl;
         }
         ebpf_free_string(error_message);
-        ebpf_free_string(report);
+        ebpf_free_programs(program_data);
         return ERROR_SUPPRESS_OUTPUT;
     }
+
+    for (ebpf_api_program_info_t* current = program_data; current != nullptr; current = current->next) {
+        if (!section.empty() && section != current->section_name) {
+            continue;
+        }
+        if (!program_name.empty() && program_name != current->program_name) {
+            continue;
+        }
+        if (program_data->next != nullptr && strcmp(current->section_name, ".text") == 0) {
+            // Skip subprograms.
+            continue;
+        }
+        unsigned long program_status =
+            _verify_program(filename, current->section_name, current->program_name, program_type, verbosity);
+        if (program_status != NO_ERROR) {
+            status = program_status;
+        }
+    }
+
+    ebpf_free_string(error_message);
+    ebpf_free_programs(program_data);
+    return status;
 }

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -307,12 +307,9 @@ ebpf_verify_and_load_program(
         }
 
         // Verify the program.
-        {
-            _verification_in_progress_helper helper;
-            result = verify_byte_code(program_type, instructions, instruction_count, error_message, error_message_size);
-            if (result != EBPF_SUCCESS) {
-                goto Exit;
-            }
+        result = verify_byte_code(program_type, instructions, instruction_count, error_message, error_message_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
         }
 
         result = _resolve_maps_in_byte_code(program_handle, instructions, instruction_count);

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -58,7 +58,7 @@ verify_byte_code(
     std::string section;
     std::string file;
     try {
-        info.type = get_program_type_windows(*program_type);
+        info.type = *get_program_type_windows(*program_type);
     } catch (std::runtime_error e) {
         error << "error: " << e.what();
         *error_message = allocate_string(error.str(), error_message_size);

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -935,9 +935,7 @@ negative_ring_buffer_test(ebpf_execution_type_t execution_type)
     REQUIRE(map_fd > 0);
 
     // Calls to ring buffer APIs on this map (array_map) must fail.
-    REQUIRE(
-        ring_buffer__new(
-            map_fd, [](void*, void*, size_t) { return 0; }, nullptr, nullptr) == nullptr);
+    REQUIRE(ring_buffer__new(map_fd, [](void*, void*, size_t) { return 0; }, nullptr, nullptr) == nullptr);
     REQUIRE(libbpf_get_error(nullptr) == EINVAL);
     uint8_t data = 0;
     REQUIRE(ebpf_ring_buffer_map_write(map_fd, &data, sizeof(data)) == EBPF_INVALID_ARGUMENT);
@@ -2858,10 +2856,6 @@ TEST_CASE("ebpf_get_program_type_by_name invalid name", "[end-to-end]")
     ebpf_program_type_t program_type;
     ebpf_attach_type_t attach_type;
 
-    REQUIRE(ebpf_get_program_type_by_name("invalid_name", &program_type, &attach_type) == EBPF_KEY_NOT_FOUND);
-
-    // Now set verification in progress and try again.
-    set_verification_in_progress(true);
     REQUIRE(ebpf_get_program_type_by_name("invalid_name", &program_type, &attach_type) == EBPF_KEY_NOT_FOUND);
 }
 

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -412,6 +412,21 @@ TEST_CASE("show verification bpf.o", "[netsh][verification]")
                   "Program terminates within 0 loop iterations\n");
 }
 
+TEST_CASE("show verification bindmonitor_bpf2bpf.o", "[netsh][verification]")
+{
+    _test_helper_netsh test_helper;
+    test_helper.initialize();
+
+    int result;
+    std::string output =
+        _run_netsh_command(handle_ebpf_show_verification, L"bindmonitor_bpf2bpf.o", nullptr, nullptr, &result);
+    REQUIRE(result == NO_ERROR);
+    REQUIRE(
+        output == "\n"
+                  "Verification succeeded\n"
+                  "Program terminates within 0 loop iterations\n");
+}
+
 TEST_CASE("show verification droppacket.o", "[netsh][verification]")
 {
     _test_helper_netsh test_helper;

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -786,8 +786,6 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
         duplicate_handle_handler = nullptr;
 
         _expect_native_module_load_failures = false;
-
-        set_verification_in_progress(false);
     } catch (...) {
     }
 }


### PR DESCRIPTION
## Description

Fixes #3884

This PR also fixes an issue uncovered by adding more SAL annotations.  Specifically, _ebpf_api_elf_verify_program_from_stream() was passing a possibly NULL stats pointer to ebpf_verify_program() which would dereference it and crash.

## Testing

Added a new unit test to run "show verif" on bindmonitor_bpf2bpf.c which has multiple programs and sections

## Documentation

No impact.

## Installation

No impact.
