### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, they will be requested for
 # review when someone opens a pull request.
-@Alan-Jowett @dthaler @dv-msft @LakshK98 @matthewige @mikeagun @mtfriesen
+* @Alan-Jowett @dthaler @dv-msft @LakshK98 @matthewige @mikeagun @mtfriesen
 @poornagmsft @saxena-anurag @shankarseal @vpidatala94

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,4 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, they will be requested for
 # review when someone opens a pull request.
-* @Alan-Jowett @dthaler @dv-msft @LakshK98 @matthewige @mikeagun @mtfriesen
-@poornagmsft @saxena-anurag @shankarseal @vpidatala94
+* @Alan-Jowett @dthaler @dv-msft @LakshK98 @matthewige @mikeagun @mtfriesen @poornagmsft @saxena-anurag @shankarseal @vpidatala94


### PR DESCRIPTION
Introducing the missing asterisk.

## Description

_Describe the purpose of and changes within this Pull Request._
#4167 broke the CODEOWNERS file by removing the asterisk from the default owners. As a result, no one was getting email notifications for PRs. This PR fixes #4237.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
N/A.

## Documentation

_Is there any documentation impact for this change?_
N/A.

## Installation

_Is there any installer impact for this change?_
N/A.