### PR TITLE
Enable WER for tests without code coverage

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -309,6 +309,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
+        set EBPF_ENABLE_WER_REPORT=yes
         cd /d ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}
         powershell.exe .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2070,7 +2070,6 @@ initialize_map(_Out_ ebpf_map_t* map, _In_ const map_cache_t& map_cache) noexcep
     map->map_definition.value_size = map_cache.verifier_map_descriptor.value_size;
     map->map_definition.max_entries = map_cache.verifier_map_descriptor.max_entries;
     map->map_definition.pinning = map_cache.pinning;
-    map->map_definition.inner_map_id = map_cache.inner_id;
     map->map_id = map_cache.id;
     map->map_definition.inner_map_id = map_cache.inner_id;
     map->inner_map_original_fd = map_cache.verifier_map_descriptor.inner_map_fd;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2070,18 +2070,7 @@ initialize_map(_Out_ ebpf_map_t* map, _In_ const map_cache_t& map_cache) noexcep
     map->map_definition.value_size = map_cache.verifier_map_descriptor.value_size;
     map->map_definition.max_entries = map_cache.verifier_map_descriptor.max_entries;
     map->map_definition.pinning = map_cache.pinning;
-
-    // Set the inner map ID if we have a real inner map fd.
-    map->map_definition.inner_map_id = EBPF_ID_NONE;
-    if (map_cache.verifier_map_descriptor.inner_map_fd != ebpf_fd_invalid) {
-        struct bpf_map_info info = {0};
-        uint32_t info_size = (uint32_t)sizeof(info);
-        if (ebpf_object_get_info_by_fd(map_cache.verifier_map_descriptor.inner_map_fd, &info, &info_size, NULL) ==
-            EBPF_SUCCESS) {
-            map->map_definition.inner_map_id = info.id;
-        }
-    }
-
+    map->map_definition.inner_map_id = map_cache.inner_id;
     map->map_id = map_cache.id;
     map->map_definition.inner_map_id = map_cache.inner_id;
     map->inner_map_original_fd = map_cache.verifier_map_descriptor.inner_map_fd;


### PR DESCRIPTION
Resolves: #4218 
Resolves: #4220 

## Description

This pull request includes a small change to the `.azure/reusable-test.yml` file. The change sets the `EBPF_ENABLE_WER_REPORT` environment variable to `yes` before running the test command.

* [`.azure/reusable-test.yml`](diffhunk://#diff-dcac258e0d6e06538fee721d1158f5806bd9bfcce3ee3161275761af9c314e80R224): Added `set EBPF_ENABLE_WER_REPORT=yes` to the script section to enable WER (Windows Error Reporting) for eBPF.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
