### PR TITLE
issue1941 - fuzz sock_addr/ops/xdp

### DIFF
--- a/tests/libfuzzer/README.md
+++ b/tests/libfuzzer/README.md
@@ -15,7 +15,7 @@ There are now four libFuzzer-based binaries:
 1) Copy the libFuzzer binary and existing corpus to a test machine (currently only Windows 10 and Server 2019 are supported).
 2) Start the libFuzzer binary, pass the path to the corpus folder, and maximum time to run:
   * `bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=1800`
-  * `core_helper_fuzzer.exe core_helper_fuzzer core_helper_corpus -max_len=139 -runs=2000 -use_value_profile=1`
+  * `core_helper_fuzzer.exe core_helper_fuzzer core_helper_corpus -max_len=139 -runs=2000 -use_value_profile=1 -helper sockaddr/xdp/sockops` `default behavior to fuzz all specific helper functions`
   * `execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -max_total_time=1800`
   * `verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=1800`
 3) If the fuzzer hits an issue, it will display the stack trace and create a file containing the input that triggered the crash.

--- a/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
@@ -19,14 +19,52 @@ struct fuzz_xdp_md_helper_t : public xdp_md_helper_t
 typedef fuzz_helper_function<fuzz_xdp_md_helper_t> fuzz_helper_function_xdp_t;
 std::unique_ptr<fuzz_helper_function_xdp_t> _fuzz_helper_function_xdp;
 
-FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int*, char***)
-{
-    // Setup fuzz_state to fuzz the general helper functions.
-    _fuzz_helper_function_xdp =
-        std::make_unique<fuzz_helper_function_xdp_t>(ebpf_general_helper_function_module_id.Guid);
+typedef fuzz_helper_function<bpf_sock_addr_t> fuzz_helper_function_sock_addr_t;
+std::unique_ptr<fuzz_helper_function_sock_addr_t> _fuzz_helper_function_sock_addr;
 
-    // Ensure that the ebpfcore runtime is stopped before the usersim runtime.
-    atexit([]() { _fuzz_helper_function_xdp.reset(); });
+typedef fuzz_helper_function<bpf_sock_ops_t> fuzz_helper_function_sock_ops_t;
+std::unique_ptr<fuzz_helper_function_sock_ops_t> _fuzz_helper_function_sock_ops;
+
+int selected_program_type = 0;
+FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    for (int i = 1; i < *argc; i++) {
+        if (strcmp((*argv)[i], "-helper") == 0  && i + 1 < *argc) {
+            const char* helper_arg = (*argv)[i + 1];
+            if (strcmp(helper_arg, "xdp") == 0) {
+                selected_program_type = 1;
+            } else if (strcmp(helper_arg, "sockaddr") == 0) {
+                selected_program_type = 2;
+            } else if (strcmp(helper_arg, "sockops") == 0) {
+                selected_program_type = 3;
+            }
+            // Remove the flag and its argument from argv.
+            for (int j = i; j < *argc - 2; j++) {
+                (*argv)[j] = (*argv)[j + 2];
+            }
+            *argc -= 2;
+            break; // process only one occurrence
+        }
+    }
+
+    if (selected_program_type == 1) {
+        _fuzz_helper_function_xdp = std::make_unique<fuzz_helper_function_xdp_t>(ebpf_general_helper_function_module_id.Guid);
+        atexit([]() { _fuzz_helper_function_xdp.reset(); });
+    } else if (selected_program_type == 2) {
+        _fuzz_helper_function_sock_addr = std::make_unique<fuzz_helper_function_sock_addr_t>(ebpf_general_helper_function_module_id.Guid);
+        atexit([]() { _fuzz_helper_function_sock_addr.reset(); });
+    } else if (selected_program_type == 3) {
+        _fuzz_helper_function_sock_ops = std::make_unique<fuzz_helper_function_sock_ops_t>(ebpf_general_helper_function_module_id.Guid);
+        atexit([]() { _fuzz_helper_function_sock_ops.reset(); });
+    } else {
+        //default
+        _fuzz_helper_function_xdp = std::make_unique<fuzz_helper_function_xdp_t>(ebpf_general_helper_function_module_id.Guid);
+        atexit([]() { _fuzz_helper_function_xdp.reset(); });
+        _fuzz_helper_function_sock_addr = std::make_unique<fuzz_helper_function_sock_addr_t>(ebpf_general_helper_function_module_id.Guid);
+        atexit([]() { _fuzz_helper_function_sock_addr.reset(); });
+        _fuzz_helper_function_sock_ops = std::make_unique<fuzz_helper_function_sock_ops_t>(ebpf_general_helper_function_module_id.Guid);
+        atexit([]() { _fuzz_helper_function_sock_ops.reset(); });
+    }
     return 0;
 }
 
@@ -34,5 +72,27 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     ebpf_watchdog_timer_t watchdog_timer;
 
-    return _fuzz_helper_function_xdp->fuzz(data, size);
+    if (selected_program_type == 1) {
+        return _fuzz_helper_function_xdp->fuzz(data, size);
+    } else if (selected_program_type == 2) {
+        return _fuzz_helper_function_sock_addr->fuzz(data, size);
+    } else if (selected_program_type == 3) {
+        return _fuzz_helper_function_sock_ops->fuzz(data, size);
+    } else {
+        //default
+        int ret = 0;
+        ret = _fuzz_helper_function_xdp->fuzz(data, size);
+        if (ret != 0) {
+            return ret;
+        }
+        ret = _fuzz_helper_function_sock_addr->fuzz(data, size);
+        if (ret != 0) {
+            return ret;
+        }
+        ret = _fuzz_helper_function_sock_ops->fuzz(data, size);
+        if (ret != 0) {
+            return ret;
+        }
+        return ret;
+    }
 }


### PR DESCRIPTION
## Description

With this pull-request we are providing an extra argument to core helper fuzz tests "-helper" that helps fuzz test helper functions specific helper functions.

In LLVM initialize, after processing our custom arg we are working towards remove it before the libfuzzer can process it.
## Testing
fuzz testing.

## Documentation
Reference -- 
https://llvm.org/docs/LibFuzzer.html
https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md