### PR TITLE
Remove EBPF_ENABLE_WER_REPORT in favour of IsDebuggerPresent()

### DIFF
--- a/.azure/reusable-test.yml
+++ b/.azure/reusable-test.yml
@@ -191,7 +191,6 @@ jobs:
 
       - script: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
-          set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe -q --cover_children --sources $(Build.SourcesDirectory)\$(PROJECT_NAME) --excluded_sources $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -- $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\$(TEST_COMMAND)
         workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)
         condition: and(eq('${{parameters.code_coverage}}', 'true'), eq('${{parameters.vs_dev}}', 'true'))
@@ -213,7 +212,6 @@ jobs:
         displayName: Run test with low resource simulation
 
       - script: |
-          set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe -q --sources $(Build.SourcesDirectory)\$(PROJECT_NAME) --excluded_sources $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -- powershell .\Run-Test.ps1 $(DUMP_PATH) $(TEST_TIMEOUT) $(TEST_COMMAND)
         workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)
         condition: and(eq('${{parameters.code_coverage}}', 'true'), ne('${{parameters.vs_dev}}', 'true'), ne('${{parameters.fault_injection}}', 'true'))

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -261,7 +261,6 @@ jobs:
       shell: cmd
       run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
-          set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
     - name: Run test with Code Coverage and low resource simulation
@@ -269,7 +268,6 @@ jobs:
       id: run_test_with_code_coverage_in_fault_injection
       shell: cmd
       run: |
-          set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 8
 
     - name: Run test with low resource simulation
@@ -278,7 +276,6 @@ jobs:
       shell: cmd
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-          set EBPF_ENABLE_WER_REPORT=yes
           powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 16
 
     - name: Run test with Code Coverage
@@ -286,7 +283,6 @@ jobs:
       id: run_test_with_code_coverage
       shell: cmd
       run: |
-          set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe -q --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 
     - name: Run test on self-hosted runner
@@ -309,7 +305,6 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
-        set EBPF_ENABLE_WER_REPORT=yes
         cd /d ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}
         powershell.exe .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -318,7 +318,6 @@ function Invoke-CICDTests
 
 
     Push-Location $WorkingDirectory
-    $env:EBPF_ENABLE_WER_REPORT = "yes"
 
     # Now create an array of test tuples, overriding only the necessary values
     # load_native_program_invalid4 has been deleted from the test list, but 0.17 tests still have this test.
@@ -458,7 +457,6 @@ function Invoke-CICDStressTests
           [parameter(Mandatory = $false)][bool] $RestartExtension = $false)
 
     Push-Location $WorkingDirectory
-    $env:EBPF_ENABLE_WER_REPORT = "yes"
 
     Write-Log "Executing eBPF kernel mode multi-threaded stress tests (restart extension:$RestartExtension)."
 

--- a/tests/unit/wer_report_test_wrapper.cpp
+++ b/tests/unit/wer_report_test_wrapper.cpp
@@ -137,20 +137,14 @@ WerReportSubmit_test(
 
 TEST_CASE("wer_report_started_shutdown", "[wer_report]")
 {
-    char* old_buffer = nullptr;
-    size_t size = 0;
-    _dupenv_s(&old_buffer, &size, "EBPF_ENABLE_WER_REPORT");
-    _putenv_s("EBPF_ENABLE_WER_REPORT", "yes");
-    {
-        _wer_report_test _wer_report_test_singleton;
-        REQUIRE(AddVectoredExceptionHandler_test_first);
-        REQUIRE(AddVectoredExceptionHandler_test_handler != nullptr);
-        REQUIRE(SetThreadStackGuarantee_test_stack_size_in_bytes == 32 * 1024);
+    if (IsDebuggerPresent()) {
+        SKIP("Debugger present, skipping test.");
     }
 
-    if (old_buffer) {
-        _putenv_s("EBPF_ENABLE_WER_REPORT", old_buffer);
-    }
+    _wer_report_test _wer_report_test_singleton;
+    REQUIRE(AddVectoredExceptionHandler_test_first);
+    REQUIRE(AddVectoredExceptionHandler_test_handler != nullptr);
+    REQUIRE(SetThreadStackGuarantee_test_stack_size_in_bytes == 32 * 1024);
 }
 
 TEST_CASE("wer_report_fatal_exception", "[wer_report]")


### PR DESCRIPTION
The unit tests inspect EBPF_ENABLE_WER_REPORT environment variable to determine whether to customise error reporting. By default, no customisation is done.
On headless environments like CI / ssh sessions this leads to the program hanging or simply being killed.

Replace the environment variable with a call to IsDebuggerPresent(): if there is a debugger we bail out. Otherwise we configure error reporting to print assertions to stderr before crashing.

This allows removing a bunch of boilerplate from CI and reduces the amount of headscratching when a test fails without any output.
