### PR TITLE
Validate previous key

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1979,9 +1979,14 @@ _next_lpm_map_key_and_value(
 {
     ebpf_core_lpm_map_t* trie_map = EBPF_FROM_FIELD(ebpf_core_lpm_map_t, core_map, map);
     ebpf_core_lpm_key_t* lpm_key = (ebpf_core_lpm_key_t*)next_key;
+    ebpf_core_lpm_key_t* previous_lpm_key = (ebpf_core_lpm_key_t*)previous_key;
 
     // Validate prefix length.
     if (!lpm_key || lpm_key->prefix_length > trie_map->max_prefix) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    if (previous_lpm_key && previous_lpm_key->prefix_length > trie_map->max_prefix) {
         return EBPF_INVALID_ARGUMENT;
     }
 


### PR DESCRIPTION
Resolves: #4194 

## Description

This pull request includes a validation enhancement to the `_next_lpm_map_key_and_value` function in the `libs/execution_context/ebpf_maps.c` file. The change ensures that the `previous_key` is also validated for its prefix length.

Validation enhancement:

* [`libs/execution_context/ebpf_maps.c`](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cR1982-R1992): Added a check to validate the prefix length of `previous_key` in the `_next_lpm_map_key_and_value` function to ensure it does not exceed the maximum allowed prefix length.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
