### PR TITLE
Extend timeout of api_tests in the CICD task to 10 minutes

### DIFF
--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -325,7 +325,7 @@ function Invoke-CICDTests
     # That causes the regression test to fail. So, we are skipping this test for now.
 
     $TestList = @(
-        (New-TestTuple -Test "api_test.exe" -Arguments "~`"load_native_program_invalid4`""),
+        (New-TestTuple -Test "api_test.exe" -Arguments "~`"load_native_program_invalid4`"" -Timeout 600),
         (New-TestTuple -Test "bpftool_tests.exe"),
         (New-TestTuple -Test "sample_ext_app.exe"),
         (New-TestTuple -Test "socket_tests.exe" -Timeout 1800)

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -1059,9 +1059,10 @@ _ebpf_sock_ops_context_create(
 
     *context = sock_ops_context;
     sock_ops_context = nullptr;
+    sock_ops_context_header = nullptr;
     retval = EBPF_SUCCESS;
 Done:
-    ebpf_free(sock_ops_context);
+    ebpf_free(sock_ops_context_header);
     sock_ops_context = nullptr;
     return retval;
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
The api_tests have been intermittently failing since #4302 was merged. The additional perf buffer stress test is likely taking the test execution time to over the allotted 5 minutes and falsely claiming a hang. Investigation from the generated crash dumps does not indicate any hang. So we are extending the timeout for these tests to 10 minutes.

The first iteration of this PR hit a bug in the execution engine fuzzer, that exposed a regression introduced by #4267 in a test module that caused memory corruption. Fixing that.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
Test automation changes.

## Documentation

_Is there any documentation impact for this change?_
N/A.

## Installation

_Is there any installer impact for this change?_
N/A.