### PR TITLE
Set /W3 for all external projects

### DIFF
--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -25,6 +25,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WholeProgramOptimization Condition="'$(EnableASAN)' != 'true'">true</WholeProgramOptimization>
       <TreatWarningAsError>false</TreatWarningAsError>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
       <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>
@@ -37,6 +38,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <TreatWarningAsError>false</TreatWarningAsError>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
## Description

Internal tools are failing because not all binaries are built with at least /W3.

This change sets the default warning level in all external projects to /W3.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
