### PR TITLE
Fix redist nuspec

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -289,6 +289,13 @@ jobs:
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\redist-package /bl:out.binlog
 
+      - name: Valdiate NuGet Redist package
+        if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: |
+           $nugetFile = Get-ChildItem -Path .\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -Filter "*eBPF-for-Windows-Redist*.nupkg" | Select-Object -ExpandProperty FullName
+           .\scripts\validate_redist_nuget_architecture.ps1 -NugetPackagePath $nugetFile -ExpectedArchitecture ${{env.BUILD_PLATFORM}}
+
       - name: Upload the NuGet Redist package
         if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/scripts/validate_redist_nuget_architecture.ps1
+++ b/scripts/validate_redist_nuget_architecture.ps1
@@ -1,0 +1,106 @@
+# Copyright (c) eBPF for Windows contributors
+# SPDX-License-Identifier: MIT
+
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$NugetPackagePath,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('x64', 'arm64')]
+    [string]$ExpectedArchitecture
+)
+
+function Extract-NuGetPackage {
+    param (
+        [string]$PackagePath,
+        [string]$DestinationFolder
+    )
+
+    if (-Not (Test-Path $PackagePath)) {
+        throw "NuGet package not found at path: $PackagePath"
+    }
+
+    if (-Not (Test-Path $DestinationFolder)) {
+        New-Item -ItemType Directory -Path $DestinationFolder | Out-Null
+    }
+
+    # Copy / rename file to a .zip
+    $ZipPackagePath = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath) + ".zip"
+    Copy-Item -Path $PackagePath -Destination $ZipPackagePath
+
+    Expand-Archive -Path $ZipPackagePath -DestinationPath $DestinationFolder -Force
+}
+
+function Get-PEArchitecture {
+    param (
+        [string]$FilePath
+    )
+
+    $stream = [System.IO.File]::OpenRead($FilePath)
+    $reader = New-Object System.IO.BinaryReader($stream)
+
+    try {
+        # Read DOS header to find PE header offset
+        $stream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $peOffset = $reader.ReadInt32()
+
+        # Seek to PE header
+        $stream.Seek($peOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $peSignature = $reader.ReadBytes(4)
+
+        if (-not ($peSignature[0] -eq 0x50 -and $peSignature[1] -eq 0x45 -and $peSignature[2] -eq 0x00 -and $peSignature[3] -eq 0x00)) {
+            throw "Invalid PE signature."
+        }
+
+        # Machine type is next
+        $machine = $reader.ReadUInt16()
+
+        switch ($machine) {
+            0x8664 { return 'x64' }
+            0xAA64 { return 'arm64' }
+            default { return "unknown(0x{0:X4})" -f $machine }
+        }
+    }
+    finally {
+        $reader.Close()
+        $stream.Close()
+    }
+}
+
+# Main
+try {
+    Write-Host "NuGet Package: $NugetPackagePath"
+    Write-Host "Expected Architecture: $ExpectedArchitecture"
+
+    $PackageName = [System.IO.Path]::GetFileNameWithoutExtension($NugetPackagePath)
+    $ExtractionPath = Join-Path -Path $env:TEMP -ChildPath "Extracted_$PackageName"
+
+    Write-Host "Extracting package to: $ExtractionPath"
+    Extract-NuGetPackage -PackagePath $NugetPackagePath -DestinationFolder $ExtractionPath
+
+    Write-Host "Extraction completed. Verifying architectures..."
+
+    $files = Get-ChildItem -Path $ExtractionPath -Recurse -Include *.dll, *.exe, *.sys
+
+    $allMatch = $true
+
+    foreach ($file in $files) {
+        $arch = Get-PEArchitecture -FilePath $file.FullName
+        Write-Host "$($file.FullName): Detected architecture = $arch"
+
+        if ($arch -ne $ExpectedArchitecture) {
+            Write-Error "Mismatch: File '$($file.FullName)' is '$arch' but expected '$ExpectedArchitecture'."
+            $allMatch = $false
+        }
+    }
+
+    if ($allMatch) {
+        Write-Host "All files match expected architecture '$ExpectedArchitecture'."
+    }
+    else {
+        throw "Architecture mismatch found in package."
+    }
+
+} catch {
+    Write-Error "Error: $_"
+}

--- a/scripts/validate_redist_nuget_architecture.ps1
+++ b/scripts/validate_redist_nuget_architecture.ps1
@@ -80,7 +80,8 @@ try {
 
     Write-Host "Extraction completed. Verifying architectures..."
 
-    $files = Get-ChildItem -Path $ExtractionPath -Recurse -Include *.dll, *.exe, *.sys
+    # Exclude vcruntime140_1.dll from validation as its architecture is ARM64EC for ARM64.
+    $files = Get-ChildItem -Path $ExtractionPath -Recurse -Include *.dll, *.exe, *.sys -Exclude *vcruntime140_1.dll
 
     $allMatch = $true
 

--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -39,14 +39,14 @@
 		<file src="..\..\scripts\ebpf_tracing_periodic_task.xml" target="lib\native\bin"/>
 
 		<!--Temporary inclusion of the VC++ Redist-->
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\concrt140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_1.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_2.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_atomic_wait.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_codecvt_ids.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\vccorlib140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\vcruntime140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\vcruntime140_1.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\concrt140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\msvcp140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\msvcp140_1.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\msvcp140_2.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\msvcp140_atomic_wait.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\msvcp140_codecvt_ids.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\vccorlib140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\vcruntime140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}{architecture}\Microsoft.VC143.CRT\vcruntime140_1.dll" target="lib\native\bin"/>
 	</files>
 </package>

--- a/tools/redist-package/ebpf-for-windows-redist.nuspec.in
+++ b/tools/redist-package/ebpf-for-windows-redist.nuspec.in
@@ -39,14 +39,14 @@
 		<file src="..\..\scripts\ebpf_tracing_periodic_task.xml" target="lib\native\bin"/>
 
 		<!--Temporary inclusion of the VC++ Redist-->
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\concrt140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_1.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_2.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_atomic_wait.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\msvcp140_codecvt_ids.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vccorlib140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vcruntime140.dll" target="lib\native\bin"/>
-		<file src="{VCToolsRedistDir}x64\Microsoft.VC143.CRT\vcruntime140_1.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\concrt140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_1.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_2.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_atomic_wait.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\msvcp140_codecvt_ids.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\vccorlib140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\vcruntime140.dll" target="lib\native\bin"/>
+		<file src="{VCToolsRedistDir}\{architecture}\Microsoft.VC143.CRT\vcruntime140_1.dll" target="lib\native\bin"/>
 	</files>
 </package>


### PR DESCRIPTION
Fixes #4381 

This PR fixes the nupsec for redist package to include the VC redist binaries for correct architecture.

## Testing

This PR adds tests.

## Documentation

No

## Installation

No
