### PR TITLE
Detect cases where maps in symbol table and btf differ

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -156,7 +156,11 @@ _parse_btf_map_info_and_populate_cache(const ELFIO::elfio& reader, const vector<
 
     // For each map in map_names, find the corresponding map descriptor and cache the map handle.
     for (auto& entry : map_names) {
-        uint32_t idx = (uint32_t)btf_map_name_to_index[entry.map_name];
+        auto btf_entry = btf_map_name_to_index.find(entry.map_name);
+        if (btf_entry == btf_map_name_to_index.end()) {
+            throw std::runtime_error(string("Map ") + entry.map_name + " not found.");
+        }
+        uint32_t idx = (uint32_t)btf_entry->second;
         auto& btf_map_descriptor = btf_map_descriptors[idx];
         // We temporarily stored BTF type ids in the descriptor's fd fields.
         int btf_type_id = btf_map_descriptor.original_fd;


### PR DESCRIPTION
Resolves: #4177

## Description

This pull request includes an important change to the `libs/api/Verifier.cpp` file to improve error handling when parsing BTF map information and populating the cache.

Error handling improvements:

* [`libs/api/Verifier.cpp`](diffhunk://#diff-c7cabf550a3d7ec7f53d5aaf8ea0e8a77d949e886b3c0f492ebd75228756b40fL159-R163): Added a check to handle cases where a map name is not found in `btf_map_name_to_index`. If a map name is not found, it now throws a `std::runtime_error` with a descriptive message.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
