### PR TITLE
Improve _invalid_parameter_suppression

### DIFF
--- a/libs/thunk/windows/platform.cpp
+++ b/libs/thunk/windows/platform.cpp
@@ -3,7 +3,6 @@
 
 #include "ebpf_api.h"
 
-#include <crtdbg.h> // For _CrtSetReportMode
 #include <cstdlib>
 #include <io.h>
 #include <stdint.h>
@@ -16,7 +15,6 @@ class _invalid_parameter_suppression
   public:
     _invalid_parameter_suppression()
     {
-        _CrtSetReportMode(_CRT_ASSERT, 0);
         previous_handler = _set_thread_local_invalid_parameter_handler(_ignore_invalid_parameter);
     }
     ~_invalid_parameter_suppression() { _set_thread_local_invalid_parameter_handler(previous_handler); }

--- a/libs/thunk/windows/platform.cpp
+++ b/libs/thunk/windows/platform.cpp
@@ -17,9 +17,9 @@ class _invalid_parameter_suppression
     _invalid_parameter_suppression()
     {
         _CrtSetReportMode(_CRT_ASSERT, 0);
-        previous_handler = _set_invalid_parameter_handler(_ignore_invalid_parameter);
+        previous_handler = _set_thread_local_invalid_parameter_handler(_ignore_invalid_parameter);
     }
-    ~_invalid_parameter_suppression() { _set_invalid_parameter_handler(previous_handler); }
+    ~_invalid_parameter_suppression() { _set_thread_local_invalid_parameter_handler(previous_handler); }
 
   private:
     static void

--- a/tests/libs/util/wer_report.hpp
+++ b/tests/libs/util/wer_report.hpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <crtdbg.h>
 #include <csignal>
+#include <iostream>
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <Windows.h>
 #include <errorrep.h>
@@ -84,8 +86,14 @@ class _wer_report
     static constexpr const wchar_t wer_event_type[] = L"Test Application Crash";
 
     static int __CRTDECL
-    _terminate_hook(int, char*, int*)
+    _terminate_hook(int reportType, char* message, int* returnValue)
     {
+        UNREFERENCED_PARAMETER(reportType);
+        UNREFERENCED_PARAMETER(returnValue);
+
+        std::cerr << message;
+        std::cerr.flush();
+
         // Convert a CRT runtime error into a SEH exception.
         RaiseException(STATUS_ASSERTION_FAILURE, 0, 0, NULL);
         return 0;


### PR DESCRIPTION
Fix race condition in _invalid_parameter_suppression

    Invalid parameter suppression currently sets the global invalid parameter
    handler. This means that concurrent execution may lead to executing the
    wrong handler.

    Instead, always set and restore the thread local handler.

Write debug assertions to stderr before terminating process

    Report assertions and errors to standard error before terminating the 
    process.

    Stop changing the reporting mode in _invalid_parameter_suppression because
    the mode is a global setting which shouldn't be changed by a library.

    Fixes https://github.com/microsoft/ebpf-for-windows/issues/4207
