### PR TITLE
Print compiler log if compilation fails

### DIFF
--- a/tests/bpf2c_tests/raw_bpf.cpp
+++ b/tests/bpf2c_tests/raw_bpf.cpp
@@ -221,7 +221,17 @@ run_bpf_code_generator_test(const std::string& data_file)
                                   std::string(" -I.." SEPARATOR ".." SEPARATOR "include ") + std::string("/Zi ") +
                                   std::string(prefix) + std::string(".c ") + std::string(" bpf_test.cpp >") +
                                   std::string(prefix) + std::string(".log 2>&1");
-    REQUIRE(system(compile_command.c_str()) == 0);
+    auto compile_result = system(compile_command.c_str());
+    if (compile_result != 0) {
+        std::ifstream log_file(std::string(prefix) + std::string(".log"));
+        std::string line;
+        std::ostringstream error;
+        while (std::getline(log_file, line)) {
+            error << line << std::endl;
+        }
+        throw std::runtime_error("Failed to compile: " + error.str());
+    }
+    REQUIRE(compile_result == 0);
     std::string test_command = std::string("." SEPARATOR) + std::string(prefix) + std::string(" ") +
                                std::string(result) + std::string(" \"") + std::string(mem) + std::string("\"");
     REQUIRE(system(test_command.c_str()) == 0);


### PR DESCRIPTION
## Description

Improve logging in bpf2c tests. If compilation fails, print the log files.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
