### PR TITLE
Temporarily skip stopping ebpf services in testing

### DIFF
--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -69,7 +69,9 @@ $Job = Start-Job -ScriptBlock {
         Run-KernelTestsOnVM -VMName $TestVMName -Config $Config
 
         # Stop eBPF components on test VMs.
-        Stop-eBPFComponentsOnVM -VMName $TestVMName
+        # Stopping the eBPF components is temporarily disabled, while we debug known issues with NetEbpfExt service stop hanging.
+        # See task #4199
+        # Stop-eBPFComponentsOnVM -VMName $TestVMName
     } catch [System.Management.Automation.RemoteException] {
         # Next, generate kernel dump.
         Write-Log $_.Exception.Message


### PR DESCRIPTION
## Description
There are known issues with Netepfext service stop hanging. While we investigate the issues, temporarily disable the service stop to prevent noise in dev work.

Issue tracking Netebpfext service stop hang: #4199

## Testing
Removes service stop as part of test execution.

## Documentation
n/a

## Installation
n/a
