### PR TITLE
Remove obsolete prog-specific helper function

### DIFF
--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -106,25 +106,6 @@ typedef enum
 } ebpf_sock_addr_helper_id_t;
 
 /**
- * @brief Get current pid and tgid (sock_addr specific only).
- *
- * @deprecated Use bpf_get_current_pid_tgid instead.
- *
- * @param[in] ctx Pointer to bpf_sock_addr_t context.
- *
- * @returns a 64-bit integer containing the current tgid
- *  and pid, and created as such:
- *
- * 	*current_task*\ **->tgid << 32 \|**
- * 	*current_task*\ **->pid**.
- */
-EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx));
-#ifndef __doxygen
-#define bpf_sock_addr_get_current_pid_tgid \
-    ((bpf_sock_addr_get_current_pid_tgid_t)BPF_FUNC_sock_addr_get_current_pid_tgid)
-#endif
-
-/**
  * @brief Set a context for consumption by a user-mode application (sock_addr specific only).
  * This function is not supported for the recv_accept hooks.
  *

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -79,17 +79,11 @@ static const ebpf_program_section_info_t _ebpf_bind_section_info[] = {
 
 enum _sock_addr_helper_functions
 {
-    SOCK_ADDR_HELPER_GET_CURRENT_PID_TGID,
     SOCK_ADDR_HELPER_SET_REDIRECT_CONTEXT,
 };
 
 // CGROUP_SOCK_ADDR extension specific helper function prototypes.
 static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
-    {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
-     BPF_FUNC_sock_addr_get_current_pid_tgid,
-     "bpf_sock_addr_get_current_pid_tgid",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
     {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
      BPF_FUNC_sock_addr_set_redirect_context,
      "bpf_sock_addr_set_redirect_context",

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -337,13 +337,6 @@ _ebpf_sock_addr_get_socket_cookie(_In_ const bpf_sock_addr_t* ctx)
     return sock_addr_ctx->transport_endpoint_handle;
 }
 
-static uint64_t
-_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
-{
-    net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
-    return (sock_addr_ctx->process_id << 32 | _get_thread_id());
-}
-
 static int
 _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void* data, _In_ uint32_t data_size)
 {
@@ -555,8 +548,7 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_blocked_contexts
 // SOCK_ADDR Program Information NPI Provider.
 //
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
@@ -992,9 +984,8 @@ _net_ebpf_extension_connection_context_initialize(
 
 _Requires_exclusive_lock_held_(
     _net_ebpf_ext_sock_addr_blocked_contexts
-        .lock) static bool _net_ebpf_ext_find_and_remove_connection_context_locked(_In_
-                                                                                       net_ebpf_extension_connection_context_t*
-                                                                                           context)
+        .lock) static bool _net_ebpf_ext_find_and_remove_connection_context_locked(_In_ net_ebpf_extension_connection_context_t*
+                                                                                       context)
 {
     bool entry_found = false;
     // Check the hash table for the entry.

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -853,13 +853,6 @@ static ebpf_program_data_t _ebpf_bind_program_data = {
 
 // SOCK_ADDR.
 static int
-_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
-{
-    UNREFERENCED_PARAMETER(ctx);
-    return -ENOTSUP;
-}
-
-static int
 _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void* data, _In_ uint32_t data_size)
 {
     UNREFERENCED_PARAMETER(ctx);
@@ -978,8 +971,7 @@ _ebpf_sock_addr_context_destroy(
     return;
 }
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,


### PR DESCRIPTION
## Description

The `bpf_sock_addr_get_current_pid_tgid()` helper function is obsolete and is no longer needed.  This PR removes the function definition all all references to it in the codebase.

## Testing

Tested locally.

## Documentation

No additional documentation needed.

## Installation

No Installer impact.

Fixes #2111 