### PR TITLE
bpf: support log_true_size for BPF_PROG_LOAD

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -143,6 +143,28 @@ typedef struct
     uint32_t kern_version; ///< Kernel version (currently ignored on Windows).
     uint32_t prog_flags;   ///< Not supported, must be zero.
     char prog_name[SYS_BPF_OBJ_NAME_LEN]; ///< Program name.
+    uint32_t prog_ifindex;                ///< Not supported, must be zero.
+    uint32_t expected_attach_type;        ///< Not supported, must be zero.
+    uint32_t prog_btf_fd;                 ///< Not supported, must be zero.
+    uint32_t func_info_rec_size;          ///< Not supported, must be zero.
+    uint64_t func_info;                   ///< Not supported, must be zero.
+    uint32_t func_info_cnt;               ///< Not supported, must be zero.
+    uint32_t line_info_rec_size;          ///< Not supported, must be zero.
+    uint64_t line_info;                   ///< Not supported, must be zero.
+    uint32_t line_info_cnt;               ///< Not supported, must be zero.
+    uint32_t attach_btf_id;               ///< Not supported, must be zero.
+    union
+    {
+        ///< Not supported, must be zero.
+        uint32_t attach_prog_fd;
+        ///< Not supported, must be zero.
+        uint32_t attach_btf_obj_fd;
+    };
+    uint32_t core_relo_cnt;      ///< Not supported, must be zero.
+    uint64_t fd_array;           ///< Not supported, must be zero.
+    uint64_t core_relos;         ///< Not supported, must be zero.
+    uint32_t core_relo_rec_size; ///< Not supported, must be zero.
+    uint32_t log_true_size;      ///< Total size of the log output. May be larger than log_size.
 } sys_bpf_prog_load_attr_t;
 
 typedef struct

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -672,6 +672,8 @@ ebpf_api_elf_enumerate_programs(
  * @param[in] log_buffer_size Size in bytes of the caller's log buffer.
  * @param[out] program_fd Returns a file descriptor for the program.
  *  The caller should call _close() on the fd to close this when done.
+ * @param[out] log_buffer_true_size The size of log buffer required to avoid
+ *  truncation.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
@@ -688,7 +690,8 @@ ebpf_program_load_bytes(
     uint32_t instruction_count,
     _Out_writes_opt_(log_buffer_size) char* log_buffer,
     size_t log_buffer_size,
-    _Out_ fd_t* program_fd) noexcept;
+    _Out_ fd_t* program_fd,
+    _Out_opt_ uint32_t* log_buffer_true_size) noexcept;
 #endif
 
 /**

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -36,7 +36,8 @@ bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_
         (uint32_t)load_attr->insns_cnt,
         log_buf,
         log_buf_sz,
-        &program_fd);
+        &program_fd,
+        nullptr);
     if (result != EBPF_SUCCESS) {
         return libbpf_result_err(result);
     }
@@ -99,7 +100,8 @@ bpf_prog_load(
         (uint32_t)insn_cnt,
         log_buffer,
         log_buffer_size,
-        &program_fd);
+        &program_fd,
+        nullptr);
     if (result != EBPF_SUCCESS) {
         return libbpf_result_err(result);
     }

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -83,7 +83,7 @@ bpf_prog_load(
         return libbpf_err(-EINVAL);
     }
 
-    if ((insn_cnt == 0) || (insn_cnt > UINT32_MAX / sizeof(ebpf_inst))) {
+    if (insns == nullptr) {
         return libbpf_err(-EINVAL);
     }
 
@@ -108,7 +108,7 @@ bpf_prog_load(
     return program_fd;
 #else
     UNREFERENCED_PARAMETER(prog_name);
-    UNREFERENCED_PARAMETER(insns);
+    UNREFERENCED_PARAMETER(insn_cnt);
     UNREFERENCED_PARAMETER(opts);
     return libbpf_err(-ENOTSUP);
 #endif

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -387,7 +387,7 @@ ebpf_verify_and_load_program(
             byte_code_size = machine_code.size();
 
             if (*error_message != nullptr) {
-                *error_message_size = (uint32_t)strlen(*error_message);
+                *error_message_size = (uint32_t)strlen(*error_message) + 1;
             }
         }
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2862,7 +2862,8 @@ TEST_CASE("ebpf_program_load_bytes-name-gen", "[end-to-end]")
         insn_cnt,
         nullptr,
         0,
-        &program_fd);
+        &program_fd,
+        nullptr);
 
     REQUIRE(result == EBPF_SUCCESS);
     REQUIRE(program_fd >= 0);


### PR DESCRIPTION
The behaviour around verifier logs on Linux is quite subtle and a bit error
prone. One API that makes everything a lot easier is the log_true_size field
which informs the caller how big the provided buffer should be. Implement
support for the field in the bpf() syscall wrapper.

See #4378