### PR TITLE
Add ebpf_get_next_pinned_object_path

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -115,6 +115,7 @@ EXPORTS
     ebpf_free_sections = ebpf_free_programs
     ebpf_free_string
     ebpf_get_attach_type_name
+    ebpf_get_next_pinned_object_path
     ebpf_get_next_pinned_program_path
     ebpf_get_program_info_from_verifier
     ebpf_get_program_type_by_name

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -517,10 +517,29 @@ extern "C"
      *
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS No more entries found.
+     * @deprecated Use ebpf_get_next_pinned_object_path() instead.
+     */
+    __declspec(deprecated("Use ebpf_get_next_pinned_object_path() instead.")) _Must_inspect_result_ ebpf_result_t
+        ebpf_get_next_pinned_program_path(
+            _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) EBPF_NO_EXCEPT;
+
+    /**
+     * @brief Retrieve the next pinned path of an eBPF object.
+     *
+     * @param[in] start_path Path to look for an entry greater than or NULL.
+     * @param[out] next_path Returns the next path in lexicographical order, if one exists.
+     * @param[in] next_path_len Length of the next path buffer.
+     * @param[in, out] type On input, the type of object to retrieve or EBPF_OBJECT_UNKNOWN.
+     *                      On output, the type of the object.
+     *
+     * @returns EBPF_SUCCESS or an error.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_get_next_pinned_program_path(
-        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) EBPF_NO_EXCEPT;
+    ebpf_get_next_pinned_object_path(
+        _In_z_ const char* start_path,
+        _Out_writes_z_(next_path_len) char* next_path,
+        size_t next_path_len,
+        _Inout_ ebpf_object_type_t* type) EBPF_NO_EXCEPT;
 
     typedef struct _ebpf_program_info ebpf_program_info_t;
 

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -532,7 +532,8 @@ extern "C"
      * @param[in, out] type On input, the type of object to retrieve or EBPF_OBJECT_UNKNOWN.
      *                      On output, the type of the object.
      *
-     * @returns EBPF_SUCCESS or an error.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval other An error occurred.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_get_next_pinned_object_path(

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3994,6 +3994,18 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_get_next_pinned_program_path(
     _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) NO_EXCEPT_TRY
 {
+    ebpf_object_type_t type = EBPF_OBJECT_PROGRAM;
+    return ebpf_get_next_pinned_object_path(start_path, next_path, EBPF_MAX_PIN_PATH_LENGTH, &type);
+}
+CATCH_NO_MEMORY_EBPF_RESULT
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_get_next_pinned_object_path(
+    _In_z_ const char* start_path,
+    _Out_writes_z_(next_path_len) char* next_path,
+    size_t next_path_len,
+    _Inout_ ebpf_object_type_t* type) NO_EXCEPT_TRY
+{
     EBPF_LOG_ENTRY();
     ebpf_assert(start_path);
     ebpf_assert(next_path);
@@ -4001,18 +4013,19 @@ ebpf_get_next_pinned_program_path(
     size_t start_path_length = strlen(start_path);
 
     ebpf_protocol_buffer_t request_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_request_t, start_path) + start_path_length);
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_request_t, start_path) + start_path_length);
     ebpf_protocol_buffer_t reply_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path) + EBPF_MAX_PIN_PATH_LENGTH - 1);
-    ebpf_operation_get_next_pinned_program_path_request_t* request =
-        reinterpret_cast<ebpf_operation_get_next_pinned_program_path_request_t*>(request_buffer.data());
-    ebpf_operation_get_next_pinned_program_path_reply_t* reply =
-        reinterpret_cast<ebpf_operation_get_next_pinned_program_path_reply_t*>(reply_buffer.data());
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path) + (next_path_len - 1));
+    ebpf_operation_get_next_pinned_object_path_request_t* request =
+        reinterpret_cast<ebpf_operation_get_next_pinned_object_path_request_t*>(request_buffer.data());
+    ebpf_operation_get_next_pinned_object_path_reply_t* reply =
+        reinterpret_cast<ebpf_operation_get_next_pinned_object_path_reply_t*>(reply_buffer.data());
 
-    request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_PROGRAM_PATH;
+    request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH;
     request->header.length = static_cast<uint16_t>(request_buffer.size());
     reply->header.length = static_cast<uint16_t>(reply_buffer.size());
 
+    request->type = *type;
     memcpy(request->start_path, start_path, start_path_length);
 
     uint32_t error = invoke_ioctl(request_buffer, reply_buffer);
@@ -4020,13 +4033,11 @@ ebpf_get_next_pinned_program_path(
     if (result != EBPF_SUCCESS) {
         EBPF_RETURN_RESULT(result);
     }
-    ebpf_assert(reply->header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_PROGRAM_PATH);
-    size_t next_path_length =
-        reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path);
-    memcpy(next_path, reply->next_path, next_path_length);
-
-    next_path[next_path_length] = '\0';
-
+    ebpf_assert(reply->header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH);
+    size_t reply_next_path_len =
+        reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path);
+    strncpy_s(next_path, next_path_len, (char*)reply->next_path, reply_next_path_len);
+    *type = reply->type;
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 CATCH_NO_MEMORY_EBPF_RESULT

--- a/libs/ebpfnetsh/pins.cpp
+++ b/libs/ebpfnetsh/pins.cpp
@@ -41,8 +41,9 @@ handle_ebpf_show_pins(
     // Read all pin paths.  Currently we get them in a non-deterministic
     // order, so we use a std::set to sort them in code point order.
     char pinpath[EBPF_MAX_PIN_PATH_LENGTH] = "";
+    ebpf_object_type_t object_type = EBPF_OBJECT_PROGRAM;
     std::set<std::string> paths;
-    while (ebpf_get_next_pinned_program_path(pinpath, pinpath) == EBPF_SUCCESS) {
+    while (ebpf_get_next_pinned_object_path(pinpath, pinpath, sizeof(pinpath), &object_type) == EBPF_SUCCESS) {
         paths.insert(pinpath);
     }
 

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -316,8 +316,9 @@ _unpin_program_by_id(ebpf_id_t id)
     // Read all pin paths.  Currently we get them in a non-deterministic
     // order, so we use a std::set to sort them in code point order.
     char pinpath[EBPF_MAX_PIN_PATH_LENGTH] = "";
+    ebpf_object_type_t object_type = EBPF_OBJECT_PROGRAM;
     std::set<std::string> paths;
-    while (ebpf_get_next_pinned_program_path(pinpath, pinpath) == EBPF_SUCCESS) {
+    while (ebpf_get_next_pinned_object_path(pinpath, pinpath, sizeof(pinpath), &object_type) == EBPF_SUCCESS) {
         paths.insert(pinpath);
     }
 

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1982,12 +1982,46 @@ _ebpf_core_protocol_get_next_pinned_program_path(
     next_path.length = reply_length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path);
     next_path.value = (uint8_t*)reply->next_path;
 
-    result =
-        ebpf_pinning_table_get_next_path(_ebpf_core_map_pinning_table, EBPF_OBJECT_PROGRAM, &start_path, &next_path);
+    ebpf_object_type_t object_type = EBPF_OBJECT_PROGRAM;
+    result = ebpf_pinning_table_get_next_path(_ebpf_core_map_pinning_table, &object_type, &start_path, &next_path);
 
     if (result == EBPF_SUCCESS) {
         reply->header.length =
             (uint16_t)next_path.length + EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path);
+    }
+    EBPF_RETURN_RESULT(result);
+}
+
+static ebpf_result_t
+_ebpf_core_protocol_get_next_pinned_object_path(
+    _In_ const ebpf_operation_get_next_pinned_object_path_request_t* request,
+    _Out_ ebpf_operation_get_next_pinned_object_path_reply_t* reply,
+    uint16_t reply_length)
+{
+    EBPF_LOG_ENTRY();
+    cxplat_utf8_string_t start_path;
+    cxplat_utf8_string_t next_path;
+
+    size_t path_length;
+    ebpf_result_t result = ebpf_safe_size_t_subtract(
+        request->header.length,
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_request_t, start_path),
+        &path_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    start_path.length = path_length;
+    start_path.value = (uint8_t*)request->start_path;
+    next_path.length = reply_length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path);
+    next_path.value = (uint8_t*)reply->next_path;
+
+    ebpf_object_type_t object_type = request->type;
+    result = ebpf_pinning_table_get_next_path(_ebpf_core_map_pinning_table, &object_type, &start_path, &next_path);
+
+    if (result == EBPF_SUCCESS) {
+        reply->header.length =
+            (uint16_t)next_path.length + EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path);
+        reply->type = object_type;
     }
     EBPF_RETURN_RESULT(result);
 }
@@ -2778,6 +2812,8 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY(
         map_get_next_key_value_batch, previous_key, data, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(program_set_flags, PROTOCOL_ALL_MODES),
+    DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY(
+        get_next_pinned_object_path, start_path, next_path, PROTOCOL_ALL_MODES),
 };
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1979,7 +1979,13 @@ _ebpf_core_protocol_get_next_pinned_program_path(
     }
     start_path.length = path_length;
     start_path.value = (uint8_t*)request->start_path;
-    next_path.length = reply_length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path);
+
+    result = ebpf_safe_size_t_subtract(
+        reply_length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path), &path_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    next_path.length = path_length;
     next_path.value = (uint8_t*)reply->next_path;
 
     ebpf_object_type_t object_type = EBPF_OBJECT_PROGRAM;
@@ -2012,7 +2018,13 @@ _ebpf_core_protocol_get_next_pinned_object_path(
     }
     start_path.length = path_length;
     start_path.value = (uint8_t*)request->start_path;
-    next_path.length = reply_length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path);
+
+    result = ebpf_safe_size_t_subtract(
+        reply_length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path), &path_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    next_path.length = path_length;
     next_path.value = (uint8_t*)reply->next_path;
 
     ebpf_object_type_t object_type = request->type;

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -35,7 +35,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_GET_NEXT_MAP_ID,
     EBPF_OPERATION_GET_NEXT_PROGRAM_ID,
     EBPF_OPERATION_GET_OBJECT_INFO,
-    EBPF_OPERATION_GET_NEXT_PINNED_PROGRAM_PATH,
+    EBPF_OPERATION_GET_NEXT_PINNED_PROGRAM_PATH, /* deprecated */
     EBPF_OPERATION_BIND_MAP,
     EBPF_OPERATION_RING_BUFFER_MAP_QUERY_BUFFER,
     EBPF_OPERATION_RING_BUFFER_MAP_ASYNC_QUERY,
@@ -47,6 +47,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_MAP_DELETE_ELEMENT_BATCH,
     EBPF_OPERATION_MAP_GET_NEXT_KEY_VALUE_BATCH,
     EBPF_OPERATION_PROGRAM_SET_FLAGS,
+    EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -349,6 +350,20 @@ typedef struct _ebpf_operation_get_next_pinned_program_path_reply
     struct _ebpf_operation_header header;
     uint8_t next_path[1];
 } ebpf_operation_get_next_pinned_program_path_reply_t;
+
+typedef struct _ebpf_operation_get_next_pinned_object_path_request
+{
+    struct _ebpf_operation_header header;
+    ebpf_object_type_t type;
+    uint8_t start_path[1];
+} ebpf_operation_get_next_pinned_object_path_request_t;
+
+typedef struct _ebpf_operation_get_next_pinned_object_path_reply
+{
+    struct _ebpf_operation_header header;
+    ebpf_object_type_t type;
+    uint8_t next_path[1];
+} ebpf_operation_get_next_pinned_object_path_reply_t;
 
 typedef struct _ebpf_operation_get_object_info_request
 {

--- a/libs/runtime/ebpf_pinning_table.h
+++ b/libs/runtime/ebpf_pinning_table.h
@@ -105,7 +105,7 @@ extern "C"
      * @brief Gets the next path in the pinning table after a given path.
      *
      * @param[in, out] pinning_table Pinning table to enumerate.
-     * @param[in, out] object_type Object type, may be EBPF_OBJECT_UNKOWN.
+     * @param[in, out] object_type Object type, may be EBPF_OBJECT_UNKNOWN.
      * @param[in] start_path Path to look for an entry greater than.
      * @param[in, out] next_path Returns the next path, if one exists.
      * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/runtime/ebpf_pinning_table.h
+++ b/libs/runtime/ebpf_pinning_table.h
@@ -105,7 +105,7 @@ extern "C"
      * @brief Gets the next path in the pinning table after a given path.
      *
      * @param[in, out] pinning_table Pinning table to enumerate.
-     * @param[in] object_type Object type.
+     * @param[in, out] object_type Object type, may be EBPF_OBJECT_UNKOWN.
      * @param[in] start_path Path to look for an entry greater than.
      * @param[in, out] next_path Returns the next path, if one exists.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -114,7 +114,7 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_get_next_path(
         _Inout_ ebpf_pinning_table_t* pinning_table,
-        ebpf_object_type_t object_type,
+        _Inout_ ebpf_object_type_t* object_type,
         _In_ const cxplat_utf8_string_t* start_path,
         _Inout_ cxplat_utf8_string_t* next_path);
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1505,6 +1505,109 @@ TEST_CASE("pinned_map_enum", "[end_to_end]")
     ebpf_test_pinned_map_enum();
 }
 
+TEST_CASE("ebpf_get_next_pinned_object_path", "[end_to_end][pinning]")
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    bpf_object_ptr unique_object;
+    fd_t program_fd;
+    const char* error_message = nullptr;
+
+    int result = ebpf_program_load(
+        SAMPLE_PATH "test_sample_ebpf_um.dll",
+        BPF_PROG_TYPE_UNSPEC,
+        EBPF_EXECUTION_NATIVE,
+        &unique_object,
+        &program_fd,
+        &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+    REQUIRE(program_fd > 0);
+
+    fd_t map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, "test_map", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(map_fd > 0);
+
+    // Pin the program and map multiple times with a shared prefix.
+    const char* prefix = "/ebpf/test/";
+    const char* paths[] = {
+        "/ebpf/test/map1",
+        "/ebpf/test/map2",
+        "/ebpf/test/program1",
+        "/ebpf/test/program2",
+    };
+    const ebpf_object_type_t object_types[] = {
+        EBPF_OBJECT_MAP,
+        EBPF_OBJECT_MAP,
+        EBPF_OBJECT_PROGRAM,
+        EBPF_OBJECT_PROGRAM,
+    };
+
+    REQUIRE(bpf_obj_pin(map_fd, paths[0]) == 0);
+    REQUIRE(bpf_obj_pin(map_fd, paths[1]) == 0);
+    REQUIRE(bpf_obj_pin(program_fd, paths[2]) == 0);
+    REQUIRE(bpf_obj_pin(program_fd, paths[3]) == 0);
+
+    char path[EBPF_MAX_PIN_PATH_LENGTH];
+    size_t expected_count = sizeof(paths) / sizeof(paths[0]);
+    const char* start_path = prefix;
+    size_t count = 0;
+
+    // Enumerate all pinned objects.
+    ebpf_object_type_t object_type = EBPF_OBJECT_UNKNOWN;
+    while (ebpf_get_next_pinned_object_path(start_path, path, sizeof(path), &object_type) == EBPF_SUCCESS) {
+        if (strncmp(path, prefix, strlen(prefix)) != 0) {
+            break;
+        }
+
+        REQUIRE(object_type == object_types[count]);
+        REQUIRE(count < expected_count);
+        REQUIRE(strcmp(path, paths[count]) == 0);
+
+        count++;
+        start_path = path;
+        object_type = EBPF_OBJECT_UNKNOWN;
+    }
+
+    REQUIRE(count == expected_count);
+
+    // Only iterate over programs.
+    start_path = prefix;
+    count = 2;
+    object_type = EBPF_OBJECT_PROGRAM;
+    while (ebpf_get_next_pinned_object_path(start_path, path, sizeof(path), &object_type) == EBPF_SUCCESS) {
+        if (strncmp(path, prefix, strlen(prefix)) != 0) {
+            break;
+        }
+
+        REQUIRE(object_type == EBPF_OBJECT_PROGRAM);
+        REQUIRE(count < expected_count);
+        REQUIRE(strcmp(path, paths[count]) == 0);
+
+        count++;
+        start_path = path;
+    }
+
+    REQUIRE(count == expected_count);
+
+    // Clean up.
+    REQUIRE(ebpf_object_unpin(paths[0]) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_unpin(paths[1]) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_unpin(paths[2]) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_unpin(paths[3]) == EBPF_SUCCESS);
+    Platform::_close(map_fd);
+    bpf_object__close(unique_object.release());
+}
+
 #if !defined(CONFIG_BPF_JIT_DISABLED)
 // This test uses ebpf_link_close() to test implicit detach.
 TEST_CASE("implicit_detach", "[end_to_end]")


### PR DESCRIPTION
It's currently not possible to find pinned maps and links. Add a function ebpf_get_next_pinned_object_path which allows doing just that.

The paths are returned in lexicographical order, which allows user space to performa a prefix match on the paths. Behind the scenes this is implemented using a linear scan of the hash table, which has quadratic running time. The same is already the case for finding the next object ID, so going with the more desirable semantics makes sense.

The existing ebpf_get_next_pinned_program_path() is deprecated because it is less flexible than the new function.

Updates https://github.com/microsoft/ebpf-for-windows/issues/4161