### PR TITLE
Enable HVCI for native only tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -249,7 +249,7 @@ jobs:
           - 'server23h2'
           - 'server2025'
     with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file" -EnableHVCI "On"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       name: driver_${{ matrix.image }}

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -873,3 +873,46 @@ function Create-VMSwitchIfNeeded {
 
     Write-Log "Successfully created $SwitchType switch with name: $SwitchName" -ForegroundColor Green
 }
+
+<#
+.SYNOPSIS
+    Helper function to enable HVCI on the target VM.
+
+.DESCRIPTION
+    This function enables Hypervisor-protected Code Integrity (HVCI) on the specified VM.
+
+.PARAMETER VmName
+    The name of the VM on which to enable HVCI.
+
+.EXAMPLE
+    Enable-HVCIOnVM -VmName 'MyVM'
+#>
+function Enable-HVCIOnVM {
+    param (
+        [Parameter(Mandatory=$True)][string]$VmName
+    )
+
+    try {
+        Write-Log "Enabling HVCI on VM: $VmName"
+        $vmCredential = New-Credential -Username $Admin -AdminPassword $AdminPassword
+        Invoke-Command -VMName $VmName -Credential $vmCredential -ScriptBlock {
+            # Enable HVCI
+            New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios" -Name "HypervisorEnforcedCodeIntegrity" -ItemType Directory -Force
+            Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" -Name "Enabled" -Value 1 -Force
+            # Restart the VM to apply changes
+            Restart-Computer -Force -ErrorAction Stop
+        }
+    } catch {
+        throw "Failed to enable HVCI on VM: $VmName with error: $_"
+    }
+
+    # Wait 1 minute for the VM to restart
+    Write-Log "Waiting for 1 minute for VM: $VmName to restart"
+    Start-Sleep -Seconds 60
+
+    # Wait for the VM to restart and be ready again
+    Write-Log "Waiting for VM: $VmName to restart and be ready again"
+    Wait-AllVMsToInitialize -VMList @(@{ Name = $VmName }) -UserName $Admin -AdminPassword $AdminPassword
+
+    Write-Log "HVCI enabled successfully on VM: $VmName" -ForegroundColor Green
+}

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -194,6 +194,16 @@ function Install-eBPFComponents
     # This is useful for detecting issues with the runner baselines.
     Print-eBPFComponentsStatus "Querying the status of eBPF drivers and services before the installation (none should be present)..." | Out-Null
 
+    # Start the Windows Installer service.
+    Write-Log("Starting the Windows Installer service...")
+    $service = Get-Service -Name "msiserver" -ErrorAction SilentlyContinue
+    if ($service -and $service.Status -ne "Running") {
+        Start-Service -Name "msiserver" -ErrorAction Stop
+        Write-Log("Windows Installer service started successfully!") -ForegroundColor Green
+    } else {
+        Write-Log("Windows Installer service is already running or not present.") -ForegroundColor Yellow
+    }
+
     # Copy the VC debug runtime DLLs to the system32 directory,
     # so that debug versions of the MSI can be installed (i.e., export_program_info.exe will not fail).
     Write-Log("Copying VC debug runtime DLLs to the $system32Path directory...")


### PR DESCRIPTION
## Description

Resolves: #1874
Enable HVCI on the VM when running native only tests.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
