### PR TITLE
Export ebpf_object_get_info_by_fd

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -129,6 +129,7 @@ EXPORTS
     ebpf_link_close
     ebpf_object_get
     ebpf_object_get_execution_type
+    ebpf_object_get_info_by_fd
     ebpf_object_load_native_by_fds
     ebpf_object_set_execution_type
     ebpf_object_unpin

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -300,6 +300,35 @@ extern "C"
     ebpf_object_unpin(_In_z_ const char* path) EBPF_NO_EXCEPT;
 
     /**
+     * @brief Obtain information about the eBPF object referred to by bpf_fd.
+     * This function populates up to info_len bytes of info, which will
+     * be in one of the following formats depending on the eBPF object type of
+     * bpf_fd:
+     *
+     * * struct bpf_link_info
+     * * struct bpf_map_info
+     * * struct bpf_prog_info
+     *
+     * @param[in] bpf_fd File descriptor referring to an eBPF object.
+     * @param[in, out] info Pointer to memory in which to write the info obtained.
+     * On input, contains any additional parameters to use. May be NULL in order to
+     * only retrieve the type of the object.
+     * @param[in, out] info_size On input, contains the maximum number of bytes to
+     * write into the info. On output, contains the actual number of bytes written.
+     * May be NULL if info is NULL.
+     * @param[out] type Optional type of the object.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_object_get_info_by_fd(
+        fd_t bpf_fd,
+        _Inout_updates_bytes_to_opt_(*info_size, *info_size) void* info,
+        _Inout_opt_ uint32_t* info_size,
+        _Out_opt_ ebpf_object_type_t* type) EBPF_NO_EXCEPT;
+
+    /**
      * @brief Detach the eBPF program from the link.
      *
      * @param[in] link_handle Handle to the link.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -502,32 +502,6 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
 
 /**
- * @brief Obtain information about the eBPF object referred to by bpf_fd.
- * This function populates up to info_len bytes of info, which will
- * be in one of the following formats depending on the eBPF object type of
- * bpf_fd:
- *
- * * struct bpf_link_info
- * * struct bpf_map_info
- * * struct bpf_prog_info
- *
- * @param[in] bpf_fd File descriptor referring to an eBPF object.
- * @param[in, out] info Pointer to memory in which to write the info obtained.
- * On input, contains any additional parameters to use.
- * @param[in, out] info_size On input, contains the maximum number of bytes to
- * write into the info.  On output, contains the actual number of bytes written.
- *
- * @retval EBPF_SUCCESS The operation was successful.
- * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
- */
-_Must_inspect_result_ ebpf_result_t
-ebpf_object_get_info_by_fd(
-    fd_t bpf_fd,
-    _Inout_updates_bytes_to_(*info_size, *info_size) void* info,
-    _Inout_ uint32_t* info_size,
-    _Out_opt_ ebpf_object_type_t* type) noexcept;
-
-/**
  * @brief Pin an object to the specified path.
  * @param[in] fd File descriptor to the object.
  * @param[in] path Path to pin the object to.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4261,13 +4261,11 @@ CATCH_NO_MEMORY_EBPF_RESULT
 _Must_inspect_result_ ebpf_result_t
 ebpf_object_get_info_by_fd(
     fd_t bpf_fd,
-    _Inout_updates_bytes_to_(*info_size, *info_size) void* info,
-    _Inout_ uint32_t* info_size,
+    _Inout_updates_bytes_to_opt_(*info_size, *info_size) void* info,
+    _Inout_opt_ uint32_t* info_size,
     _Out_opt_ ebpf_object_type_t* type) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
-    ebpf_assert(info);
-    ebpf_assert(info_size);
 
     ebpf_handle_t handle = _get_handle_from_file_descriptor(bpf_fd);
     if (handle == ebpf_handle_invalid) {

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -192,8 +192,8 @@ ebpf_result_to_errno(ebpf_result_t result)
 _Must_inspect_result_ ebpf_result_t
 ebpf_object_get_info(
     ebpf_handle_t handle,
-    _Inout_updates_bytes_to_(*info_size, *info_size) void* info,
-    _Inout_ uint32_t* info_size,
+    _Inout_updates_bytes_to_opt_(*info_size, *info_size) void* info,
+    _Inout_opt_ uint32_t* info_size,
     _Out_opt_ ebpf_object_type_t* type) noexcept;
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2138,6 +2138,13 @@ _ebpf_core_protocol_get_object_info(
         return result;
     }
 
+    reply->type = object->type;
+
+    if (input_buffer_size == 0) {
+        EBPF_OBJECT_RELEASE_REFERENCE(object);
+        return EBPF_SUCCESS;
+    }
+
     // List of object types is fixed at compile time.
     switch (object->type) {
     case EBPF_OBJECT_LINK:
@@ -2156,7 +2163,6 @@ _ebpf_core_protocol_get_object_info(
     }
 
     if (result == EBPF_SUCCESS) {
-        reply->type = object->type;
         reply->header.length = FIELD_OFFSET(ebpf_operation_get_object_info_reply_t, info) + info_size;
     }
     EBPF_OBJECT_RELEASE_REFERENCE(object);


### PR DESCRIPTION
Export a function which allows retrieving the object info along with its type. bpf_obj_get_info_by_fd is almost identical but requires the caller to know the type of the object.