### PR TITLE
Add ebpf core callout to validate native image attach

### DIFF
--- a/ebpfcore/EbpfCore.vcxproj
+++ b/ebpfcore/EbpfCore.vcxproj
@@ -88,7 +88,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS630;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib;$(DDK_LIB_PATH)\Aux_Klib.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/spgo /spdin:$(SolutionDir)spd\ebpfcore.spd %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -108,7 +108,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS630;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib;$(DDK_LIB_PATH)\Aux_Klib.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/spgo /spdin:$(SolutionDir)spd\ebpfcore.spd %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -128,7 +128,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS630;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib;$(DDK_LIB_PATH)\Aux_Klib.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <DriverSign>
@@ -147,7 +147,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS630;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib;$(DDK_LIB_PATH)\Aux_Klib.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <DriverSign>

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -22,6 +22,9 @@ extern "C"
 
     typedef uint32_t(__stdcall* ebpf_hook_function)(uint8_t*);
 
+    typedef ebpf_result_t (*ebpf_core_native_module_authorization_function_t)(
+        _In_ const cxplat_utf8_string_t* module_name);
+
     /**
      * @brief Initialize the eBPF core execution context.
      *
@@ -290,6 +293,29 @@ extern "C"
         uint32_t count_of_maps,
         _In_reads_(count_of_maps) const ebpf_handle_t* map_handles,
         _Out_writes_(count_of_maps) uintptr_t* map_value_addresses);
+
+    /**
+     * @brief Invoke any registered authorization function for the native module and check if the module is authorized.
+     *
+     * @param[in] module_name Full path of the native module to be authorized.
+     * @retval EBPF_SUCCESS The module us authorized to be run.
+     * @retval EBPF_ACCESS_DENIED The module is not authorized to be run.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_core_authorize_native_module(_In_ cxplat_utf8_string_t* module_name);
+
+    /**
+     * @brief Register or unregister a native module authorization function.
+     *
+     * @param[in] native_module_authorization Pointer to the native module authorization function. If NULL, unregisters
+     * the function.
+     * @return EBPF_SUCCESS The operation was successful.
+     * @return EBPF_INVALID_ARGUMENT Attempt was made to register an authorization function when one is already
+     * registered.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_core_register_native_module_authorization(
+        _In_opt_ const ebpf_core_native_module_authorization_function_t native_module_authorization);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

Add new API ebpf_core_register_native_module_authorization to invoker if the execution context control over what drivers can attach as native modules.
Add ebpf_driver_authorize_native_module as a stub to ebpfcore to implement current behavior (allow any HLK signed driver to attach).
Update usersim to latest.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
