### PR TITLE
set EBPF_ID_NONE to 0

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -93,7 +93,7 @@ static const char* const _ebpf_pin_type_names[] = {
 };
 
 typedef uint32_t ebpf_id_t;
-#define EBPF_ID_NONE UINT32_MAX
+#define EBPF_ID_NONE 0
 
 /**
  * @brief eBPF Map Definition as it is stored in memory.

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -214,7 +214,7 @@ ebpf_object_initialize(
     object->get_context_header_support = get_context_header_support_function;
     object->id = ebpf_interlocked_increment_int32((volatile int32_t*)&_ebpf_next_id);
     // Skip invalid IDs.
-    while (object->id == 0 || object->id == EBPF_ID_NONE) {
+    while (object->id == EBPF_ID_NONE) {
         object->id = ebpf_interlocked_increment_int32((volatile int32_t*)&_ebpf_next_id);
     }
     ebpf_list_initialize(&object->object_list_entry);

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -809,7 +809,7 @@ TEST_CASE("show maps", "[netsh][maps]")
                   "                              Key  Value      Max  Inner\n"
                   "     ID            Map Type  Size   Size  Entries     ID  Pins  Name\n"
                   "=======  ==================  ====  =====  =======  =====  ====  ========\n"
-                  "      3                hash     4      4        1     -1     0  inner_map\n"
+                  "      3                hash     4      4        1      0     0  inner_map\n"
                   "      4       array_of_maps     4      4        1      3     0  outer_map\n");
 
     output = _run_netsh_command(handle_ebpf_delete_program, L"5", nullptr, nullptr, &result);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1047,7 +1047,7 @@ TEST_CASE("libbpf create queue", "[libbpf]")
     REQUIRE(info.value_size == value_size);
     REQUIRE(info.max_entries == max_entries);
     REQUIRE(info.map_flags == 0);
-    REQUIRE(info.inner_map_id == -1);
+    REQUIRE(info.inner_map_id == EBPF_ID_NONE);
     REQUIRE(info.pinned_path_count == 0);
     REQUIRE(info.id > 0);
     REQUIRE(strcmp(info.name, "MapName") == 0);
@@ -1106,7 +1106,7 @@ TEST_CASE("libbpf create ringbuf", "[libbpf]")
     REQUIRE(info.value_size == 0);
     REQUIRE(info.max_entries == max_entries);
     REQUIRE(info.map_flags == 0);
-    REQUIRE(info.inner_map_id == -1);
+    REQUIRE(info.inner_map_id == EBPF_ID_NONE);
     REQUIRE(info.pinned_path_count == 0);
     REQUIRE(info.id > 0);
     REQUIRE(strcmp(info.name, "MapName") == 0);


### PR DESCRIPTION
## Description

Set the value of EBPF_ID_NONE as proposed in #4098. 
Closes #4098.

## Testing

Changes made to expected output in testcases that expected value of EBPF_ID_NONE to be UINT32_MAX.

## Documentation

NA

## Installation

NA
