### PR TITLE
Pickup bpf_performance with post-breaking changes

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -222,7 +222,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
         cd ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.11.0/build-Release-windows-2022.zip -OutFile bpf_performance.zip
+        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.12.0/build-Release-windows-2022.zip -OutFile bpf_performance.zip
 
     - name: Prepare 1ES artifacts
       if: steps.skip_check.outputs.should_skip != 'true' && (inputs.build_artifact == 'Build-x64' && matrix.configurations == 'Release')


### PR DESCRIPTION
## Description

Switch from version 0.11.0 to version 0.12.0 of BPF performance suite to handle breaking changes in bpf2c.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
