### PR TITLE
Pickup version of ebpf-verifier that fixes loops

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -518,8 +518,7 @@ ebpf_api_elf_enumerate_programs(
                 }
                 auto& instruction_sequence = std::get<InstructionSeq>(instruction_sequence_or_error);
                 // auto program = crab::prepare_cfg(program, raw_program.info, verifier_options.cfg_opts);
-                auto program =
-                    Program::from_sequence(instruction_sequence, raw_program.info, verifier_options.cfg_opts);
+                auto program = Program::from_sequence(instruction_sequence, raw_program.info, verifier_options);
                 std::map<std::string, int> stats = collect_stats(program);
                 for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
                     _ebpf_add_stat(info, it->first, it->second);

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -181,7 +181,7 @@ ebpf_verify_program(
         if (info.type.platform_specific_data == (uintptr_t)&EBPF_PROGRAM_TYPE_UNSPECIFIED) {
             throw std::runtime_error("Unspecified program type.");
         }
-        const auto program = Program::from_sequence(instruction_sequence, info, options.cfg_opts);
+        const auto program = Program::from_sequence(instruction_sequence, info, options);
         auto invariants = analyze(program);
         if (options.verbosity_opts.print_invariants) {
             print_invariants(os, program, options.verbosity_opts.simplify, invariants);

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -506,35 +506,17 @@ TEST_CASE("show verification xdp_datasize_unsafe.o", "[netsh][verification]")
     output = strip_paths(output);
 
     // Perform a line by line comparison to detect any differences.
-    std::string expected_output =
-        "Verification failed\n"
-        "\n"
-        "Verification report:\n"
-        "\n"
-        "; ./tests/sample/unsafe/xdp_datasize_unsafe.c:33\n"
-        ";     if (next_header + sizeof(ETHERNET_HEADER) > (char*)ctx->data_end) {\n"
-        "\n"
-        "4: Invalid type (r3.type in {number, ctx, stack, packet, shared})\n"
-        "5: Invalid type (valid_access(r3.offset) for comparison/subtraction)\n"
-        "5: Invalid type (r3.type in {number, ctx, stack, packet, shared})\n"
-        "5: Cannot subtract pointers to different regions (r3.type == r1.type in {ctx, stack, packet})\n"
-        "\n"
-        "; ./tests/sample/unsafe/xdp_datasize_unsafe.c:39\n"
-        ";     if (ethernet_header->Type != ntohs(ETHERNET_TYPE_IPV4) && ethernet_header->Type != "
-        "ntohs(ETHERNET_TYPE_IPV6)) {\n"
-        "\n"
-        "6: Invalid type (r2.type in {ctx, stack, packet, shared})\n"
-        "6: Invalid type (valid_access(r2.offset+12, width=2) for read)\n"
-        "8: Invalid type (r1.type == number)\n"
-        "10: Invalid type (r1.type == number)\n"
-        "\n"
-        "; ./tests/sample/unsafe/xdp_datasize_unsafe.c:44\n"
-        ";     return rc;\n"
-        "\n"
-        "12: Invalid type (r0.type == number)\n"
-        "\n"
-        "9 errors\n"
-        "\n";
+    std::string expected_output = "Verification failed\n"
+                                  "\n"
+                                  "Verification report:\n"
+                                  "\n"
+                                  "; ./tests/sample/unsafe/xdp_datasize_unsafe.c:33\n"
+                                  ";     if (next_header + sizeof(ETHERNET_HEADER) > (char*)ctx->data_end) {\n"
+                                  "\n"
+                                  "4: Invalid type (r3.type in {number, ctx, stack, packet, shared})\n"
+                                  "\n"
+                                  "1 errors\n"
+                                  "\n";
 
     // Split both output and expected_output into lines.
     std::istringstream output_stream(output);

--- a/tests/sample/undocked/map.c
+++ b/tests/sample/undocked/map.c
@@ -116,82 +116,16 @@ test_LRU_map(struct _ebpf_map_definition_in_file* map)
     int result;
 
     // Insert capacity + 1 entries
-#if 0
-    for (key = 0; key < 11; key++) {
+    // Verifier can't handle loops with == as the boundary condition. Clang optimizer converts all loops to have an ==
+    // condition by default. So we need to use a volatile variable to make the compiler honor our loop condition.
+    for (volatile uint32_t i = 0; i < 11; i++) {
+        key = i;
         result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
         if (result < 0) {
             bpf_printk("bpf_map_update_elem returned %d", result);
             return result;
         }
     }
-#else
-    // Work around temporary compiler limitation.
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 1;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 2;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 3;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 4;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 5;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 6;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 7;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 8;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 9;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-    key = 10;
-    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
-    if (result < 0) {
-        bpf_printk("bpf_map_update_elem returned %d", result);
-        return result;
-    }
-#endif
     return 0;
 }
 
@@ -236,50 +170,25 @@ struct _ebpf_map_definition_in_file STACK_map;
 inline __attribute__((always_inline)) int
 test_PUSH_POP_map(struct _ebpf_map_definition_in_file* map)
 {
-    int i;
     PEEK_VALUE(map, 0, -7);
     POP_VALUE(map, 0, -7);
 
-#if 0
-    for (i = 0; i < 10; i++) {
+    // Verifier can't handle loops with == as the boundary condition. Clang optimizer converts all loops to have an ==
+    // condition by default. So we need to use a volatile variable to make the compiler honor our loop condition.
+    for (volatile int i = 0; i < 10; i++) {
         PUSH_VALUE(map, i, FALSE, 0);
     }
-#else
-    // Work around current verifier limitation.
-    PUSH_VALUE(map, 0, FALSE, 0);
-    PUSH_VALUE(map, 1, FALSE, 0);
-    PUSH_VALUE(map, 2, FALSE, 0);
-    PUSH_VALUE(map, 3, FALSE, 0);
-    PUSH_VALUE(map, 4, FALSE, 0);
-    PUSH_VALUE(map, 5, FALSE, 0);
-    PUSH_VALUE(map, 6, FALSE, 0);
-    PUSH_VALUE(map, 7, FALSE, 0);
-    PUSH_VALUE(map, 8, FALSE, 0);
-    PUSH_VALUE(map, 9, FALSE, 0);
-#endif
 
     PUSH_VALUE(map, 10, FALSE, -29);
     PUSH_VALUE(map, 10, TRUE, 0);
 
     PEEK_VALUE(map, (map == &STACK_map) ? 10 : 1, 0);
 
-#if 0
-    for (i = 0; i < 10; i++) {
+    // Verifier can't handle loops with == as the boundary condition. Clang optimizer converts all loops to have an ==
+    // condition by default. So we need to use a volatile variable to make the compiler honor our loop condition.
+    for (volatile int i = 0; i < 10; i++) {
         POP_VALUE(map, (map == &STACK_map) ? 10 - i : i + 1, 0);
     }
-#else
-    // Work around current verifier limitation.
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 0 : 0 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 1 : 1 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 2 : 2 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 3 : 3 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 4 : 4 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 5 : 5 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 6 : 6 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 7 : 7 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 8 : 8 + 1, 0);
-    POP_VALUE(map, (map == &STACK_map) ? 10 - 9 : 9 + 1, 0);
-#endif
 
     PEEK_VALUE(map, 0, -7);
     POP_VALUE(map, 0, -7);


### PR DESCRIPTION
Resolves: #1993 

## Description

Pickup latest version of ebpf-verifier with fix for loop termination checks.
Update revert workaround in samples for missing loop support.
Update expected output now that "assume assertions is honored correctly".

## Testing

CI/CD

## Documentation

No.

## Installation

No.
