### PR TITLE
Global variable support

### DIFF
--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -86,6 +86,14 @@ extern "C"
         const char** values; // Array of strings containing the initial values.
     } map_initial_values_t;
 
+    typedef struct _global_variable_section
+    {
+        const char* name;
+        unsigned char* address_of_map_value;
+        size_t size;
+        const void* initial_data;
+    } global_variable_section_t;
+
     /**
      * @brief Program entry.
      * This structure contains the address of the program and additional information about the program.
@@ -146,6 +154,9 @@ extern "C"
         void (*map_initial_values)(
             _Outptr_result_buffer_maybenull_(*count) map_initial_values_t** map_initial_values,
             _Out_ size_t* count); ///< Returns the list of initial values for maps in this module.
+        void (*global_variable_sections)(
+            _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections,
+            _Out_ size_t* count); ///< Returns the list of global variables in this module.
     } metadata_table_t;
 
     /**

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2499,6 +2499,8 @@ _ebpf_pe_get_map_definitions(
             for (int map_index = 0; map_offset + sizeof(map_entry_t) <= section_header.Misc.VirtualSize;
                  map_offset += sizeof(map_entry_t), map_index++) {
                 map_entry_t* entry = (map_entry_t*)(buffer->buf + map_offset);
+                // Issue: https://github.com/microsoft/ebpf-for-windows/issues/4168
+                // This heuristic is fragile and will break when map_entry_t changes.
                 if (entry->address != nullptr) {
                     // bpf2c generates a section that has map names longer than sizeof(map_entry_t)
                     // at the end of the section.  This entry seems to be a map name string, so we've

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -550,6 +550,39 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
+_Must_inspect_result_ ebpf_result_t
+ebpf_core_resolve_map_value_address(
+    uint32_t count_of_maps,
+    _In_reads_(count_of_maps) const ebpf_handle_t* map_handles,
+    _Out_writes_(count_of_maps) uintptr_t* map_addresses)
+{
+    EBPF_LOG_ENTRY();
+    uint32_t map_index = 0;
+    ebpf_result_t return_value = EBPF_SUCCESS;
+
+    for (map_index = 0; map_index < count_of_maps; map_index++) {
+        ebpf_map_t* map;
+        return_value =
+            EBPF_OBJECT_REFERENCE_BY_HANDLE(map_handles[map_index], EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
+
+        if (return_value != EBPF_SUCCESS) {
+            goto Done;
+        }
+
+        return_value = ebpf_map_get_value_address(map, &map_addresses[map_index]);
+
+        // First release the map reference, then check the return value.
+        EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
+
+        if (return_value != EBPF_SUCCESS) {
+            goto Done;
+        }
+    }
+
+Done:
+    EBPF_RETURN_RESULT(return_value);
+}
+
 #if !defined(CONFIG_BPF_JIT_DISABLED)
 static ebpf_result_t
 _ebpf_core_protocol_resolve_map(

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -272,6 +272,25 @@ extern "C"
     ebpf_core_update_map_with_handle(
         ebpf_handle_t map_handle, _In_ const uint8_t* key, size_t key_length, ebpf_handle_t value);
 
+    /**
+     * @brief Resolve the provided map handles to address of the first value in the map if
+     * the map is an array map or NULL if the map is not an array map.
+     *
+     * @param[in] program_handle Handle of the program to associate maps with.
+     * @param[in] count_of_maps Number of map handles.
+     * @param[in] map_handles Array of map handles containing "count_of_maps" handles.
+     * @param[out] map_addresses Array of map value addresses of size "count_of_maps"
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_OBJECT The provided handle is not valid.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_core_resolve_map_value_address(
+        uint32_t count_of_maps,
+        _In_reads_(count_of_maps) const ebpf_handle_t* map_handles,
+        _Out_writes_(count_of_maps) uintptr_t* map_value_addresses);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -3033,3 +3033,15 @@ ebpf_map_get_next_key_and_value_batch(
 
     return result;
 }
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_map_get_value_address(_In_ const ebpf_map_t* map, _Out_ uintptr_t* value_address)
+{
+    if (map->ebpf_map_definition.type != BPF_MAP_TYPE_ARRAY) {
+        return EBPF_INVALID_ARGUMENT;
+    } else {
+        ebpf_core_map_t* core_map = (ebpf_core_map_t*)map;
+        *value_address = (uintptr_t)core_map->data;
+    }
+    return EBPF_SUCCESS;
+}

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -323,6 +323,18 @@ extern "C"
         _Out_writes_bytes_to_(*key_and_value_length, *key_and_value_length) uint8_t* key_and_value,
         int flags);
 
+    /**
+     * @brief Get the address of the first value in the map if it is an array or
+     * return EBPF_INVALID_ARGUMENT if it is not an array map.
+     *
+     * @param[in] map Map to query.
+     * @param[out] value_address Map value address.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT The provided map is not valid.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_map_get_value_address(_In_ const ebpf_map_t* map, _Out_ uintptr_t* value_address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -432,6 +432,14 @@ _ebpf_native_map_initial_values_fallback(
     *count = 0;
 }
 
+static void
+_ebpf_native_global_variable_sections_fallback(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    global_variable_sections = NULL;
+    *count = 0;
+}
+
 static NTSTATUS
 _ebpf_native_provider_attach_client_callback(
     _In_ HANDLE nmr_binding_handle,
@@ -496,6 +504,10 @@ _ebpf_native_provider_attach_client_callback(
     // Initialize the map initial values function pointer if it is not present.
     if (!client_context->table.map_initial_values) {
         client_context->table.map_initial_values = _ebpf_native_map_initial_values_fallback;
+    }
+
+    if (!client_context->table.global_variable_sections) {
+        client_context->table.global_variable_sections = _ebpf_native_global_variable_sections_fallback;
     }
 
     ebpf_lock_create(&client_context->lock);
@@ -940,6 +952,39 @@ _ebpf_native_set_initial_map_values(_Inout_ ebpf_native_module_t* module)
         if (result != EBPF_SUCCESS) {
             break;
         }
+    }
+
+    EBPF_RETURN_RESULT(result);
+}
+
+static ebpf_result_t
+_ebpf_native_initialize_global_variables(_Inout_ ebpf_native_module_t* module)
+{
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+    global_variable_section_t* global_variables = NULL;
+    size_t global_variable_count = 0;
+
+    // Get global variables.
+    module->table.global_variable_sections(&global_variables, &global_variable_count);
+
+    // For each entry.
+    for (size_t i = 0; i < global_variable_count; i++) {
+        ebpf_native_map_t* native_map = _ebpf_native_find_map_by_name(module, global_variables[i].name);
+        if (native_map == NULL) {
+            result = EBPF_INVALID_ARGUMENT;
+            break;
+        }
+
+        // Resolve initial value address.
+        result = ebpf_core_resolve_map_value_address(
+            1, &native_map->handle, (uintptr_t*)&global_variables[i].address_of_map_value);
+        if (result != EBPF_SUCCESS) {
+            break;
+        }
+
+        // Copy the initial value to the map.
+        memcpy(global_variables[i].address_of_map_value, global_variables[i].initial_data, global_variables[i].size);
     }
 
     EBPF_RETURN_RESULT(result);
@@ -1631,6 +1676,17 @@ ebpf_native_load_programs(
             EBPF_TRACELOG_LEVEL_VERBOSE,
             EBPF_TRACELOG_KEYWORD_NATIVE,
             "ebpf_native_load_programs: set initial map values failed",
+            module_id);
+        goto Done;
+    }
+
+    // Setup global variables.
+    result = _ebpf_native_initialize_global_variables(module);
+    if (result != EBPF_SUCCESS) {
+        EBPF_LOG_MESSAGE_GUID(
+            EBPF_TRACELOG_LEVEL_VERBOSE,
+            EBPF_TRACELOG_KEYWORD_NATIVE,
+            "ebpf_native_load_programs: resolve map value addresses failed",
             module_id);
         goto Done;
     }

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -197,4 +205,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t atomic_instruction_fetch_add_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -167,4 +175,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t atomic_instruction_fetch_add_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -328,4 +336,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t atomic_instruction_fetch_add_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -197,4 +205,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bad_map_name_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -167,4 +175,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bad_map_name_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -328,4 +336,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bad_map_name_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 // Forward references for local functions.
 static uint64_t
 BindMonitor_Callee1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context);
@@ -516,4 +524,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_bpf2bpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 // Forward references for local functions.
 static uint64_t
 BindMonitor_Callee1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context);
@@ -486,4 +494,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_bpf2bpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 // Forward references for local functions.
 static uint64_t
 BindMonitor_Callee1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context);
@@ -647,4 +655,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_bpf2bpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -91,6 +91,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_helpers[] = {
     {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
@@ -598,4 +606,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_Callee0_helpers[] = {
     {NULL, 13, "helper_id_13"},
     {NULL, 5, "helper_id_5"},
@@ -6272,4 +6280,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_mt_tailcall_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_Callee0_helpers[] = {
     {NULL, 13, "helper_id_13"},
     {NULL, 5, "helper_id_5"},
@@ -6242,4 +6250,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_mt_tailcall_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_Callee0_helpers[] = {
     {NULL, 13, "helper_id_13"},
     {NULL, 5, "helper_id_5"},
@@ -6403,4 +6411,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_mt_tailcall_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -61,6 +61,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_helpers[] = {
     {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
@@ -568,4 +576,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t bind_monitor_helpers[] = {
     {NULL, 11, "helper_id_11"},
 };
@@ -203,4 +211,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_ringbuf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t bind_monitor_helpers[] = {
     {NULL, 11, "helper_id_11"},
 };
@@ -173,4 +181,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_ringbuf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t bind_monitor_helpers[] = {
     {NULL, 11, "helper_id_11"},
 };
@@ -334,4 +342,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_ringbuf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -222,6 +222,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_helpers[] = {
     {NULL, 19, "helper_id_19"},
     {NULL, 20, "helper_id_20"},
@@ -729,4 +737,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -139,6 +139,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 7;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 5, "helper_id_5"},
@@ -816,4 +824,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_tailcall_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -109,6 +109,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 7;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 5, "helper_id_5"},
@@ -786,4 +794,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_tailcall_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -270,6 +270,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 7;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t BindMonitor_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 5, "helper_id_5"},
@@ -947,4 +955,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bindmonitor_tailcall_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 2, "helper_id_2"},
 };
@@ -195,4 +203,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bpf_call_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 2, "helper_id_2"},
 };
@@ -165,4 +173,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bpf_call_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 2, "helper_id_2"},
 };
@@ -326,4 +334,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bpf_call_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID func_program_type_guid = {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
 #pragma code_seg(push, ".text")
@@ -126,4 +134,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID func_program_type_guid = {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
 #pragma code_seg(push, ".text")
@@ -96,4 +104,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID func_program_type_guid = {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
 #pragma code_seg(push, ".text")
@@ -257,4 +265,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t bpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t count_tcp_connect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -264,4 +272,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_count_connect4_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t count_tcp_connect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -234,4 +242,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_count_connect4_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t count_tcp_connect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -395,4 +403,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_count_connect4_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t count_tcp_connect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -264,4 +272,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_count_connect6_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t count_tcp_connect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -234,4 +242,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_count_connect6_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t count_tcp_connect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -395,4 +403,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_count_connect6_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID tcp_mt_connect4_program_type_guid = {
     0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
 static GUID tcp_mt_connect4_attach_type_guid = {
@@ -201,4 +209,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_mt_connect4_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID tcp_mt_connect4_program_type_guid = {
     0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
 static GUID tcp_mt_connect4_attach_type_guid = {
@@ -171,4 +179,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_mt_connect4_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID tcp_mt_connect4_program_type_guid = {
     0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
 static GUID tcp_mt_connect4_attach_type_guid = {
@@ -332,4 +340,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_mt_connect4_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID tcp_mt_connect6_program_type_guid = {
     0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
 static GUID tcp_mt_connect6_attach_type_guid = {
@@ -201,4 +209,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_mt_connect6_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID tcp_mt_connect6_program_type_guid = {
     0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
 static GUID tcp_mt_connect6_attach_type_guid = {
@@ -171,4 +179,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_mt_connect6_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID tcp_mt_connect6_program_type_guid = {
     0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
 static GUID tcp_mt_connect6_attach_type_guid = {
@@ -332,4 +340,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_mt_connect6_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
@@ -972,4 +980,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_sock_addr2_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
@@ -942,4 +950,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_sock_addr2_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
@@ -1103,4 +1111,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_sock_addr2_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -91,6 +91,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t authorize_connect4_helpers[] = {
     {NULL, 26, "helper_id_26"},
     {NULL, 2, "helper_id_2"},
@@ -891,4 +899,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_sock_addr_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -61,6 +61,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t authorize_connect4_helpers[] = {
     {NULL, 26, "helper_id_26"},
     {NULL, 2, "helper_id_2"},
@@ -861,4 +869,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_sock_addr_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -222,6 +222,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t authorize_connect4_helpers[] = {
     {NULL, 26, "helper_id_26"},
     {NULL, 2, "helper_id_2"},
@@ -1022,4 +1030,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t cgroup_sock_addr_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t decapsulate_permit_packet_helpers[] = {
     {NULL, 65536, "helper_id_65536"},
 };
@@ -531,4 +539,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t decap_permit_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t decapsulate_permit_packet_helpers[] = {
     {NULL, 65536, "helper_id_65536"},
 };
@@ -501,4 +509,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t decap_permit_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t decapsulate_permit_packet_helpers[] = {
     {NULL, 65536, "helper_id_65536"},
 };
@@ -662,4 +670,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t decap_permit_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t divide_by_zero_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -204,4 +212,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t divide_by_zero_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t divide_by_zero_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -174,4 +182,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t divide_by_zero_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t divide_by_zero_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -335,4 +343,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t divide_by_zero_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t DropPacket_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -353,4 +361,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t droppacket_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t DropPacket_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -323,4 +331,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t droppacket_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t DropPacket_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -484,4 +492,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t droppacket_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t encap_reflect_packet_helpers[] = {
     {NULL, 65536, "helper_id_65536"},
     {NULL, 10, "helper_id_10"},
@@ -1232,4 +1240,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t encap_reflect_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t encap_reflect_packet_helpers[] = {
     {NULL, 65536, "helper_id_65536"},
     {NULL, 10, "helper_id_10"},
@@ -1202,4 +1210,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t encap_reflect_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t encap_reflect_packet_helpers[] = {
     {NULL, 65536, "helper_id_65536"},
     {NULL, 10, "helper_id_10"},
@@ -1363,4 +1371,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t encap_reflect_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
@@ -1,0 +1,264 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from global_vars_and_map.o
+
+#include "bpf2c.h"
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+#define metadata_table global_vars_and_map##_metadata_table
+extern metadata_table_t metadata_table;
+
+bool APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         24,                // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         LIBBPF_PIN_NONE,   // Pinning type for the map.
+         13,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
+     },
+     "some_config_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         24,                 // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         29,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.bss"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 2;
+}
+
+const char global__bss_initial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "global_.bss",
+        .size = 24,
+        .initial_data = &global__bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
+    *count = 1;
+}
+
+static helper_function_entry_t GlobalVariableAndMapTest_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+    {NULL, 22, "helper_id_22"},
+};
+
+static GUID GlobalVariableAndMapTest_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID GlobalVariableAndMapTest_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t GlobalVariableAndMapTest_maps[] = {
+    0,
+    1,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+GlobalVariableAndMapTest(void* context)
+#line 40 "sample/undocked/global_vars_and_map.c"
+{
+#line 40 "sample/undocked/global_vars_and_map.c"
+    // Prologue.
+#line 40 "sample/undocked/global_vars_and_map.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r0 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r1 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r2 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r3 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r4 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r5 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r10 = 0;
+
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r1 = (uintptr_t)context;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r1 offset=-4 imm=0
+#line 43 "sample/undocked/global_vars_and_map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/undocked/global_vars_and_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-4
+#line 43 "sample/undocked/global_vars_and_map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r1 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r0 = GlobalVariableAndMapTest_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 44 "sample/undocked/global_vars_and_map.c"
+    if ((GlobalVariableAndMapTest_helpers[0].tail_call) && (r0 == 0)) {
+#line 44 "sample/undocked/global_vars_and_map.c"
+        return 0;
+#line 44 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_JEQ_IMM pc=8 dst=r0 src=r0 offset=7 imm=0
+#line 45 "sample/undocked/global_vars_and_map.c"
+    if (r0 == IMMEDIATE(0)) {
+#line 45 "sample/undocked/global_vars_and_map.c"
+        goto label_1;
+#line 45 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_LDDW pc=9 dst=r1 src=r2 offset=0 imm=2
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r1 = POINTER(_global_variable_sections[0].address_of_map_value + 0);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=24
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r2 = IMMEDIATE(24);
+    // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r0 offset=0 imm=0
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r3 = r0;
+    // EBPF_OP_MOV64_IMM pc=13 dst=r4 src=r0 offset=0 imm=24
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r4 = IMMEDIATE(24);
+    // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=22
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r0 = GlobalVariableAndMapTest_helpers[1].address(r1, r2, r3, r4, r5, context);
+#line 50 "sample/undocked/global_vars_and_map.c"
+    if ((GlobalVariableAndMapTest_helpers[1].tail_call) && (r0 == 0)) {
+#line 50 "sample/undocked/global_vars_and_map.c"
+        return 0;
+#line 50 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=0
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_MOV64_REG pc=16 dst=r0 src=r1 offset=0 imm=0
+#line 53 "sample/undocked/global_vars_and_map.c"
+    r0 = r1;
+    // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
+#line 53 "sample/undocked/global_vars_and_map.c"
+    return r0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        GlobalVariableAndMapTest,
+        "sample~1",
+        "sample_ext",
+        "GlobalVariableAndMapTest",
+        GlobalVariableAndMapTest_maps,
+        2,
+        GlobalVariableAndMapTest_helpers,
+        2,
+        18,
+        &GlobalVariableAndMapTest_program_type_guid,
+        &GlobalVariableAndMapTest_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 21;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t global_vars_and_map_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
@@ -1,0 +1,234 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from global_vars_and_map.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         24,                // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         LIBBPF_PIN_NONE,   // Pinning type for the map.
+         13,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
+     },
+     "some_config_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         24,                 // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         29,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.bss"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 2;
+}
+
+const char global__bss_initial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "global_.bss",
+        .size = 24,
+        .initial_data = &global__bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
+    *count = 1;
+}
+
+static helper_function_entry_t GlobalVariableAndMapTest_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+    {NULL, 22, "helper_id_22"},
+};
+
+static GUID GlobalVariableAndMapTest_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID GlobalVariableAndMapTest_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t GlobalVariableAndMapTest_maps[] = {
+    0,
+    1,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+GlobalVariableAndMapTest(void* context)
+#line 40 "sample/undocked/global_vars_and_map.c"
+{
+#line 40 "sample/undocked/global_vars_and_map.c"
+    // Prologue.
+#line 40 "sample/undocked/global_vars_and_map.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r0 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r1 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r2 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r3 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r4 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r5 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r10 = 0;
+
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r1 = (uintptr_t)context;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r1 offset=-4 imm=0
+#line 43 "sample/undocked/global_vars_and_map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/undocked/global_vars_and_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-4
+#line 43 "sample/undocked/global_vars_and_map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r1 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r0 = GlobalVariableAndMapTest_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 44 "sample/undocked/global_vars_and_map.c"
+    if ((GlobalVariableAndMapTest_helpers[0].tail_call) && (r0 == 0)) {
+#line 44 "sample/undocked/global_vars_and_map.c"
+        return 0;
+#line 44 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_JEQ_IMM pc=8 dst=r0 src=r0 offset=7 imm=0
+#line 45 "sample/undocked/global_vars_and_map.c"
+    if (r0 == IMMEDIATE(0)) {
+#line 45 "sample/undocked/global_vars_and_map.c"
+        goto label_1;
+#line 45 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_LDDW pc=9 dst=r1 src=r2 offset=0 imm=2
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r1 = POINTER(_global_variable_sections[0].address_of_map_value + 0);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=24
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r2 = IMMEDIATE(24);
+    // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r0 offset=0 imm=0
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r3 = r0;
+    // EBPF_OP_MOV64_IMM pc=13 dst=r4 src=r0 offset=0 imm=24
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r4 = IMMEDIATE(24);
+    // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=22
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r0 = GlobalVariableAndMapTest_helpers[1].address(r1, r2, r3, r4, r5, context);
+#line 50 "sample/undocked/global_vars_and_map.c"
+    if ((GlobalVariableAndMapTest_helpers[1].tail_call) && (r0 == 0)) {
+#line 50 "sample/undocked/global_vars_and_map.c"
+        return 0;
+#line 50 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=0
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_MOV64_REG pc=16 dst=r0 src=r1 offset=0 imm=0
+#line 53 "sample/undocked/global_vars_and_map.c"
+    r0 = r1;
+    // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
+#line 53 "sample/undocked/global_vars_and_map.c"
+    return r0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        GlobalVariableAndMapTest,
+        "sample~1",
+        "sample_ext",
+        "GlobalVariableAndMapTest",
+        GlobalVariableAndMapTest_maps,
+        2,
+        GlobalVariableAndMapTest_helpers,
+        2,
+        18,
+        &GlobalVariableAndMapTest_program_type_guid,
+        &GlobalVariableAndMapTest_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 21;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t global_vars_and_map_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
@@ -1,0 +1,395 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from global_vars_and_map.o
+
+#define NO_CRT
+#include "bpf2c.h"
+
+#include <guiddef.h>
+#include <wdm.h>
+#include <wsk.h>
+
+DRIVER_INITIALIZE DriverEntry;
+DRIVER_UNLOAD DriverUnload;
+RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
+
+#define metadata_table global_vars_and_map##_metadata_table
+
+static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
+                             0xc847aac8,
+                             0xa6f2,
+                             0x4b53,
+                             {0xae, 0xa3, 0xf4, 0xa9, 0x4b, 0x9a, 0x80, 0xcb}};
+static NPI_MODULEID _bpf2c_module_id = {sizeof(_bpf2c_module_id), MIT_GUID, {0}};
+static HANDLE _bpf2c_nmr_client_handle;
+static HANDLE _bpf2c_nmr_provider_handle;
+extern metadata_table_t metadata_table;
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context);
+
+static const NPI_CLIENT_CHARACTERISTICS _bpf2c_npi_client_characteristics = {
+    0,                                  // Version
+    sizeof(NPI_CLIENT_CHARACTERISTICS), // Length
+    _bpf2c_npi_client_attach_provider,
+    _bpf2c_npi_client_detach_provider,
+    NULL,
+    {0,                                 // Version
+     sizeof(NPI_REGISTRATION_INSTANCE), // Length
+     &_bpf2c_npi_id,
+     &_bpf2c_module_id,
+     0,
+     &metadata_table}};
+
+static NTSTATUS
+_bpf2c_query_npi_module_id(
+    _In_ const wchar_t* value_name,
+    unsigned long value_type,
+    _In_ const void* value_data,
+    unsigned long value_length,
+    _Inout_ void* context,
+    _Inout_ void* entry_context)
+{
+    UNREFERENCED_PARAMETER(value_name);
+    UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(entry_context);
+
+    if (value_type != REG_BINARY) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (value_length != sizeof(_bpf2c_module_id.Guid)) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    memcpy(&_bpf2c_module_id.Guid, value_data, value_length);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_path)
+{
+    NTSTATUS status;
+    RTL_QUERY_REGISTRY_TABLE query_table[] = {
+        {
+            NULL,                      // Query routine
+            RTL_QUERY_REGISTRY_SUBKEY, // Flags
+            L"Parameters",             // Name
+            NULL,                      // Entry context
+            REG_NONE,                  // Default type
+            NULL,                      // Default data
+            0,                         // Default length
+        },
+        {
+            _bpf2c_query_npi_module_id,  // Query routine
+            RTL_QUERY_REGISTRY_REQUIRED, // Flags
+            L"NpiModuleId",              // Name
+            NULL,                        // Entry context
+            REG_NONE,                    // Default type
+            NULL,                        // Default data
+            0,                           // Default length
+        },
+        {0}};
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, registry_path->Buffer, query_table, NULL, NULL);
+    if (!NT_SUCCESS(status)) {
+        goto Exit;
+    }
+
+    status = NmrRegisterClient(&_bpf2c_npi_client_characteristics, NULL, &_bpf2c_nmr_client_handle);
+
+Exit:
+    if (NT_SUCCESS(status)) {
+        driver_object->DriverUnload = DriverUnload;
+    }
+
+    return status;
+}
+
+void
+DriverUnload(_In_ DRIVER_OBJECT* driver_object)
+{
+    NTSTATUS status = NmrDeregisterClient(_bpf2c_nmr_client_handle);
+    if (status == STATUS_PENDING) {
+        NmrWaitForClientDeregisterComplete(_bpf2c_nmr_client_handle);
+    }
+    UNREFERENCED_PARAMETER(driver_object);
+}
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    void* provider_binding_context = NULL;
+    void* provider_dispatch_table = NULL;
+
+    UNREFERENCED_PARAMETER(client_context);
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+
+    if (_bpf2c_nmr_provider_handle != NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+#pragma warning(push)
+#pragma warning( \
+    disable : 6387) // Param 3 does not adhere to the specification for the function 'NmrClientAttachProvider'
+    // As per MSDN, client dispatch can be NULL, but SAL does not allow it.
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nf-netioddk-nmrclientattachprovider
+    status = NmrClientAttachProvider(
+        nmr_binding_handle, client_context, NULL, &provider_binding_context, &provider_dispatch_table);
+    if (status != STATUS_SUCCESS) {
+        goto Done;
+    }
+#pragma warning(pop)
+    _bpf2c_nmr_provider_handle = nmr_binding_handle;
+
+Done:
+    return status;
+}
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
+{
+    _bpf2c_nmr_provider_handle = NULL;
+    UNREFERENCED_PARAMETER(client_binding_context);
+    return STATUS_SUCCESS;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         24,                // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         LIBBPF_PIN_NONE,   // Pinning type for the map.
+         13,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
+     },
+     "some_config_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         24,                 // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         29,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.bss"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 2;
+}
+
+const char global__bss_initial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "global_.bss",
+        .size = 24,
+        .initial_data = &global__bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
+    *count = 1;
+}
+
+static helper_function_entry_t GlobalVariableAndMapTest_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+    {NULL, 22, "helper_id_22"},
+};
+
+static GUID GlobalVariableAndMapTest_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID GlobalVariableAndMapTest_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t GlobalVariableAndMapTest_maps[] = {
+    0,
+    1,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+GlobalVariableAndMapTest(void* context)
+#line 40 "sample/undocked/global_vars_and_map.c"
+{
+#line 40 "sample/undocked/global_vars_and_map.c"
+    // Prologue.
+#line 40 "sample/undocked/global_vars_and_map.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r0 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r1 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r2 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r3 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r4 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r5 = 0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    register uint64_t r10 = 0;
+
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r1 = (uintptr_t)context;
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=0
+#line 40 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r1 offset=-4 imm=0
+#line 43 "sample/undocked/global_vars_and_map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/undocked/global_vars_and_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-4
+#line 43 "sample/undocked/global_vars_and_map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r1 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r0 = GlobalVariableAndMapTest_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 44 "sample/undocked/global_vars_and_map.c"
+    if ((GlobalVariableAndMapTest_helpers[0].tail_call) && (r0 == 0)) {
+#line 44 "sample/undocked/global_vars_and_map.c"
+        return 0;
+#line 44 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=1
+#line 44 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_JEQ_IMM pc=8 dst=r0 src=r0 offset=7 imm=0
+#line 45 "sample/undocked/global_vars_and_map.c"
+    if (r0 == IMMEDIATE(0)) {
+#line 45 "sample/undocked/global_vars_and_map.c"
+        goto label_1;
+#line 45 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_LDDW pc=9 dst=r1 src=r2 offset=0 imm=2
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r1 = POINTER(_global_variable_sections[0].address_of_map_value + 0);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=24
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r2 = IMMEDIATE(24);
+    // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r0 offset=0 imm=0
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r3 = r0;
+    // EBPF_OP_MOV64_IMM pc=13 dst=r4 src=r0 offset=0 imm=24
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r4 = IMMEDIATE(24);
+    // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=22
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r0 = GlobalVariableAndMapTest_helpers[1].address(r1, r2, r3, r4, r5, context);
+#line 50 "sample/undocked/global_vars_and_map.c"
+    if ((GlobalVariableAndMapTest_helpers[1].tail_call) && (r0 == 0)) {
+#line 50 "sample/undocked/global_vars_and_map.c"
+        return 0;
+#line 50 "sample/undocked/global_vars_and_map.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=15 dst=r1 src=r0 offset=0 imm=0
+#line 50 "sample/undocked/global_vars_and_map.c"
+    r1 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_MOV64_REG pc=16 dst=r0 src=r1 offset=0 imm=0
+#line 53 "sample/undocked/global_vars_and_map.c"
+    r0 = r1;
+    // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
+#line 53 "sample/undocked/global_vars_and_map.c"
+    return r0;
+#line 40 "sample/undocked/global_vars_and_map.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        GlobalVariableAndMapTest,
+        "sample~1",
+        "sample_ext",
+        "GlobalVariableAndMapTest",
+        GlobalVariableAndMapTest_maps,
+        2,
+        GlobalVariableAndMapTest_helpers,
+        2,
+        18,
+        &GlobalVariableAndMapTest_program_type_guid,
+        &GlobalVariableAndMapTest_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 21;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t global_vars_and_map_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/global_vars_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_dll.c
@@ -1,0 +1,259 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from global_vars.o
+
+#include "bpf2c.h"
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+#define metadata_table global_vars##_metadata_table
+extern metadata_table_t metadata_table;
+
+bool APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         26,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.rodata"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         8,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         24,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.data"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         23,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.bss"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 3;
+}
+
+const char global__rodata_initial_data[] = {10, 0, 0, 0};
+
+const char global__data_initial_data[] = {20, 0, 0, 0, 40, 0, 0, 0};
+
+const char global__bss_initial_data[] = {0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "global_.rodata",
+        .size = 4,
+        .initial_data = &global__rodata_initial_data,
+    },
+    {
+        .name = "global_.data",
+        .size = 8,
+        .initial_data = &global__data_initial_data,
+    },
+    {
+        .name = "global_.bss",
+        .size = 4,
+        .initial_data = &global__bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
+    *count = 3;
+}
+
+static GUID GlobalVariableTest_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID GlobalVariableTest_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t GlobalVariableTest_maps[] = {
+    0,
+    1,
+    2,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+GlobalVariableTest(void* context)
+#line 30 "sample/undocked/global_vars.c"
+{
+#line 30 "sample/undocked/global_vars.c"
+    // Prologue.
+#line 30 "sample/undocked/global_vars.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r0 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r1 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r2 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r3 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r10 = 0;
+
+#line 30 "sample/undocked/global_vars.c"
+    r1 = (uintptr_t)context;
+#line 30 "sample/undocked/global_vars.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_LDDW pc=0 dst=r1 src=r2 offset=0 imm=3
+#line 30 "sample/undocked/global_vars.c"
+    r1 = POINTER(_global_variable_sections[0].address_of_map_value + 0);
+    // EBPF_OP_LDXW pc=2 dst=r1 src=r1 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_LDDW pc=3 dst=r2 src=r2 offset=0 imm=2
+#line 30 "sample/undocked/global_vars.c"
+    r2 = POINTER(_global_variable_sections[1].address_of_map_value + 0);
+    // EBPF_OP_LDXW pc=5 dst=r2 src=r2 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_ADD64_REG pc=6 dst=r2 src=r1 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r2 += r1;
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r2 offset=0 imm=1
+#line 30 "sample/undocked/global_vars.c"
+    r1 = POINTER(_global_variable_sections[2].address_of_map_value + 0);
+    // EBPF_OP_STXW pc=9 dst=r1 src=r2 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
+    // EBPF_OP_LDDW pc=10 dst=r2 src=r2 offset=0 imm=2
+#line 31 "sample/undocked/global_vars.c"
+    r2 = POINTER(_global_variable_sections[1].address_of_map_value + 4);
+    // EBPF_OP_LDXW pc=12 dst=r2 src=r2 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_LDXW pc=13 dst=r3 src=r1 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_ADD64_REG pc=14 dst=r3 src=r2 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r3 += r2;
+    // EBPF_OP_STXW pc=15 dst=r1 src=r3 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r3;
+    // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=0
+#line 32 "sample/undocked/global_vars.c"
+    r0 = IMMEDIATE(0);
+    // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
+#line 32 "sample/undocked/global_vars.c"
+    return r0;
+#line 30 "sample/undocked/global_vars.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        GlobalVariableTest,
+        "sample~1",
+        "sample_ext",
+        "GlobalVariableTest",
+        GlobalVariableTest_maps,
+        3,
+        NULL,
+        0,
+        18,
+        &GlobalVariableTest_program_type_guid,
+        &GlobalVariableTest_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 21;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t global_vars_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/global_vars_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_raw.c
@@ -1,0 +1,229 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from global_vars.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         26,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.rodata"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         8,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         24,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.data"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         23,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.bss"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 3;
+}
+
+const char global__rodata_initial_data[] = {10, 0, 0, 0};
+
+const char global__data_initial_data[] = {20, 0, 0, 0, 40, 0, 0, 0};
+
+const char global__bss_initial_data[] = {0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "global_.rodata",
+        .size = 4,
+        .initial_data = &global__rodata_initial_data,
+    },
+    {
+        .name = "global_.data",
+        .size = 8,
+        .initial_data = &global__data_initial_data,
+    },
+    {
+        .name = "global_.bss",
+        .size = 4,
+        .initial_data = &global__bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
+    *count = 3;
+}
+
+static GUID GlobalVariableTest_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID GlobalVariableTest_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t GlobalVariableTest_maps[] = {
+    0,
+    1,
+    2,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+GlobalVariableTest(void* context)
+#line 30 "sample/undocked/global_vars.c"
+{
+#line 30 "sample/undocked/global_vars.c"
+    // Prologue.
+#line 30 "sample/undocked/global_vars.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r0 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r1 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r2 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r3 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r10 = 0;
+
+#line 30 "sample/undocked/global_vars.c"
+    r1 = (uintptr_t)context;
+#line 30 "sample/undocked/global_vars.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_LDDW pc=0 dst=r1 src=r2 offset=0 imm=3
+#line 30 "sample/undocked/global_vars.c"
+    r1 = POINTER(_global_variable_sections[0].address_of_map_value + 0);
+    // EBPF_OP_LDXW pc=2 dst=r1 src=r1 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_LDDW pc=3 dst=r2 src=r2 offset=0 imm=2
+#line 30 "sample/undocked/global_vars.c"
+    r2 = POINTER(_global_variable_sections[1].address_of_map_value + 0);
+    // EBPF_OP_LDXW pc=5 dst=r2 src=r2 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_ADD64_REG pc=6 dst=r2 src=r1 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r2 += r1;
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r2 offset=0 imm=1
+#line 30 "sample/undocked/global_vars.c"
+    r1 = POINTER(_global_variable_sections[2].address_of_map_value + 0);
+    // EBPF_OP_STXW pc=9 dst=r1 src=r2 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
+    // EBPF_OP_LDDW pc=10 dst=r2 src=r2 offset=0 imm=2
+#line 31 "sample/undocked/global_vars.c"
+    r2 = POINTER(_global_variable_sections[1].address_of_map_value + 4);
+    // EBPF_OP_LDXW pc=12 dst=r2 src=r2 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_LDXW pc=13 dst=r3 src=r1 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_ADD64_REG pc=14 dst=r3 src=r2 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r3 += r2;
+    // EBPF_OP_STXW pc=15 dst=r1 src=r3 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r3;
+    // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=0
+#line 32 "sample/undocked/global_vars.c"
+    r0 = IMMEDIATE(0);
+    // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
+#line 32 "sample/undocked/global_vars.c"
+    return r0;
+#line 30 "sample/undocked/global_vars.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        GlobalVariableTest,
+        "sample~1",
+        "sample_ext",
+        "GlobalVariableTest",
+        GlobalVariableTest_maps,
+        3,
+        NULL,
+        0,
+        18,
+        &GlobalVariableTest_program_type_guid,
+        &GlobalVariableTest_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 21;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t global_vars_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/global_vars_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_sys.c
@@ -1,0 +1,390 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from global_vars.o
+
+#define NO_CRT
+#include "bpf2c.h"
+
+#include <guiddef.h>
+#include <wdm.h>
+#include <wsk.h>
+
+DRIVER_INITIALIZE DriverEntry;
+DRIVER_UNLOAD DriverUnload;
+RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
+
+#define metadata_table global_vars##_metadata_table
+
+static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
+                             0xc847aac8,
+                             0xa6f2,
+                             0x4b53,
+                             {0xae, 0xa3, 0xf4, 0xa9, 0x4b, 0x9a, 0x80, 0xcb}};
+static NPI_MODULEID _bpf2c_module_id = {sizeof(_bpf2c_module_id), MIT_GUID, {0}};
+static HANDLE _bpf2c_nmr_client_handle;
+static HANDLE _bpf2c_nmr_provider_handle;
+extern metadata_table_t metadata_table;
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context);
+
+static const NPI_CLIENT_CHARACTERISTICS _bpf2c_npi_client_characteristics = {
+    0,                                  // Version
+    sizeof(NPI_CLIENT_CHARACTERISTICS), // Length
+    _bpf2c_npi_client_attach_provider,
+    _bpf2c_npi_client_detach_provider,
+    NULL,
+    {0,                                 // Version
+     sizeof(NPI_REGISTRATION_INSTANCE), // Length
+     &_bpf2c_npi_id,
+     &_bpf2c_module_id,
+     0,
+     &metadata_table}};
+
+static NTSTATUS
+_bpf2c_query_npi_module_id(
+    _In_ const wchar_t* value_name,
+    unsigned long value_type,
+    _In_ const void* value_data,
+    unsigned long value_length,
+    _Inout_ void* context,
+    _Inout_ void* entry_context)
+{
+    UNREFERENCED_PARAMETER(value_name);
+    UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(entry_context);
+
+    if (value_type != REG_BINARY) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (value_length != sizeof(_bpf2c_module_id.Guid)) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    memcpy(&_bpf2c_module_id.Guid, value_data, value_length);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_path)
+{
+    NTSTATUS status;
+    RTL_QUERY_REGISTRY_TABLE query_table[] = {
+        {
+            NULL,                      // Query routine
+            RTL_QUERY_REGISTRY_SUBKEY, // Flags
+            L"Parameters",             // Name
+            NULL,                      // Entry context
+            REG_NONE,                  // Default type
+            NULL,                      // Default data
+            0,                         // Default length
+        },
+        {
+            _bpf2c_query_npi_module_id,  // Query routine
+            RTL_QUERY_REGISTRY_REQUIRED, // Flags
+            L"NpiModuleId",              // Name
+            NULL,                        // Entry context
+            REG_NONE,                    // Default type
+            NULL,                        // Default data
+            0,                           // Default length
+        },
+        {0}};
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, registry_path->Buffer, query_table, NULL, NULL);
+    if (!NT_SUCCESS(status)) {
+        goto Exit;
+    }
+
+    status = NmrRegisterClient(&_bpf2c_npi_client_characteristics, NULL, &_bpf2c_nmr_client_handle);
+
+Exit:
+    if (NT_SUCCESS(status)) {
+        driver_object->DriverUnload = DriverUnload;
+    }
+
+    return status;
+}
+
+void
+DriverUnload(_In_ DRIVER_OBJECT* driver_object)
+{
+    NTSTATUS status = NmrDeregisterClient(_bpf2c_nmr_client_handle);
+    if (status == STATUS_PENDING) {
+        NmrWaitForClientDeregisterComplete(_bpf2c_nmr_client_handle);
+    }
+    UNREFERENCED_PARAMETER(driver_object);
+}
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    void* provider_binding_context = NULL;
+    void* provider_dispatch_table = NULL;
+
+    UNREFERENCED_PARAMETER(client_context);
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+
+    if (_bpf2c_nmr_provider_handle != NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+#pragma warning(push)
+#pragma warning( \
+    disable : 6387) // Param 3 does not adhere to the specification for the function 'NmrClientAttachProvider'
+    // As per MSDN, client dispatch can be NULL, but SAL does not allow it.
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nf-netioddk-nmrclientattachprovider
+    status = NmrClientAttachProvider(
+        nmr_binding_handle, client_context, NULL, &provider_binding_context, &provider_dispatch_table);
+    if (status != STATUS_SUCCESS) {
+        goto Done;
+    }
+#pragma warning(pop)
+    _bpf2c_nmr_provider_handle = nmr_binding_handle;
+
+Done:
+    return status;
+}
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
+{
+    _bpf2c_nmr_provider_handle = NULL;
+    UNREFERENCED_PARAMETER(client_binding_context);
+    return STATUS_SUCCESS;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         26,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.rodata"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         8,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         24,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.data"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         23,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "global_.bss"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 3;
+}
+
+const char global__rodata_initial_data[] = {10, 0, 0, 0};
+
+const char global__data_initial_data[] = {20, 0, 0, 0, 40, 0, 0, 0};
+
+const char global__bss_initial_data[] = {0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "global_.rodata",
+        .size = 4,
+        .initial_data = &global__rodata_initial_data,
+    },
+    {
+        .name = "global_.data",
+        .size = 8,
+        .initial_data = &global__data_initial_data,
+    },
+    {
+        .name = "global_.bss",
+        .size = 4,
+        .initial_data = &global__bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
+    *count = 3;
+}
+
+static GUID GlobalVariableTest_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID GlobalVariableTest_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t GlobalVariableTest_maps[] = {
+    0,
+    1,
+    2,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+GlobalVariableTest(void* context)
+#line 30 "sample/undocked/global_vars.c"
+{
+#line 30 "sample/undocked/global_vars.c"
+    // Prologue.
+#line 30 "sample/undocked/global_vars.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r0 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r1 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r2 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r3 = 0;
+#line 30 "sample/undocked/global_vars.c"
+    register uint64_t r10 = 0;
+
+#line 30 "sample/undocked/global_vars.c"
+    r1 = (uintptr_t)context;
+#line 30 "sample/undocked/global_vars.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_LDDW pc=0 dst=r1 src=r2 offset=0 imm=3
+#line 30 "sample/undocked/global_vars.c"
+    r1 = POINTER(_global_variable_sections[0].address_of_map_value + 0);
+    // EBPF_OP_LDXW pc=2 dst=r1 src=r1 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_LDDW pc=3 dst=r2 src=r2 offset=0 imm=2
+#line 30 "sample/undocked/global_vars.c"
+    r2 = POINTER(_global_variable_sections[1].address_of_map_value + 0);
+    // EBPF_OP_LDXW pc=5 dst=r2 src=r2 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_ADD64_REG pc=6 dst=r2 src=r1 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    r2 += r1;
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r2 offset=0 imm=1
+#line 30 "sample/undocked/global_vars.c"
+    r1 = POINTER(_global_variable_sections[2].address_of_map_value + 0);
+    // EBPF_OP_STXW pc=9 dst=r1 src=r2 offset=0 imm=0
+#line 30 "sample/undocked/global_vars.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
+    // EBPF_OP_LDDW pc=10 dst=r2 src=r2 offset=0 imm=2
+#line 31 "sample/undocked/global_vars.c"
+    r2 = POINTER(_global_variable_sections[1].address_of_map_value + 4);
+    // EBPF_OP_LDXW pc=12 dst=r2 src=r2 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
+    // EBPF_OP_LDXW pc=13 dst=r3 src=r1 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_ADD64_REG pc=14 dst=r3 src=r2 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    r3 += r2;
+    // EBPF_OP_STXW pc=15 dst=r1 src=r3 offset=0 imm=0
+#line 31 "sample/undocked/global_vars.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r3;
+    // EBPF_OP_MOV64_IMM pc=16 dst=r0 src=r0 offset=0 imm=0
+#line 32 "sample/undocked/global_vars.c"
+    r0 = IMMEDIATE(0);
+    // EBPF_OP_EXIT pc=17 dst=r0 src=r0 offset=0 imm=0
+#line 32 "sample/undocked/global_vars.c"
+    return r0;
+#line 30 "sample/undocked/global_vars.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        GlobalVariableTest,
+        "sample~1",
+        "sample_ext",
+        "GlobalVariableTest",
+        GlobalVariableTest_maps,
+        3,
+        NULL,
+        0,
+        18,
+        &GlobalVariableTest_program_type_guid,
+        &GlobalVariableTest_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 21;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t global_vars_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -256,4 +264,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t hash_of_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/hash_of_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -226,4 +234,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t hash_of_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/hash_of_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -387,4 +395,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t hash_of_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -103,6 +103,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 4;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -348,4 +356,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t inner_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/inner_map_raw.c
+++ b/tests/bpf2c_tests/expected/inner_map_raw.c
@@ -73,6 +73,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 4;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -318,4 +326,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t inner_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/inner_map_sys.c
+++ b/tests/bpf2c_tests/expected/inner_map_sys.c
@@ -234,6 +234,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 4;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -479,4 +487,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t inner_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -151,6 +151,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 8;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_maps_helpers[] = {
     {NULL, 2, "helper_id_2"},
     {NULL, 1, "helper_id_1"},
@@ -9407,4 +9415,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -256,4 +264,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_btf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -226,4 +234,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_btf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -387,4 +395,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_btf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -240,4 +248,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_legacy_id_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -210,4 +218,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_legacy_id_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -371,4 +379,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_legacy_id_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -240,4 +248,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_legacy_idx_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -210,4 +218,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_legacy_idx_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -371,4 +379,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_in_map_legacy_idx_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -121,6 +121,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 8;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_maps_helpers[] = {
     {NULL, 2, "helper_id_2"},
     {NULL, 1, "helper_id_1"},
@@ -9377,4 +9385,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -91,6 +91,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -295,4 +303,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_reuse_2_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -61,6 +61,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -265,4 +273,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_reuse_2_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -222,6 +222,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -426,4 +434,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_reuse_2_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -91,6 +91,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -295,4 +303,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_reuse_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -61,6 +61,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -265,4 +273,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_reuse_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -222,6 +222,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 3;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t lookup_update_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 2, "helper_id_2"},
@@ -426,4 +434,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_reuse_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -282,6 +282,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 8;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_maps_helpers[] = {
     {NULL, 2, "helper_id_2"},
     {NULL, 1, "helper_id_1"},
@@ -9538,4 +9546,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/multiple_programs_dll.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID program1_program_type_guid = {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID program1_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
 #pragma code_seg(push, "bind_4")
@@ -270,4 +278,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t multiple_programs_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/multiple_programs_raw.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID program1_program_type_guid = {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID program1_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
 #pragma code_seg(push, "bind_4")
@@ -240,4 +248,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t multiple_programs_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/multiple_programs_sys.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID program1_program_type_guid = {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID program1_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
 #pragma code_seg(push, "bind_4")
@@ -401,4 +409,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t multiple_programs_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -57,6 +57,18 @@ static map_entry_t _maps[] = {
          0,                  // The id of the inner map template.
      },
      "pidtgid_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         12,                 // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         31,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "pidtgid.bss"},
 };
 #pragma data_seg(pop)
 
@@ -64,6 +76,26 @@ static void
 _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
     *maps = _maps;
+    *count = 2;
+}
+
+const char pidtgid_bss_initial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "pidtgid.bss",
+        .size = 12,
+        .initial_data = &pidtgid_bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
     *count = 1;
 }
 
@@ -246,4 +278,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t pidtgid_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -27,6 +27,18 @@ static map_entry_t _maps[] = {
          0,                  // The id of the inner map template.
      },
      "pidtgid_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         12,                 // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         31,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "pidtgid.bss"},
 };
 #pragma data_seg(pop)
 
@@ -34,6 +46,26 @@ static void
 _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
     *maps = _maps;
+    *count = 2;
+}
+
+const char pidtgid_bss_initial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "pidtgid.bss",
+        .size = 12,
+        .initial_data = &pidtgid_bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
     *count = 1;
 }
 
@@ -216,4 +248,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t pidtgid_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -188,6 +188,18 @@ static map_entry_t _maps[] = {
          0,                  // The id of the inner map template.
      },
      "pidtgid_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         12,                 // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         31,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "pidtgid.bss"},
 };
 #pragma data_seg(pop)
 
@@ -195,6 +207,26 @@ static void
 _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
     *maps = _maps;
+    *count = 2;
+}
+
+const char pidtgid_bss_initial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma data_seg(push, "global_variables")
+static global_variable_section_t _global_variable_sections[] = {
+    {
+        .name = "pidtgid.bss",
+        .size = 12,
+        .initial_data = &pidtgid_bss_initial_data,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = _global_variable_sections;
     *count = 1;
 }
 
@@ -377,4 +409,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t pidtgid_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 12, "helper_id_12"},
     {NULL, 19, "helper_id_19"},
@@ -699,4 +707,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t printk_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 12, "helper_id_12"},
     {NULL, 13, "helper_id_13"},
@@ -584,4 +592,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t printk_legacy_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 12, "helper_id_12"},
     {NULL, 13, "helper_id_13"},
@@ -554,4 +562,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t printk_legacy_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 12, "helper_id_12"},
     {NULL, 13, "helper_id_13"},
@@ -715,4 +723,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t printk_legacy_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 12, "helper_id_12"},
     {NULL, 19, "helper_id_19"},
@@ -669,4 +677,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t printk_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t func_helpers[] = {
     {NULL, 12, "helper_id_12"},
     {NULL, 19, "helper_id_19"},
@@ -830,4 +838,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t printk_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID reflect_packet_program_type_guid = {
     0xce8ccef8, 0x4241, 0x4975, {0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c}};
 static GUID reflect_packet_attach_type_guid = {
@@ -831,4 +839,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t reflect_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID reflect_packet_program_type_guid = {
     0xce8ccef8, 0x4241, 0x4975, {0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c}};
 static GUID reflect_packet_attach_type_guid = {
@@ -801,4 +809,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t reflect_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID reflect_packet_program_type_guid = {
     0xce8ccef8, 0x4241, 0x4975, {0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c}};
 static GUID reflect_packet_attach_type_guid = {
@@ -962,4 +970,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t reflect_packet_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t connection_monitor_helpers[] = {
     {NULL, 19, "helper_id_19"},
     {NULL, 1, "helper_id_1"},
@@ -750,4 +758,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t sockops_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t connection_monitor_helpers[] = {
     {NULL, 19, "helper_id_19"},
     {NULL, 1, "helper_id_1"},
@@ -720,4 +728,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t sockops_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t connection_monitor_helpers[] = {
     {NULL, 19, "helper_id_19"},
     {NULL, 1, "helper_id_1"},
@@ -881,4 +889,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t sockops_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/strings_dll.c
+++ b/tests/bpf2c_tests/expected/strings_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t StringOpsTest_helpers[] = {
     {NULL, 29, "helper_id_29"},
     {NULL, 27, "helper_id_27"},
@@ -516,4 +524,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t strings_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/strings_raw.c
+++ b/tests/bpf2c_tests/expected/strings_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t StringOpsTest_helpers[] = {
     {NULL, 29, "helper_id_29"},
     {NULL, 27, "helper_id_27"},
@@ -486,4 +494,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t strings_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/strings_sys.c
+++ b/tests/bpf2c_tests/expected/strings_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t StringOpsTest_helpers[] = {
     {NULL, 29, "helper_id_29"},
     {NULL, 27, "helper_id_27"},
@@ -647,4 +655,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t strings_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~1")
@@ -279,4 +287,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_bad_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~1")
@@ -249,4 +257,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_bad_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~1")
@@ -410,4 +418,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_bad_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~1")
@@ -274,4 +282,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~2")
@@ -294,4 +302,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~2")
@@ -264,4 +272,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~2")
@@ -425,4 +433,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_map_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t bind_test_callee0_helpers[] = {
     {NULL, 14, "helper_id_14"},
     {NULL, 5, "helper_id_5"},
@@ -7777,4 +7785,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_max_exceed_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t bind_test_callee0_helpers[] = {
     {NULL, 14, "helper_id_14"},
     {NULL, 5, "helper_id_5"},
@@ -7747,4 +7755,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_max_exceed_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t bind_test_callee0_helpers[] = {
     {NULL, 14, "helper_id_14"},
     {NULL, 5, "helper_id_5"},
@@ -7908,4 +7916,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_max_exceed_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t callee0_helpers[] = {
     {NULL, 5, "helper_id_5"},
 };
@@ -301,4 +309,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_multiple_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t callee0_helpers[] = {
     {NULL, 5, "helper_id_5"},
 };
@@ -271,4 +279,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_multiple_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t callee0_helpers[] = {
     {NULL, 5, "helper_id_5"},
 };
@@ -432,4 +440,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_multiple_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~1")
@@ -244,4 +252,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t recurse_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 13, "helper_id_13"},
@@ -303,4 +311,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_recursive_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t recurse_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 13, "helper_id_13"},
@@ -273,4 +281,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_recursive_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t recurse_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 13, "helper_id_13"},
@@ -434,4 +442,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_recursive_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t callee_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -328,4 +336,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_same_section_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t callee_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -298,4 +306,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_same_section_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t callee_helpers[] = {
     {NULL, 1, "helper_id_1"},
 };
@@ -459,4 +467,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_same_section_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t sequential0_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 13, "helper_id_13"},
@@ -7002,4 +7010,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_sequential_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t sequential0_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 13, "helper_id_13"},
@@ -6972,4 +6980,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_sequential_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t sequential0_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 13, "helper_id_13"},
@@ -7133,4 +7141,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_sequential_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static GUID callee_program_type_guid = {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 static GUID callee_attach_type_guid = {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
 #pragma code_seg(push, "sample~1")
@@ -405,4 +413,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t tail_call_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_program_entry_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 65537, "helper_id_65537"},
@@ -327,4 +335,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_sample_ebpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_program_entry_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 65537, "helper_id_65537"},
@@ -297,4 +305,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_sample_ebpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_program_entry_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 65537, "helper_id_65537"},
@@ -458,4 +466,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_sample_ebpf_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
@@ -79,6 +79,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_program_entry_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 65537, "helper_id_65537"},
@@ -397,4 +405,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_sample_implicit_helpers_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
@@ -49,6 +49,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_program_entry_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 65537, "helper_id_65537"},
@@ -367,4 +375,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_sample_implicit_helpers_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
@@ -210,6 +210,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 2;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_program_entry_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 65537, "helper_id_65537"},
@@ -528,4 +536,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_sample_implicit_helpers_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -67,6 +67,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_utility_helpers_helpers[] = {
     {NULL, 6, "helper_id_6"},
     {NULL, 7, "helper_id_7"},
@@ -401,4 +409,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_utility_helpers_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -37,6 +37,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_utility_helpers_helpers[] = {
     {NULL, 6, "helper_id_6"},
     {NULL, 7, "helper_id_7"},
@@ -371,4 +379,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_utility_helpers_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -198,6 +198,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 1;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t test_utility_helpers_helpers[] = {
     {NULL, 6, "helper_id_6"},
     {NULL, 7, "helper_id_7"},
@@ -532,4 +540,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t test_utility_helpers_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t UtilityTest_helpers[] = {
     {NULL, 23, "helper_id_23"},
     {NULL, 22, "helper_id_22"},
@@ -576,4 +584,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t utility_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/utility_raw.c
+++ b/tests/bpf2c_tests/expected/utility_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t UtilityTest_helpers[] = {
     {NULL, 23, "helper_id_23"},
     {NULL, 22, "helper_id_22"},
@@ -546,4 +554,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t utility_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/utility_sys.c
+++ b/tests/bpf2c_tests/expected/utility_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t UtilityTest_helpers[] = {
     {NULL, 23, "helper_id_23"},
     {NULL, 22, "helper_id_22"},
@@ -707,4 +715,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t utility_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
@@ -50,6 +50,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t xdp_invalid_socket_cookie_helpers[] = {
     {NULL, 26, "helper_id_26"},
     {NULL, 13, "helper_id_13"},
@@ -195,4 +203,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t xdp_invalid_socket_cookie_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_raw.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_raw.c
@@ -20,6 +20,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t xdp_invalid_socket_cookie_helpers[] = {
     {NULL, 26, "helper_id_26"},
     {NULL, 13, "helper_id_13"},
@@ -165,4 +173,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t xdp_invalid_socket_cookie_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_sys.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_sys.c
@@ -181,6 +181,14 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
     *count = 0;
 }
 
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_t** global_variable_sections, _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
 static helper_function_entry_t xdp_invalid_socket_cookie_helpers[] = {
     {NULL, 26, "helper_id_26"},
     {NULL, 13, "helper_id_13"},
@@ -326,4 +334,11 @@ _get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** ma
 }
 
 metadata_table_t xdp_invalid_socket_cookie_metadata_table = {
-    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1074,6 +1074,169 @@ map_test(ebpf_execution_type_t execution_type)
     bpf_object__close(unique_object.release());
 }
 
+void
+global_variable_test(ebpf_execution_type_t execution_type)
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    int result;
+    const char* error_message = nullptr;
+    bpf_object_ptr unique_object;
+    fd_t program_fd;
+    bpf_link_ptr link;
+
+    if (execution_type != EBPF_EXECUTION_NATIVE) {
+        // Skip this test in JIT-compiled and interpreted mode.
+        return;
+    }
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "global_vars_um.dll" : "global_vars.o");
+
+    result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_SAMPLE, execution_type, &unique_object, &program_fd, &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+
+    auto rodata = bpf_object__find_map_by_name(unique_object.get(), "global_.rodata");
+    REQUIRE(rodata != nullptr);
+    auto rodata_fd = bpf_map__fd(rodata);
+    REQUIRE(rodata_fd > 0);
+
+    auto data = bpf_object__find_map_by_name(unique_object.get(), "global_.data");
+    REQUIRE(data != nullptr);
+    auto data_fd = bpf_map__fd(data);
+    REQUIRE(data_fd > 0);
+
+    auto bss = bpf_object__find_map_by_name(unique_object.get(), "global_.bss");
+    REQUIRE(bss != nullptr);
+    auto bss_fd = bpf_map__fd(bss);
+    REQUIRE(bss_fd > 0);
+
+    uint32_t key = 0;
+    uint32_t value[2] = {};
+    REQUIRE(bpf_map_lookup_elem(bss_fd, &key, value) == EBPF_SUCCESS);
+    REQUIRE(value[0] == 0);
+
+    REQUIRE(bpf_map_lookup_elem(rodata_fd, &key, value) == EBPF_SUCCESS);
+    REQUIRE(value[0] == 10);
+
+    REQUIRE(bpf_map_lookup_elem(data_fd, &key, value) == EBPF_SUCCESS);
+    REQUIRE(value[0] == 20);
+    REQUIRE(value[1] == 40);
+
+    REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
+    uint32_t hook_result;
+    INITIALIZE_SAMPLE_CONTEXT
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
+    // Program should return 0 if all the map tests pass.
+    REQUIRE(hook_result >= 0);
+
+    value[0] = 0;
+    REQUIRE(bpf_map_lookup_elem(bss_fd, &key, &value) == EBPF_SUCCESS);
+    REQUIRE(value[0] == 70);
+
+    hook.detach_and_close_link(&link);
+
+    bpf_object__close(unique_object.release());
+}
+
+void
+global_variable_and_map_test(ebpf_execution_type_t execution_type)
+{
+    typedef struct _some_config_struct
+    {
+        int some_config_field;
+        int some_other_config_field;
+        uint64_t some_config_field_64;
+        uint64_t some_other_config_field_64;
+    } some_config_struct_t;
+
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    int result;
+    const char* error_message = nullptr;
+    bpf_object_ptr unique_object;
+    fd_t program_fd;
+    bpf_link_ptr link;
+
+    if (execution_type != EBPF_EXECUTION_NATIVE) {
+        // Skip this test in JIT-compiled and interpreted mode.
+        return;
+    }
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    const char* file_name =
+        (execution_type == EBPF_EXECUTION_NATIVE ? "global_vars_and_map_um.dll" : "global_vars_and_map.o");
+
+    result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_SAMPLE, execution_type, &unique_object, &program_fd, &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+
+    auto bss = bpf_object__find_map_by_name(unique_object.get(), "global_.bss");
+    REQUIRE(bss != nullptr);
+    auto bss_fd = bpf_map__fd(bss);
+    REQUIRE(bss_fd > 0);
+
+    auto some_config_map = bpf_object__find_map_by_name(unique_object.get(), "some_config_map");
+    REQUIRE(some_config_map != nullptr);
+    auto some_config_map_fd = bpf_map__fd(some_config_map);
+    REQUIRE(some_config_map_fd > 0);
+
+    uint32_t key = 0;
+    some_config_struct_t value{};
+    REQUIRE(bpf_map_lookup_elem(bss_fd, &key, &value) == EBPF_SUCCESS);
+    REQUIRE(value.some_config_field == 0);
+    REQUIRE(value.some_other_config_field == 0);
+    REQUIRE(value.some_config_field_64 == 0);
+    REQUIRE(value.some_other_config_field_64 == 0);
+
+    value.some_config_field = 10;
+    value.some_other_config_field = 20;
+    value.some_config_field_64 = 30;
+    value.some_other_config_field_64 = 40;
+
+    REQUIRE(bpf_map_update_elem(some_config_map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
+
+    REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
+    uint32_t hook_result;
+    INITIALIZE_SAMPLE_CONTEXT
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
+    // Program should return 0 if all the map tests pass.
+    REQUIRE(hook_result >= 0);
+
+    value = {};
+    REQUIRE(bpf_map_lookup_elem(bss_fd, &key, &value) == EBPF_SUCCESS);
+
+    REQUIRE(value.some_config_field == 10);
+    REQUIRE(value.some_other_config_field == 20);
+    REQUIRE(value.some_config_field_64 == 30);
+    REQUIRE(value.some_other_config_field_64 == 40);
+
+    hook.detach_and_close_link(&link);
+
+    bpf_object__close(unique_object.release());
+}
+
 DECLARE_ALL_TEST_CASES("droppacket", "[end_to_end]", droppacket_test);
 DECLARE_ALL_TEST_CASES("divide_by_zero", "[end_to_end]", divide_by_zero_test_um);
 DECLARE_ALL_TEST_CASES("bindmonitor", "[end_to_end]", bindmonitor_test);
@@ -1084,6 +1247,8 @@ DECLARE_ALL_TEST_CASES("negative_ring_buffer_test", "[end_to_end]", negative_rin
 DECLARE_ALL_TEST_CASES("utility-helpers", "[end_to_end]", _utility_helper_functions_test);
 DECLARE_ALL_TEST_CASES("map", "[end_to_end]", map_test);
 DECLARE_ALL_TEST_CASES("bad_map_name", "[end_to_end]", bad_map_name_um);
+DECLARE_ALL_TEST_CASES("global_variable", "[end_to_end]", global_variable_test);
+DECLARE_ALL_TEST_CASES("global_variable_and_map", "[end_to_end]", global_variable_and_map_test);
 
 TEST_CASE("enum programs", "[end_to_end]")
 {

--- a/tests/sample/cgroup_count_connect4.c
+++ b/tests/sample/cgroup_count_connect4.c
@@ -24,7 +24,7 @@ struct
     __uint(max_entries, 1);
 } connect4_count_map SEC(".maps");
 
-const uint16_t remote_port = SOCKET_TEST_PORT;
+static const uint16_t remote_port = SOCKET_TEST_PORT;
 
 SEC("cgroup/connect4")
 int

--- a/tests/sample/cgroup_count_connect6.c
+++ b/tests/sample/cgroup_count_connect6.c
@@ -24,7 +24,7 @@ struct
     __uint(max_entries, 1);
 } connect6_count_map SEC(".maps");
 
-const uint16_t remote_port = SOCKET_TEST_PORT;
+static const uint16_t remote_port = SOCKET_TEST_PORT;
 
 SEC("cgroup/connect6")
 int

--- a/tests/sample/cgroup_mt_connect4.c
+++ b/tests/sample/cgroup_mt_connect4.c
@@ -16,8 +16,8 @@
 #include "net/ip.h"
 #include "socket_tests_common.h"
 
-const uint16_t remote_port = SOCKET_TEST_PORT;
-const uint16_t redirect_offset = 1000;
+static const uint16_t remote_port = SOCKET_TEST_PORT;
+static const uint16_t redirect_offset = 1000;
 
 SEC("cgroup/connect4")
 int

--- a/tests/sample/cgroup_mt_connect6.c
+++ b/tests/sample/cgroup_mt_connect6.c
@@ -16,8 +16,8 @@
 #include "net/ip.h"
 #include "socket_tests_common.h"
 
-const uint16_t remote_port = SOCKET_TEST_PORT;
-const uint16_t redirect_offset = 1000;
+static const uint16_t remote_port = SOCKET_TEST_PORT;
+static const uint16_t redirect_offset = 1000;
 
 SEC("cgroup/connect6")
 int

--- a/tests/sample/undocked/global_vars.c
+++ b/tests/sample/undocked/global_vars.c
@@ -1,0 +1,33 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Whenever this sample program changes, bpf2c_tests will fail unless the
+// expected files in tests\bpf2c_tests\expected are updated. The following
+// script can be used to regenerate the expected files:
+//     generate_expected_bpf2c_output.ps1
+//
+// Usage:
+// .\scripts\generate_expected_bpf2c_output.ps1 <build_output_path>
+// Example:
+// .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
+
+#include "bpf_helpers.h"
+#include "sample_ext_helpers.h"
+
+// Note:
+// .rodata section is read-only data section and has size of 4 bytes (int)
+// .data section is data section and has size of 8 bytes (2 * int)
+// .bss section is uninitialized data section and has size of 4 bytes (int)
+static const volatile int global_var = 10; // This is inserted into the .rodata section
+static volatile int global_var2 = 20;      // This is inserted into the .data section
+static volatile int global_var3;           // This is inserted into the .bss section
+static volatile int global_var4 = 40;      // This is also inserted into the .data section
+
+SEC("sample_ext")
+int
+GlobalVariableTest(sample_program_context_t* ctx)
+{
+    global_var3 = global_var + global_var2;
+    global_var3 += global_var4;
+    return 0;
+}

--- a/tests/sample/undocked/global_vars_and_map.c
+++ b/tests/sample/undocked/global_vars_and_map.c
@@ -1,0 +1,53 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Whenever this sample program changes, bpf2c_tests will fail unless the
+// expected files in tests\bpf2c_tests\expected are updated. The following
+// script can be used to regenerate the expected files:
+//     generate_expected_bpf2c_output.ps1
+//
+// Usage:
+// .\scripts\generate_expected_bpf2c_output.ps1 <build_output_path>
+// Example:
+// .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
+
+#include "bpf_helpers.h"
+#include "sample_ext_helpers.h"
+
+// Declare some configuration struct that will be used in the map and as a global variable.
+typedef struct _some_config_struct
+{
+    int some_config_field;
+    int some_other_config_field;
+    uint64_t some_config_field_64;
+    uint64_t some_other_config_field_64;
+} some_config_struct_t;
+
+// Declare a hash-map with a single entry of type some_config_struct_t.
+struct
+{
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, uint32_t);
+    __type(value, some_config_struct_t);
+    __uint(max_entries, 1);
+} some_config_map SEC(".maps");
+
+// Declare a global variable of type some_config_struct_t.
+static some_config_struct_t global_config;
+
+SEC("sample_ext")
+int
+GlobalVariableAndMapTest(sample_program_context_t* ctx)
+{
+    // Look up the value in the map.
+    uint32_t key = 0;
+    some_config_struct_t* value = bpf_map_lookup_elem(&some_config_map, &key);
+    if (!value) {
+        return 1;
+    }
+
+    // Update the global variable with the value from the map.
+    memcpy((void*)&global_config, value, sizeof(some_config_struct_t));
+
+    return 0;
+}

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -232,6 +232,15 @@ bpf_code_generator::is_section_valid(const ELFIO::section* section) const
     return true;
 }
 
+bpf_code_generator::unsafe_string
+bpf_code_generator::get_section_name_by_index(ELFIO::Elf_Half index) const
+{
+    if (index >= reader.sections.size()) {
+        throw bpf_code_generator_exception("invalid section index");
+    }
+    return reader.sections[index]->get_name();
+}
+
 // This constructor is called when we are starting from an ELF file,
 // and so have function names we can use when generating code.
 bpf_code_generator::bpf_code_generator(
@@ -347,7 +356,7 @@ bpf_code_generator::generate(const bpf_code_generator::unsafe_string& program_na
 
     program.generate_labels();
     program.build_function_table();
-    program.encode_instructions(map_definitions);
+    program.encode_instructions(map_definitions, global_variable_sections);
 }
 
 std::vector<int32_t>
@@ -420,6 +429,12 @@ static bool
 _is_btf_map_section(const std::string& name)
 {
     return name == ".maps";
+}
+
+static bool
+_is_btf_global_variable_section(const std::string& name)
+{
+    return name == ".data" || name == ".rodata" || name == ".bss";
 }
 
 // Legacy (non-BTF) maps sections are identified as any section called "maps", or matching "maps/<map-name>".
@@ -500,6 +515,10 @@ bpf_code_generator::parse_btf_maps_section(const unsafe_string& name)
             if (map.name.empty()) {
                 map.name = "__anonymous_" + std::to_string(++anonymous_map_count);
             }
+            // Skip the global variable maps as they are handled seperately.
+            if (map.name == ".bss" || map.name == ".data" || map.name == ".rodata") {
+                continue;
+            }
             map_offsets.insert({map.name, map_descriptors.size()});
             map_descriptors.push_back({
                 .original_fd = static_cast<int>(map.type_id),
@@ -511,7 +530,6 @@ bpf_code_generator::parse_btf_maps_section(const unsafe_string& name)
             });
         }
         auto map_name_to_index = map_offsets;
-        size_t index = 0;
 
         std::map<std::pair<size_t, size_t>, unsafe_string> map_names_by_offset;
         std::map<unsafe_string, size_t> map_names_to_values_offset;
@@ -594,7 +612,7 @@ bpf_code_generator::parse_btf_maps_section(const unsafe_string& name)
                     }
                 }
             }
-            map_definitions[unsafe_symbol_name] = {map_definition, index++};
+            map_definitions[unsafe_symbol_name] = {map_definition, map_definitions.size()};
         }
 
         // Extract any initial values for maps.
@@ -673,6 +691,68 @@ bpf_code_generator::parse_btf_maps_section(const unsafe_string& name)
     }
 }
 
+/**
+ * @brief Given the file name and the section name, generate a libbpf compatible map name for the global variable map.
+ *
+ * @param[in] c_file_name The name of the EBPF program as a c style name.
+ * @param[in] section_name The section name.
+ * @return The libbpf compatible map name.
+ */
+static std::string
+_get_btf_global_var_map_name(
+    const bpf_code_generator::unsafe_string& c_file_name, const bpf_code_generator::unsafe_string& section_name)
+{
+    std::string c_file_name_str = c_file_name.raw();
+    // Truncate the name to at most 7 characters to match how libbpf handles map names for global variables.
+    // See: https://github.com/libbpf/libbpf/blob/444f3c0e7a0fbfeeac4b3809a184c6640ce10306/src/libbpf.c#L1839C1-L1871C5
+    // The truncated name may result in a collision, but this is the behavior on which libbpf consumers rely.
+    c_file_name_str.resize(min(c_file_name_str.size(), (size_t)7));
+    return c_file_name_str + section_name.raw();
+}
+
+void
+bpf_code_generator::parse_btf_global_variable_section(const unsafe_string& name)
+{
+    auto btf_section = get_required_section(".BTF");
+    std::optional<libbtf::btf_type_data> btf_data = vector_of<std::byte>(*btf_section);
+    std::vector<EbpfMapDescriptor> map_descriptors;
+
+    auto map_data = libbtf::parse_btf_map_section(btf_data.value());
+
+    bool section_has_map = false;
+
+    for (const auto& map : map_data) {
+        if (map.name != name.raw()) {
+            continue;
+        }
+        section_has_map = true;
+        ebpf_map_definition_in_file_t map_definition{};
+        map_definition.type = BPF_MAP_TYPE_ARRAY;
+        map_definition.key_size = map.key_size;
+        map_definition.value_size = map.value_size;
+        map_definition.max_entries = map.max_entries;
+        map_definition.id = map.type_id;
+
+        map_definitions[_get_btf_global_var_map_name(c_name, name)] = {map_definition, map_definitions.size()};
+    }
+
+    if (!section_has_map) {
+        return;
+    }
+
+    // Extract any initial values for global variables.
+    auto section = reader.sections[name.raw()];
+    std::vector<std::uint8_t> data;
+    data.resize(section->get_size());
+    if (section->get_data()) {
+        memcpy(data.data(), section->get_data(), section->get_size());
+    }
+
+    // Save the data for the global variable section.
+    global_variable_sections.insert(
+        {_get_btf_global_var_map_name(c_name, name), {global_variable_sections.size(), data}});
+}
+
 // Parse global data (currently map information) in the eBPF file.
 void
 bpf_code_generator::parse_global_data()
@@ -681,6 +761,8 @@ bpf_code_generator::parse_global_data()
         std::string name = section->get_name();
         if (_is_btf_map_section(name)) {
             parse_btf_maps_section(name);
+        } else if (_is_btf_global_variable_section(name)) {
+            parse_btf_global_variable_section(name);
         } else if (_is_legacy_map_section(name)) {
             parse_legacy_maps_section(name);
         }
@@ -811,6 +893,7 @@ bpf_code_generator::extract_relocations_and_maps(_In_ const struct _ebpf_api_pro
         map_section = get_optional_section(".maps");
     }
     ELFIO::const_symbol_section_accessor symbols{reader, get_required_section(".symtab")};
+    std::set<unsafe_string> global_variable_section_names{".data", ".rodata", ".bss"};
 
     unsafe_string section_name(program->section_name);
     auto relocations = get_optional_section(".rel" + section_name);
@@ -846,11 +929,23 @@ bpf_code_generator::extract_relocations_and_maps(_In_ const struct _ebpf_api_pro
                 }
                 current_program->output_instructions[(offset - current_program->offset_in_section) / sizeof(ebpf_inst)]
                     .relocation = unsafe_name;
+
+                auto relocation_section_name = get_section_name_by_index(section_index);
+
                 if (map_section && section_index == map_section->get_index()) {
                     // Check that the map exists in the list of map definitions.
                     if (map_definitions.find(unsafe_name) == map_definitions.end()) {
                         throw bpf_code_generator_exception("map not found in map definitions: " + unsafe_name);
                     }
+                } else if (
+                    global_variable_section_names.find(relocation_section_name) !=
+                    global_variable_section_names.end()) {
+                    if (!unsafe_name.empty()) {
+                        throw bpf_code_generator_exception("Global variables must be static");
+                    }
+                    current_program
+                        ->output_instructions[(offset - current_program->offset_in_section) / sizeof(ebpf_inst)]
+                        .relocation = _get_btf_global_var_map_name(c_name, relocation_section_name);
                 }
             }
         }
@@ -953,7 +1048,8 @@ bpf_code_generator::bpf_code_generator_program::build_function_table()
 
 void
 bpf_code_generator::bpf_code_generator_program::encode_instructions(
-    std::map<unsafe_string, map_entry_t>& map_definitions)
+    std::map<unsafe_string, map_entry_t>& map_definitions,
+    std::map<unsafe_string, global_variable_section_t>& global_variable_sections)
 {
     std::vector<output_instruction_t>& program_output = output_instructions;
     auto effective_program_name = !program_name.empty() ? program_name : elf_section_name;
@@ -1219,14 +1315,14 @@ bpf_code_generator::bpf_code_generator_program::encode_instructions(
                 throw bpf_code_generator_exception("invalid operand", output.instruction_offset);
             }
             std::string destination = get_register_name(inst.dst);
-            if (output.relocation.empty()) {
+            if (inst.src == INST_LD_MODE_IMM) {
                 uint64_t imm = static_cast<uint32_t>(program_output[i].instruction.imm);
                 imm <<= 32;
                 imm |= static_cast<uint32_t>(output.instruction.imm);
                 std::string source;
                 source = "(uint64_t)" + std::to_string(imm);
                 output.lines.push_back(std::format("{} = {};", destination, source));
-            } else {
+            } else if (inst.src == INST_LD_MODE_MAP_FD) {
                 std::string source;
                 auto map_definition = map_definitions.find(output.relocation);
                 if (map_definition == map_definitions.end()) {
@@ -1234,6 +1330,22 @@ bpf_code_generator::bpf_code_generator_program::encode_instructions(
                         "Map " + output.relocation + " doesn't exist", output.instruction_offset);
                 }
                 source = std::format("_maps[{}].address", std::to_string(map_definition->second.index));
+                output.lines.push_back(std::format("{} = POINTER({});", destination, source));
+                referenced_map_indices.insert(map_definitions[output.relocation].index);
+            } else if (inst.src == INST_LD_MODE_MAP_VALUE) {
+                std::string source;
+                uint64_t imm = static_cast<uint32_t>(program_output[i].instruction.imm);
+                auto global_section = global_variable_sections.find(output.relocation);
+                if (global_section == global_variable_sections.end()) {
+                    throw bpf_code_generator_exception(
+                        "Map " + output.relocation + " doesn't exist", output.instruction_offset);
+                }
+                source = std::format(
+                    "_global_variable_sections[{}].address_of_map_value + {}",
+                    std::to_string(global_section->second.index),
+                    std::to_string(imm));
+                // As an example, this produces the following line:
+                // r0 = POINTER(_global_variable_sections[1].address_of_map_value + 4);
                 output.lines.push_back(std::format("{} = POINTER({});", destination, source));
                 referenced_map_indices.insert(map_definitions[output.relocation].index);
             }
@@ -1661,6 +1773,64 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         output_stream << std::endl;
     }
 
+    // Emit global variable sections.
+    if (global_variable_sections.size() > 0) {
+        size_t global_variable_section_size = global_variable_sections.size();
+        // Sort global variable sections by index.
+        std::vector<std::tuple<bpf_code_generator::unsafe_string, global_variable_section_t>>
+            global_variable_sections_by_index(global_variable_section_size);
+        for (const auto& pair : global_variable_sections) {
+            if (pair.second.index >= global_variable_sections_by_index.size()) {
+                throw bpf_code_generator_exception("Invalid global variable section");
+            }
+            global_variable_sections_by_index[pair.second.index] = pair;
+        }
+
+        for (const auto& [name, entry] : global_variable_sections_by_index) {
+            output_stream << "const char " << name.c_identifier() << "_initial_data[] = {";
+            for (size_t i = 0; i < entry.initial_data.size(); i++) {
+                output_stream << std::to_string(entry.initial_data.at(i));
+                if (i < entry.initial_data.size() - 1) {
+                    output_stream << ", ";
+                }
+            }
+            output_stream << "};" << std::endl << std::endl;
+        }
+
+        output_stream << "#pragma data_seg(push, \"global_variables\")" << std::endl;
+        output_stream << "static global_variable_section_t _global_variable_sections[] = {" << std::endl;
+
+        for (const auto& [name, entry] : global_variable_sections_by_index) {
+            output_stream << INDENT "{" << std::endl;
+            output_stream << INDENT INDENT ".name = " << name.quoted() << "," << std::endl;
+            output_stream << INDENT INDENT ".size = " << std::to_string(entry.initial_data.size()) << "," << std::endl;
+            output_stream << INDENT INDENT ".initial_data = &" << name.c_identifier() + "_initial_data," << std::endl;
+            output_stream << INDENT "}," << std::endl;
+        }
+        output_stream << "};" << std::endl;
+        output_stream << "#pragma data_seg(pop)" << std::endl;
+        output_stream << std::endl;
+        output_stream << "static void" << std::endl << "_get_global_variable_sections(" << std::endl;
+        output_stream << INDENT "_Outptr_result_buffer_maybenull_(*count) global_variable_section_t** "
+                                "global_variable_sections, _Out_ size_t* count)"
+                      << std::endl;
+        output_stream << "{" << std::endl;
+        output_stream << INDENT "*global_variable_sections = _global_variable_sections;" << std::endl;
+        output_stream << INDENT "*count = " << std::to_string(global_variable_sections.size()) << ";" << std::endl;
+        output_stream << "}" << std::endl;
+        output_stream << std::endl;
+    } else {
+        output_stream << "static void" << std::endl << "_get_global_variable_sections(" << std::endl;
+        output_stream << INDENT "_Outptr_result_buffer_maybenull_(*count) global_variable_section_t** "
+                                "global_variable_sections, _Out_ size_t* count)"
+                      << std::endl;
+        output_stream << "{" << std::endl;
+        output_stream << INDENT "*global_variable_sections = NULL;" << std::endl;
+        output_stream << INDENT "*count = 0;" << std::endl;
+        output_stream << "}" << std::endl;
+        output_stream << std::endl;
+    }
+
     // Get count of programs not including subprograms.
     size_t program_count = 0;
     for (auto& [name, program] : programs) {
@@ -1946,15 +2116,15 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
     output_stream << "}" << std::endl;
     output_stream << std::endl;
 
-    std::string meta_data_table = "metadata_table_t " + c_name.c_identifier() + "_metadata_table = {";
-    meta_data_table +=
-        "sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};\n";
-
-    if ((meta_data_table.size() - 1) > LINE_BREAK_WIDTH) {
-        meta_data_table.insert(meta_data_table.find_first_of("{") + 1, "\n" INDENT);
-    }
-
-    output_stream << meta_data_table;
+    output_stream << "metadata_table_t " << c_name.c_identifier() << "_metadata_table = {" << std::endl;
+    output_stream << INDENT "sizeof(metadata_table_t)," << std::endl;
+    output_stream << INDENT "_get_programs," << std::endl;
+    output_stream << INDENT "_get_maps," << std::endl;
+    output_stream << INDENT "_get_hash," << std::endl;
+    output_stream << INDENT "_get_version," << std::endl;
+    output_stream << INDENT "_get_map_initial_values," << std::endl;
+    output_stream << INDENT "_get_global_variable_sections," << std::endl;
+    output_stream << "};\n";
 }
 
 std::string

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -253,6 +253,14 @@ class bpf_code_generator
     parse_btf_maps_section(const unsafe_string& name);
 
     /**
+     * @brief Parse BTF map information in the eBPF file.
+     *
+     * @param[in] section_name Section in the ELF file to parse maps in.
+     */
+    void
+    parse_btf_global_variable_section(const unsafe_string& name);
+
+    /**
      * @brief Parse legacy map information in the eBPF file.
      *
      * @param[in] section_name Section in the ELF file to parse maps in.
@@ -327,6 +335,12 @@ class bpf_code_generator
         ELFIO::Elf_Xword size)>
         symbol_visitor_t;
 
+    typedef struct _global_variable_section
+    {
+        size_t index;
+        std::vector<uint8_t> initial_data;
+    } global_variable_section_t;
+
     class bpf_code_generator_program
     {
       public:
@@ -364,7 +378,9 @@ class bpf_code_generator
          * @param[in] map_definitions Map definitions.
          */
         void
-        encode_instructions(std::map<unsafe_string, map_entry_t>& map_definitions);
+        encode_instructions(
+            std::map<unsafe_string, map_entry_t>& map_definitions,
+            std::map<unsafe_string, global_variable_section_t>& global_variable_sections);
 
         /**
          * @brief Get the name of a register from its index.
@@ -485,6 +501,9 @@ class bpf_code_generator
     bool
     is_section_valid(const ELFIO::section* section) const;
 
+    unsafe_string
+    get_section_name_by_index(ELFIO::Elf_Half index) const;
+
     /**
      * @brief Invoke the visitor for each symbol in the ELF file section.
      *
@@ -502,4 +521,5 @@ class bpf_code_generator
     btf_section_to_instruction_to_line_info_t section_line_info;
     std::optional<std::vector<uint8_t>> elf_file_hash;
     std::map<unsafe_string, std::vector<unsafe_string>> map_initial_values;
+    std::map<unsafe_string, global_variable_section_t> global_variable_sections;
 };


### PR DESCRIPTION
Resolves: #3958

## Description

This pull request introduces several changes to the eBPF code generation and execution context, primarily focusing on handling global variables and improving section parsing. The most important changes include adding support for global variable sections, updating version numbers, and improving error handling.

Note: This change results in native modules that will crash when run on older versions of ebpfcore.sys. Therefore NMR version is being bumped to 1 to prevent attaching to older versions of the runtime.

### Enhancements to global variable handling:

* [`tools/bpf2c/bpf_code_generator.cpp`](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R434-R439): Added support for parsing global variable sections such as `.data`, `.rodata`, and `.bss`. This includes skipping these sections in `parse_btf_maps_section` and generating libbpf compatible map names for global variables. [[1]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R434-R439) [[2]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R518-R521) [[3]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R695-R732) [[4]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R741-R742) [[5]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R873) [[6]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72L847-R923) [[7]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72L1229-R1299) [[8]](diffhunk://#diff-ebd1caea5d9c54a6bc52da70244cacfcfb877dbcccdc7d01314efcebb80b0f72R1309-R1322)

* [`tools/bpf2c/bpf_code_generator.h`](diffhunk://#diff-96043cff0e3ceb2f40b7193c5d2a01672f7f6af3bb81c7cdafb2ebd18897c0a1R255-R262): Declared new methods for parsing global variable sections and getting section names by index. [[1]](diffhunk://#diff-96043cff0e3ceb2f40b7193c5d2a01672f7f6af3bb81c7cdafb2ebd18897c0a1R255-R262) [[2]](diffhunk://#diff-96043cff0e3ceb2f40b7193c5d2a01672f7f6af3bb81c7cdafb2ebd18897c0a1R496-R498)

### Version updates:

* [`libs/execution_context/ebpf_native.c`](diffhunk://#diff-c2246e5ec5594b061b298b0947eb7f2e3fd28fc8570d4ded49bb9ce50e7567e3L106-R106): Updated the version number in `_ebpf_native_provider_characteristics` from 0 to 1.
* [`tools/bpf2c/bpf2c_driver.c`](diffhunk://#diff-7df79ffcbf3384d3a6310c5a6b13f10e3e89b30b73d011214a7caa9af343f266L37-R37): Updated the version number in `_bpf2c_npi_client_characteristics` from 0 to 1. Added version check in `_bpf2c_npi_client_attach_provider`. [[1]](diffhunk://#diff-7df79ffcbf3384d3a6310c5a6b13f10e3e89b30b73d011214a7caa9af343f266L37-R37) [[2]](diffhunk://#diff-7df79ffcbf3384d3a6310c5a6b13f10e3e89b30b73d011214a7caa9af343f266L134-R137)

### Additional changes:

* [`include/bpf2c.h`](diffhunk://#diff-7f473819de223acb9f4207d47cc2d5b6260e875fd85d0b7f51ad150550c9d798R74): Added `address_of_value` to the `map_entry_t` structure.
* [`tests/sample/global_vars.c`](diffhunk://#diff-cfa28e373ab91c97e86e6a2621507b78aaf31304da0a6fa97a515dcb83c57567R1-R34): Added a new sample program to test global variables.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
