### PR TITLE
remove @exception from documentation.

### DIFF
--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -14,7 +14,7 @@
  * @param[in] link_fd File descriptor of link to detach.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBADF The file descriptor was not found.
  *
@@ -46,7 +46,7 @@ bpf_link_get_fd_by_id(__u32 id);
  * @param[out] next_id Pointer to where to write the next ID.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -ENOENT No more IDs found.
  */
@@ -93,7 +93,7 @@ bpf_map_create(
  * @param[in] key Pointer to key to look up.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -124,7 +124,7 @@ bpf_map_get_fd_by_id(__u32 id);
  * @param[out] next_id Pointer to where to write the next ID.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -ENOENT No more IDs found.
  */
@@ -142,7 +142,7 @@ bpf_map_get_next_id(__u32 start_id, __u32* next_id);
  * next key.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -161,7 +161,7 @@ bpf_map_get_next_key(int fd, const void* key, void* next_key);
  * value.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -180,7 +180,7 @@ bpf_map_lookup_elem(int fd, const void* key, void* value);
  * @param[in] flags Flags (currently 0).
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -349,7 +349,7 @@ bpf_obj_get(const char* pathname);
  * write into the info.  On output, contains the actual number of bytes written.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  * @retval -EFAULT A pointer passed in the input info was invalid.
  */
 int
@@ -410,7 +410,7 @@ bpf_prog_get_fd_by_id(__u32 id);
  * @param[out] next_id Pointer to where to write the next ID.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -ENOENT No more IDs found.
  */

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -13,10 +13,10 @@
  *
  * @param[in] link_fd File descriptor of link to detach.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBADF The file descriptor was not found.
+ * @retval -EBADF The file descriptor was not found.
  *
  * @sa bpf_link__destroy
  * @sa bpf_link__disconnect
@@ -34,7 +34,7 @@ bpf_link_detach(int link_fd);
  * The caller should call _close() on the fd to close this when done.
  * A negative value indicates an error occurred and errno was set.
  *
- * @exception ENOENT No link with the specified ID was found.
+ * @retval -ENOENT No link with the specified ID was found.
  */
 int
 bpf_link_get_fd_by_id(__u32 id);
@@ -45,10 +45,10 @@ bpf_link_get_fd_by_id(__u32 id);
  * @param[in] start_id ID to look for an ID after. The start_id need not exist.
  * @param[out] next_id Pointer to where to write the next ID.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception ENOENT No more IDs found.
+ * @retval -ENOENT No more IDs found.
  */
 int
 bpf_link_get_next_id(__u32 start_id, __u32* next_id);
@@ -74,8 +74,8 @@ bpf_link_get_next_id(__u32 start_id, __u32* next_id);
  * The caller should call _close() on the fd to close this when done.
  * A negative value indicates an error occurred and errno was set.
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  */
 int
 bpf_map_create(
@@ -92,12 +92,12 @@ bpf_map_create(
  * @param[in] fd File descriptor of map to update.
  * @param[in] key Pointer to key to look up.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception EBADF The file descriptor was not found.
- * @exception ENOMEM Out of memory.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -EBADF The file descriptor was not found.
+ * @retval -ENOMEM Out of memory.
  */
 int
 bpf_map_delete_elem(int fd, const void* key);
@@ -112,7 +112,7 @@ bpf_map_delete_elem(int fd, const void* key);
  * The caller should call _close() on the fd to close this when done.
  * A negative value indicates an error occurred and errno was set.
  *
- * @exception ENOENT No map with the specified ID was found.
+ * @retval -ENOENT No map with the specified ID was found.
  */
 int
 bpf_map_get_fd_by_id(__u32 id);
@@ -123,10 +123,10 @@ bpf_map_get_fd_by_id(__u32 id);
  * @param[in] start_id ID to look for an ID after. The start_id need not exist.
  * @param[out] next_id Pointer to where to write the next ID.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception ENOENT No more IDs found.
+ * @retval -ENOENT No more IDs found.
  */
 int
 bpf_map_get_next_id(__u32 start_id, __u32* next_id);
@@ -141,12 +141,12 @@ bpf_map_get_next_id(__u32 start_id, __u32* next_id);
  * @param[out] next_key Pointer to memory in which to write the
  * next key.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception EBADF The file descriptor was not found.
- * @exception ENOMEM Out of memory.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -EBADF The file descriptor was not found.
+ * @retval -ENOMEM Out of memory.
  */
 int
 bpf_map_get_next_key(int fd, const void* key, void* next_key);
@@ -160,12 +160,12 @@ bpf_map_get_next_key(int fd, const void* key, void* next_key);
  * @param[out] value Pointer to memory in which to write the
  * value.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception EBADF The file descriptor was not found.
- * @exception ENOMEM Out of memory.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -EBADF The file descriptor was not found.
+ * @retval -ENOMEM Out of memory.
  */
 int
 bpf_map_lookup_elem(int fd, const void* key, void* value);
@@ -179,9 +179,12 @@ bpf_map_lookup_elem(int fd, const void* key, void* value);
  * @param[in] value Pointer to value.
  * @param[in] flags Flags (currently 0).
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception EBADF The file descriptor was not found.
- * @exception ENOMEM Out of memory.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
+ *
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -EBADF The file descriptor was not found.
+ * @retval -ENOMEM Out of memory.
  */
 int
 bpf_map_update_elem(int fd, const void* key, const void* value, __u64 flags);
@@ -345,9 +348,9 @@ bpf_obj_get(const char* pathname);
  * @param[in, out] info_len On input, contains the maximum number of bytes to
  * write into the info.  On output, contains the actual number of bytes written.
  *
- * @retval 0 The operation was successful.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  * @retval -EFAULT A pointer passed in the input info was invalid.
- * @retval <0 An error occured, and errno was set.
  */
 int
 bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len);
@@ -360,7 +363,7 @@ bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len);
  * @param[in] pathname Path name to pin the object to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  */
 int
 bpf_obj_pin(int fd, const char* pathname);
@@ -380,7 +383,7 @@ bpf_obj_pin(int fd, const char* pathname);
  * @param[in] opts Optional set of options affecting the bind operation.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  */
 int
 bpf_prog_bind_map(int prog_fd, int map_fd, const struct bpf_prog_bind_opts* opts);
@@ -395,7 +398,7 @@ bpf_prog_bind_map(int prog_fd, int map_fd, const struct bpf_prog_bind_opts* opts
  * The caller should call _close() on the fd to close this when done.
  * A negative value indicates an error occurred and errno was set.
  *
- * @exception ENOENT No program with the specified ID was found.
+ * @retval -ENOENT No program with the specified ID was found.
  */
 int
 bpf_prog_get_fd_by_id(__u32 id);
@@ -406,10 +409,10 @@ bpf_prog_get_fd_by_id(__u32 id);
  * @param[in] start_id ID to look for an ID after. The start_id need not exist.
  * @param[out] next_id Pointer to where to write the next ID.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception ENOENT No more IDs found.
+ * @retval -ENOENT No more IDs found.
  */
 int
 bpf_prog_get_next_id(__u32 start_id, __u32* next_id);
@@ -428,9 +431,9 @@ bpf_prog_get_next_id(__u32 start_id, __u32* next_id);
  * The caller should call _close() on the fd to close this when done.
  * A negative value indicates an error occurred and errno was set.
  *
- * @exception EACCES The program failed verification.
- * @exception EINVAL One or more parameters are incorrect.
- * @exception ENOMEM Out of memory.
+ * @retval -EACCES The program failed verification.
+ * @retval -EINVAL One or more parameters are incorrect.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_load_program
  * @sa bpf_load_program_xattr

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -13,8 +13,8 @@
  *
  * @param[in] link_fd File descriptor of link to detach.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBADF The file descriptor was not found.
  *
@@ -45,8 +45,8 @@ bpf_link_get_fd_by_id(__u32 id);
  * @param[in] start_id ID to look for an ID after. The start_id need not exist.
  * @param[out] next_id Pointer to where to write the next ID.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -ENOENT No more IDs found.
  */
@@ -92,8 +92,8 @@ bpf_map_create(
  * @param[in] fd File descriptor of map to update.
  * @param[in] key Pointer to key to look up.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -123,8 +123,8 @@ bpf_map_get_fd_by_id(__u32 id);
  * @param[in] start_id ID to look for an ID after. The start_id need not exist.
  * @param[out] next_id Pointer to where to write the next ID.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -ENOENT No more IDs found.
  */
@@ -141,8 +141,8 @@ bpf_map_get_next_id(__u32 start_id, __u32* next_id);
  * @param[out] next_key Pointer to memory in which to write the
  * next key.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -160,8 +160,8 @@ bpf_map_get_next_key(int fd, const void* key, void* next_key);
  * @param[out] value Pointer to memory in which to write the
  * value.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -179,8 +179,8 @@ bpf_map_lookup_elem(int fd, const void* key, void* value);
  * @param[in] value Pointer to value.
  * @param[in] flags Flags (currently 0).
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -EBADF The file descriptor was not found.
@@ -348,8 +348,8 @@ bpf_obj_get(const char* pathname);
  * @param[in, out] info_len On input, contains the maximum number of bytes to
  * write into the info.  On output, contains the actual number of bytes written.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  * @retval -EFAULT A pointer passed in the input info was invalid.
  */
 int
@@ -409,8 +409,8 @@ bpf_prog_get_fd_by_id(__u32 id);
  * @param[in] start_id ID to look for an ID after. The start_id need not exist.
  * @param[out] next_id Pointer to where to write the next ID.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -ENOENT No more IDs found.
  */

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -49,8 +49,8 @@ bpf_link__fd(const struct bpf_link* link);
  * @param[in] link Link to pin.
  * @param[in] path Path to pin the link to.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBUSY A pin path was previously specified.
  * @retval -EEXIST Something is already pinned to the specified path.
@@ -67,8 +67,8 @@ bpf_link__pin(struct bpf_link* link, const char* path);
  *
  * @param[in] link Link to unpin.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOENT The link was not pinned.
@@ -159,8 +159,8 @@ bpf_map__name(const struct bpf_map* map);
  * @param[in] map Map to pin.
  * @param[in] path Path to pin the map to.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBUSY A pin path was previously specified.
  * @retval -EEXIST Something is already pinned to the specified path.
@@ -189,8 +189,8 @@ bpf_map__type(const struct bpf_map* map);
  * @param[in] map Map to unpin.
  * @param[in] path Path from which to unpin the map.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOENT The map was not pinned.
@@ -283,8 +283,8 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
  *
  * @param[in] obj Object from which to load programs.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOMEM Out of memory.
@@ -361,8 +361,8 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
  * @param[in] object Object to pin.
  * @param[in] path Path to pin the object to.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBUSY Something is already pinned to the specified path.
  * @retval -EINVAL An invalid argument was provided.
@@ -382,8 +382,8 @@ bpf_object__pin(struct bpf_object* object, const char* path);
  * @param[in] obj Object to pin maps of.
  * @param[in] path Path to pin the maps to.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBUSY Something is already pinned to the specified path.
  * @retval -EINVAL An invalid argument was provided.
@@ -402,8 +402,8 @@ bpf_object__pin_maps(struct bpf_object* obj, const char* path);
  * @param[in] obj Object to pin programs of.
  * @param[in] path Path to pin the programs to.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBUSY Something is already pinned to the specified path.
  * @retval -EINVAL An invalid argument was provided.
@@ -448,8 +448,8 @@ bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* prog)
  * @param[in] obj Object to unpin maps of.
  * @param[in] path Path from which to unpin the maps.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  *
@@ -466,8 +466,8 @@ bpf_object__unpin_maps(struct bpf_object* obj, const char* path);
  * @param[in] obj Object to unpin programs of.
  * @param[in] path Path from which to unpin the programs.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  *
@@ -535,8 +535,8 @@ bpf_program__autoload(const struct bpf_program* prog);
  *
  * @param[in] prog The program to update.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @sa bpf_object__load
  * @sa bpf_object__load_xattr
@@ -553,8 +553,8 @@ bpf_program__set_autoload(struct bpf_program* prog, bool autoload);
  * @param[in] type Attach type.
  * @param[in] flags Flags (currently 0).
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  */
 int
@@ -566,8 +566,8 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
  * @param[in] attachable_fd File descriptor corresponding to the attach point.
  * @param[in] type Attach type.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  */
 int
@@ -580,8 +580,8 @@ bpf_prog_detach(int attachable_fd, enum bpf_attach_type type);
  * @param[in] attachable_fd File descriptor corresponding to the attach point.
  * @param[in] type Attach type.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  */
 int
@@ -658,8 +658,8 @@ bpf_program__name(const struct bpf_program* prog);
  * @param[in] prog Program to pin.
  * @param[in] path Path to pin the program to.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EBUSY A pin path was previously specified.
  * @retval -EEXIST Something is already pinned to the specified path.
@@ -741,8 +741,8 @@ bpf_program__unload(struct bpf_program* prog);
  * @param[in] prog Program to unpin.
  * @param[in] path Path from which to unpin the program.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOENT The program was not pinned.
@@ -762,8 +762,8 @@ bpf_program__unpin(struct bpf_program* prog, const char* path);
  *                  the specified interface index.
  * @param[in] opts Options (currently unused).
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @sa bpf_program__attach_xdp
  * @sa bpf_xdp_detach
@@ -780,8 +780,8 @@ bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attac
  *                  the specified interface index.
  * @param[in] opts Options (currently unused).
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @sa bpf_link_detach
  * @sa bpf_program__attach_xdp
@@ -797,8 +797,8 @@ bpf_xdp_detach(int ifindex, __u32 flags, const struct bpf_xdp_attach_opts* opts)
  * @param[in] flags Flags (currently 0).
  * @param[out] prog_id The ID of the program attached.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  * @sa bpf_xdp_attach
  */
@@ -812,8 +812,8 @@ bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id);
  * @param[in] name The textual representation of an attach type.
  * @param[out] attach_type Returns the attach type.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  */
 int
 libbpf_attach_type_by_name(const char* name, enum bpf_attach_type* attach_type);
@@ -849,8 +849,8 @@ libbpf_bpf_prog_type_str(enum bpf_prog_type t);
  * @param[out] prog_type Program type.
  * @param[out] expected_attach_type Expected attach type.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  */
 int
 libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type);
@@ -879,8 +879,8 @@ libbpf_get_error(const void* ptr);
  * @param[out] buf Pointer to buffer to write message into.
  * @param[in] size Size of output buffer.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  */
 int
 libbpf_strerror(int err, char* buf, size_t size);
@@ -936,8 +936,8 @@ bpf_program__flags(const struct bpf_program* prog);
  * @param[in] prog A pointer to the BPF program.
  * @param[in] flags The flags to set.
  *
- * @return 0, on success; negative error code, otherwise (errno is also set to
- * the error code)
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
  *
  */
 int

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -49,13 +49,13 @@ bpf_link__fd(const struct bpf_link* link);
  * @param[in] link Link to pin.
  * @param[in] path Path to pin the link to.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBUSY A pin path was previously specified.
- * @exception EEXIST Something is already pinned to the specified path.
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EBUSY A pin path was previously specified.
+ * @retval -EEXIST Something is already pinned to the specified path.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_link__unpin
  */
@@ -67,11 +67,11 @@ bpf_link__pin(struct bpf_link* link, const char* path);
  *
  * @param[in] link Link to unpin.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOENT The link was not pinned.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOENT The link was not pinned.
  *
  * @sa bpf_link__pin
  */
@@ -159,13 +159,13 @@ bpf_map__name(const struct bpf_map* map);
  * @param[in] map Map to pin.
  * @param[in] path Path to pin the map to.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBUSY A pin path was previously specified.
- * @exception EEXIST Something is already pinned to the specified path.
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EBUSY A pin path was previously specified.
+ * @retval -EEXIST Something is already pinned to the specified path.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_map_unpin
  * @sa bpf_object__pin_maps
@@ -189,11 +189,11 @@ bpf_map__type(const struct bpf_map* map);
  * @param[in] map Map to unpin.
  * @param[in] path Path from which to unpin the map.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOENT The map was not pinned.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOENT The map was not pinned.
  *
  * @sa bpf_map_pin
  * @sa bpf_object__unpin_maps
@@ -248,7 +248,7 @@ bpf_object__close(struct bpf_object* object);
  *
  * @returns The map found, or NULL if none.
  *
- * @exception ENOENT The map was not found.
+ * @retval -ENOENT The map was not found.
  */
 struct bpf_map*
 bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name);
@@ -285,11 +285,11 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
  *
  * @param[in] obj Object from which to load programs.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_object__load_xattr
  * @sa bpf_object__open
@@ -362,12 +362,12 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
  * @param[in] object Object to pin.
  * @param[in] path Path to pin the object to.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBUSY Something is already pinned to the specified path.
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EBUSY Something is already pinned to the specified path.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_object__pin_maps
  * @sa bpf_object__pin_programs
@@ -383,12 +383,12 @@ bpf_object__pin(struct bpf_object* object, const char* path);
  * @param[in] obj Object to pin maps of.
  * @param[in] path Path to pin the maps to.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBUSY Something is already pinned to the specified path.
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EBUSY Something is already pinned to the specified path.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_map__pin
  * @sa bpf_object__pin
@@ -403,12 +403,12 @@ bpf_object__pin_maps(struct bpf_object* obj, const char* path);
  * @param[in] obj Object to pin programs of.
  * @param[in] path Path to pin the programs to.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBUSY Something is already pinned to the specified path.
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EBUSY Something is already pinned to the specified path.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_program__pin
  * @sa bpf_object__pin
@@ -449,10 +449,10 @@ bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* prog)
  * @param[in] obj Object to unpin maps of.
  * @param[in] path Path from which to unpin the maps.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
+ * @retval -EINVAL An invalid argument was provided.
  *
  * @sa bpf_map__unpin
  * @sa bpf_object__pin_maps
@@ -467,10 +467,10 @@ bpf_object__unpin_maps(struct bpf_object* obj, const char* path);
  * @param[in] obj Object to unpin programs of.
  * @param[in] path Path from which to unpin the programs.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
+ * @retval -EINVAL An invalid argument was provided.
  *
  * @sa bpf_program__unpin
  * @sa bpf_object__pin_programs
@@ -535,8 +535,8 @@ bpf_program__autoload(const struct bpf_program* prog);
  *
  * @param[in] prog The program to update.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  * @sa bpf_object__load
  * @sa bpf_object__load_xattr
@@ -553,8 +553,8 @@ bpf_program__set_autoload(struct bpf_program* prog, bool autoload);
  * @param[in] type Attach type.
  * @param[in] flags Flags (currently 0).
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  */
 int
@@ -566,8 +566,8 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
  * @param[in] attachable_fd File descriptor corresponding to the attach point.
  * @param[in] type Attach type.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  */
 int
@@ -580,8 +580,8 @@ bpf_prog_detach(int attachable_fd, enum bpf_attach_type type);
  * @param[in] attachable_fd File descriptor corresponding to the attach point.
  * @param[in] type Attach type.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  */
 int
@@ -656,13 +656,13 @@ bpf_program__name(const struct bpf_program* prog);
  * @param[in] prog Program to pin.
  * @param[in] path Path to pin the program to.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EBUSY A pin path was previously specified.
- * @exception EEXIST Something is already pinned to the specified path.
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOMEM Out of memory.
+ * @retval -EBUSY A pin path was previously specified.
+ * @retval -EEXIST Something is already pinned to the specified path.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOMEM Out of memory.
  *
  * @sa bpf_object__pin
  * @sa bpf_object__pin_programs
@@ -690,8 +690,8 @@ bpf_program__section_name(const struct bpf_program* prog);
  * @sa bpf_program__attach
  * @sa bpf_program__get_expected_attach_type
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  */
 int
 bpf_program__set_expected_attach_type(struct bpf_program* prog, enum bpf_attach_type type);
@@ -705,8 +705,8 @@ bpf_program__set_expected_attach_type(struct bpf_program* prog, enum bpf_attach_
  * @sa bpf_program__set_expected_attach_type
  * @sa bpf_program__type
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  */
 int
 bpf_program__set_type(struct bpf_program* prog, enum bpf_prog_type type);
@@ -740,11 +740,11 @@ bpf_program__unload(struct bpf_program* prog);
  * @param[in] prog Program to unpin.
  * @param[in] path Path from which to unpin the program.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
- * @exception EINVAL An invalid argument was provided.
- * @exception ENOENT The program was not pinned.
+ * @retval -EINVAL An invalid argument was provided.
+ * @retval -ENOENT The program was not pinned.
  *
  * @sa bpf_object__unpin_programs
  * @sa bpf_program__pin
@@ -761,8 +761,8 @@ bpf_program__unpin(struct bpf_program* prog, const char* path);
  *                  the specified interface index.
  * @param[in] opts Options (currently unused).
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  * @sa bpf_program__attach_xdp
  * @sa bpf_xdp_detach
@@ -779,8 +779,8 @@ bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attac
  *                  the specified interface index.
  * @param[in] opts Options (currently unused).
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  * @sa bpf_link_detach
  * @sa bpf_program__attach_xdp
@@ -796,8 +796,8 @@ bpf_xdp_detach(int ifindex, __u32 flags, const struct bpf_xdp_attach_opts* opts)
  * @param[in] flags Flags (currently 0).
  * @param[out] prog_id The ID of the program attached.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  * @sa bpf_xdp_attach
  */
@@ -811,8 +811,8 @@ bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id);
  * @param[in] name The textual representation of an attach type.
  * @param[out] attach_type Returns the attach type.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  */
 int
 libbpf_attach_type_by_name(const char* name, enum bpf_attach_type* attach_type);
@@ -848,8 +848,8 @@ libbpf_bpf_prog_type_str(enum bpf_prog_type t);
  * @param[out] prog_type Program type.
  * @param[out] expected_attach_type Expected attach type.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  */
 int
 libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type);
@@ -878,8 +878,8 @@ libbpf_get_error(const void* ptr);
  * @param[out] buf Pointer to buffer to write message into.
  * @param[in] size Size of output buffer.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  */
 int
 libbpf_strerror(int err, char* buf, size_t size);
@@ -935,8 +935,8 @@ bpf_program__flags(const struct bpf_program* prog);
  * @param[in] prog A pointer to the BPF program.
  * @param[in] flags The flags to set.
  *
- * @retval 0 The operation was successful.
- * @retval <0 An error occurred, and errno was set.
+ * @return 0, on success; negative error code, otherwise (errno is also set to
+ * the error code)
  *
  */
 int

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -50,7 +50,7 @@ bpf_link__fd(const struct bpf_link* link);
  * @param[in] path Path to pin the link to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBUSY A pin path was previously specified.
  * @retval -EEXIST Something is already pinned to the specified path.
@@ -68,7 +68,7 @@ bpf_link__pin(struct bpf_link* link, const char* path);
  * @param[in] link Link to unpin.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOENT The link was not pinned.
@@ -160,7 +160,7 @@ bpf_map__name(const struct bpf_map* map);
  * @param[in] path Path to pin the map to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBUSY A pin path was previously specified.
  * @retval -EEXIST Something is already pinned to the specified path.
@@ -190,7 +190,7 @@ bpf_map__type(const struct bpf_map* map);
  * @param[in] path Path from which to unpin the map.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOENT The map was not pinned.
@@ -284,7 +284,7 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
  * @param[in] obj Object from which to load programs.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOMEM Out of memory.
@@ -362,7 +362,7 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
  * @param[in] path Path to pin the object to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBUSY Something is already pinned to the specified path.
  * @retval -EINVAL An invalid argument was provided.
@@ -383,7 +383,7 @@ bpf_object__pin(struct bpf_object* object, const char* path);
  * @param[in] path Path to pin the maps to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBUSY Something is already pinned to the specified path.
  * @retval -EINVAL An invalid argument was provided.
@@ -403,7 +403,7 @@ bpf_object__pin_maps(struct bpf_object* obj, const char* path);
  * @param[in] path Path to pin the programs to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBUSY Something is already pinned to the specified path.
  * @retval -EINVAL An invalid argument was provided.
@@ -449,7 +449,7 @@ bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* prog)
  * @param[in] path Path from which to unpin the maps.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  *
@@ -467,7 +467,7 @@ bpf_object__unpin_maps(struct bpf_object* obj, const char* path);
  * @param[in] path Path from which to unpin the programs.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  *
@@ -536,7 +536,7 @@ bpf_program__autoload(const struct bpf_program* prog);
  * @param[in] prog The program to update.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @sa bpf_object__load
  * @sa bpf_object__load_xattr
@@ -554,7 +554,7 @@ bpf_program__set_autoload(struct bpf_program* prog, bool autoload);
  * @param[in] flags Flags (currently 0).
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  */
 int
@@ -567,7 +567,7 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
  * @param[in] type Attach type.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  */
 int
@@ -581,7 +581,7 @@ bpf_prog_detach(int attachable_fd, enum bpf_attach_type type);
  * @param[in] type Attach type.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  */
 int
@@ -659,7 +659,7 @@ bpf_program__name(const struct bpf_program* prog);
  * @param[in] path Path to pin the program to.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EBUSY A pin path was previously specified.
  * @retval -EEXIST Something is already pinned to the specified path.
@@ -742,7 +742,7 @@ bpf_program__unload(struct bpf_program* prog);
  * @param[in] path Path from which to unpin the program.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @retval -EINVAL An invalid argument was provided.
  * @retval -ENOENT The program was not pinned.
@@ -763,7 +763,7 @@ bpf_program__unpin(struct bpf_program* prog, const char* path);
  * @param[in] opts Options (currently unused).
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @sa bpf_program__attach_xdp
  * @sa bpf_xdp_detach
@@ -781,7 +781,7 @@ bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attac
  * @param[in] opts Options (currently unused).
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @sa bpf_link_detach
  * @sa bpf_program__attach_xdp
@@ -798,7 +798,7 @@ bpf_xdp_detach(int ifindex, __u32 flags, const struct bpf_xdp_attach_opts* opts)
  * @param[out] prog_id The ID of the program attached.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @sa bpf_xdp_attach
  */
@@ -813,7 +813,7 @@ bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id);
  * @param[out] attach_type Returns the attach type.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  */
 int
 libbpf_attach_type_by_name(const char* name, enum bpf_attach_type* attach_type);
@@ -850,7 +850,7 @@ libbpf_bpf_prog_type_str(enum bpf_prog_type t);
  * @param[out] expected_attach_type Expected attach type.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  */
 int
 libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type);
@@ -880,7 +880,7 @@ libbpf_get_error(const void* ptr);
  * @param[in] size Size of output buffer.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  */
 int
 libbpf_strerror(int err, char* buf, size_t size);
@@ -937,7 +937,7 @@ bpf_program__flags(const struct bpf_program* prog);
  * @param[in] flags The flags to set.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  */
 int

--- a/include/bpf/libbpf_legacy.h
+++ b/include/bpf/libbpf_legacy.h
@@ -16,7 +16,7 @@
  *                  the specified interface index.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @deprecated Use bpf_xdp_attach() instead.
  *
@@ -84,7 +84,7 @@ struct bpf_object_load_attr
  * @param[in] attr Structure with load attributes.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @deprecated Use bpf_object__load() instead.
  *
@@ -120,7 +120,7 @@ bpf_object__next(struct bpf_object* prev);
  * @param[in] obj Object with programs to be unloaded.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @deprecated Use bpf_object__close() instead.
  *
@@ -151,7 +151,7 @@ bpf_object__unload(struct bpf_object* obj);
  * bpf_object__close() on the object returned.
  *
  * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
+ * @retval <0 An error occurred, and errno was set.
  *
  * @deprecated Use bpf_object__open() and bpf_object__load() instead.
  *

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -698,7 +698,7 @@ ebpf_api_elf_enumerate_programs(
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
  * @retval EBPF_NO_MEMORY Out of memory.
  * @retval EBPF_VERIFICATION_FAILED The program failed verification.
- * @retval EBPF_FAILED Some other error occured.
+ * @retval EBPF_FAILED Some other error occurred.
  */
 _Must_inspect_result_ ebpf_result_t
 ebpf_program_load_bytes(

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1404,7 +1404,7 @@ _ebpf_test_tail_call(_In_z_ const char* filename, uint32_t expected_result)
     REQUIRE(error == 0);
 
     // Is bpf_tail_call expected to work?
-    // Verify stack unwind occured.
+    // Verify stack unwind occurred.
     if ((int)expected_result >= 0) {
         REQUIRE(value == 0);
     } else {


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
Closes #3684. Removes `@exception` keyword from documentation. Fixes documentation of return values to be negative. Changed wording about return status value to be consistent with Linux libbpf documentation.

Fixed spelling mistakes in a few files.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
N/A.

## Documentation

_Is there any documentation impact for this change?_
Documentation only change.

## Installation

_Is there any installer impact for this change?_
N/A.