### PR TITLE
ebpf API to export a function to get handle from a program/map fd

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -121,12 +121,12 @@ EXPORTS
     ebpf_get_bpf_program_type
     ebpf_get_ebpf_attach_type
     ebpf_get_ebpf_program_type
+    ebpf_get_handle_from_fd
     ebpf_get_next_pinned_object_path
     ebpf_get_next_pinned_program_path
     ebpf_get_program_info_from_verifier
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name
-    ebpf_get_handle_from_fd
     ebpf_link_close
     ebpf_object_get
     ebpf_object_get_execution_type

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -117,6 +117,7 @@ EXPORTS
     ebpf_get_program_info_from_verifier
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name
+    ebpf_get_handle_from_fd
     ebpf_link_close
     ebpf_object_get
     ebpf_object_get_execution_type

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -468,14 +468,14 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 /**
  * @brief Get an object's handle based on its fd.
  *
- * @param[in] fd of the object.
- * @param[out] intptr_t OS basedhandle to the object.
+ * @param[in] File Descriptor of the object.
+ * @param[out] ebpf_handle_t OS based handle to the object.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_PARAMETER No such FD was found.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_get_handle_from_fd(int fd, _Out_ intptr_t* handle) noexcept;
+ebpf_get_handle_from_fd(int fd, _Out_ ebpf_handle_t* handle) noexcept;
 
 /**
  * @brief Look for the next link ID greater than a given ID.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -466,7 +466,7 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 
 /**
- * @brief Get an object's handle based on it's fd.
+ * @brief Get an object's handle based on its fd.
  *
  * @param[in] fd of the object.
  * @param[out] intptr_t OS basedhandle to the object.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -468,7 +468,7 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 /**
  * @brief Get an object's handle based on its fd.
  *
- * @param[in] File Descriptor of the object.
+ * @param[in] fd File descriptor of the object.
  * @param[out] ebpf_handle_t OS based handle to the object.
  *
  * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -469,7 +469,7 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
  * @brief Get an object's handle based on its fd.
  *
  * @param[in] fd File descriptor of the object.
- * @param[out] ebpf_handle_t OS based handle to the object.
+ * @param[out] handle OS based handle to the object.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_PARAMETER No such FD was found.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -465,6 +465,18 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 
 /**
+ * @brief Get an object's handle based on it's fd.
+ *
+ * @param[in] fd of the object.
+ * @param[out] intptr_t OS basedhandle to the object.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_INVALID_PARAMETER No such FD was found.
+ */
+_Must_inspect_result_ ebpf_result_t
+ebpf_get_handle_from_fd(int fd, _Out_ intptr_t* handle) noexcept;
+
+/**
  * @brief Look for the next link ID greater than a given ID.
  *
  * @param[in] start_id ID to look for an ID after.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3978,6 +3978,19 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) NO_EXCEPT_TRY
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
+ebpf_get_handle_from_fd(int fd, _Out_ intptr_t* handle) NO_EXCEPT_TRY
+{
+    EBPF_LOG_ENTRY();
+    intptr_t fdHandle = intptr_t(-1);
+    if (fdHandle = Platform::_get_osfhandle(fd); fdHandle == intptr_t(-1)) {
+        EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(errno));
+    }
+    *handle = fdHandle;
+    EBPF_RETURN_RESULT(EBPF_SUCCESS);
+}
+CATCH_NO_MEMORY_EBPF_RESULT
+
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_pinned_program_path(
     _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) NO_EXCEPT_TRY
 {

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4041,14 +4041,14 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) NO_EXCEPT_TRY
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_get_handle_from_fd(int fd, _Out_ intptr_t* handle) NO_EXCEPT_TRY
+ebpf_get_handle_from_fd(int fd, _Out_ ebpf_handle_t* handle) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
-    intptr_t fdHandle = intptr_t(-1);
-    if (fdHandle = Platform::_get_osfhandle(fd); fdHandle == intptr_t(-1)) {
+    ebpf_assert(handle);
+    *handle = Platform::_get_osfhandle(fd);
+    if (*handle == ebpf_handle_invalid) {
         EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(errno));
     }
-    *handle = fdHandle;
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 CATCH_NO_MEMORY_EBPF_RESULT

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1100,7 +1100,8 @@ TEST_CASE("ioctl_stress", "[stress]")
     fd_t process_map_fd = bpf_object__find_map_fd_by_name(object, "process_map");
 
     // Subscribe to the ring buffer with empty callback
-    auto ring = ring_buffer__new(process_map_fd, [](void*, void*, size_t) { return 0; }, nullptr, nullptr);
+    auto ring = ring_buffer__new(
+        process_map_fd, [](void*, void*, size_t) { return 0; }, nullptr, nullptr);
 
     // Run 4 threads per cpu
     // Get cpu count
@@ -1324,4 +1325,16 @@ TEST_CASE("Test program order", "[native_tests]")
 
     // Clean up.
     bpf_object__close(object);
+}
+
+TEST_CASE("get_handle_from_fd", "")
+{
+    fd_t map_fd1 = bpf_map_create(BPF_MAP_TYPE_ARRAY, "map", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(map_fd1 > 0);
+
+    intptr_t handle;
+
+    REQUIRE(ebpf_get_handle_from_fd(map_fd1, &handle) == EBPF_SUCCESS);
+    REQUIRE(handle != (intptr_t)(-1));
+    _close(map_fd1);
 }


### PR DESCRIPTION
## Description

As suggested in the [issue here](https://github.com/microsoft/ebpf-for-windows/issues/4176), an api to convert FDs to Windows handle can be useful for consumers of libbpf. An example is to use the handle for various Windows APIs that need a handle and do not operate on FDs. 

Fixes #4176

## Testing
 Unit test added to get the handle of a map's FD. 

## Documentation


## Installation
No installer changes. 
