### PR TITLE
Update OneBranch PostBuildEvent to use platform-scoped destination directory

### DIFF
--- a/tools/onebranch/onebranch.vcxproj
+++ b/tools/onebranch/onebranch.vcxproj
@@ -45,22 +45,22 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyDebug' And '$(BuildOneBranch)'=='True'">
     <PostBuildEvent>
-      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\x64_NativeOnlyDebug</Command>
+      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyRelease' And '$(BuildOneBranch)'=='True'">
     <PostBuildEvent>
-      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\x64_NativeOnlyRelease</Command>
+      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_NativeOnlyRelease</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' And '$(BuildOneBranch)'=='True'">
     <PostBuildEvent>
-      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\x64_Debug</Command>
+      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_Debug</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' And '$(BuildOneBranch)'=='True'">
     <PostBuildEvent>
-      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\x64_Release</Command>
+      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_Release</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Ensure OneBranch builds complete successfully.

The `onebranch.vcxproj` `<PostBuildEvent>` copies binary files to a destination which has `x64` encoded into the path, irrespective of the platform being built. This causes ARM64 binaries to be placed in a directory prefixed with `x64`, and hence, the OneBranch build signing tasks don't find the files, so doesn't sign them. This causes official builds to break due to code signing policy violation.

Fix this by using the `$(Platform)` variable value in destination path instead of `x64`.

Fixes #4371

## Testing

* Inspection only so far. Local build kicked off.

## Documentation

N/A

## Installation

N/A