### PR TITLE
Use SAFE_REQUIRE in native_helper

### DIFF
--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -24,10 +24,20 @@ typedef class _native_module_helper
     void
     initialize(_In_z_ const char* file_name_prefix)
     {
-        initialize(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY);
+        initialize(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY, true);
     }
     void
-    initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type);
+    initialize(_In_z_ const char* file_name_prefix, bool is_main_thread)
+    {
+        initialize(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY, is_main_thread);
+    }
+    void
+    initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
+    {
+        initialize(file_name_prefix, execution_type, true);
+    }
+    void
+    initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type, bool is_main_thread);
     std::string
     get_file_name() const
     {
@@ -39,4 +49,5 @@ typedef class _native_module_helper
   private:
     std::string _file_name;
     bool _delete_file_on_destruction = false;
+    bool _is_main_thread = true;
 } native_module_helper_t;

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -43,7 +43,7 @@ connection_test(
     uint32_t protocol)
 {
     native_module_helper_t helper;
-    helper.initialize("cgroup_sock_addr");
+    helper.initialize("cgroup_sock_addr", _is_main_thread);
 
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     bpf_object_ptr object_ptr(object);
@@ -173,7 +173,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
     uint32_t program_info_size = sizeof(program_info);
 
     native_module_helper_t helper;
-    helper.initialize("cgroup_sock_addr");
+    helper.initialize("cgroup_sock_addr", _is_main_thread);
 
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     bpf_object_ptr object_ptr(object);
@@ -267,7 +267,7 @@ connection_monitor_test(
     bool disconnect)
 {
     native_module_helper_t helper;
-    helper.initialize("sockops");
+    helper.initialize("sockops", _is_main_thread);
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     bpf_object_ptr object_ptr(object);
 
@@ -469,7 +469,7 @@ TEST_CASE("connection_monitor_test_disconnect_tcp_v6", "[sock_ops_tests]")
 TEST_CASE("attach_sockops_programs", "[sock_ops_tests]")
 {
     native_module_helper_t helper;
-    helper.initialize("sockops");
+    helper.initialize("sockops", _is_main_thread);
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     bpf_object_ptr object_ptr(object);
 
@@ -695,7 +695,7 @@ multi_attach_test(uint32_t compartment_id, socket_family_t family, ADDRESS_FAMIL
 
     // Load the programs.
     for (uint32_t i = 0; i < MULTIPLE_ATTACH_PROGRAM_COUNT; i++) {
-        helpers[i].initialize("cgroup_sock_addr2");
+        helpers[i].initialize("cgroup_sock_addr2", _is_main_thread);
         objects[i] = bpf_object__open(helpers[i].get_file_name().c_str());
         SAFE_REQUIRE(objects[i] != nullptr);
         object_ptrs[i] = bpf_object_ptr(objects[i]);
@@ -745,7 +745,7 @@ multi_attach_test(uint32_t compartment_id, socket_family_t family, ADDRESS_FAMIL
     // Now attach a 4th program to different compartment. It should not get invoked, and its verdict should not affect
     // the connection.
     native_module_helper_t helper;
-    helper.initialize("cgroup_sock_addr2");
+    helper.initialize("cgroup_sock_addr2", _is_main_thread);
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     SAFE_REQUIRE(object != nullptr);
     bpf_object_ptr object_ptr(object);
@@ -781,7 +781,7 @@ multi_attach_test_redirection(
 
     // Load 3 programs.
     for (uint32_t i = 0; i < MULTIPLE_ATTACH_PROGRAM_COUNT; i++) {
-        helpers[i].initialize("cgroup_sock_addr2");
+        helpers[i].initialize("cgroup_sock_addr2", _is_main_thread);
         objects[i] = bpf_object__open(helpers[i].get_file_name().c_str());
         SAFE_REQUIRE(objects[i] != nullptr);
         object_ptrs[i] = bpf_object_ptr(objects[i]);
@@ -1058,7 +1058,7 @@ test_multi_attach_combined(socket_family_t family, ADDRESS_FAMILY address_family
 
     // Load the programs.
     for (uint32_t i = 0; i < program_count_per_hook * 2; i++) {
-        helpers[i].initialize("cgroup_sock_addr2");
+        helpers[i].initialize("cgroup_sock_addr2", _is_main_thread);
         objects[i] = bpf_object__open(helpers[i].get_file_name().c_str());
         SAFE_REQUIRE(objects[i] != nullptr);
         object_ptrs[i] = bpf_object_ptr(objects[i]);
@@ -1222,8 +1222,8 @@ TEST_CASE("multi_attach_test_invocation_order", "[sock_addr_tests][multi_attach_
     int result = 0;
     native_module_helper_t native_helpers_specific;
     native_module_helper_t native_helpers_wildcard;
-    native_helpers_specific.initialize("cgroup_sock_addr2");
-    native_helpers_wildcard.initialize("cgroup_sock_addr2");
+    native_helpers_specific.initialize("cgroup_sock_addr2", _is_main_thread);
+    native_helpers_wildcard.initialize("cgroup_sock_addr2", _is_main_thread);
     socket_family_t family = socket_family_t::Dual;
     ADDRESS_FAMILY address_family = AF_INET;
     bpf_attach_type_t attach_type = (address_family == AF_INET) ? BPF_CGROUP_INET4_CONNECT : BPF_CGROUP_INET6_CONNECT;
@@ -1421,7 +1421,7 @@ void
 thread_function_attach_detach(std::stop_token token, uint32_t compartment_id, uint16_t destination_port)
 {
     native_module_helper_t helper;
-    helper.initialize("cgroup_sock_addr2");
+    helper.initialize("cgroup_sock_addr2", _is_main_thread);
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     SAFE_REQUIRE(object != nullptr);
     bpf_object_ptr object_ptr(object);
@@ -1478,7 +1478,7 @@ thread_function_allow_block_connection(
     uint32_t compartment_id)
 {
     native_module_helper_t helper;
-    helper.initialize("cgroup_sock_addr2");
+    helper.initialize("cgroup_sock_addr2", _is_main_thread);
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     SAFE_REQUIRE(object != nullptr);
     bpf_object_ptr object_ptr(object);


### PR DESCRIPTION
## Description

`socket_tests` uses `native_module_helper_t` to load native images, which internally calls REQUIRE(). In some cases `socket_tests` create `native_module_helper_t` in worker thread also. That causes issue as REQUIRE should not be called from worker threads.

This PR changes logic in native_module_helper_t to call REQUIRE only when it is created in main thread.

## Testing

Existing CICD

## Documentation

No

## Installation

No
