### PR TITLE
Fix llvm build break on new GitHub runners

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -149,10 +149,16 @@ jobs:
       run: |
         echo "$env:VCINSTALLDIR\tools\llvm\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Check for Clang version
+    - name: Check for Clang version (MSVC)
       if: steps.skip_check.outputs.should_skip != 'true'
       run:
         clang.exe --version
+
+    - name: Check for Clang version (LLVM)
+      if: steps.skip_check.outputs.should_skip != 'true'
+      shell: cmd
+      run:
+        '"c:\Program Files\llvm\bin\clang.exe" --version'
 
     - name: Cache nuget packages
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -406,7 +406,7 @@
     <CustomBuild Include="custom_program_type\*.c">
       <FileType>CppCode</FileType>
       <Command>
-        clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c custom_program_type\%(Filename).c -o $(OutputPath)%(Filename).o
+        $(ClangExec) $(ClangFlags) -I../xdp -I../socket -I./ext/inc -I../../netebpfext -c custom_program_type\%(Filename).c -o $(OutputPath)%(Filename).o
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
       <!-- Don't run bpf2c in parallel when built with fuzzing flags as this triggers failures. -->


### PR DESCRIPTION
## Description

Use $(ClangExec) in place of clang to select the correct version of Clang.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
