### PR TITLE
Allocate stable program and attach type IDs for ntosebpfext

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -223,6 +223,13 @@ enum bpf_prog_type
      */
     BPF_PROG_TYPE_SOCK_OPS,
 
+    /** @brief Program type for handling process related events.
+     *
+     * **Attach type(s):**
+     *  \ref BPF_CGROUP_SOCK_OPS
+     */
+    BPF_PROG_TYPE_PROCESS,
+
     /** @brief Program type for handling incoming packets as early as possible.
      *
      * **eBPF program prototype:** \ref xdp_hook_t
@@ -325,6 +332,12 @@ enum bpf_attach_type
      * **Program type:** \ref BPF_PROG_TYPE_XDP_TEST
      */
     BPF_XDP_TEST,
+
+    /** @brief Attach type for process related events.
+     *
+     * **Program type:** \ref BPF_PROG_TYPE_PROCESS
+     */
+    BPF_ATTACH_TYPE_PROCESS,
 
     __MAX_BPF_ATTACH_TYPE,
 };

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2590,6 +2590,9 @@ TEST_CASE("libbpf attach type names", "[libbpf]")
         // Skip XDP type as it is supported only with the xdp-for-windows repo.
         if (i == BPF_XDP)
             continue;
+        if (i == BPF_ATTACH_TYPE_PROCESS)
+            continue; // requires ntosebpfext
+
         const char* type_str = libbpf_bpf_attach_type_str((enum bpf_attach_type)i);
 
         REQUIRE(libbpf_attach_type_by_name(type_str, &attach_type) == 0);


### PR DESCRIPTION
Add BPF_PROG_TYPE_PROCESS and BPF_ATTACH_TYPE_PROCESS so that users of the libbpf API can refer to ntosebpfext program types without having to resort to GUIDs.

Updates https://github.com/microsoft/ntosebpfext/issues/152

