### PR TITLE
Fix content of redistributable NuGet package not being extracted on install/restore

### DIFF
--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -19,33 +19,33 @@
 	</metadata>
 	<files>
 		<file src="..\..\tools\redist-package\README.md" target="."/>
-		<file src="bpftool.exe" target="package\bin"/>
-		<file src="bpftool.pdb" target="package\bin"/>
-		<file src="ebpfapi.dll" target="package\bin"/>
-		<file src="ebpfapi.pdb" target="package\bin"/>
-		<file src="ebpfnetsh.dll" target="package\bin"/>
-		<file src="ebpfnetsh.pdb" target="package\bin"/>
-		<file src="export_program_info.exe" target="package\bin"/>
-		<file src="export_program_info.pdb" target="package\bin"/>
+		<file src="bpftool.exe" target="lib\native\bin"/>
+		<file src="bpftool.pdb" target="lib\native\bin"/>
+		<file src="ebpfapi.dll" target="lib\native\bin"/>
+		<file src="ebpfapi.pdb" target="lib\native\bin"/>
+		<file src="ebpfnetsh.dll" target="lib\native\bin"/>
+		<file src="ebpfnetsh.pdb" target="lib\native\bin"/>
+		<file src="export_program_info.exe" target="lib\native\bin"/>
+		<file src="export_program_info.pdb" target="lib\native\bin"/>
 		<!--eBPF drivers-->
-		<file src="eBPFCore.sys" target="package\bin\drivers"/>
-		<file src="eBPFCore.pdb" target="package\bin\drivers"/>
-		<file src="NetEbpfExt.sys" target="package\bin\drivers"/>
-		<file src="NetEbpfExt.pdb" target="package\bin\drivers"/>
+		<file src="eBPFCore.sys" target="lib\native\bin\drivers"/>
+		<file src="eBPFCore.pdb" target="lib\native\bin\drivers"/>
+		<file src="NetEbpfExt.sys" target="lib\native\bin\drivers"/>
+		<file src="NetEbpfExt.pdb" target="lib\native\bin\drivers"/>
 		<!--eBPF tracing -->
-		<file src="..\..\scripts\ebpf_tracing.cmd" target="package\bin"/>
-		<file src="..\..\scripts\ebpf_tracing_startup_task.xml" target="package\bin"/>
-		<file src="..\..\scripts\ebpf_tracing_periodic_task.xml" target="package\bin"/>
+		<file src="..\..\scripts\ebpf_tracing.cmd" target="lib\native\bin"/>
+		<file src="..\..\scripts\ebpf_tracing_startup_task.xml" target="lib\native\bin"/>
+		<file src="..\..\scripts\ebpf_tracing_periodic_task.xml" target="lib\native\bin"/>
 
 		<!--Temporary inclusion of the VC++ Redist-->
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\concrt140.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_1.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_2.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_atomic_wait.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_codecvt_ids.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vccorlib140.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vcruntime140.dll" target="package\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vcruntime140_1.dll" target="package\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\concrt140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_1.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_2.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_atomic_wait.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_codecvt_ids.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vccorlib140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vcruntime140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vcruntime140_1.dll" target="lib\native\bin"/>
 	</files>
 </package>


### PR DESCRIPTION
## Description

Update binary targets in redistributable NuGet package to `lib` directory to avoid NuGet exclusion of `package` directory. For some (undocumented) reason, placing content in a top-level `packages` directory prevents NuGet tooling from extracting that content. As such, the only files that get extracted are the 3 files placed in the package root, per below:

```Powershell
PS C:\> nuget install -Source C:\src\github\ebpf-for-windows\x64\Release eBPF-for-Windows-Redist -Version 0.21.0 -OutputDirectory C:\temp\packages
PS C:\> gci C:\temp\packages\eBPF-for-Windows-Redist.0.21.0 -Recurse

    Directory: C:\temp\packages\eBPF-for-Windows-Redist.0.21.0 

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          11/20/2024 10:42 AM          12811 .signature.p7s
-a---           3/10/2025 11:50 PM        6200768 eBPF-for-Windows-Redist.0.21.0 .nupkg
-a---          11/20/2024  6:28 PM            119 README.md
```

It appears any other top-level directory name can be used, so we've chosen to use `lib` as the top-level folder as this conforms to [NuGet naming conventions](https://learn.microsoft.com/en-us/nuget/create-packages/creating-a-package#from-a-convention-based-working-directory).

Fixes #4277

## Testing

Performed `nuget install` with newly generated package and validated all package contents are extracted:

```Powershell
PS C:\> gci -Recurse C:\temp\packages\eBPF-for-Windows-Redist.x64.0.21.0                                                                                                  

    Directory: C:\temp\packages\eBPF-for-Windows-Redist.x64.0.21.0

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----           3/10/2025 11:47 PM                lib
-a---           3/10/2025 11:47 PM        7241201 eBPF-for-Windows-Redist.x64.0.21.0.nupkg
-a---           2/20/2025  2:30 PM            119 README.md

    Directory: C:\temp\packages\eBPF-for-Windows-Redist.x64.0.21.0\lib

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----           3/10/2025 11:47 PM                native

    Directory: C:\temp\packages\eBPF-for-Windows-Redist.x64.0.21.0\lib\native

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----           3/10/2025 11:47 PM                bin

    Directory: C:\temp\packages\eBPF-for-Windows-Redist.x64.0.21.0\lib\native\bin

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----           3/10/2025 11:47 PM                drivers
-a---           3/10/2025 11:47 PM          82432 bpftool.exe
-a---           3/10/2025 11:47 PM         946176 bpftool.pdb
-a---           2/14/2025  3:45 PM         322672 concrt140.dll
-a---           2/20/2025  2:30 PM           2444 ebpf_tracing_periodic_task.xml
-a---           2/20/2025  2:30 PM           2096 ebpf_tracing_startup_task.xml
-a---           2/20/2025  2:30 PM          12296 ebpf_tracing.cmd
-a---           3/10/2025 11:47 PM        1690624 EbpfApi.dll
-a---           3/10/2025 11:47 PM       12611584 EbpfApi.pdb
-a---           3/10/2025 11:47 PM          99328 ebpfnetsh.dll
-a---           3/10/2025 11:47 PM        1888256 ebpfnetsh.pdb
-a---           3/10/2025 11:47 PM          98304 export_program_info.exe
-a---           3/10/2025 11:47 PM        3960832 export_program_info.pdb
-a---           2/14/2025  3:45 PM          35920 msvcp140_1.dll
-a---           2/14/2025  3:45 PM         267888 msvcp140_2.dll
-a---           2/14/2025  3:45 PM          50288 msvcp140_atomic_wait.dll
-a---           2/14/2025  3:45 PM          31856 msvcp140_codecvt_ids.dll
-a---           2/14/2025  3:45 PM         575568 msvcp140.dll
-a---           2/14/2025  3:45 PM         351824 vccorlib140.dll
-a---           2/14/2025  3:45 PM          49776 vcruntime140_1.dll
-a---           2/14/2025  3:45 PM         120400 vcruntime140.dll

    Directory: C:\temp\packages\eBPF-for-Windows-Redist.x64.0.21.0\lib\native\bin\drivers

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---           3/10/2025 11:47 PM        2453504 EbpfCore.pdb
-a---           3/10/2025 11:47 PM         332280 EbpfCore.sys
-a---           3/10/2025 11:47 PM        1478656 netebpfext.pdb
-a---           3/10/2025 11:47 PM         145280 netebpfext.sys
```

## Documentation

N/A

## Installation

N/A
