### PR TITLE
#4135 - Closing the last program descriptor detaches a link

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -372,6 +372,10 @@ ebpf_link_attach_program(_Inout_ ebpf_link_t* link, _Inout_ ebpf_program_t* prog
 
     // Attach the program to the link.
     ebpf_program_attach_link(program, link);
+    //
+    // add extra ref on the attached program
+    //
+    EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)program);
     link_attached_to_program = true;
 
     ebpf_lock_unlock(&link->lock, state);
@@ -428,6 +432,10 @@ Done:
 
         if (link_attached_to_program) {
             ebpf_program_detach_link(program, link);
+            //
+            // decrement program refcount
+            //
+            EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)program);
             link_attached_to_program = false;
             link->program = NULL;
         }
@@ -479,6 +487,10 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     link->nmr_client_handle = NULL;
 
     ebpf_program_detach_link(link->program, link);
+    //
+    // remove extra ref on attached program
+    //
+    EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)link->program);
 
     ebpf_free((void*)link->client_data.data);
 


### PR DESCRIPTION
## Description

Possible fix for bug 4135.
Add/remove program refcount when link is attached/detached.






