### PR TITLE
Organize nupkgs for publishing

### DIFF
--- a/scripts/Set-Version.ps1
+++ b/scripts/Set-Version.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) eBPF for Windows contributors
 # SPDX-License-Identifier: MIT
 
-param ($InputFile, $OutputFile, [parameter(Mandatory=$false)]$VCToolsRedistDir, [parameter(Mandatory=$false)]$architecture)
+param ($InputFile, $OutputFile, [parameter(Mandatory=$false)]$VCToolsRedistDir, [parameter(Mandatory=$false)]$architecture, [parameter(Mandatory=$false)]$configuration)
 
 # The git commit ID is in the include directory and is in the format:
 # #define GIT_COMMIT_ID "some commit id"
@@ -26,4 +26,9 @@ $content = $content.Replace("{version}", $version)
 $content = $content.Replace("{VCToolsRedistDir}", $VCToolsRedistDir)
 $content = $content.Replace("{git_commit_id}", $git_commit_id)
 $content = $content.Replace("{architecture}", $architecture)
+if ($configuration -match "Release") {
+    $content = $content.Replace("{configuration}", "")
+} else {
+    $content = $content.Replace("{configuration}", ".$configuration")
+}
 set-content $OutputFile $content

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -35,7 +35,13 @@ function CopyPackages {
         [string]$Arch
     )
     $BinDir = FormatBinDir $Config $Arch
-    xcopy /y ".\$Arch\$Config\*.nupkg" $BinDir
+
+    $PackagesDir = "$BinDir\packages"
+    if (-not (Test-Path -Path $PackagesDir)) {
+        New-Item -ItemType Directory -Path $PackagesDir
+    }    
+
+    xcopy /y ".\$Arch\$Config\*.nupkg" $PackagesDir
     xcopy /y ".\$Arch\$Config\*.msi" $BinDir
 }
 

--- a/tools/nuget/ebpf-for-windows.nuspec.in
+++ b/tools/nuget/ebpf-for-windows.nuspec.in
@@ -5,7 +5,7 @@
 <package>
 	<metadata>
 		<title>eBPF for Windows SDK</title>
-		<id>eBPF-for-Windows.{architecture}</id>
+		<id>eBPF-for-Windows.{architecture}{configuration}</id>
 		<version>{version}</version>
 		<authors>eBPF for Windows Contributors</authors>
 		<owners>eBPF for Windows Contributors</owners>

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -178,7 +178,7 @@ popd $(OutDir)</Command>
       <FileType>Document</FileType>
       <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(EbpfVersion).nupkg</Outputs>
       <Command>
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -Configuration $(Configuration)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.props.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).props -Architecture $(Platform)
         NuGet.exe pack $(OutDir)ebpf-for-windows.$(Platform).nuspec -OutputDirectory $(OutDir)</Command>
     </CustomBuild>

--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -5,7 +5,7 @@
 <package>
 	<metadata>
 		<title>eBPF for Windows Redist</title>
-		<id>eBPF-for-Windows-Redist</id>
+		<id>eBPF-for-Windows-Redist.{architecture}{configuration}</id>
 		<version>{version}</version>
 		<authors>eBPF for Windows Contributors</authors>
 		<owners>eBPF for Windows Contributors</owners>

--- a/tools/redist-package/redist-package.vcxproj
+++ b/tools/redist-package/redist-package.vcxproj
@@ -125,17 +125,17 @@
   <ItemGroup Condition="'$(Analysis)'==''">
     <CustomBuild Include="ebpf-for-windows-redist.nuspec.in">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)'
+      <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
-      <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)'
+      <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
       <Outputs Condition="'$(Configuration)'=='Debug'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
       <Outputs Condition="'$(Configuration)'=='Release'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyRelease'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
-      <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)'
+      <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
-      <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)'
+      <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
     </CustomBuild>
   </ItemGroup>


### PR DESCRIPTION
## Description

This change:
* Modifies the post-build script to copy the unsigned nupkgs to the `packages` subdirectory under `build\bin\<arch>`. This directory is monitored by internal pipelines to publish nuget packages.
* Updates the name of the core package to include the configuration in the generated name, for non-release configurations. eg. `eBPF-for-Windows.x64` for the "NativeOnlyRelease" configuration and `eBPF-for-Windows.x64.NativeOnlyDebug` for the "NativeOnlyDebug" configuration.
* Updates the name of the SDK package to include the architecture in the generated name. Similar to the core package, it may also include the configuration for non-release configurations. eg. `eBPF-for-Windows-Redist.x64` or `eBPF-for-Windows-Redist.x64.NativeOnlyDebug`

## Testing

Internal pipelines were run and confirmed to publish the packages as expected
