### PR TITLE
support partial output buffer for get_info API.

### DIFF
--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -116,14 +116,19 @@ query_map_definition(
 {
     bpf_map_info info = {0};
     uint32_t info_size = sizeof(info);
-    ebpf_result_t result = ebpf_object_get_info(handle, &info, &info_size, NULL);
+    ebpf_object_type_t object_type = EBPF_OBJECT_UNKNOWN;
+    ebpf_result_t result = ebpf_object_get_info(handle, &info, &info_size, &object_type);
     if (result == EBPF_SUCCESS) {
-        *id = info.id;
-        *type = info.type;
-        *key_size = info.key_size;
-        *value_size = info.value_size;
-        *max_entries = info.max_entries;
-        *inner_map_id = info.inner_map_id;
+        if (object_type != EBPF_OBJECT_MAP) {
+            result = EBPF_INVALID_ARGUMENT;
+        } else {
+            *id = info.id;
+            *type = info.type;
+            *key_size = info.key_size;
+            *value_size = info.value_size;
+            *max_entries = info.max_entries;
+            *inner_map_id = info.inner_map_id;
+        }
     }
     return result;
 }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2058,12 +2058,15 @@ ebpf_program_get_info(
 {
     EBPF_LOG_ENTRY();
     const struct bpf_prog_info* input_info = (const struct bpf_prog_info*)input_buffer;
-    struct bpf_prog_info* output_info = (struct bpf_prog_info*)output_buffer;
-    if (*output_buffer_size < sizeof(*output_info)) {
-        EBPF_RETURN_RESULT(EBPF_INSUFFICIENT_BUFFER);
-    }
 
-    if (input_buffer_size < sizeof(*input_info)) {
+    // The input buffer must be large enough to hold the map IDs.
+    if (input_buffer_size < EBPF_OFFSET_OF(struct bpf_prog_info, name)) {
+        EBPF_LOG_MESSAGE_UINT64_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_PROGRAM,
+            "ebpf_program_get_info input buffer smaller than minimum required size.",
+            input_buffer_size,
+            EBPF_OFFSET_OF(struct bpf_prog_info, name));
         EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
     }
 
@@ -2088,17 +2091,38 @@ ebpf_program_get_info(
                 }
             }
         } __except (EXCEPTION_EXECUTE_HANDLER) {
+            EBPF_LOG_MESSAGE_UINT64(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_PROGRAM,
+                "User mode map_ids buffer invalid or too small.",
+                (uint64_t)((uintptr_t)map_ids));
             EBPF_RETURN_RESULT(EBPF_INVALID_POINTER);
         }
     }
 
+    struct bpf_prog_info local_program = {0};
+    struct bpf_prog_info* output_info = &local_program;
+
+    if (*output_buffer_size < sizeof(*output_info)) {
+        EBPF_LOG_MESSAGE_UINT64_UINT64(
+            EBPF_TRACELOG_LEVEL_WARNING,
+            EBPF_TRACELOG_KEYWORD_PROGRAM,
+            "ebpf_program_get_info output buffer too small.",
+            *output_buffer_size,
+            sizeof(*output_info));
+    }
+
     memset(output_info, 0, sizeof(*output_info));
     output_info->id = program->object.id;
+    size_t program_name_length = program->parameters.program_name.length;
     strncpy_s(
         output_info->name,
         sizeof(output_info->name),
         (char*)program->parameters.program_name.value,
-        program->parameters.program_name.length);
+        program_name_length);
+    if (program_name_length < sizeof(output_info->name)) {
+        memset(output_info->name + program_name_length, 0, sizeof(output_info->name) - program_name_length);
+    }
     output_info->nr_map_ids = program->count_of_maps;
     output_info->map_ids = (uintptr_t)map_ids;
     output_info->type = _ebpf_program_get_bpf_prog_type(program);
@@ -2107,7 +2131,11 @@ ebpf_program_get_info(
     output_info->pinned_path_count = program->object.pinned_path_count;
     output_info->link_count = program->link_count;
 
-    *output_buffer_size = sizeof(*output_info);
+    // Copy the local map info to the user supplied buffer, as much as will fit.
+    uint16_t out_size = min(sizeof(*output_info), *output_buffer_size);
+    memcpy(output_buffer, output_info, out_size);
+    *output_buffer_size = out_size;
+
     EBPF_RETURN_RESULT(result);
 }
 

--- a/tests/bpftool_tests/bpftool_tests.cpp
+++ b/tests/bpftool_tests/bpftool_tests.cpp
@@ -236,16 +236,7 @@ TEST_CASE("prog prog run", "[prog][load]")
     REQUIRE(offset != std::string::npos);
     std::string map_id1 = std::to_string(atoi(output.substr(offset + 9).c_str()));
 
-    // The sample program is expected to have a single map. The output format
-    // differs based on whether the program is loaded as a native driver or not.
-    if (std::string(EBPF_PROGRAM_FILE_EXTENSION) == ".sys") {
-        REQUIRE(output == id + ": sample  name test_program_entry  \n  map_ids " + map_id1 + "\n");
-    } else {
-        offset = output.find(",");
-        REQUIRE(offset != std::string::npos);
-        std::string map_id2 = std::to_string(atoi(output.substr(offset + 1).c_str()));
-        REQUIRE(output == id + ": sample  name test_program_entry  \n  map_ids " + map_id1 + "," + map_id2 + "\n");
-    }
+    REQUIRE(output == id + ": sample  name test_program_entry  \n  map_ids " + map_id1 + "\n");
 
     std::filesystem::path input_file = "ctx_in.txt";
     std::filesystem::path output_file = "ctx_out.txt";


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
This PR fixes #4160 by allowing smaller output buffer than the size of the struct for `bpf_obj_get_info_by_fd` API. The changes were made for program, map and link objects. This PR found two incidental issues:
1. In JIT case, the `count_of_maps` for eBPF program object was set to the count of map references in individual instructions, instead of total number of unique maps referred to by the program.
2. The `query_map_definition` invoked `bpf_obj_get_info_by_fd` but did not check if the returned object type was indeed that of a map.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
Test cases were added in libbpf unit tests to invoke ``bpf_obj_get_info_by_fd`  with smaller output buffers.

## Documentation

_Is there any documentation impact for this change?_
N/A.

## Installation

_Is there any installer impact for this change?_
N/A.