### PR TITLE
Fix fuzzerdebug builds when building with new runners

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -149,10 +149,16 @@ jobs:
       run: |
         echo "$env:VCINSTALLDIR\tools\llvm\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Check for Clang version
+    - name: Check for Clang version (MSVC)
       if: steps.skip_check.outputs.should_skip != 'true'
       run:
         clang.exe --version
+
+    - name: Check for Clang version (LLVM)
+      if: steps.skip_check.outputs.should_skip != 'true'
+      shell: cmd
+      run:
+        '"c:\Program Files\llvm\bin\clang.exe" --version'
 
     - name: Cache nuget packages
       if: steps.skip_check.outputs.should_skip != 'true'


### PR DESCRIPTION
## Description

Use $(ClangExec) in place of clang to select the correct version of clang.

## Testing

CI/CD

## Documentation

CI/CD

## Installation

CI/CD
