### PR TITLE
Install working clang in Setup-DevEnv.ps1

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -16,7 +16,6 @@
     "Microsoft.VisualStudio.Component.VC.DiagnosticTools",
     "Microsoft.VisualStudio.Component.Windows11SDK.22621",
     "Microsoft.VisualStudio.Component.VC.ATL",
-    "Microsoft.VisualStudio.Component.SecurityIssueAnalysis",
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
     "Microsoft.VisualStudio.Component.Windows11Sdk.WindowsPerformanceToolkit",
@@ -27,9 +26,6 @@
     "Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest",
     "Microsoft.VisualStudio.Component.VC.ASAN",
     "Microsoft.VisualStudio.Component.Vcpkg",
-    "Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset",
-    "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
-    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",
     "Component.Microsoft.Windows.DriverKit"

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -27,5 +27,6 @@ Doxyfile
 \.github/workflows/build.yml
 \.gitignore
 \.gitmodules
+\.vsconfig
 packages.config
 installer/LICENSE.rtf

--- a/scripts/Setup-DevEnv.ps1
+++ b/scripts/Setup-DevEnv.ps1
@@ -7,13 +7,11 @@ if ((get-filehash -Algorithm SHA256 $env:TEMP\install_choco.ps1).Hash -ne '44E04
 
 choco install git -y --params "'/GitAndUnixToolsOnPath /WindowsTerminal /NoAutoCrlf'"
 choco install visualstudio2022community --version 117.4.2.0 -y
-choco install visualstudio2022buildtools --version 117.4.2.0 -y
 
 echo "Adding required components to Visual Studio"
 Invoke-WebRequest 'https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/.vsconfig' -OutFile $env:TEMP\ebpf-for-windows.vsconfig
-# The out-null seems to be required to make powershell wait
-# for the command to exit.
-&"C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" modify --installpath "$env:ProgramFiles\Microsoft Visual Studio\2022\Community" --config "$env:TEMP\ebpf-for-windows.vsconfig" --quiet | out-null
+& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" modify --installpath "$env:ProgramFiles\Microsoft Visual Studio\2022\Community" --config "$env:TEMP\ebpf-for-windows.vsconfig" --passive
 
+choco install llvm --version=18.1.8 -y
 choco install nuget.commandline --version 6.4.0 -y
 choco install cmake.portable --version 3.25.1 -y


### PR DESCRIPTION
Clang shipping with Visual Studio currently doesn't support the bpf target, see https://github.com/microsoft/ebpf-for-windows/issues/4227 The same goes for clang 19 as distributed by chocolatey.

Install the older clang 18 using chocolatey to at least have a working build. Also prefer the chocolatey clang over Visual Studio clang for now.