### PR TITLE
Reformat all code with clang-format 18.1.8

### DIFF
--- a/include/bpf/bpf_legacy.h
+++ b/include/bpf/bpf_legacy.h
@@ -50,8 +50,8 @@ struct bpf_create_map_attr
  * @exception EINVAL An invalid argument was provided.
  * @exception ENOMEM Out of memory.
  */
-__declspec(deprecated("Use bpf_map_create() instead.")) int bpf_create_map(
-    enum bpf_map_type map_type, int key_size, int value_size, int max_entries, __u32 map_flags);
+__declspec(deprecated("Use bpf_map_create() instead.")) int
+bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max_entries, __u32 map_flags);
 
 /**
  * @brief Create a new map-in-map.
@@ -73,7 +73,8 @@ __declspec(deprecated("Use bpf_map_create() instead.")) int bpf_create_map(
  * @exception EINVAL An invalid argument was provided.
  * @exception ENOMEM Out of memory.
  */
-__declspec(deprecated("Use bpf_map_create() instead.")) int bpf_create_map_in_map(
+__declspec(deprecated("Use bpf_map_create() instead.")) int
+bpf_create_map_in_map(
     enum bpf_map_type map_type, const char* name, int key_size, int inner_map_fd, int max_entries, __u32 map_flags);
 
 /**
@@ -90,8 +91,8 @@ __declspec(deprecated("Use bpf_map_create() instead.")) int bpf_create_map_in_ma
  *
  * @deprecated Use bpf_map_create() instead.
  */
-__declspec(deprecated("Use bpf_map_create() instead.")) int bpf_create_map_xattr(
-    const struct bpf_create_map_attr* create_attr);
+__declspec(deprecated("Use bpf_map_create() instead.")) int
+bpf_create_map_xattr(const struct bpf_create_map_attr* create_attr);
 
 /** @} */
 
@@ -153,7 +154,8 @@ struct bpf_load_program_attr
  * @sa bpf_prog_load
  * @sa bpf_load_program_xattr
  */
-__declspec(deprecated("Use bpf_prog_load() instead.")) int bpf_load_program(
+__declspec(deprecated("Use bpf_prog_load() instead.")) int
+bpf_load_program(
     enum bpf_prog_type type,
     const struct bpf_insn* insns,
     size_t insns_cnt,
@@ -182,8 +184,8 @@ __declspec(deprecated("Use bpf_prog_load() instead.")) int bpf_load_program(
  * @sa bpf_prog_load
  * @sa bpf_load_program
  */
-__declspec(deprecated("Use bpf_prog_load() instead.")) int bpf_load_program_xattr(
-    const struct bpf_load_program_attr* load_attr, char* log_buf, size_t log_buf_sz);
+__declspec(deprecated("Use bpf_prog_load() instead.")) int
+bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_buf, size_t log_buf_sz);
 
 /** @} */
 

--- a/include/bpf/libbpf_legacy.h
+++ b/include/bpf/libbpf_legacy.h
@@ -24,7 +24,8 @@
  * @sa bpf_xdp_attach
  * @sa bpf_xdp_detach
  */
-__declspec(deprecated("Use bpf_xdp_attach() instead.")) int bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags);
+__declspec(deprecated("Use bpf_xdp_attach() instead.")) int
+bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags);
 
 /** @} */
 
@@ -45,8 +46,8 @@ __declspec(deprecated("Use bpf_xdp_attach() instead.")) int bpf_set_link_xdp_fd(
  *
  * @sa bpf_map__prev
  */
-__declspec(deprecated("Use bpf_object__next_map() instead.")) struct bpf_map* bpf_map__next(
-    const struct bpf_map* map, const struct bpf_object* obj);
+__declspec(deprecated("Use bpf_object__next_map() instead.")) struct bpf_map*
+bpf_map__next(const struct bpf_map* map, const struct bpf_object* obj);
 
 /**
  * @brief Get the previous map for a given eBPF object.
@@ -60,8 +61,8 @@ __declspec(deprecated("Use bpf_object__next_map() instead.")) struct bpf_map* bp
  *
  * @sa bpf_map__next
  */
-__declspec(deprecated("Use bpf_object__prev_map() instead.")) struct bpf_map* bpf_map__prev(
-    const struct bpf_map* map, const struct bpf_object* obj);
+__declspec(deprecated("Use bpf_object__prev_map() instead.")) struct bpf_map*
+bpf_map__prev(const struct bpf_map* map, const struct bpf_object* obj);
 
 /** @} */
 
@@ -94,7 +95,8 @@ struct bpf_object_load_attr
  * @sa bpf_object__load_xattr
  * @sa bpf_prog_load
  */
-__declspec(deprecated("Use bpf_object__load() instead.")) int bpf_object__load_xattr(struct bpf_object_load_attr* attr);
+__declspec(deprecated("Use bpf_object__load() instead.")) int
+bpf_object__load_xattr(struct bpf_object_load_attr* attr);
 
 /**
  * @brief Get the next eBPF object opened by the calling process.
@@ -105,8 +107,8 @@ __declspec(deprecated("Use bpf_object__load() instead.")) int bpf_object__load_x
  *
  * @deprecated Track bpf_objects in application code instead.
  */
-__declspec(deprecated("Track bpf_objects in application code instead.")) struct bpf_object* bpf_object__next(
-    struct bpf_object* prev);
+__declspec(deprecated("Track bpf_objects in application code instead.")) struct bpf_object*
+bpf_object__next(struct bpf_object* prev);
 
 #define bpf_object__for_each_safe(pos, tmp)                                            \
     for ((pos) = bpf_object__next(NULL), (tmp) = bpf_object__next(pos); (pos) != NULL; \
@@ -126,7 +128,8 @@ __declspec(deprecated("Track bpf_objects in application code instead.")) struct 
  * @sa bpf_object__load_xattr
  * @sa bpf_prog_load
  */
-__declspec(deprecated("Use bpf_object__close() instead.")) int bpf_object__unload(struct bpf_object* obj);
+__declspec(deprecated("Use bpf_object__close() instead.")) int
+bpf_object__unload(struct bpf_object* obj);
 
 /** @} */
 
@@ -161,8 +164,8 @@ __declspec(deprecated("Use bpf_object__close() instead.")) int bpf_object__unloa
  * @sa bpf_object__close
  * @sa bpf_program__attach
  */
-__declspec(deprecated("Use bpf_object__open() and bpf_object__load() instead.")) int bpf_prog_load_deprecated(
-    const char* file, enum bpf_prog_type type, struct bpf_object** pobj, int* prog_fd);
+__declspec(deprecated("Use bpf_object__open() and bpf_object__load() instead.")) int
+bpf_prog_load_deprecated(const char* file, enum bpf_prog_type type, struct bpf_object** pobj, int* prog_fd);
 
 /**
  * @brief Get the next program for a given eBPF object.
@@ -176,8 +179,8 @@ __declspec(deprecated("Use bpf_object__open() and bpf_object__load() instead."))
  *
  * @sa bpf_program__prev
  */
-__declspec(deprecated("Use bpf_object__next_program() instead.")) struct bpf_program* bpf_program__next(
-    struct bpf_program* prog, const struct bpf_object* obj);
+__declspec(deprecated("Use bpf_object__next_program() instead.")) struct bpf_program*
+bpf_program__next(struct bpf_program* prog, const struct bpf_object* obj);
 
 /**
  * @brief Get the previous eBPF program for a given eBPF object.
@@ -191,8 +194,8 @@ __declspec(deprecated("Use bpf_object__next_program() instead.")) struct bpf_pro
  *
  * @sa bpf_program__next
  */
-__declspec(deprecated("Use bpf_object__prev_program() instead.")) struct bpf_program* bpf_program__prev(
-    struct bpf_program* prog, const struct bpf_object* obj);
+__declspec(deprecated("Use bpf_object__prev_program() instead.")) struct bpf_program*
+bpf_program__prev(struct bpf_program* prog, const struct bpf_object* obj);
 
 /**
  * @brief Get the eBPF program size in bytes.
@@ -203,6 +206,7 @@ __declspec(deprecated("Use bpf_object__prev_program() instead.")) struct bpf_pro
  *
  * @deprecated Use bpf_program__insn_cnt() instead.
  */
-__declspec(deprecated("Use bpf_program__insn_cnt() instead.")) size_t bpf_program__size(const struct bpf_program* prog);
+__declspec(deprecated("Use bpf_program__insn_cnt() instead.")) size_t
+bpf_program__size(const struct bpf_program* prog);
 
 /** @} */

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -96,11 +96,11 @@ extern "C"
      * @deprecated Use ebpf_enumerate_programs() instead.
      */
     __declspec(deprecated("Use ebpf_enumerate_programs() instead.")) _Must_inspect_result_ ebpf_result_t
-        ebpf_enumerate_sections(
-            _In_z_ const char* file,
-            bool verbose,
-            _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-            _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
+    ebpf_enumerate_sections(
+        _In_z_ const char* file,
+        bool verbose,
+        _Outptr_result_maybenull_ ebpf_section_info_t** infos,
+        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
     /**
      * @brief Free memory returned from \ref ebpf_enumerate_programs.
@@ -114,8 +114,8 @@ extern "C"
      * @param[in] data Memory to free.
      * @deprecated Use ebpf_free_programs() instead.
      */
-    __declspec(deprecated("Use ebpf_free_programs() instead.")) void ebpf_free_sections(
-        _In_opt_ _Post_invalid_ ebpf_section_info_t* infos) EBPF_NO_EXCEPT;
+    __declspec(deprecated("Use ebpf_free_programs() instead.")) void
+    ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos) EBPF_NO_EXCEPT;
 
     /**
      * @brief Convert an eBPF program to human readable byte code.
@@ -144,7 +144,8 @@ extern "C"
      * @param[out] error_message On failure points to a text description of
      *  the error.
      */
-    __declspec(deprecated("Use ebpf_api_elf_disassemble_program() instead.")) uint32_t ebpf_api_elf_disassemble_section(
+    __declspec(deprecated("Use ebpf_api_elf_disassemble_program() instead.")) uint32_t
+    ebpf_api_elf_disassemble_section(
         _In_z_ const char* file,
         _In_z_ const char* section,
         _Outptr_result_maybenull_z_ const char** disassembly,

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -192,7 +192,7 @@ typedef struct _bpf_sock_ops
             uint32_t remote_ip6[4];
         }; ///< Remote IP address.
         uint32_t remote_port;
-    };                       ///< Remote IP address and port stored in network byte order.
+    }; ///< Remote IP address and port stored in network byte order.
     uint8_t protocol;        ///< IP protocol.
     uint32_t compartment_id; ///< Network compartment Id.
     uint64_t interface_luid; ///< Interface LUID.

--- a/include/ebpf_program_attach_type_guids.h
+++ b/include/ebpf_program_attach_type_guids.h
@@ -41,8 +41,8 @@ extern "C"
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
      */
-    __declspec(selectany)
-        ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT = EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID;
+    __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT =
+        EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID;
 
 #define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID                                     \
     {                                                                                  \
@@ -54,8 +54,8 @@ extern "C"
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
      */
-    __declspec(selectany)
-        ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT = EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID;
+    __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT =
+        EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID;
 
 #define EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID                                 \
     {                                                                                  \
@@ -67,8 +67,8 @@ extern "C"
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
      */
-    __declspec(selectany)
-        ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT = EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID;
+    __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT =
+        EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID;
 
 #define EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID                                 \
     {                                                                                  \
@@ -80,8 +80,8 @@ extern "C"
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
      */
-    __declspec(selectany)
-        ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT = EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID;
+    __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT =
+        EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID;
 
 #define EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID                                          \
     {                                                                                  \
@@ -165,8 +165,8 @@ extern "C"
      *  \ref EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT
      *  \ref EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT
      */
-    __declspec(selectany)
-        ebpf_program_type_t EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID;
+    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR =
+        EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID;
 
 #define EBPF_PROGRAM_TYPE_SOCK_OPS_GUID                                                \
     {                                                                                  \

--- a/include/ebpf_windows.h
+++ b/include/ebpf_windows.h
@@ -77,70 +77,63 @@ typedef enum _ebpf_helper_function
 #define EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION 1
 #define EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_attach_provider_data_t, link_type)
 #define EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_attach_provider_data_t)
-#define EBPF_ATTACH_PROVIDER_DATA_HEADER                                                           \
-    {                                                                                              \
-        EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION, EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_SIZE, \
-            EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_TOTAL_SIZE                                   \
-    }
+#define EBPF_ATTACH_PROVIDER_DATA_HEADER             \
+    {EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION,      \
+     EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_SIZE, \
+     EBPF_ATTACH_PROVIDER_DATA_CURRENT_VERSION_TOTAL_SIZE}
 
 #define EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION 1
 #define EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_SIZE \
     EBPF_SIZE_INCLUDING_FIELD(ebpf_program_type_descriptor_t, is_privileged)
 #define EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_program_type_descriptor_t)
-#define EBPF_PROGRAM_TYPE_DESCRIPTOR_HEADER                                                              \
-    {                                                                                                    \
-        EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION, EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_SIZE, \
-            EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_TOTAL_SIZE                                      \
-    }
+#define EBPF_PROGRAM_TYPE_DESCRIPTOR_HEADER             \
+    {EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION,      \
+     EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_SIZE, \
+     EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_TOTAL_SIZE}
 
 #define EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION 1
 #define EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_SIZE \
     EBPF_SIZE_INCLUDING_FIELD(ebpf_helper_function_prototype_t, implicit_context)
 #define EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_helper_function_prototype_t)
-#define EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER                                                                \
-    {                                                                                                        \
-        EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION, EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_SIZE, \
-            EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_TOTAL_SIZE                                        \
-    }
+#define EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER             \
+    {EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION,      \
+     EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_SIZE, \
+     EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_TOTAL_SIZE}
 
 #define EBPF_PROGRAM_INFORMATION_CURRENT_VERSION 1
 #define EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_SIZE \
     EBPF_SIZE_INCLUDING_FIELD(ebpf_program_info_t, global_helper_prototype)
 #define EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_program_info_t)
-#define EBPF_PROGRAM_INFORMATION_HEADER                                                          \
-    {                                                                                            \
-        EBPF_PROGRAM_INFORMATION_CURRENT_VERSION, EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_SIZE, \
-            EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_TOTAL_SIZE                                  \
-    }
+#define EBPF_PROGRAM_INFORMATION_HEADER             \
+    {EBPF_PROGRAM_INFORMATION_CURRENT_VERSION,      \
+     EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_SIZE, \
+     EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_TOTAL_SIZE}
 
 #define EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION 1
 #define EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_SIZE \
     EBPF_SIZE_INCLUDING_FIELD(ebpf_helper_function_addresses_t, helper_function_address)
 #define EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_helper_function_addresses_t)
-#define EBPF_HELPER_FUNCTION_ADDRESSES_HEADER                                                                \
-    {                                                                                                        \
-        EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION, EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_SIZE, \
-            EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_TOTAL_SIZE                                        \
-    }
+#define EBPF_HELPER_FUNCTION_ADDRESSES_HEADER             \
+    {EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION,      \
+     EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_SIZE, \
+     EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_TOTAL_SIZE}
 
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION 1
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE EBPF_SIZE_INCLUDING_FIELD(ebpf_program_data_t, capabilities)
 #define EBPF_PROGRAM_DATA_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_program_data_t)
-#define EBPF_PROGRAM_DATA_HEADER                                                   \
-    {                                                                              \
-        EBPF_PROGRAM_DATA_CURRENT_VERSION, EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE, \
-            EBPF_PROGRAM_DATA_CURRENT_VERSION_TOTAL_SIZE                           \
-    }
+#define EBPF_PROGRAM_DATA_HEADER             \
+    {EBPF_PROGRAM_DATA_CURRENT_VERSION,      \
+     EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE, \
+     EBPF_PROGRAM_DATA_CURRENT_VERSION_TOTAL_SIZE}
 
 #define EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION 1
 #define EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_SIZE \
     EBPF_SIZE_INCLUDING_FIELD(ebpf_program_section_info_t, bpf_attach_type)
 #define EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_TOTAL_SIZE sizeof(ebpf_program_section_info_t)
-#define EBPF_PROGRAM_SECTION_INFORMATION_HEADER                                                                  \
-    {                                                                                                            \
-        EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION, EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_SIZE, \
-            EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_TOTAL_SIZE                                          \
-    }
+#define EBPF_PROGRAM_SECTION_INFORMATION_HEADER             \
+    {EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION,      \
+     EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_SIZE, \
+     EBPF_PROGRAM_SECTION_INFORMATION_CURRENT_VERSION_TOTAL_SIZE}
 
 /**
  * @brief Header of an eBPF extension data structure.

--- a/libs/api_common/windows_program_type.h
+++ b/libs/api_common/windows_program_type.h
@@ -7,15 +7,9 @@
 #include "ebpf_program_types.h"
 #include "ebpf_verifier_wrapper.hpp"
 
-#define PTYPE(name, descr, native_type, prefixes) \
-    {                                             \
-        name, descr, native_type, prefixes        \
-    }
+#define PTYPE(name, descr, native_type, prefixes) {name, descr, native_type, prefixes}
 
-#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
-    {                                                        \
-        name, descr, native_type, prefixes, true             \
-    }
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) {name, descr, native_type, prefixes, true}
 
 // Allow for comma as a separator between multiple prefixes, to make
 // the preprocessor treat a prefix list as one macro argument.

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2627,65 +2627,62 @@ typedef struct _ebpf_protocol_handler
 #define PROTOCOL_ALL_MODES PROTOCOL_NATIVE_MODE
 #endif
 
-#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(OPERATION, FLAGS)             \
-    {                                                                                 \
-        EBPF_PROTOCOL_FIXED_REQUEST_NO_REPLY, (void*)_ebpf_core_protocol_##OPERATION, \
-            sizeof(ebpf_operation_##OPERATION##_request_t), .flags.value = FLAGS      \
-    }
+#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(OPERATION, FLAGS) \
+    {EBPF_PROTOCOL_FIXED_REQUEST_NO_REPLY,                                \
+     (void*)_ebpf_core_protocol_##OPERATION,                              \
+     sizeof(ebpf_operation_##OPERATION##_request_t),                      \
+     .flags.value = FLAGS}
 
-#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(OPERATION, FLAGS)                              \
-    {                                                                                                     \
-        EBPF_PROTOCOL_FIXED_REQUEST_FIXED_REPLY, (void*)_ebpf_core_protocol_##OPERATION,                  \
-            sizeof(ebpf_operation_##OPERATION##_request_t), sizeof(ebpf_operation_##OPERATION##_reply_t), \
-            .flags.value = FLAGS                                                                          \
-    }
+#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(OPERATION, FLAGS) \
+    {EBPF_PROTOCOL_FIXED_REQUEST_FIXED_REPLY,                                \
+     (void*)_ebpf_core_protocol_##OPERATION,                                 \
+     sizeof(ebpf_operation_##OPERATION##_request_t),                         \
+     sizeof(ebpf_operation_##OPERATION##_reply_t),                           \
+     .flags.value = FLAGS}
 
-#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_VARIABLE_REPLY(OPERATION, VARIABLE_REPLY, FLAGS)        \
-    {                                                                                                  \
-        EBPF_PROTOCOL_FIXED_REQUEST_VARIABLE_REPLY, (void*)_ebpf_core_protocol_##OPERATION,            \
-            sizeof(ebpf_operation_##OPERATION##_request_t),                                            \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_reply_t, VARIABLE_REPLY), .flags.value = FLAGS \
-    }
+#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_VARIABLE_REPLY(OPERATION, VARIABLE_REPLY, FLAGS) \
+    {EBPF_PROTOCOL_FIXED_REQUEST_VARIABLE_REPLY,                                                \
+     (void*)_ebpf_core_protocol_##OPERATION,                                                    \
+     sizeof(ebpf_operation_##OPERATION##_request_t),                                            \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_reply_t, VARIABLE_REPLY),                      \
+     .flags.value = FLAGS}
 
-#define DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_NO_REPLY(OPERATION, VARIABLE_REQUEST, FLAGS)             \
-    {                                                                                                      \
-        EBPF_PROTOCOL_VARIABLE_REQUEST_NO_REPLY, (void*)_ebpf_core_protocol_##OPERATION,                   \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST), .flags.value = FLAGS \
-    }
+#define DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_NO_REPLY(OPERATION, VARIABLE_REQUEST, FLAGS) \
+    {EBPF_PROTOCOL_VARIABLE_REQUEST_NO_REPLY,                                                  \
+     (void*)_ebpf_core_protocol_##OPERATION,                                                   \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST),                 \
+     .flags.value = FLAGS}
 
 #define DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_FIXED_REPLY(OPERATION, VARIABLE_REQUEST, FLAGS) \
-    {                                                                                             \
-        EBPF_PROTOCOL_VARIABLE_REQUEST_FIXED_REPLY, (void*)_ebpf_core_protocol_##OPERATION,       \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST),             \
-            sizeof(ebpf_operation_##OPERATION##_reply_t), .flags.value = FLAGS                    \
-    }
+    {EBPF_PROTOCOL_VARIABLE_REQUEST_FIXED_REPLY,                                                  \
+     (void*)_ebpf_core_protocol_##OPERATION,                                                      \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST),                    \
+     sizeof(ebpf_operation_##OPERATION##_reply_t),                                                \
+     .flags.value = FLAGS}
 
 #define DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY(OPERATION, VARIABLE_REQUEST, VARIABLE_REPLY, FLAGS) \
-    {                                                                                                                \
-        EBPF_PROTOCOL_VARIABLE_REQUEST_VARIABLE_REPLY, (void*)_ebpf_core_protocol_##OPERATION,                       \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST),                                \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_reply_t, VARIABLE_REPLY), .flags.value = FLAGS               \
-    }
+    {EBPF_PROTOCOL_VARIABLE_REQUEST_VARIABLE_REPLY,                                                                  \
+     (void*)_ebpf_core_protocol_##OPERATION,                                                                         \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST),                                       \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_reply_t, VARIABLE_REPLY),                                           \
+     .flags.value = FLAGS}
 
-#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY_ASYNC(OPERATION, FLAGS)                        \
-    {                                                                                                     \
-        EBPF_PROTOCOL_FIXED_REQUEST_FIXED_REPLY_ASYNC, (void*)_ebpf_core_protocol_##OPERATION,            \
-            sizeof(ebpf_operation_##OPERATION##_request_t), sizeof(ebpf_operation_##OPERATION##_reply_t), \
-            .flags.value = FLAGS                                                                          \
-    }
+#define DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY_ASYNC(OPERATION, FLAGS) \
+    {EBPF_PROTOCOL_FIXED_REQUEST_FIXED_REPLY_ASYNC,                                \
+     (void*)_ebpf_core_protocol_##OPERATION,                                       \
+     sizeof(ebpf_operation_##OPERATION##_request_t),                               \
+     sizeof(ebpf_operation_##OPERATION##_reply_t),                                 \
+     .flags.value = FLAGS}
 
-#define DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY_ASYNC(                                \
-    OPERATION, VARIABLE_REQUEST, VARIABLE_REPLY, FLAGS)                                                \
-    {                                                                                                  \
-        EBPF_PROTOCOL_VARIABLE_REQUEST_VARIABLE_REPLY_ASYNC, (void*)_ebpf_core_protocol_##OPERATION,   \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST),                  \
-            EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_reply_t, VARIABLE_REPLY), .flags.value = FLAGS \
-    }
+#define DECLARE_PROTOCOL_HANDLER_VARIABLE_REQUEST_VARIABLE_REPLY_ASYNC(        \
+    OPERATION, VARIABLE_REQUEST, VARIABLE_REPLY, FLAGS)                        \
+    {EBPF_PROTOCOL_VARIABLE_REQUEST_VARIABLE_REPLY_ASYNC,                      \
+     (void*)_ebpf_core_protocol_##OPERATION,                                   \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_request_t, VARIABLE_REQUEST), \
+     EBPF_OFFSET_OF(ebpf_operation_##OPERATION##_reply_t, VARIABLE_REPLY),     \
+     .flags.value = FLAGS}
 
-#define DECLARE_PROTOCOL_HANDLER_INVALID(type) \
-    {                                          \
-        type, NULL, 0, 0, .flags.value = 0     \
-    }
+#define DECLARE_PROTOCOL_HANDLER_INVALID(type) {type, NULL, 0, 0, .flags.value = 0}
 
 #define ALIAS_TYPES(X, Y)                                                  \
     typedef ebpf_operation_##X##_request_t ebpf_operation_##Y##_request_t; \

--- a/libs/runtime/ebpf_bitmap.c
+++ b/libs/runtime/ebpf_bitmap.c
@@ -48,7 +48,7 @@ static_assert(sizeof(ebpf_bitmap_cursor_internal_t) == sizeof(ebpf_bitmap_cursor
 #define OFFSET_IN_BLOCK(X) ((X) % BITS_IN_BLOCK)
 
 // Give the bit offset of the start of the block containing X.
-#define START_OF_BLOCK(X) ((X)-OFFSET_IN_BLOCK(X))
+#define START_OF_BLOCK(X) ((X) - OFFSET_IN_BLOCK(X))
 
 // Calculate a bitmask so the lowest X bits are set.
 #define BIT_COUNT_MASK(X) (((uint64_t)1 << (X)) - 1)

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -33,10 +33,7 @@ extern "C"
 #define AFFINITY_MASK(n) ((ULONG_PTR)(1) << (n))
 #endif
 
-#define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
-    {                                         \
-        ((uint8_t*)(x)), sizeof((x)) - 1      \
-    }
+#define EBPF_UTF8_STRING_FROM_CONST_STRING(x) {((uint8_t*)(x)), sizeof((x)) - 1}
 
 #define EBPF_NS_PER_FILETIME 100
 #define EBPF_FILETIME_PER_MS 10000

--- a/libs/runtime/user/kernel_um.cpp
+++ b/libs/runtime/user/kernel_um.cpp
@@ -189,7 +189,7 @@ typedef unsigned long PFN_NUMBER;
 #define PAGE_ALIGN(Va) ((void*)((ULONG_PTR)(Va) & ~(PAGE_SIZE - 1)))
 #define BYTE_OFFSET(Va) ((unsigned long)((LONG_PTR)(Va) & (PAGE_SIZE - 1)))
 #define ADDRESS_AND_SIZE_TO_SPAN_PAGES(Va, size)                                                                \
-    (((((size)-1) >> PAGE_SHIFT) +                                                                              \
+    (((((size) - 1) >> PAGE_SHIFT) +                                                                            \
       (((((unsigned long)(size - 1) & (PAGE_SIZE - 1)) + (PtrToUlong(Va) & (PAGE_SIZE - 1)))) >> PAGE_SHIFT)) + \
      1L)
 

--- a/libs/shared/tracelog.c
+++ b/libs/shared/tracelog.c
@@ -138,8 +138,8 @@ ebpf_trace_terminate()
         ebpf_assert(!"Invalid keyword");                                               \
         break;                                                                         \
     }
-__declspec(noinline) void ebpf_log_ntstatus_api_failure(
-    ebpf_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status)
+__declspec(noinline) void
+ebpf_log_ntstatus_api_failure(ebpf_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status)
 {
     EBPF_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH(api_name, status);
 }
@@ -192,7 +192,8 @@ __declspec(noinline) void ebpf_log_ntstatus_api_failure(
         ebpf_assert(!"Invalid keyword");                                                                \
         break;                                                                                          \
     }
-__declspec(noinline) void ebpf_log_ntstatus_api_failure_message(
+__declspec(noinline) void
+ebpf_log_ntstatus_api_failure_message(
     ebpf_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status, _In_z_ const char* message)
 {
     _EBPF_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING_KEYWORD_SWITCH(api_name, status, message);
@@ -244,8 +245,8 @@ __declspec(noinline) void ebpf_log_ntstatus_api_failure_message(
         ebpf_assert(!"Invalid keyword");                                      \
         break;                                                                \
     }
-__declspec(noinline) void ebpf_log_message(
-    ebpf_tracelog_level_t trace_level, ebpf_tracelog_keyword_t keyword, _In_z_ const char* message)
+__declspec(noinline) void
+ebpf_log_message(ebpf_tracelog_level_t trace_level, ebpf_tracelog_keyword_t keyword, _In_z_ const char* message)
 {
     switch (trace_level) {
     CASE_LOG_ALWAYS:
@@ -319,7 +320,8 @@ __declspec(noinline) void ebpf_log_message(
         ebpf_assert(!"Invalid keyword");                                                           \
         break;                                                                                     \
     }
-__declspec(noinline) void ebpf_log_message_string(
+__declspec(noinline) void
+ebpf_log_message_string(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -397,7 +399,8 @@ __declspec(noinline) void ebpf_log_message_string(
         ebpf_assert(!"Invalid keyword");                                                                \
         break;                                                                                          \
     }
-__declspec(noinline) void ebpf_log_message_utf8_string(
+__declspec(noinline) void
+ebpf_log_message_utf8_string(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -475,7 +478,8 @@ __declspec(noinline) void ebpf_log_message_utf8_string(
         ebpf_assert(!"Invalid keyword");                                                       \
         break;                                                                                 \
     }
-__declspec(noinline) void ebpf_log_message_wstring(
+__declspec(noinline) void
+ebpf_log_message_wstring(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -555,7 +559,8 @@ __declspec(noinline) void ebpf_log_message_wstring(
         ebpf_assert(!"Invalid keyword");                                                                             \
         break;                                                                                                       \
     }
-__declspec(noinline) void ebpf_log_message_guid_guid_string(
+__declspec(noinline) void
+ebpf_log_message_guid_guid_string(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -636,7 +641,8 @@ __declspec(noinline) void ebpf_log_message_guid_guid_string(
         ebpf_assert(!"Invalid keyword");                                                              \
         break;                                                                                        \
     }
-__declspec(noinline) void ebpf_log_message_guid_guid(
+__declspec(noinline) void
+ebpf_log_message_guid_guid(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -715,7 +721,8 @@ __declspec(noinline) void ebpf_log_message_guid_guid(
         ebpf_assert(!"Invalid keyword");                                                 \
         break;                                                                           \
     }
-__declspec(noinline) void ebpf_log_message_guid(
+__declspec(noinline) void
+ebpf_log_message_guid(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -793,7 +800,8 @@ __declspec(noinline) void ebpf_log_message_guid(
         ebpf_assert(!"Invalid keyword");                                                       \
         break;                                                                                 \
     }
-__declspec(noinline) void ebpf_log_message_ntstatus(
+__declspec(noinline) void
+ebpf_log_message_ntstatus(
     ebpf_tracelog_level_t trace_level, ebpf_tracelog_keyword_t keyword, _In_z_ const char* message, NTSTATUS status)
 {
     switch (trace_level) {
@@ -868,7 +876,8 @@ __declspec(noinline) void ebpf_log_message_ntstatus(
         ebpf_assert(!"Invalid keyword");                                                    \
         break;                                                                              \
     }
-__declspec(noinline) void ebpf_log_message_uint64(
+__declspec(noinline) void
+ebpf_log_message_uint64(
     ebpf_tracelog_level_t trace_level, ebpf_tracelog_keyword_t keyword, _In_z_ const char* message, uint64_t value)
 {
     switch (trace_level) {
@@ -944,7 +953,8 @@ __declspec(noinline) void ebpf_log_message_uint64(
         ebpf_assert(!"Invalid keyword");                                                                    \
         break;                                                                                              \
     }
-__declspec(noinline) void ebpf_log_message_uint64_uint64(
+__declspec(noinline) void
+ebpf_log_message_uint64_uint64(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -1023,7 +1033,8 @@ __declspec(noinline) void ebpf_log_message_uint64_uint64(
         ebpf_assert(!"Invalid keyword");                                                              \
         break;                                                                                        \
     }
-__declspec(noinline) void ebpf_log_message_binary(
+__declspec(noinline) void
+ebpf_log_message_binary(
     ebpf_tracelog_level_t trace_level,
     ebpf_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -1102,7 +1113,8 @@ __declspec(noinline) void ebpf_log_message_binary(
         ebpf_assert(!"Invalid keyword");                                                   \
         break;                                                                             \
     }
-__declspec(noinline) void ebpf_log_message_error(
+__declspec(noinline) void
+ebpf_log_message_error(
     ebpf_tracelog_level_t trace_level, ebpf_tracelog_keyword_t keyword, _In_z_ const char* message, ebpf_result_t error)
 {
     switch (trace_level) {
@@ -1139,7 +1151,8 @@ __declspec(noinline) void ebpf_log_message_error(
         TraceLoggingWideString(wstring, "Message"),                   \
         TraceLoggingString(api, "Api"),                               \
         TraceLoggingNTStatus(status));
-__declspec(noinline) void ebpf_log_ntstatus_wstring_api(
+__declspec(noinline) void
+ebpf_log_ntstatus_wstring_api(
     ebpf_tracelog_keyword_t keyword, _In_z_ const wchar_t* wstring, _In_z_ const char* api, NTSTATUS status)
 {
     switch (keyword) {

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -983,9 +983,8 @@ _net_ebpf_extension_connection_context_initialize(
 
 _Requires_exclusive_lock_held_(
     _net_ebpf_ext_sock_addr_blocked_contexts
-        .lock) static bool _net_ebpf_ext_find_and_remove_connection_context_locked(_In_
-                                                                                       net_ebpf_extension_connection_context_t*
-                                                                                           context)
+        .lock) static bool _net_ebpf_ext_find_and_remove_connection_context_locked(_In_ net_ebpf_extension_connection_context_t*
+                                                                                       context)
 {
     bool entry_found = false;
     // Check the hash table for the entry.

--- a/netebpfext/net_ebpf_ext_tracelog.c
+++ b/netebpfext/net_ebpf_ext_tracelog.c
@@ -101,7 +101,8 @@ net_ebpf_ext_trace_terminate()
 #pragma warning(push)
 #pragma warning(disable : 6262) // Function uses 'N' bytes of stack.  Consider moving some data to heap.
 
-__declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure(
+__declspec(noinline) void
+net_ebpf_ext_log_ntstatus_api_failure(
     net_ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status)
 {
     NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH(api_name, status);
@@ -134,7 +135,8 @@ __declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure(
         break;                                                                                                        \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure_message_string(
+__declspec(noinline) void
+net_ebpf_ext_log_ntstatus_api_failure_message_string(
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* api_name,
     NTSTATUS status,
@@ -169,7 +171,8 @@ __declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure_message_string(
         break;                                                              \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message(
+__declspec(noinline) void
+net_ebpf_ext_log_message(
     net_ebpf_ext_tracelog_level_t trace_level, net_ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* message)
 {
     switch (trace_level) {
@@ -222,7 +225,8 @@ __declspec(noinline) void net_ebpf_ext_log_message(
         break;                                                                                   \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_string(
+__declspec(noinline) void
+net_ebpf_ext_log_message_string(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -278,7 +282,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_string(
         break;                                                                               \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_ntstatus(
+__declspec(noinline) void
+net_ebpf_ext_log_message_ntstatus(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -334,7 +339,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_ntstatus(
         break;                                                                          \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_bool(
+__declspec(noinline) void
+net_ebpf_ext_log_message_bool(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -390,7 +396,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_bool(
         break;                                                                             \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_pointer(
+__declspec(noinline) void
+net_ebpf_ext_log_message_pointer(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -446,7 +453,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_pointer(
         break;                                                                             \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_uint32(
+__declspec(noinline) void
+net_ebpf_ext_log_message_uint32(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -502,7 +510,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_uint32(
         break;                                                                             \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_uint64(
+__declspec(noinline) void
+net_ebpf_ext_log_message_uint64(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -558,7 +567,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_uint64(
         break;                                                                                                     \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure_uint64_uint64(
+__declspec(noinline) void
+net_ebpf_ext_log_ntstatus_api_failure_uint64_uint64(
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* api_name,
     NTSTATUS status,
@@ -593,7 +603,8 @@ __declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure_uint64_uint64(
         break;                                                                                            \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_uint64_uint64(
+__declspec(noinline) void
+net_ebpf_ext_log_message_uint64_uint64(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,
@@ -652,7 +663,8 @@ __declspec(noinline) void net_ebpf_ext_log_message_uint64_uint64(
         break;                                                                                                      \
     }
 
-__declspec(noinline) void net_ebpf_ext_log_message_uint64_uint64_uint64(
+__declspec(noinline) void
+net_ebpf_ext_log_message_uint64_uint64_uint64(
     net_ebpf_ext_tracelog_level_t trace_level,
     net_ebpf_ext_tracelog_keyword_t keyword,
     _In_z_ const char* message,

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/empty_dll.c
+++ b/tests/bpf2c_tests/expected/empty_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/invalid_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/invalid_maps1_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/invalid_maps2_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/invalid_maps3_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps3_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/multiple_programs_dll.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/printk_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/strings_dll.c
+++ b/tests/bpf2c_tests/expected/strings_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_adjust_head_unsafe_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/xdp_datasize_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_datasize_unsafe_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/xdp_invalid_socket_cookie_dll.c
@@ -28,7 +28,11 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
 
 #include "bpf2c.h"
 

--- a/tests/end_to_end/test_helper.hpp
+++ b/tests/end_to_end/test_helper.hpp
@@ -43,8 +43,8 @@ class _test_helper_libbpf
 class _test_handle_helper
 {
   public:
-    _test_handle_helper() : handle(ebpf_handle_invalid){};
-    _test_handle_helper(ebpf_handle_t handle) : handle(handle){};
+    _test_handle_helper() : handle(ebpf_handle_invalid) {};
+    _test_handle_helper(ebpf_handle_t handle) : handle(handle) {};
     _test_handle_helper(const _test_handle_helper& object) = delete;
     void
     operator=(const _test_handle_helper& object) = delete;

--- a/tests/stress/km/stress_tests_km.cpp
+++ b/tests/stress/km/stress_tests_km.cpp
@@ -253,9 +253,9 @@ _start_extension_restart_thread(
 struct object_table_entry
 {
     std::unique_ptr<std::mutex> lock{nullptr};
-    _Guarded_by_(lock) bool available{true};
-    _Guarded_by_(lock) bpf_object_ptr object{nullptr};
-    _Guarded_by_(lock) bool loaded{false};
+    _Guarded_by_(lock) bool available { true };
+    _Guarded_by_(lock) bpf_object_ptr object { nullptr };
+    _Guarded_by_(lock) bool loaded { false };
     bool attach{false};
 
     // The following fields are for debugging this test itself.

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -387,30 +387,12 @@ TEST_CASE("valid bpf_load_program_xattr", "[libbpf][deprecated]")
 // Define macros that appear in the Linux man page to values in ebpf_vm_isa.h.
 #define BPF_LD_MAP_FD(reg, fd) \
     {INST_OP_LDDW_IMM, (reg), 1, 0, (fd)}, { 0 }
-#define BPF_ALU64_IMM(op, reg, imm)                                     \
-    {                                                                   \
-        INST_CLS_ALU64 | INST_SRC_IMM | ((op) << 4), (reg), 0, 0, (imm) \
-    }
-#define BPF_MOV64_IMM(reg, imm)                                  \
-    {                                                            \
-        INST_CLS_ALU64 | INST_SRC_IMM | 0xb0, (reg), 0, 0, (imm) \
-    }
-#define BPF_MOV64_REG(dst, src)                                  \
-    {                                                            \
-        INST_CLS_ALU64 | INST_SRC_REG | 0xb0, (dst), (src), 0, 0 \
-    }
-#define BPF_EXIT_INSN() \
-    {                   \
-        INST_OP_EXIT    \
-    }
-#define BPF_CALL_FUNC(imm)           \
-    {                                \
-        INST_OP_CALL, 0, 0, 0, (imm) \
-    }
-#define BPF_STX_MEM(sz, dst, src, off)                              \
-    {                                                               \
-        INST_CLS_STX | INST_MODE_MEM | (sz), (dst), (src), (off), 0 \
-    }
+#define BPF_ALU64_IMM(op, reg, imm) {INST_CLS_ALU64 | INST_SRC_IMM | ((op) << 4), (reg), 0, 0, (imm)}
+#define BPF_MOV64_IMM(reg, imm) {INST_CLS_ALU64 | INST_SRC_IMM | 0xb0, (reg), 0, 0, (imm)}
+#define BPF_MOV64_REG(dst, src) {INST_CLS_ALU64 | INST_SRC_REG | 0xb0, (dst), (src), 0, 0}
+#define BPF_EXIT_INSN() {INST_OP_EXIT}
+#define BPF_CALL_FUNC(imm) {INST_OP_CALL, 0, 0, 0, (imm)}
+#define BPF_STX_MEM(sz, dst, src, off) {INST_CLS_STX | INST_MODE_MEM | (sz), (dst), (src), (off), 0}
 #define BPF_W INST_SIZE_W
 #define BPF_REG_1 R1_ARG
 #define BPF_REG_2 R2_ARG

--- a/tools/bpf2c/bpf2c_dll.c
+++ b/tools/bpf2c/bpf2c_dll.c
@@ -25,4 +25,8 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}

--- a/tools/netsh/dllmain.c
+++ b/tools/netsh/dllmain.c
@@ -88,10 +88,7 @@ typedef struct _CMD_ENTRY_ORIGINAL
     unsigned long dwFlags;              // Flags (see CMD_FLAGS_xxx above)
     PNS_OSVERSIONCHECK pOsVersionCheck; // Check for the version of the OS this command can run against
 } CMD_ENTRY_ORIGINAL, *PCMD_ENTRY_ORIGINAL;
-#define CREATE_CMD_ENTRY_ORIGINAL(t, f)                           \
-    {                                                             \
-        CMD_##t, f, HLP_##t, HLP_##t##_EX, CMD_FLAG_PRIVATE, NULL \
-    }
+#define CREATE_CMD_ENTRY_ORIGINAL(t, f) {CMD_##t, f, HLP_##t, HLP_##t##_EX, CMD_FLAG_PRIVATE, NULL}
 
 typedef struct _CMD_ENTRY_LONG
 {
@@ -104,10 +101,7 @@ typedef struct _CMD_ENTRY_LONG
     PNS_OSVERSIONCHECK pOsVersionCheck; // Check for the version of the OS this command can run against
     void* pfnCustomHelpFn;
 } CMD_ENTRY_LONG, *PCMD_ENTRY_LONG;
-#define CREATE_CMD_ENTRY_LONG(t, f)                                     \
-    {                                                                   \
-        CMD_##t, f, HLP_##t, HLP_##t##_EX, CMD_FLAG_PRIVATE, NULL, NULL \
-    }
+#define CREATE_CMD_ENTRY_LONG(t, f) {CMD_##t, f, HLP_##t, HLP_##t##_EX, CMD_FLAG_PRIVATE, NULL, NULL}
 
 CMD_ENTRY_ORIGINAL g_EbpfAddCommandTableOriginal[] = {
     CREATE_CMD_ENTRY_ORIGINAL(EBPF_ADD_PROGRAM, handle_ebpf_add_program),
@@ -166,14 +160,9 @@ static CMD_GROUP_ENTRY g_EbpfGroupCommands[] = {
     CREATE_CMD_GROUP_ENTRY(GROUP_SHOW, g_EbpfShowCommandTable),
 };
 #else
-#define CREATE_CMD_GROUP_ENTRY_ORIGINAL(t, s)                                            \
-    {                                                                                    \
-        CMD_##t, HLP_##t, sizeof(s) / sizeof(CMD_ENTRY_ORIGINAL), 0, (PCMD_ENTRY)s, NULL \
-    }
-#define CREATE_CMD_GROUP_ENTRY_LONG(t, s)                                            \
-    {                                                                                \
-        CMD_##t, HLP_##t, sizeof(s) / sizeof(CMD_ENTRY_LONG), 0, (PCMD_ENTRY)s, NULL \
-    }
+#define CREATE_CMD_GROUP_ENTRY_ORIGINAL(t, s) \
+    {CMD_##t, HLP_##t, sizeof(s) / sizeof(CMD_ENTRY_ORIGINAL), 0, (PCMD_ENTRY)s, NULL}
+#define CREATE_CMD_GROUP_ENTRY_LONG(t, s) {CMD_##t, HLP_##t, sizeof(s) / sizeof(CMD_ENTRY_LONG), 0, (PCMD_ENTRY)s, NULL}
 static CMD_GROUP_ENTRY g_EbpfGroupCommandsOriginal[] = {
     CREATE_CMD_GROUP_ENTRY_ORIGINAL(GROUP_ADD, g_EbpfAddCommandTableOriginal),
     CREATE_CMD_GROUP_ENTRY_ORIGINAL(GROUP_DELETE, g_EbpfDeleteCommandTableOriginal),
@@ -224,7 +213,8 @@ EbpfStartHelper(const GUID* parentGuid, unsigned long version)
     return status;
 }
 
-__declspec(dllexport) unsigned long InitHelperDll(unsigned long netshVersion, void* reserved)
+__declspec(dllexport) unsigned long
+InitHelperDll(unsigned long netshVersion, void* reserved)
 {
     NS_HELPER_ATTRIBUTES attributes = {0};
     UNREFERENCED_PARAMETER(netshVersion);


### PR DESCRIPTION
## Description

The project has upgraded from clang-format 17.* to clang-format 18.1.8, which interprets the .clang-format file slightly differently. This results in spurious whitespace changes when developers make changes to existing files and then format them. To eliminate the noise from other PRs this PR takes the onetime hit of reformatting all the code using clang-format 18.1.8.

Reformat the code base using clang-format 18.1.8 to eliminate future unrelated whitespace changes on other PRs.

## Testing

CI/CD - Whitespace only changes

## Documentation

No.

## Installation

No.
