### PR TITLE
Fix a few NuGet packaging issues

### DIFF
--- a/tools/nuget/ebpf-for-windows.nuspec.in
+++ b/tools/nuget/ebpf-for-windows.nuspec.in
@@ -19,7 +19,7 @@
 	</metadata>
 	<files>
 		<file src="..\..\tools\nuget\README.md" target="."/>
-		<file src="ebpf-for-windows.{architecture}.props" target="build\native"/>
+		<file src="ebpf-for-windows.{architecture}.props" target="build\native\eBPF-for-Windows.{architecture}{configuration}.props"/>
 		<file src="Convert-BpfToNative.ps1" target="build\native\bin"/>
 		<file src="bpf2c.exe" target="build\native\bin"/>
 		<file src="bpf2c.pdb" target="build\native\bin"/>

--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -19,6 +19,7 @@
 	</metadata>
 	<files>
 		<file src="..\..\tools\redist-package\README.md" target="."/>
+		<file src="..\..\tools\redist-package\ebpf-for-windows-redist.props" target="build\native\eBPF-for-Windows-Redist.{architecture}{configuration}.props"/>
 		<file src="bpftool.exe" target="lib\native\bin"/>
 		<file src="bpftool.pdb" target="lib\native\bin"/>
 		<file src="ebpfapi.dll" target="lib\native\bin"/>

--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -13,7 +13,7 @@
 		<license type="expression">MIT</license>
 		<projectUrl>https://github.com/Microsoft/ebpf-for-windows</projectUrl>
 		<repository type="git" url="https://github.com/microsoft/ebpf-for-windows.git"/>
-		<tags>resdist redistributable ebpf</tags>
+		<tags>redist redistributable ebpf native</tags>
 		<description>eBPF for Windows Redistributable</description>
 		<readme>README.md</readme>
 	</metadata>

--- a/tools/redist-package/ebpf-for-windows-redist.props
+++ b/tools/redist-package/ebpf-for-windows-redist.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) eBPF for Windows contributors
+  SPDX-License-Identifier: MIT
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+  <PropertyGroup>
+	  <EbpfBinPath>$(MSBuildThisFileDirectory)..\..\lib\native\bin</EbpfBinPath>
+  </PropertyGroup>
+</Project>

--- a/tools/redist-package/redist-package.vcxproj
+++ b/tools/redist-package/redist-package.vcxproj
@@ -158,6 +158,7 @@ NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />
+    <None Include="ebpf-for-windows-redist.props" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
## Description

Fix issue where the redistributable NuGet package isn't restored when listed as a package dependency of another package. Eg.

```XML
<group targetFramework="native0.0">
  <dependency id="eBPF-for-Windows-Redist" version="0.21.0" />
</group>  
```

This is due to the package not containing any content that targets the `native` target framework moniker (TFM). The package must contain at least one item group that specifies the `native` TFM, otherwise the dependency is silently ignored as the tooling doesn't detect any matching content. While the package does place content under `lib\native`, the `lib` directory is specifically excluded for native packages (see [Creating native packages](https://learn.microsoft.com/en-us/nuget/guides/native-packages)).

Also fix the issue where consumption of the SDK package doesn't automatically update the consuming project to import the `.props` file. This occurs because the `.props` file must use the package id as the filename for the auto-import behavior to be enabled (see [MSBuild .props and .targets in a package](https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets)).

Last, fix a typo in the tags for the redist package.

Fixes #4325 
Fixes #4326
Fixes #4327

Changes:
* Add `native` tag to redistributable NuGet package tags.
* Fix typo 'resdist' -> 'redist' in the redistributable NuGet package tags.
* Add `.props` file to redistributable NuGet package, with variable containing binary path.
* Rename `.props` file in SDK NuGet package to include package ID such that it will be auto-imported to MSBuild projects for consumers.

## Testing

* Rebuilt entire solution, consumed both packages in a test native C++ project both as a direct package reference and as a package dependency. 

## Documentation

N/A

## Installation

N/A