### PR TITLE
Make context header support mandatory

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -101,17 +101,17 @@ structure from provided data and context buffers.
 context structure and populates the returned data and context buffers.
 * `required_irql`: IRQL at which the eBPF program is invoked by bpf_prog_test_run_opts.
 * `capabilities`: 32-bit integer describing the optional capabilities / features supported by the extension.
-   * `supports_context_header`: Flag indicating extension supports adding a context header at the start of each context passed to the eBPF program.
+   * `supports_context_header`: Required flag indicating extension supports adding a context header at the start of each context passed to the eBPF program. This flag must be set.
 
 **Capabilities**
 
 `supports_context_header`:
 
 Flag indicating that extension supports adding a context header at the start of each context passed to the eBPF program.
-An extension can choose to opt in to support context header at the start of each program context structure that is
-passed to the eBPF program. To support this feature, the extension can use the macro `EBPF_CONTEXT_HEADER` to include
-the context header at the start of the program context structure. Even when the context header is added, the pointer
-passed to the eBPF program is after the context header.
+This is required for all extensions to support so the core can store runtime state needed by helpers.
+To support this feature, the extension can use the macro `EBPF_CONTEXT_HEADER` to include
+the context header at the start of the program context structure. The context pointer passed to the
+eBPF program points immediately after the context header.
 
 *Example*
 
@@ -135,8 +135,9 @@ typedef struct _sample_program_context_header
     sample_program_context_t context;
 } sample_program_context_header_t;
 ```
-The extension passes a pointer to `context` inside `sample_program_context_header_t`, and not a pointer to
-`sample_program_context_header_t`, when invoking the eBPF program.
+The extension passes a pointer to `context` inside `sample_program_context_header_t` and not a pointer to
+`sample_program_context_header_t` when invoking the eBPF program. The header is not accessible
+by the program.
 
 #### `ebpf_program_info_t` Struct
 The various fields of this structure should be set as follows:

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -81,7 +81,7 @@ typedef union _program_data_capabilities
     uint32_t value;
     struct
     {
-        bool supports_context_header : 1; // Program supports context header.
+        bool supports_context_header : 1; // Program supports context header (required).
     };
 } program_data_capabilities_t;
 

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2469,13 +2469,8 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     if (supports_context_header) {
         ebpf_program_set_runtime_state(&execution_context_state, program_context);
     } else {
-        ebpf_get_execution_context_state(&execution_context_state);
-        return_value = ebpf_state_store(
-            ebpf_program_get_state_index(), (uintptr_t)&execution_context_state, &execution_context_state);
-        if (return_value != EBPF_SUCCESS) {
-            goto Done;
-        }
-        state_stored = true;
+        result = EBPF_INVALID_ARGUMENT;
+        goto Done;
     }
 
     uint64_t start_time = cxplat_query_time_since_boot_precise(false);

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -2348,7 +2348,7 @@ TEST_CASE("INVALID_PROGRAM_DATA", "[execution_context][negative]")
         EBPF_HELPER_FUNCTION_ADDRESSES_HEADER, EBPF_COUNT_OF(helper_functions), (uint64_t*)helper_functions};
 
     ebpf_program_data_t _test_program_data = {
-        EBPF_PROGRAM_DATA_HEADER, &_test_program_info, &helper_function_addresses};
+        EBPF_PROGRAM_DATA_HEADER, &_test_program_info, &helper_function_addresses, nullptr, nullptr, nullptr, 0, true};
 
     auto provider_attach_client_callback =
         [](HANDLE, void*, const NPI_REGISTRATION_INSTANCE*, void*, const void*, void**, const void**) -> NTSTATUS {

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -164,7 +164,8 @@ typedef struct _net_ebpf_extension_wfp_filter_context
     if ((filter_context)->wfp_engine_handle != NULL) {        \
         FwpmEngineClose((filter_context)->wfp_engine_handle); \
     }                                                         \
-    ExFreePool((filter_context));
+    ExFreePool(((uint8_t*)filter_context - 64));
+// Note: We need to subtract the header from the context to get the pointer to free.
 
 #define REFERENCE_FILTER_CONTEXT(filter_context)                  \
     if ((filter_context) != NULL) {                               \

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -437,7 +437,7 @@ _ebpf_bind_context_create(
 {
     NET_EBPF_EXT_LOG_ENTRY();
     ebpf_result_t result;
-    bind_context_header_t* context_header = NULL;
+    bind_context_header_t* bind_context_header = NULL;
     bind_md_t* bind_context = NULL;
 
     *context = NULL;
@@ -449,12 +449,12 @@ _ebpf_bind_context_create(
         goto Exit;
     }
 
-    context_header = (bind_context_header_t*)ExAllocatePoolUninitialized(
+    bind_context_header = (bind_context_header_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(bind_context_header_t), NET_EBPF_EXTENSION_POOL_TAG);
     NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
-        NET_EBPF_EXT_TRACELOG_KEYWORD_BIND, context_header, "bind_context", result);
+        NET_EBPF_EXT_TRACELOG_KEYWORD_BIND, bind_context_header, "bind_context_header", result);
 
-    bind_context = &context_header->context;
+    bind_context = &bind_context_header->context;
     // Copy the context from the caller.
     memcpy(bind_context, context_in, sizeof(bind_md_t));
 
@@ -468,13 +468,13 @@ _ebpf_bind_context_create(
     }
 
     *context = bind_context;
-    context_header = NULL;
+    bind_context_header = NULL;
     result = EBPF_SUCCESS;
 
 Exit:
-    if (context_header) {
-        ExFreePool(context_header);
-        context_header = NULL;
+    if (bind_context_header) {
+        ExFreePool(bind_context_header);
+        bind_context_header = NULL;
     }
     NET_EBPF_EXT_RETURN_RESULT(result);
 }
@@ -491,13 +491,13 @@ _ebpf_bind_context_destroy(
 
     bind_md_t* bind_context = (bind_md_t*)context;
     bind_md_t* bind_context_out = (bind_md_t*)context_out;
-    bind_context_header_t* header = NULL;
+    bind_context_header_t* bind_context_header = NULL;
 
     if (!bind_context) {
         goto Exit;
     }
 
-    header = CONTAINING_RECORD(bind_context, bind_context_header_t, context);
+    bind_context_header = CONTAINING_RECORD(bind_context, bind_context_header_t, context);
 
     if (context_out != NULL && *context_size_out >= sizeof(bind_md_t)) {
         // Copy the context to the caller.
@@ -519,7 +519,7 @@ _ebpf_bind_context_destroy(
         *data_size_out = 0;
     }
 
-    ExFreePool(header);
+    ExFreePool(bind_context_header);
 
 Exit:
     NET_EBPF_EXT_LOG_EXIT();

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -94,6 +94,7 @@ static ebpf_program_data_t _ebpf_xdp_test_program_data = {
     .context_create = _ebpf_xdp_context_create,
     .context_destroy = _ebpf_xdp_context_delete,
     .required_irql = DISPATCH_LEVEL,
+    .capabilities = {.supports_context_header = true},
 };
 
 // Set the program type as the provider module id.
@@ -334,6 +335,12 @@ typedef struct _net_ebpf_xdp_md
     NET_BUFFER_LIST* original_nbl;
     NET_BUFFER_LIST* cloned_nbl;
 } net_ebpf_xdp_md_t;
+
+typedef struct _net_ebpf_xdp_md_header
+{
+    EBPF_CONTEXT_HEADER;
+    net_ebpf_xdp_md_t context;
+} net_ebpf_xdp_md_header_t;
 
 //
 // NBL Clone Functions.
@@ -656,7 +663,9 @@ net_ebpf_ext_layer_2_classify(
     NET_BUFFER* net_buffer = NULL;
     uint8_t* packet_buffer;
     uint32_t result = 0;
-    net_ebpf_xdp_md_t net_xdp_ctx = {0};
+    net_ebpf_xdp_md_header_t net_xdp_ctx_header = {0};
+    net_ebpf_xdp_md_t* net_xdp_ctx = &net_xdp_ctx_header.context;
+    xdp_md_t* xdp_ctx = &net_xdp_ctx->base;
     net_ebpf_extension_xdp_wfp_filter_context_t* filter_context = NULL;
     uint32_t client_if_index;
     ebpf_result_t program_result;
@@ -700,17 +709,17 @@ net_ebpf_ext_layer_2_classify(
         goto Exit;
     }
 
-    net_xdp_ctx.base.ingress_ifindex =
+    xdp_ctx->ingress_ifindex =
         incoming_fixed_values->incomingValue[FWPS_FIELD_INBOUND_MAC_FRAME_NATIVE_INTERFACE_INDEX].value.uint32;
 
     client_if_index = filter_context->if_index;
-    ASSERT((client_if_index == 0) || (client_if_index == net_xdp_ctx.base.ingress_ifindex));
-    if (client_if_index != 0 && client_if_index != net_xdp_ctx.base.ingress_ifindex) {
+    ASSERT((client_if_index == 0) || (client_if_index == xdp_ctx->ingress_ifindex));
+    if (client_if_index != 0 && client_if_index != xdp_ctx->ingress_ifindex) {
         // The client is not interested in this ingress ifindex.
         goto Exit;
     }
 
-    net_xdp_ctx.original_nbl = nbl;
+    net_xdp_ctx->original_nbl = nbl;
 
     net_buffer = NET_BUFFER_LIST_FIRST_NB(nbl);
     if (net_buffer == NULL) {
@@ -723,7 +732,7 @@ net_ebpf_ext_layer_2_classify(
     if (!packet_buffer) {
         // Data in net_buffer not contiguous.
         // Allocate a cloned NBL with contiguous data.
-        status = _net_ebpf_ext_allocate_cloned_nbl(&net_xdp_ctx, 0);
+        status = _net_ebpf_ext_allocate_cloned_nbl(net_xdp_ctx, 0);
         if (!NT_SUCCESS(status)) {
             NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(
                 NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
@@ -733,11 +742,11 @@ net_ebpf_ext_layer_2_classify(
             goto Exit;
         }
     } else {
-        net_xdp_ctx.base.data = packet_buffer;
-        net_xdp_ctx.base.data_end = packet_buffer + net_buffer->DataLength;
+        xdp_ctx->data = packet_buffer;
+        xdp_ctx->data_end = packet_buffer + net_buffer->DataLength;
     }
 
-    program_result = net_ebpf_extension_hook_invoke_programs(&net_xdp_ctx, &filter_context->base, &result);
+    program_result = net_ebpf_extension_hook_invoke_programs(xdp_ctx, &filter_context->base, &result);
     if (program_result == EBPF_OBJECT_NOT_FOUND) {
         // No programs found.
         goto Exit;
@@ -748,13 +757,13 @@ net_ebpf_ext_layer_2_classify(
 
     switch (result) {
     case XDP_PASS:
-        if (net_xdp_ctx.cloned_nbl != NULL) {
+        if (net_xdp_ctx->cloned_nbl != NULL) {
             // Drop the original NBL.
             classify_output->actionType = FWP_ACTION_BLOCK;
             classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
 
             // Inject the cloned NBL in receive path.
-            status = _net_ebpf_ext_receive_inject_cloned_nbl(net_xdp_ctx.cloned_nbl, incoming_fixed_values);
+            status = _net_ebpf_ext_receive_inject_cloned_nbl(net_xdp_ctx->cloned_nbl, incoming_fixed_values);
             if (NT_SUCCESS(status)) {
                 // If cloned packet could be successfully injected, no need to audit for dropping the original.
                 // So absorb the original packet.
@@ -771,7 +780,7 @@ net_ebpf_ext_layer_2_classify(
         // The inbound original NBL will be allowed to proceed in the ingress path.
         break;
     case XDP_TX:
-        _net_ebpf_ext_handle_xdp_tx(&net_xdp_ctx, incoming_fixed_values);
+        _net_ebpf_ext_handle_xdp_tx(net_xdp_ctx, incoming_fixed_values);
         // Absorb the original NBL.
         classify_output->actionType = FWP_ACTION_BLOCK;
         classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
@@ -786,8 +795,8 @@ net_ebpf_ext_layer_2_classify(
         // Do not audit XDP drops.
         classify_output->flags |= FWPS_CLASSIFY_OUT_FLAG_ABSORB;
         // Free cloned NBL, if any.
-        if (net_xdp_ctx.cloned_nbl != NULL) {
-            _net_ebpf_ext_free_nbl(net_xdp_ctx.cloned_nbl, TRUE);
+        if (net_xdp_ctx->cloned_nbl != NULL) {
+            _net_ebpf_ext_free_nbl(net_xdp_ctx->cloned_nbl, TRUE);
         }
         break;
     }
@@ -819,6 +828,7 @@ _ebpf_xdp_context_create(
 {
     NTSTATUS status = STATUS_SUCCESS;
     ebpf_result_t result;
+    net_ebpf_xdp_md_header_t* new_context_header = NULL;
     net_ebpf_xdp_md_t* new_context = NULL;
     MDL* mdl_chain = NULL;
     NET_BUFFER_LIST* new_nbl = NULL;
@@ -836,11 +846,13 @@ _ebpf_xdp_context_create(
         goto Exit;
     }
 
-    new_context = (net_ebpf_xdp_md_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_xdp_md_t), NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(NET_EBPF_EXT_TRACELOG_KEYWORD_XDP, new_context, "new_context", result);
+    new_context_header = (net_ebpf_xdp_md_header_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(net_ebpf_xdp_md_header_t), NET_EBPF_EXTENSION_POOL_TAG);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_XDP, new_context_header, "new_context_header", result);
 
-    memset(new_context, 0, sizeof(net_ebpf_xdp_md_t));
+    memset(new_context_header, 0, sizeof(net_ebpf_xdp_md_header_t));
+    new_context = &new_context_header->context;
 
     // Create a MDL with the packet buffer.
     mdl_chain = IoAllocateMdl((void*)data_in, (unsigned long)data_size_in, FALSE, FALSE, NULL);
@@ -882,7 +894,7 @@ _ebpf_xdp_context_create(
 
 Exit:
     if (new_context) {
-        ExFreePool(new_context);
+        ExFreePool(new_context_header);
     }
 
     if (mdl_chain) {
@@ -904,12 +916,15 @@ _ebpf_xdp_context_delete(
     _Inout_ size_t* context_size_out)
 {
     net_ebpf_xdp_md_t* xdp_context = (net_ebpf_xdp_md_t*)context;
+    net_ebpf_xdp_md_header_t* xdp_context_header = NULL;
 
     NET_EBPF_EXT_LOG_ENTRY();
 
     if (!context) {
         goto Exit;
     }
+
+    xdp_context_header = CONTAINING_RECORD(context, net_ebpf_xdp_md_header_t, context);
 
     // Copy the packet data to the output buffer.
     if (data_out != NULL && data_size_out != NULL && xdp_context->base.data != NULL) {
@@ -947,7 +962,7 @@ _ebpf_xdp_context_delete(
         _net_ebpf_ext_free_nbl(xdp_context->cloned_nbl, TRUE);
     }
 
-    ExFreePool(xdp_context);
+    ExFreePool(xdp_context_header);
 
 Exit:
     NET_EBPF_EXT_LOG_EXIT();

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1075,7 +1075,12 @@ TEST_CASE("ioctl_stress", "[stress]")
                     uint32_t key = 0;
                     uint32_t value;
                     bpf_test_run_opts opts = {};
-                    bind_md_t ctx = {};
+                    struct
+                    {
+                        EBPF_CONTEXT_HEADER;
+                        bind_md_t context;
+                    } ctx_header = {0};
+                    bind_md_t* ctx = &ctx_header.context;
                     int result;
                     switch (test_case) {
                     case 0:
@@ -1106,10 +1111,10 @@ TEST_CASE("ioctl_stress", "[stress]")
                         // Run the program to trigger a ring buffer event
                         std::string app_id = "api_test.exe";
 
-                        opts.ctx_in = &ctx;
-                        opts.ctx_size_in = sizeof(ctx);
-                        opts.ctx_out = &ctx;
-                        opts.ctx_size_out = sizeof(ctx);
+                        opts.ctx_in = ctx;
+                        opts.ctx_size_in = sizeof(*ctx);
+                        opts.ctx_out = ctx;
+                        opts.ctx_size_out = sizeof(*ctx);
                         opts.data_in = app_id.data();
                         opts.data_size_in = static_cast<uint32_t>(app_id.size());
                         opts.data_out = app_id.data();

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -438,10 +438,11 @@ droppacket_test(ebpf_execution_type_t execution_type)
     REQUIRE(bpf_map_update_elem(dropped_packet_map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
 
     // Test that we drop the packet and increment the map
-    xdp_md_t ctx0{packet0.data(), packet0.data() + packet0.size(), 0, TEST_IFINDEX};
+    xdp_md_header_t ctx0_header{{0}, {packet0.data(), packet0.data() + packet0.size(), 0, TEST_IFINDEX}};
+    xdp_md_t* ctx0 = &ctx0_header.context;
 
-    uint32_t hook_result;
-    REQUIRE(hook.fire(&ctx0, &hook_result) == EBPF_SUCCESS);
+    uint32_t hook_result = 0;
+    REQUIRE(hook.fire(ctx0, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_DROP);
 
     REQUIRE(bpf_map_lookup_elem(dropped_packet_map_fd, &key, &value) == EBPF_SUCCESS);
@@ -454,10 +455,11 @@ droppacket_test(ebpf_execution_type_t execution_type)
 
     // Create a normal (not 0-byte) UDP packet.
     auto packet10 = prepare_udp_packet(10, ETHERNET_TYPE_IPV4);
-    xdp_md_t ctx10{packet10.data(), packet10.data() + packet10.size(), 0, TEST_IFINDEX};
+    xdp_md_header_t ctx10_header{{0}, {packet10.data(), packet10.data() + packet10.size(), 0, TEST_IFINDEX}};
+    xdp_md_t* ctx10 = &ctx10_header.context;
 
     // Test that we don't drop the normal packet.
-    REQUIRE(hook.fire(&ctx10, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx10, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_PASS);
 
     REQUIRE(bpf_map_lookup_elem(dropped_packet_map_fd, &key, &value) == EBPF_SUCCESS);
@@ -469,7 +471,7 @@ droppacket_test(ebpf_execution_type_t execution_type)
     REQUIRE(hook.attach_link(program_fd, &if_index, sizeof(if_index), &link) == EBPF_SUCCESS);
 
     // Fire a 0-length UDP packet on the interface index in the map, which should be dropped.
-    REQUIRE(hook.fire(&ctx0, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx0, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_DROP);
     REQUIRE(bpf_map_lookup_elem(dropped_packet_map_fd, &key, &value) == EBPF_SUCCESS);
     REQUIRE(value == 1);
@@ -488,7 +490,7 @@ droppacket_test(ebpf_execution_type_t execution_type)
     REQUIRE(hook.batch_begin(sizeof(state), state) == EBPF_SUCCESS);
     // Process 10 packets in batch mode.
     for (int i = 0; i < 10; i++) {
-        REQUIRE(hook.batch_invoke(&ctx0, &hook_result, state) == EBPF_SUCCESS);
+        REQUIRE(hook.batch_invoke(ctx0, &hook_result, state) == EBPF_SUCCESS);
         REQUIRE(hook_result == XDP_DROP);
     }
     REQUIRE(hook.batch_end(state) == EBPF_SUCCESS);
@@ -499,8 +501,9 @@ droppacket_test(ebpf_execution_type_t execution_type)
     REQUIRE(bpf_map_delete_elem(dropped_packet_map_fd, &key) == EBPF_SUCCESS);
 
     // Fire a 0-length packet on any interface that is not in the map, which should be allowed.
-    xdp_md_t ctx4{packet0.data(), packet0.data() + packet0.size(), 0, if_index + 1};
-    REQUIRE(hook.fire(&ctx4, &hook_result) == EBPF_SUCCESS);
+    xdp_md_header_t ctx4_header{{0}, {packet0.data(), packet0.data() + packet0.size(), 0, if_index + 1}};
+    xdp_md_t* ctx4 = &ctx4_header.context;
+    REQUIRE(hook.fire(ctx4, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_PASS);
     REQUIRE(bpf_map_lookup_elem(dropped_packet_map_fd, &key, &value) == EBPF_SUCCESS);
     REQUIRE(value == 0);
@@ -544,7 +547,7 @@ divide_by_zero_test_um(ebpf_execution_type_t execution_type)
     // Empty context (not used by the eBPF program).
     INITIALIZE_SAMPLE_CONTEXT;
 
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 0);
 
@@ -1027,7 +1030,7 @@ _utility_helper_functions_test(ebpf_execution_type_t execution_type)
     // Dummy context (not used by the eBPF program).
     INITIALIZE_SAMPLE_CONTEXT
 
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 0);
 
@@ -1063,7 +1066,7 @@ map_test(ebpf_execution_type_t execution_type)
     REQUIRE(result == 0);
 
     REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
     INITIALIZE_SAMPLE_CONTEXT
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     // Program should return 0 if all the map tests pass.
@@ -1135,7 +1138,7 @@ global_variable_test(ebpf_execution_type_t execution_type)
     REQUIRE(value[1] == 40);
 
     REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
     INITIALIZE_SAMPLE_CONTEXT
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     // Program should return 0 if all the map tests pass.
@@ -1218,7 +1221,7 @@ global_variable_and_map_test(ebpf_execution_type_t execution_type)
     REQUIRE(bpf_map_update_elem(some_config_map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
 
     REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
     INITIALIZE_SAMPLE_CONTEXT
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     // Program should return 0 if all the map tests pass.
@@ -2102,13 +2105,14 @@ _xdp_reflect_packet_test(ebpf_execution_type_t execution_type, ADDRESS_FAMILY ad
     udp_packet_t packet(address_family);
     packet.set_destination_port(ntohs(REFLECTION_TEST_PORT));
 
-    xdp_md_t ctx{packet.data(), packet.data() + packet.size(), 0, TEST_IFINDEX};
+    xdp_md_header_t ctx_header{{0}, {packet.data(), packet.data() + packet.size(), 0, TEST_IFINDEX}};
+    xdp_md_t* ctx = &ctx_header.context;
 
-    uint32_t hook_result;
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    uint32_t hook_result = 0;
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_TX);
 
-    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
+    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx->data);
     REQUIRE(memcmp(ethernet_header->Destination, _test_source_mac.data(), sizeof(ethernet_header->Destination)) == 0);
     REQUIRE(memcmp(ethernet_header->Source, _test_destination_mac.data(), sizeof(ethernet_header->Source)) == 0);
 
@@ -2158,11 +2162,11 @@ _xdp_encap_reflect_packet_test(ebpf_execution_type_t execution_type, ADDRESS_FAM
     // Dummy context (not used by the eBPF program).
     xdp_md_helper_t ctx(packet.packet());
 
-    uint32_t hook_result;
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    uint32_t hook_result = 0;
+    REQUIRE(hook.fire(ctx.get_ctx(), &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_TX);
 
-    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
+    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.context.data);
     REQUIRE(memcmp(ethernet_header->Destination, _test_source_mac.data(), sizeof(ethernet_header->Destination)) == 0);
     REQUIRE(memcmp(ethernet_header->Source, _test_destination_mac.data(), sizeof(ethernet_header->Source)) == 0);
 
@@ -2290,12 +2294,12 @@ _xdp_decapsulate_permit_packet_test(ebpf_execution_type_t execution_type, ADDRES
     uint8_t* inner_ip_header = packet.packet().data() + offset;
     std::vector<uint8_t> inner_ip_datagram(inner_ip_header, packet.packet().data() + packet.packet().size());
 
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
     xdp_md_helper_t ctx(packet.packet());
-    REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook.fire(ctx.get_ctx(), &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == XDP_PASS);
 
-    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.data);
+    ebpf::ETHERNET_HEADER* ethernet_header = reinterpret_cast<ebpf::ETHERNET_HEADER*>(ctx.context.data);
 
     if (address_family == AF_INET) {
         ebpf::IPV4_HEADER* ipv4_header = reinterpret_cast<ebpf::IPV4_HEADER*>(ethernet_header + 1);
@@ -2411,7 +2415,7 @@ _map_reuse_test(ebpf_execution_type_t execution_type)
     REQUIRE(info.name[0] == 0);
 
     INITIALIZE_SAMPLE_CONTEXT
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
 
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
@@ -2521,7 +2525,7 @@ _auto_pinned_maps_test(ebpf_execution_type_t execution_type)
     REQUIRE(port_map_fd > 0);
 
     INITIALIZE_SAMPLE_CONTEXT
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
 
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
@@ -2594,7 +2598,7 @@ TEST_CASE("auto_pinned_maps_custom_path", "[end_to_end]")
     REQUIRE(port_map_fd > 0);
 
     INITIALIZE_SAMPLE_CONTEXT
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
 
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
@@ -2705,7 +2709,7 @@ _map_reuse_2_test(ebpf_execution_type_t execution_type)
     program_helper.initialize(file_name, BPF_PROG_TYPE_SAMPLE, "lookup_update", EBPF_EXECUTION_ANY, nullptr, 0, hook);
 
     INITIALIZE_SAMPLE_CONTEXT
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
 
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);
@@ -2781,7 +2785,7 @@ _map_reuse_3_test(ebpf_execution_type_t execution_type)
     program_helper.initialize(file_name, BPF_PROG_TYPE_SAMPLE, "lookup_update", EBPF_EXECUTION_ANY, nullptr, 0, hook);
 
     INITIALIZE_SAMPLE_CONTEXT
-    uint32_t hook_result;
+    uint32_t hook_result = 0;
 
     REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 200);

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -34,6 +34,18 @@ typedef struct _bind_context_header
     bind_md_t context;
 } bind_context_header_t;
 
+typedef struct _sock_addr_context_header
+{
+    EBPF_CONTEXT_HEADER;
+    bpf_sock_addr_t context;
+} sock_addr_context_header_t;
+
+typedef struct _sock_ops_context_header
+{
+    EBPF_CONTEXT_HEADER;
+    bpf_sock_ops_t context;
+} sock_ops_context_header_t;
+
 #define INITIALIZE_BIND_CONTEXT      \
     bind_context_header_t header{0}; \
     bind_md_t* ctx = &header.context;
@@ -363,12 +375,18 @@ typedef class _single_instance_hook : public _hook_helper
     bpf_link* link_object = nullptr;
 } single_instance_hook_t;
 
-typedef class xdp_md_helper : public xdp_md_t
+typedef struct _xdp_md_header
+{
+    EBPF_CONTEXT_HEADER;
+    xdp_md_t context;
+} xdp_md_header_t;
+
+typedef class xdp_md_helper : public xdp_md_header_t
 {
   public:
     xdp_md_helper(std::vector<uint8_t>& packet)
-        : xdp_md_t{packet.data(), packet.data() + packet.size()}, _packet(&packet), _begin(0), _end(packet.size()),
-          cloned_nbl(nullptr)
+        : xdp_md_header_t{{0}, {packet.data(), packet.data() + packet.size()}}, _packet(&packet), _begin(0),
+          _end(packet.size()), cloned_nbl(nullptr)
     {
         original_nbl = &_original_nbl_storage;
         _original_nbl_storage.FirstNetBuffer = &_original_nb;
@@ -376,6 +394,24 @@ typedef class xdp_md_helper : public xdp_md_t
         _original_nb.MdlChain = &_original_mdl;
         _original_mdl.byte_count = (unsigned long)packet.size();
         _original_mdl.start_va = packet.data();
+    }
+
+    static inline xdp_md_helper*
+    from_ctx(xdp_md_t* ctx)
+    {
+        return (xdp_md_helper*)CONTAINING_RECORD(ctx, xdp_md_header_t, context);
+    }
+
+    static inline const xdp_md_helper*
+    from_ctx(const xdp_md_t* ctx)
+    {
+        return (xdp_md_helper*)CONTAINING_RECORD(ctx, xdp_md_header_t, context);
+    }
+
+    xdp_md_t*
+    get_ctx()
+    {
+        return &context;
     }
 
     int
@@ -410,8 +446,8 @@ typedef class xdp_md_helper : public xdp_md_t
             }
         }
         // Adjust xdp_md data pointers.
-        data = _packet->data() + _begin;
-        data_end = _packet->data() + _end;
+        context.data = _packet->data() + _begin;
+        context.data_end = _packet->data() + _end;
     Done:
         return return_value;
     }
@@ -431,9 +467,9 @@ typedef class _test_xdp_helper
 {
   public:
     static int
-    adjust_head(_In_ const xdp_md_t* ctx, int delta)
+    adjust_head(_In_ xdp_md_t* ctx, int delta)
     {
-        return ((xdp_md_helper_t*)ctx)->adjust_head(delta);
+        return xdp_md_helper_t::from_ctx(ctx)->adjust_head(delta);
     }
 } test_xdp_helper_t;
 
@@ -448,11 +484,13 @@ _xdp_context_create(
 {
     ebpf_result_t retval = EBPF_FAILED;
     *context = nullptr;
+    xdp_md_t* xdp_context = nullptr;
 
-    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
-    if (xdp_context == nullptr) {
+    xdp_md_header_t* xdp_context_header = reinterpret_cast<xdp_md_header_t*>(malloc(sizeof(xdp_md_header_t)));
+    if (xdp_context_header == nullptr) {
         goto Done;
     }
+    xdp_context = &xdp_context_header->context;
 
     if (context_in) {
         if (context_size_in < sizeof(xdp_md_t)) {
@@ -468,10 +506,11 @@ _xdp_context_create(
 
     *context = xdp_context;
     xdp_context = nullptr;
+    xdp_context_header = nullptr;
     retval = EBPF_SUCCESS;
 Done:
-    free(xdp_context);
-    xdp_context = nullptr;
+    free(xdp_context_header);
+    xdp_context_header = nullptr;
     return retval;
 }
 
@@ -488,6 +527,7 @@ _xdp_context_destroy(
     }
 
     xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(context);
+    xdp_md_header_t* xdp_context_header = CONTAINING_RECORD(xdp_context, xdp_md_header_t, context);
     uint8_t* data = reinterpret_cast<uint8_t*>(xdp_context->data);
     uint8_t* data_end = reinterpret_cast<uint8_t*>(xdp_context->data_end);
     size_t data_length = data_end - data;
@@ -505,7 +545,7 @@ _xdp_context_destroy(
         *context_size_out = sizeof(xdp_md_t);
     }
 
-    free(context);
+    free(xdp_context_header);
 }
 
 typedef class _test_global_helper
@@ -642,6 +682,7 @@ _sample_test_context_create(
     }
 
     *context = sample_context;
+    sample_context = nullptr;
     context_header = nullptr;
     retval = EBPF_SUCCESS;
 
@@ -710,7 +751,10 @@ static ebpf_program_data_t _mock_xdp_program_data = {
     &_mock_xdp_helper_function_address_table,
     nullptr,
     _xdp_context_create,
-    _xdp_context_destroy};
+    _xdp_context_destroy,
+    0,
+    {.supports_context_header = true},
+};
 
 // XDP_TEST.
 static ebpf_program_data_t _ebpf_xdp_test_program_data = {
@@ -719,7 +763,10 @@ static ebpf_program_data_t _ebpf_xdp_test_program_data = {
     &_mock_xdp_helper_function_address_table,
     nullptr,
     _xdp_context_create,
-    _xdp_context_destroy};
+    _xdp_context_destroy,
+    0,
+    {.supports_context_header = true},
+};
 
 // Bind.
 static ebpf_result_t
@@ -732,12 +779,14 @@ _ebpf_bind_context_create(
 {
     ebpf_result_t retval;
     *context = nullptr;
-
-    bind_md_t* bind_context = reinterpret_cast<bind_md_t*>(ebpf_allocate(sizeof(bind_md_t)));
-    if (bind_context == nullptr) {
+    bind_md_t* bind_context = nullptr;
+    bind_context_header_t* bind_context_header =
+        reinterpret_cast<bind_context_header_t*>(ebpf_allocate(sizeof(bind_context_header_t)));
+    if (bind_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
     }
+    bind_context = &bind_context_header->context;
 
     if (context_in) {
         if (context_size_in < sizeof(bind_md_t)) {
@@ -758,10 +807,11 @@ _ebpf_bind_context_create(
 
     *context = bind_context;
     bind_context = nullptr;
+    bind_context_header = nullptr;
     retval = EBPF_SUCCESS;
 Done:
-    ebpf_free(bind_context);
-    bind_context = nullptr;
+    ebpf_free(bind_context_header);
+    bind_context_header = nullptr;
     return retval;
 }
 
@@ -779,14 +829,15 @@ _ebpf_bind_context_destroy(
     }
 
     bind_md_t* bind_context = reinterpret_cast<bind_md_t*>(context);
+    bind_context_header_t* bind_context_header = CONTAINING_RECORD(bind_context, bind_context_header_t, context);
     if (context_out && *context_size_out >= sizeof(bind_md_t)) {
         bind_md_t* provided_context = (bind_md_t*)context_out;
         *provided_context = *bind_context;
         *context_size_out = sizeof(bind_md_t);
     }
 
-    ebpf_free(bind_context);
-    bind_context = nullptr;
+    ebpf_free(bind_context_header);
+    bind_context_header = nullptr;
 
     *data_size_out = 0;
     return;
@@ -870,11 +921,14 @@ _ebpf_sock_addr_context_create(
     ebpf_result_t retval;
     *context = nullptr;
 
-    bpf_sock_addr_t* sock_addr_context = reinterpret_cast<bpf_sock_addr_t*>(ebpf_allocate(sizeof(bpf_sock_addr_t)));
-    if (sock_addr_context == nullptr) {
+    bpf_sock_addr_t* sock_addr_context = nullptr;
+    sock_addr_context_header_t* sock_addr_context_header =
+        reinterpret_cast<sock_addr_context_header_t*>(ebpf_allocate(sizeof(sock_addr_context_header_t)));
+    if (sock_addr_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
     }
+    sock_addr_context = &sock_addr_context_header->context;
 
     if (context_in) {
         if (context_size_in < sizeof(bpf_sock_addr_t)) {
@@ -887,9 +941,10 @@ _ebpf_sock_addr_context_create(
 
     *context = sock_addr_context;
     sock_addr_context = nullptr;
+    sock_addr_context_header = nullptr;
     retval = EBPF_SUCCESS;
 Done:
-    ebpf_free(sock_addr_context);
+    ebpf_free(sock_addr_context_header);
     sock_addr_context = nullptr;
     return retval;
 }
@@ -908,14 +963,16 @@ _ebpf_sock_addr_context_destroy(
     }
 
     bpf_sock_addr_t* sock_addr_context = reinterpret_cast<bpf_sock_addr_t*>(context);
+    sock_addr_context_header_t* sock_addr_context_header =
+        CONTAINING_RECORD(sock_addr_context, sock_addr_context_header_t, context);
     if (context_out && *context_size_out >= sizeof(bpf_sock_addr_t)) {
         bpf_sock_addr_t* provided_context = (bpf_sock_addr_t*)context_out;
         *provided_context = *sock_addr_context;
         *context_size_out = sizeof(bpf_sock_addr_t);
     }
 
-    ebpf_free(sock_addr_context);
-    sock_addr_context = nullptr;
+    ebpf_free(sock_addr_context_header);
+    sock_addr_context_header = nullptr;
 
     *data_size_out = 0;
     return;
@@ -948,6 +1005,7 @@ static ebpf_program_data_t _ebpf_sock_addr_program_data = {
     .context_create = &_ebpf_sock_addr_context_create,
     .context_destroy = &_ebpf_sock_addr_context_destroy,
     .required_irql = DISPATCH_LEVEL,
+    .capabilities = {.supports_context_header = true},
 };
 
 // SOCK_OPS.
@@ -989,11 +1047,14 @@ _ebpf_sock_ops_context_create(
     ebpf_result_t retval;
     *context = nullptr;
 
-    bpf_sock_ops_t* sock_ops_context = reinterpret_cast<bpf_sock_ops_t*>(ebpf_allocate(sizeof(bpf_sock_ops_t)));
-    if (sock_ops_context == nullptr) {
+    bpf_sock_ops_t* sock_ops_context = nullptr;
+    sock_ops_context_header_t* sock_ops_context_header =
+        reinterpret_cast<sock_ops_context_header_t*>(ebpf_allocate(sizeof(sock_ops_context_header_t)));
+    if (sock_ops_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
     }
+    sock_ops_context = &sock_ops_context_header->context;
 
     if (context_in) {
         if (context_size_in < sizeof(bpf_sock_ops_t)) {
@@ -1027,13 +1088,16 @@ _ebpf_sock_ops_context_destroy(
     }
 
     bpf_sock_ops_t* sock_ops_context = reinterpret_cast<bpf_sock_ops_t*>(context);
+    sock_ops_context_header_t* sock_ops_context_header =
+        CONTAINING_RECORD(sock_ops_context, sock_ops_context_header_t, context);
     if (context_out && *context_size_out >= sizeof(bpf_sock_ops_t)) {
         bpf_sock_ops_t* provided_context = (bpf_sock_ops_t*)context_out;
         *provided_context = *sock_ops_context;
         *context_size_out = sizeof(bpf_sock_ops_t);
     }
 
-    ebpf_free(sock_ops_context);
+    ebpf_free(sock_ops_context_header);
+    sock_ops_context_header = nullptr;
 
     *data_size_out = 0;
     return;
@@ -1046,6 +1110,7 @@ static ebpf_program_data_t _ebpf_sock_ops_program_data = {
     .context_create = &_ebpf_sock_ops_context_create,
     .context_destroy = &_ebpf_sock_ops_context_destroy,
     .required_irql = DISPATCH_LEVEL,
+    .capabilities = {.supports_context_header = true},
 };
 
 // Sample extension.

--- a/tests/libfuzzer/include/fuzz_helper_function.hpp
+++ b/tests/libfuzzer/include/fuzz_helper_function.hpp
@@ -193,8 +193,12 @@ template <typename context_type> class fuzz_helper_function
                 break;
             }
             case EBPF_ARGUMENT_TYPE_PTR_TO_CTX:
-                // Put the context into the argument.
-                argument[arg_count] = (uint64_t)&context;
+                // Put the context into the argument (all program contexts must support header, so subtract it out).
+                struct _ctx_header
+                {
+                    EBPF_CONTEXT_HEADER;
+                };
+                argument[arg_count] = (uint64_t)&context - sizeof(_ctx_header);
                 break;
             case EBPF_ARGUMENT_TYPE_PTR_TO_MAP: {
                 // Put a map pointer into the argument.


### PR DESCRIPTION
## Description

As of #4144 context header support will be necessary for all programs to support so that the core can determine context data support for a program. This change makes the header support mandatory and updates all tests missing headers.

- Makes header support mandatory for programs and extensions.
- Completes context header support for netebpfext.
- Adds context header support to all test/mock bpf program contexts.

## Testing

Covered by existing tests.

## Documentation

Updated eBPFExtensions.md to describe the new requirements.

## Installation

No installation change, but this is a breaking change.
