### PR TITLE
Perf event array cleanup.

### DIFF
--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -642,7 +642,7 @@ typedef void (*perf_buffer_lost_fn)(void* ctx, int cpu, uint64_t cnt);
  * @brief Subscribe for notifications from the input perf event array map.
  *
  * @param[in] perf_event_array_map_fd File descriptor to the perf event array map.
- * @param[in, out] sample_callback_context Pointer to supplied context to be passed in notification callback.
+ * @param[in, out] callback_context Pointer to supplied context to be passed in notification callback.
  * @param[in] sample_callback Function pointer to notification handler.
  * @param[in] lost_callback Function pointer to lost record notification handler.
  * @param[out] subscription Opaque pointer to perf event array subscription object.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4388,6 +4388,7 @@ typedef struct _ebpf_ring_buffer_subscription
         if (ring_buffer_map_handle != ebpf_handle_invalid) {
             Platform::CloseHandle(ring_buffer_map_handle);
         }
+        EBPF_LOG_EXIT();
     }
     std::mutex lock;
     _Write_guarded_by_(lock) boolean unsubscribed;
@@ -4760,7 +4761,7 @@ typedef struct _ebpf_perf_event_array_subscription
           async_ioctl_completion(nullptr), async_ioctl_failed(false)
     {
     }
-    ~_ebpf_perf_event_array_subscription() { EBPF_LOG_ENTRY(); }
+    ~_ebpf_perf_event_array_subscription() { EBPF_LOG_ENTRY(); EBPF_LOG_EXIT(); }
     std::mutex lock;
     _Write_guarded_by_(lock) boolean unsubscribed;
     ebpf_handle_t perf_event_array_map_handle;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4761,7 +4761,11 @@ typedef struct _ebpf_perf_event_array_subscription
           async_ioctl_completion(nullptr), async_ioctl_failed(false)
     {
     }
-    ~_ebpf_perf_event_array_subscription() { EBPF_LOG_ENTRY(); EBPF_LOG_EXIT(); }
+    ~_ebpf_perf_event_array_subscription()
+    {
+        EBPF_LOG_ENTRY();
+        EBPF_LOG_EXIT();
+    }
     std::mutex lock;
     _Write_guarded_by_(lock) boolean unsubscribed;
     ebpf_handle_t perf_event_array_map_handle;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2199,7 +2199,6 @@ Exit:
 static ebpf_result_t
 _ebpf_core_protocol_map_async_query(
     _In_ const ebpf_operation_map_async_query_request_t* request,
-    //_Inout_updates_bytes_(reply_length) ebpf_operation_map_async_query_reply_t* reply,
     _Inout_ ebpf_operation_map_async_query_reply_t* reply,
     uint16_t reply_length,
     _Inout_ void* async_context)

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2297,7 +2297,7 @@ _ebpf_perf_event_array_map_cancel_async_query(_In_ _Frees_ptr_ ebpf_core_map_asy
     uint32_t cpu_id = (uint32_t)context->index;
     ebpf_core_perf_event_array_map_t* perf_event_array_map =
         EBPF_FROM_FIELD(ebpf_core_perf_event_array_map_t, core_map, context->map);
-    if(cpu_id >= perf_event_array_map->ring_count) {
+    if (cpu_id >= perf_event_array_map->ring_count) {
         EBPF_LOG_MESSAGE_UINT64(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Invalid CPU ID", cpu_id);
         ebpf_free(context);
     } else {

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -256,13 +256,6 @@ typedef struct _ebpf_core_perf_event_array_map
 {
     ebpf_core_map_t core_map;
     uint32_t ring_count;
-    // Flag that is set the first time an async operation is queued to the map.
-    // This flag only transitions from off -> on. When this flag is set,
-    // updates to the map acquire the lock and check the async_contexts list.
-    // Note that queueing an async operation thus causes a perf degradation
-    // for all subsequent updates, so should only be allowed by admin.
-    // Note that we use a single trip wire for the perf array, so once
-    // one ring receives an async request the whole perf array uses async.
     uint32_t pad1;
     uint64_t pad2[3];
     ebpf_core_perf_ring_t rings[1];
@@ -2304,10 +2297,14 @@ _ebpf_perf_event_array_map_cancel_async_query(_In_ _Frees_ptr_ ebpf_core_map_asy
     uint32_t cpu_id = (uint32_t)context->index;
     ebpf_core_perf_event_array_map_t* perf_event_array_map =
         EBPF_FROM_FIELD(ebpf_core_perf_event_array_map_t, core_map, context->map);
-    ebpf_assert(cpu_id < perf_event_array_map->ring_count);
+    if(cpu_id >= perf_event_array_map->ring_count) {
+        EBPF_LOG_MESSAGE_UINT64(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Invalid CPU ID", cpu_id);
+        ebpf_free(context);
+    } else {
+        ebpf_core_perf_ring_t* ring = &perf_event_array_map->rings[cpu_id];
+        _map_async_query_cancel(&ring->async, context);
+    }
 
-    ebpf_core_perf_ring_t* ring = &perf_event_array_map->rings[cpu_id];
-    _map_async_query_cancel(&ring->async, context);
     EBPF_LOG_EXIT();
 }
 
@@ -2327,9 +2324,12 @@ _ebpf_perf_event_array_map_signal_async_query_complete(
     ebpf_core_perf_event_array_map_t* perf_event_array_map =
         EBPF_FROM_FIELD(ebpf_core_perf_event_array_map_t, core_map, map);
     uint32_t cpu_id = (uint32_t)index;
-    ebpf_assert(cpu_id < perf_event_array_map->ring_count);
-    ebpf_core_perf_ring_t* ring = &perf_event_array_map->rings[cpu_id];
-    _map_async_query_complete(&perf_event_array_map->core_map, &ring->async);
+    if (cpu_id >= perf_event_array_map->ring_count) {
+        EBPF_LOG_MESSAGE_UINT64(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Invalid CPU ID", cpu_id);
+    } else {
+        ebpf_core_perf_ring_t* ring = &perf_event_array_map->rings[cpu_id];
+        _map_async_query_complete(&perf_event_array_map->core_map, &ring->async);
+    }
 }
 
 static ebpf_result_t
@@ -2760,11 +2760,11 @@ ebpf_perf_event_array_map_output_with_capture(
         if (ctx_data_start == NULL || ctx_data_end == NULL) {
             // no context data pointer.
             result = EBPF_OPERATION_NOT_SUPPORTED;
-            goto ExitPreDispatch;
+            goto exit_pre_dispatch;
         } else if ((uint64_t)(ctx_data_end - ctx_data_start) < (uint64_t)capture_length) {
             // Requested capture length larger than data.
             result = EBPF_INVALID_ARGUMENT;
-            goto ExitPreDispatch;
+            goto exit_pre_dispatch;
         }
 
         extra_data = ctx_data_start;
@@ -2776,7 +2776,7 @@ ebpf_perf_event_array_map_output_with_capture(
         if (target_cpu != (uint32_t)EBPF_MAP_FLAG_CURRENT_CPU) {
             // Passive producers must specify current cpu flag.
             result = EBPF_INVALID_ARGUMENT;
-            goto ExitPreDispatch;
+            goto exit_pre_dispatch;
         }
         irql_at_enter = ebpf_raise_irql(DISPATCH_LEVEL);
     }
@@ -2816,7 +2816,7 @@ Exit:
     if (irql_at_enter < DISPATCH_LEVEL) {
         ebpf_lower_irql(irql_at_enter);
     }
-ExitPreDispatch:
+exit_pre_dispatch:
     EBPF_RETURN_RESULT(result);
 }
 

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -143,6 +143,44 @@ static const NPI_CLIENT_CHARACTERISTICS _ebpf_program_type_specific_program_info
     },
 };
 
+/**
+ * @brief Set the context_descriptor in the program context header.
+ *
+ * Writes a pointer to the ebpf_program_t object to Slot [1].
+ *
+ * @note Extension must support context headers.
+ *
+ * @param[in] context_descriptor Pointer to the context descriptor for the program.
+ * @param[in,out] program_context Pointer to the program context to set the header for.
+ */
+void
+ebpf_program_set_header_context_descriptor(
+    _In_ const ebpf_context_descriptor_t* context_descriptor, _Inout_ void* program_context)
+{
+    // slot [1] contains the context_descriptor for the program.
+    ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
+
+    header->context_header[1] = (uint64_t)context_descriptor;
+}
+
+/**
+ * @brief Get the context descriptor from the program context header.
+ *
+ * Slot [1] contains the context descriptor pointer.
+ *
+ * @note Extension must support context headers.
+ *
+ * @param[in] program_context Pointer to the program context.
+ * @param[out] context_descriptor Pointer to the program context to set.
+ */
+void
+ebpf_program_get_header_context_descriptor(
+    _In_ const void* program_context, _Outptr_ const ebpf_context_descriptor_t** context_descriptor)
+{
+    ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
+    *context_descriptor = (ebpf_context_descriptor_t*)header->context_header[1];
+}
+
 _Requires_lock_held_(program->lock) static ebpf_result_t _ebpf_program_update_helpers(_Inout_ ebpf_program_t* program);
 
 static ebpf_result_t
@@ -2695,24 +2733,6 @@ void
 ebpf_program_set_flags(_Inout_ ebpf_program_t* program, uint64_t flags)
 {
     program->flags = flags;
-}
-
-void
-ebpf_program_set_header_context_descriptor(
-    _In_ const ebpf_context_descriptor_t* context_descriptor, _Inout_ void* program_context)
-{
-    // slot [1] contains the context_descriptor for the program.
-    ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
-
-    header->context_header[1] = (uint64_t)context_descriptor;
-}
-
-void
-ebpf_program_get_header_context_descriptor(
-    _In_ const void* program_context, _Outptr_ const ebpf_context_descriptor_t** context_descriptor)
-{
-    ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
-    *context_descriptor = (ebpf_context_descriptor_t*)header->context_header[1];
 }
 
 void

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -476,34 +476,6 @@ extern "C"
     ebpf_program_set_flags(_Inout_ ebpf_program_t* program, uint64_t flags);
 
     /**
-     * @brief Set the context_descriptor in the program context header.
-     *
-     * Writes a pointer to the ebpf_program_t object to Slot [1].
-     *
-     * @note Extension must support context headers.
-     *
-     * @param[in] context_descriptor Pointer to the context descriptor for the program.
-     * @param[in,out] program_context Pointer to the program context to set the header for.
-     */
-    void
-    ebpf_program_set_header_context_descriptor(
-        _In_ const ebpf_context_descriptor_t* context_descriptor, _Inout_ void* program_context);
-
-    /**
-     * @brief Get the context descriptor from the program context header.
-     *
-     * Slot [1] contains the context descriptor pointer.
-     *
-     * @note Extension must support context headers.
-     *
-     * @param[in] program_context Pointer to the program context.
-     * @param[out] context_descriptor Pointer to the program context to set.
-     */
-    void
-    ebpf_program_get_header_context_descriptor(
-        _In_ const void* program_context, _Outptr_ const ebpf_context_descriptor_t** context_descriptor);
-
-    /**
      * @brief Get the data start and end pointers from the program context.
      *
      * @note Extension must support context headers.

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -17,6 +17,18 @@
 #include <optional>
 #include <set>
 
+extern "C"
+{
+    // program context descriptor helpers
+    // - Defined in ebpf_program.c, declared here for unit testing.
+    void
+    ebpf_program_set_header_context_descriptor(
+        _In_ const ebpf_context_descriptor_t* context_descriptor, _Inout_ void* program_context);
+    void
+    ebpf_program_get_header_context_descriptor(
+        _In_ const void* program_context, _Outptr_ const ebpf_context_descriptor_t** context_descriptor);
+}
+
 #if !defined(CONFIG_BPF_JIT_DISABLED)
 typedef struct _free_trampoline_table
 {


### PR DESCRIPTION
## Description

Cleanup in perf event array map code.

- Comment updates.
- Log exit in ringbuf and perf array ebpf_api.cpp code.
- Confirm cpu id in ioctls.

Follow-up to #4144 as part of #658.

## Testing

Covered by existing tests.

## Documentation

N/A

## Installation

No impact.
