### PR TITLE
Build arm64 binaries on arm64 runners

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -84,7 +84,10 @@ jobs:
     strategy:
       matrix:
         configurations: ${{ fromJSON(inputs.configurations) }}
-    runs-on: windows-2022
+
+    # Make runs-on conditionally based on the architecture input.
+    # This is needed to support both x64 and ARM64 builds.
+    runs-on: ${{ inputs.architecture == 'x64' && 'windows-2022' || 'windows-11-arm' }}
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: ${{inputs.solution_file}}
@@ -116,6 +119,7 @@ jobs:
           powershell.exe "echo 'msvc_tools_version=%VCToolsVersion%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
           powershell.exe "echo 'ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
           powershell.exe "echo 'VCINSTALLDIR=%VCINSTALLDIR%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
+          powershell.exe "echo $env:PROCESSOR_ARCHITECTURE"
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         if: steps.skip_check.outputs.should_skip != 'true'
@@ -191,7 +195,7 @@ jobs:
       - name: Build
         if: steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.BUILD_OPTIONS}} ${{env.SOLUTION_FILE_PATH}}  /bl:out.binlog
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:HostPlatform=${{env.BUILD_PLATFORM}} ${{env.BUILD_OPTIONS}} ${{env.SOLUTION_FILE_PATH}}  /bl:out.binlog
 
       - name: Check DLL dependencies for distributed binaries
         if: steps.skip_check.outputs.should_skip != 'true' && ((inputs.build_artifact == 'Build-x64' && matrix.configurations == 'Debug') || (inputs.build_artifact == 'Build-x64-native-only' && matrix.configurations == 'NativeOnlyRelease'))
@@ -275,7 +279,7 @@ jobs:
       - name: Build the NuGet package
         if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\nuget /bl:out.binlog
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:HostPlatform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\nuget /bl:out.binlog
 
       - name: Upload the NuGet package
         if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'
@@ -287,7 +291,7 @@ jobs:
       - name: Build the NuGet Redist package
         if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\redist-package /bl:out.binlog
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:HostPlatform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\redist-package /bl:out.binlog
 
       - name: Valdiate NuGet Redist package
         if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'

--- a/tests/sample/undocked/map.c
+++ b/tests/sample/undocked/map.c
@@ -111,6 +111,8 @@ test_GENERAL_map(struct _ebpf_map_definition_in_file* map)
 inline __attribute__((always_inline)) int
 test_LRU_map(struct _ebpf_map_definition_in_file* map)
 {
+// Older versions of Clang generate code that the verifier can't handle when processing this loop.
+#if CLANG_VERSION >= 1800
     uint32_t key = 0;
     uint32_t value = 1;
     int result;
@@ -126,6 +128,7 @@ test_LRU_map(struct _ebpf_map_definition_in_file* map)
             return result;
         }
     }
+#endif
     return 0;
 }
 

--- a/tools/export_program_info/export_program_info.vcxproj
+++ b/tools/export_program_info/export_program_info.vcxproj
@@ -100,16 +100,16 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
 </Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)export_program_info.log;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -124,16 +124,16 @@ $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
 </Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)export_program_info.log;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -148,16 +148,16 @@ $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
 </Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)export_program_info.log;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -174,16 +174,16 @@ $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
 </Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)export_program_info.log;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -200,16 +200,16 @@ $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe &gt; $(OutputPath)export_program_info.log
 </Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)export_program_info.log;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>

--- a/undocked/tools/export_program_info_sample/export_program_info_sample.vcxproj
+++ b/undocked/tools/export_program_info_sample/export_program_info_sample.vcxproj
@@ -100,15 +100,15 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info_sample.exe --clear
 $(OutputPath)export_program_info_sample.exe</Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)ebpf_bind_program_data.h;$(OutputPath)ebpf_xdp_program_data.h;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -123,15 +123,15 @@ $(OutputPath)export_program_info_sample.exe</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info_sample.exe --clear
 $(OutputPath)export_program_info_sample.exe</Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)ebpf_bind_program_data.h;$(OutputPath)ebpf_xdp_program_data.h;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -146,15 +146,15 @@ $(OutputPath)export_program_info_sample.exe</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info_sample.exe --clear
 $(OutputPath)export_program_info_sample.exe</Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)ebpf_bind_program_data.h;$(OutputPath)ebpf_xdp_program_data.h;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -171,15 +171,15 @@ $(OutputPath)export_program_info_sample.exe</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info_sample.exe --clear
 $(OutputPath)export_program_info_sample.exe</Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)ebpf_bind_program_data.h;$(OutputPath)ebpf_xdp_program_data.h;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>
@@ -196,15 +196,15 @@ $(OutputPath)export_program_info_sample.exe</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Command>cd /d $(OutputPath)
 $(OutputPath)export_program_info_sample.exe --clear
 $(OutputPath)export_program_info_sample.exe</Command>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Message>Exporting Program Information</Message>
     </CustomBuildStep>
-    <CustomBuildStep Condition="'$(Platform)'=='x64'">
+    <CustomBuildStep Condition="'$(Platform)'=='$(HostPlatform)'">
       <Outputs>$(OutputPath)ebpf_bind_program_data.h;$(OutputPath)ebpf_xdp_program_data.h;%(Outputs)</Outputs>
     </CustomBuildStep>
   </ItemDefinitionGroup>

--- a/wdk.props
+++ b/wdk.props
@@ -5,10 +5,19 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
-    <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
+    <HostPlatform Condition="'$(HostPlatform)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WDKVersion>10.0.26100.3323</WDKVersion>
   </PropertyGroup>
+  <!-- Log the WDK version -->
+  <Target Name="LogWDKVersion" BeforeTargets="PrepareForBuild">
+    <Message Importance="high" Text="Using WDK version $(WDKVersion)" />
+    <Message Importance="high" Text="Using Windows target platform version $(WindowsTargetPlatformVersion)" />
+    <Message Importance="high" Text="Using host platform $(HostPlatform)" />
+    <Message Importance="high" Text="Using target platform $(Platform)" />
+    <Message Importance="high" Text="PROCESSOR_ARCHITECTURE is $(PROCESSOR_ARCHITECTURE)" />
+    <Message Importance="high" Text="PROCESSOR_ARCHITEW6432 is $(PROCESSOR_ARCHITEW6432)" />
+  </Target>
 
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props')" />


### PR DESCRIPTION
## Description

Build ARM64 binaries natively on ARM64 runners to allow bpf2c to operate correctly.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
