### PR TITLE
Module auth cleanup

### DIFF
--- a/ebpfapi/ebpfapi.vcxproj
+++ b/ebpfapi/ebpfapi.vcxproj
@@ -186,10 +186,7 @@
     <ClCompile Include="..\libs\thunk\windows\platform.cpp" />
     <ClCompile Include="..\libs\shared\hash.cpp" />
     <ClCompile Include="dllmain.cpp" />
-    <ClCompile Include="rpc_client.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)'=='NativeOnlyDebug'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)'=='NativeOnlyRelease'">true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="rpc_client.cpp"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="Source.def" />

--- a/ebpfapi/rpc_client.cpp
+++ b/ebpfapi/rpc_client.cpp
@@ -61,7 +61,7 @@ ebpf_rpc_load_program(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_rpc_authorize_native_module(_In_z_ const char* image_path) noexcept
+ebpf_rpc_authorize_native_module(_In_ GUID* module_id, _In_z_ const char* image_path) noexcept
 {
     ebpf_result_t result;
 
@@ -76,7 +76,7 @@ ebpf_rpc_authorize_native_module(_In_z_ const char* image_path) noexcept
         return EBPF_INVALID_ARGUMENT;
     }
 
-    RpcTryExcept { result = ebpf_client_verify_and_authorize_native_image(full_image_path); }
+    RpcTryExcept { result = ebpf_client_verify_and_authorize_native_image(module_id, full_image_path); }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {
         EBPF_LOG_MESSAGE_UINT64(

--- a/ebpfapi/rpc_client.cpp
+++ b/ebpfapi/rpc_client.cpp
@@ -60,6 +60,37 @@ ebpf_rpc_load_program(
         return result;
 }
 
+_Must_inspect_result_ ebpf_result_t
+ebpf_rpc_authorize_native_module(_In_z_ const char* image_path) noexcept
+{
+    ebpf_result_t result;
+
+    if (_initialize_rpc_binding() != RPC_S_OK) {
+        return EBPF_NO_MEMORY;
+    }
+
+    // Get the full path of the image.
+    char full_image_path[MAX_PATH];
+    if (GetFullPathNameA(image_path, sizeof(full_image_path), full_image_path, nullptr) == 0) {
+        EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, GetFullPathNameA);
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    RpcTryExcept { result = ebpf_client_verify_and_authorize_native_image(full_image_path); }
+    RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
+    {
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_API,
+            "RPC call ebpf_client_verify_and_authorize_native_image threw exception",
+            RpcExceptionCode());
+        result = EBPF_RPC_EXCEPTION;
+    }
+    RpcEndExcept
+
+        return result;
+}
+
 /**
  * @brief Initialize the RPC binding handle. This is expensive and should be
  * done once when required. This function is idempotent and thread safe.
@@ -81,7 +112,7 @@ _initialize_rpc_binding()
         RPC_C_SECURITY_QOS_VERSION_5,
         RPC_C_QOS_CAPABILITIES_MUTUAL_AUTH,
         RPC_C_QOS_IDENTITY_DYNAMIC,
-        RPC_C_IMP_LEVEL_IDENTIFY};
+        RPC_C_IMP_LEVEL_IMPERSONATE};
 
     RPC_STATUS status =
         RpcStringBindingCompose(nullptr, (RPC_WSTR)_protocol_sequence, nullptr, nullptr, nullptr, &string_binding);

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -83,11 +83,13 @@ _ebpf_driver_build_privileged_security_descriptor()
     NTSTATUS status = STATUS_SUCCESS;
     SECURITY_DESCRIPTOR security_descriptor;
     PSECURITY_DESCRIPTOR self_relative_security_descriptor = NULL;
-    ULONG sidSubAuthorities[] = {3453964624, 2861012444, 1105579853, 3193141192, 1897355174};
-    SID_IDENTIFIER_AUTHORITY svcAuth = {0x00, 0x00, 0x00, 0x00, 0x00, 0x50}; // S-1-5-80
+    const ULONG sidSubAuthorities[] = {3453964624, 2861012444, 1105579853, 3193141192, 1897355174};
+    const SID_IDENTIFIER_AUTHORITY svcAuth = {0x00, 0x00, 0x00, 0x00, 0x00, 0x50}; // S-1-5-80
+    const subauthority_count = EBPF_COUNT_OF(sidSubAuthorities);
+    ULONG security_descriptor_size = 0;
 
-    sid =
-        (PSID)ebpf_allocate_with_tag(RtlLengthRequiredSid(5), 'fpBE'); // Use a tag to help with debugging memory leaks
+    sid = (PSID)ebpf_allocate_with_tag(
+        RtlLengthRequiredSid(subauthority_count), 'fpBE'); // Use a tag to help with debugging memory leaks
     if (sid == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, ebpf_allocate_with_tag, status);
@@ -95,72 +97,71 @@ _ebpf_driver_build_privileged_security_descriptor()
     }
 
     // Initialize the SID for the ebpfsvc service.
-    status = RtlInitializeSid(sid, &svcAuth, 5);
+    status = RtlInitializeSid(sid, &svcAuth, subauthority_count);
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlInitializeSid, status);
         goto Exit;
     }
 
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < subauthority_count; i++) {
         *RtlSubAuthoritySid(sid, i) = sidSubAuthorities[i];
     }
 
     status = RtlCreateSecurityDescriptor(&security_descriptor, SECURITY_DESCRIPTOR_REVISION);
-
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlCreateSecurityDescriptor, status);
         goto Exit;
     }
 
-    // Allocate and initialize a DACL with one ACE
+    // Allocate and initialize a DACL with one ACE.
     ULONG aclSize = sizeof(ACL) + sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(sid) - sizeof(ULONG);
     dacl = (PACL)ebpf_allocate_with_tag(aclSize, 'fpBE'); // Use a tag to help with debugging memory leaks
-
     if (dacl == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, ebpf_allocate_with_tag, status);
         goto Exit;
     }
 
+    // Create the DACL with one ACE that allows GENERIC_ALL access to the ebpfsvc service SID.
     status = RtlCreateAcl(dacl, aclSize, ACL_REVISION);
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlCreateAcl, status);
         goto Exit;
     }
 
+    // Add an ACE to the DACL that grants GENERIC_ALL access to the ebpfsvc service SID.
     status = RtlAddAccessAllowedAce(dacl, ACL_REVISION, GENERIC_ALL, sid);
-
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlAddAccessAllowedAce, status);
         goto Exit;
     }
 
+    // Set the DACL in the security descriptor.
     status = RtlSetDaclSecurityDescriptor(&security_descriptor, TRUE, dacl, FALSE);
-
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlSetDaclSecurityDescriptor, status);
         goto Exit;
     }
 
     // Convert security descriptor to self-relative format.
-    ULONG security_descriptor_size = 0;
-
+    // First, we need to determine the size of the self-relative security descriptor.
     status = RtlAbsoluteToSelfRelativeSD(&security_descriptor, NULL, &security_descriptor_size);
     if (status != STATUS_BUFFER_TOO_SMALL) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlAbsoluteToSelfRelativeSD, status);
         goto Exit;
     }
-    self_relative_security_descriptor = ebpf_allocate_with_tag(security_descriptor_size, 'fpBE');
 
+    // Allocate memory for the self-relative security descriptor.
+    self_relative_security_descriptor = ebpf_allocate_with_tag(security_descriptor_size, 'fpBE');
     if (self_relative_security_descriptor == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, ebpf_allocate_with_tag, status);
         goto Exit;
     }
 
+    // Convert the absolute security descriptor to self-relative format.
     status =
         RtlAbsoluteToSelfRelativeSD(&security_descriptor, self_relative_security_descriptor, &security_descriptor_size);
-
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlAbsoluteToSelfRelativeSD, status);
         goto Exit;

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -85,7 +85,7 @@ _ebpf_driver_build_privileged_security_descriptor()
     PSECURITY_DESCRIPTOR self_relative_security_descriptor = NULL;
     const ULONG sidSubAuthorities[] = {3453964624, 2861012444, 1105579853, 3193141192, 1897355174};
     const SID_IDENTIFIER_AUTHORITY svcAuth = {0x00, 0x00, 0x00, 0x00, 0x00, 0x50}; // S-1-5-80
-    const subauthority_count = EBPF_COUNT_OF(sidSubAuthorities);
+    const ULONG subauthority_count = EBPF_COUNT_OF(sidSubAuthorities);
     ULONG security_descriptor_size = 0;
 
     sid = (PSID)ebpf_allocate_with_tag(
@@ -97,13 +97,13 @@ _ebpf_driver_build_privileged_security_descriptor()
     }
 
     // Initialize the SID for the ebpfsvc service.
-    status = RtlInitializeSid(sid, &svcAuth, subauthority_count);
+    status = RtlInitializeSid(sid, (SID_IDENTIFIER_AUTHORITY*)&svcAuth, (UCHAR)subauthority_count);
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlInitializeSid, status);
         goto Exit;
     }
 
-    for (int i = 0; i < subauthority_count; i++) {
+    for (ULONG i = 0; i < subauthority_count; i++) {
         *RtlSubAuthoritySid(sid, i) = sidSubAuthorities[i];
     }
 

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -41,6 +41,8 @@ static BOOLEAN _ebpf_driver_unloading_flag = FALSE;
 
 const char ebpf_core_version[] = EBPF_VERSION " " GIT_COMMIT_ID;
 
+PSECURITY_DESCRIPTOR ebpf_execution_context_privileged_security_descriptor = NULL;
+
 //
 // Pre-Declarations
 //
@@ -65,7 +67,123 @@ static _Function_class_(EVT_WDF_DRIVER_UNLOAD) _IRQL_requires_same_
 
     _ebpf_driver_unloading_flag = TRUE;
 
+    if (ebpf_execution_context_privileged_security_descriptor) {
+        ebpf_free(ebpf_execution_context_privileged_security_descriptor);
+        ebpf_execution_context_privileged_security_descriptor = NULL;
+    }
+
     ebpf_core_terminate();
+}
+
+static _Check_return_ NTSTATUS
+_ebpf_driver_build_privileged_security_descriptor()
+{
+    PACL dacl = NULL;
+    PSID sid = NULL;
+    NTSTATUS status = STATUS_SUCCESS;
+    SECURITY_DESCRIPTOR security_descriptor;
+    PSECURITY_DESCRIPTOR self_relative_security_descriptor = NULL;
+    ULONG sidSubAuthorities[] = {3453964624, 2861012444, 1105579853, 3193141192, 1897355174};
+    SID_IDENTIFIER_AUTHORITY svcAuth = {0x00, 0x00, 0x00, 0x00, 0x00, 0x50}; // S-1-5-80
+
+    sid =
+        (PSID)ebpf_allocate_with_tag(RtlLengthRequiredSid(5), 'fpBE'); // Use a tag to help with debugging memory leaks
+    if (sid == NULL) {
+        status = STATUS_INSUFFICIENT_RESOURCES;
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, ebpf_allocate_with_tag, status);
+        goto Exit;
+    }
+
+    // Initialize the SID for the ebpfsvc service.
+    status = RtlInitializeSid(sid, &svcAuth, 5);
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlInitializeSid, status);
+        goto Exit;
+    }
+
+    for (int i = 0; i < 5; i++) {
+        *RtlSubAuthoritySid(sid, i) = sidSubAuthorities[i];
+    }
+
+    status = RtlCreateSecurityDescriptor(&security_descriptor, SECURITY_DESCRIPTOR_REVISION);
+
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlCreateSecurityDescriptor, status);
+        goto Exit;
+    }
+
+    // Allocate and initialize a DACL with one ACE
+    ULONG aclSize = sizeof(ACL) + sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(sid) - sizeof(ULONG);
+    dacl = (PACL)ebpf_allocate_with_tag(aclSize, 'fpBE'); // Use a tag to help with debugging memory leaks
+
+    if (dacl == NULL) {
+        status = STATUS_INSUFFICIENT_RESOURCES;
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, ebpf_allocate_with_tag, status);
+        goto Exit;
+    }
+
+    status = RtlCreateAcl(dacl, aclSize, ACL_REVISION);
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlCreateAcl, status);
+        goto Exit;
+    }
+
+    status = RtlAddAccessAllowedAce(dacl, ACL_REVISION, GENERIC_ALL, sid);
+
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlAddAccessAllowedAce, status);
+        goto Exit;
+    }
+
+    status = RtlSetDaclSecurityDescriptor(&security_descriptor, TRUE, dacl, FALSE);
+
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlSetDaclSecurityDescriptor, status);
+        goto Exit;
+    }
+
+    // Convert security descriptor to self-relative format.
+    ULONG security_descriptor_size = 0;
+
+    status = RtlAbsoluteToSelfRelativeSD(&security_descriptor, NULL, &security_descriptor_size);
+    if (status != STATUS_BUFFER_TOO_SMALL) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlAbsoluteToSelfRelativeSD, status);
+        goto Exit;
+    }
+    self_relative_security_descriptor = ebpf_allocate_with_tag(security_descriptor_size, 'fpBE');
+
+    if (self_relative_security_descriptor == NULL) {
+        status = STATUS_INSUFFICIENT_RESOURCES;
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, ebpf_allocate_with_tag, status);
+        goto Exit;
+    }
+
+    status =
+        RtlAbsoluteToSelfRelativeSD(&security_descriptor, self_relative_security_descriptor, &security_descriptor_size);
+
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_ERROR, RtlAbsoluteToSelfRelativeSD, status);
+        goto Exit;
+    }
+
+    // Set the global security descriptor to the self-relative format.
+    ebpf_execution_context_privileged_security_descriptor = self_relative_security_descriptor;
+    self_relative_security_descriptor = NULL;
+
+Exit:
+    if (sid) {
+        ebpf_free(sid);
+    }
+
+    if (dacl) {
+        ebpf_free(dacl);
+    }
+
+    if (self_relative_security_descriptor) {
+        ebpf_free(self_relative_security_descriptor);
+    }
+
+    return status;
 }
 
 static _Check_return_ NTSTATUS
@@ -147,6 +265,7 @@ _ebpf_driver_initialize_objects(
     WDF_DRIVER_CONFIG driver_configuration;
     WDF_IO_QUEUE_CONFIG io_queue_configuration;
     BOOLEAN device_create_flag = FALSE;
+    BOOLEAN ebpf_core_initialized = FALSE;
 
     // IMPORTANT NOTE: The choice of implementing part of the driver initialization in another function
     // (_ebpf_driver_initialize_device()) is deliberate.  We perform a lot of standard WDF driver initialization here
@@ -196,10 +315,23 @@ _ebpf_driver_initialize_objects(
         goto Exit;
     }
 
+    ebpf_core_initialized = TRUE;
+
+    status = _ebpf_driver_build_privileged_security_descriptor();
+    if (!NT_SUCCESS(status)) {
+        EBPF_LOG_NTSTATUS_API_FAILURE(
+            EBPF_TRACELOG_KEYWORD_ERROR, _ebpf_driver_build_privileged_security_descriptor, status);
+        goto Exit;
+    }
+
     WdfControlFinishInitializing(*device);
 
 Exit:
     if (!NT_SUCCESS(status)) {
+        if (ebpf_core_initialized) {
+            ebpf_core_terminate();
+        }
+
         if (device_create_flag && device != NULL) {
 
             // Release the reference on the newly created object, since we couldn't initialize it.
@@ -234,6 +366,30 @@ _ebpf_driver_io_device_control_cancel(WDFREQUEST request)
     ebpf_core_cancel_protocol_handler(request);
 }
 
+static bool
+_ebpf_driver_is_caller_privileged()
+{
+    // Check if the caller has the required privileges.
+    SECURITY_SUBJECT_CONTEXT subject_context;
+    SeCaptureSubjectContext(&subject_context);
+    ACCESS_MASK granted_access = 0;
+    GENERIC_MAPPING generic_mapping = {1, 1, 1, 1}; // No generic mapping needed for this check
+    NTSTATUS status;
+    BOOLEAN result = SeAccessCheck(
+        ebpf_execution_context_privileged_security_descriptor,
+        &subject_context,
+        FALSE,            // Subject context is not locked
+        GENERIC_ALL,      // Desired access
+        0,                // Previously granted access
+        NULL,             // No privileges
+        &generic_mapping, // Generic mapping
+        KernelMode,       // Access mode
+        &granted_access,  // Granted access
+        &status);
+    SeReleaseSubjectContext(&subject_context);
+    return result && NT_SUCCESS(status) && granted_access == GENERIC_ALL; // Check if granted access matches GENERIC_ALL
+}
+
 static VOID
 _ebpf_driver_io_device_control(
     _In_ WDFQUEUE queue,
@@ -251,6 +407,7 @@ _ebpf_driver_io_device_control(
     const struct _ebpf_operation_header* user_request = NULL;
     struct _ebpf_operation_header* user_reply = NULL;
     bool async = false;
+    bool privileged = false;
     bool wdf_request_ref_acquired = false;
 
     device = WdfIoQueueGetDevice(queue);
@@ -294,10 +451,17 @@ _ebpf_driver_io_device_control(
                 }
 
                 status = ebpf_result_to_ntstatus(ebpf_core_get_protocol_handler_properties(
-                    user_request->id, &minimum_request_size, &minimum_reply_size, &async));
+                    user_request->id, &minimum_request_size, &minimum_reply_size, &async, &privileged));
                 if (status != STATUS_SUCCESS) {
                     EBPF_LOG_NTSTATUS_API_FAILURE(
                         EBPF_TRACELOG_KEYWORD_ERROR, ebpf_core_get_protocol_handler_properties, status);
+                    goto Done;
+                }
+
+                if (privileged && !_ebpf_driver_is_caller_privileged()) {
+                    EBPF_LOG_MESSAGE(
+                        EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_ERROR, "Caller is not privileged");
+                    status = STATUS_ACCESS_DENIED;
                     goto Done;
                 }
 

--- a/ebpfsvc/rpc_api.cpp
+++ b/ebpfsvc/rpc_api.cpp
@@ -54,6 +54,7 @@ ebpf_server_verify_and_load_program(
 
 ebpf_result_t
 ebpf_server_verify_and_authorize_native_image(
+    /* [in] */ GUID* module_id,
     /* [string][in] */ char* image_path)
 {
     HANDLE native_image_handle = INVALID_HANDLE_VALUE;
@@ -67,7 +68,7 @@ ebpf_server_verify_and_authorize_native_image(
         goto Exit;
     }
 
-    result = ebpf_authorize_native_module(native_image_handle);
+    result = ebpf_authorize_native_module(module_id, native_image_handle);
 Exit:
     if (native_image_handle != INVALID_HANDLE_VALUE) {
         CloseHandle(native_image_handle);

--- a/ebpfsvc/rpc_api.cpp
+++ b/ebpfsvc/rpc_api.cpp
@@ -57,49 +57,20 @@ ebpf_server_verify_and_authorize_native_image(
     /* [string][in] */ char* image_path)
 {
     HANDLE native_image_handle = INVALID_HANDLE_VALUE;
-    ebpf_result_t result = EBPF_SUCCESS;
-    bool impersonated = false;
+    ebpf_result_t result;
     if (RpcImpersonateClient(nullptr) != RPC_S_OK) {
-        result = EBPF_ACCESS_DENIED;
-        goto Exit;
+        return EBPF_ACCESS_DENIED;
     }
-
-    impersonated = true;
-
-    native_image_handle = CreateFileA(
-        image_path,
-        GENERIC_READ,
-        FILE_SHARE_READ | FILE_SHARE_DELETE,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS,
-        nullptr);
-
-    if (native_image_handle == INVALID_HANDLE_VALUE) {
-        result = win32_error_code_to_ebpf_result(GetLastError());
-        goto Exit;
-    }
-
-    if (!(RpcRevertToSelf() == RPC_S_OK)) {
-        result = EBPF_ACCESS_DENIED;
-        goto Exit;
-    }
-    impersonated = false;
-
-    // Revert to self before calling the authorization function.
-    // This is necessary to ensure that the authorization function does not run with the client's impersonation token.
-    result = ebpf_authorize_native_module(native_image_handle);
+    result = ebpf_verify_signature_and_open_file(image_path, &native_image_handle);
+    (void)RpcRevertToSelf();
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }
+
+    result = ebpf_authorize_native_module(native_image_handle);
 Exit:
     if (native_image_handle != INVALID_HANDLE_VALUE) {
         CloseHandle(native_image_handle);
-    }
-    if (!(RpcRevertToSelf() == RPC_S_OK)) {
-        // If reverting to self fails, we still return the result of the authorization.
-        // This is a best-effort operation.
-        return EBPF_ACCESS_DENIED;
     }
     return result;
 }

--- a/ebpfsvc/rpc_api.cpp
+++ b/ebpfsvc/rpc_api.cpp
@@ -51,3 +51,55 @@ ebpf_server_verify_and_load_program(
     return EBPF_OPERATION_NOT_SUPPORTED;
 #endif
 }
+
+ebpf_result_t
+ebpf_server_verify_and_authorize_native_image(
+    /* [string][in] */ char* image_path)
+{
+    HANDLE native_image_handle = INVALID_HANDLE_VALUE;
+    ebpf_result_t result = EBPF_SUCCESS;
+    bool impersonated = false;
+    if (RpcImpersonateClient(nullptr) != RPC_S_OK) {
+        result = EBPF_ACCESS_DENIED;
+        goto Exit;
+    }
+
+    impersonated = true;
+
+    native_image_handle = CreateFileA(
+        image_path,
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS,
+        nullptr);
+
+    if (native_image_handle == INVALID_HANDLE_VALUE) {
+        result = win32_error_code_to_ebpf_result(GetLastError());
+        goto Exit;
+    }
+
+    if (!(RpcRevertToSelf() == RPC_S_OK)) {
+        result = EBPF_ACCESS_DENIED;
+        goto Exit;
+    }
+    impersonated = false;
+
+    // Revert to self before calling the authorization function.
+    // This is necessary to ensure that the authorization function does not run with the client's impersonation token.
+    result = ebpf_authorize_native_module(native_image_handle);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+Exit:
+    if (native_image_handle != INVALID_HANDLE_VALUE) {
+        CloseHandle(native_image_handle);
+    }
+    if (!(RpcRevertToSelf() == RPC_S_OK)) {
+        // If reverting to self fails, we still return the result of the authorization.
+        // This is a best-effort operation.
+        return EBPF_ACCESS_DENIED;
+    }
+    return result;
+}

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -749,16 +749,6 @@ extern "C"
         _In_reads_bytes_(data_length) const void* data,
         size_t data_length) EBPF_NO_EXCEPT;
 
-    /**
-     * @brief Authorize a native module to be loaded.
-     *
-     * @param[in] module_path Path to the native module to be authorized.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Out of memory.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_authorize_native_module(_In_z_ const char* module_path) EBPF_NO_EXCEPT;
-
 #ifdef __cplusplus
 }
 #endif

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3778,7 +3778,7 @@ _ebpf_object_load_native(
         // Create a driver service with a random name.
         service_name = guid_to_wide_string(&service_name_guid);
 
-        result = ebpf_rpc_authorize_native_module(file_name_string.c_str());
+        result = ebpf_rpc_authorize_native_module(&provider_module_id, file_name_string.c_str());
         if (result != EBPF_SUCCESS) {
             EBPF_LOG_MESSAGE_STRING(
                 EBPF_TRACELOG_LEVEL_ERROR,

--- a/libs/api/rpc_client.h
+++ b/libs/api/rpc_client.h
@@ -15,3 +15,6 @@ ebpf_rpc_load_program(
     _In_ const ebpf_program_load_info* info,
     _Outptr_result_maybenull_z_ const char** logs,
     _Inout_ uint32_t* logs_size) noexcept;
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_rpc_authorize_native_module(_In_z_ const char* image_path) noexcept;

--- a/libs/api/rpc_client.h
+++ b/libs/api/rpc_client.h
@@ -17,4 +17,4 @@ ebpf_rpc_load_program(
     _Inout_ uint32_t* logs_size) noexcept;
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_rpc_authorize_native_module(_In_z_ const char* image_path) noexcept;
+ebpf_rpc_authorize_native_module(_In_ GUID* module_id, _In_z_ const char* image_path) noexcept;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2285,7 +2285,7 @@ static ebpf_result_t
 _ebpf_core_protocol_authorize_native_module(_In_ const ebpf_operation_authorize_native_module_request_t* request)
 {
     EBPF_LOG_ENTRY();
-    ebpf_result_t result = ebpf_native_authorize_module(request->module_hash);
+    ebpf_result_t result = ebpf_native_authorize_module(&request->module_id, request->module_hash);
     EBPF_RETURN_RESULT(result);
 }
 

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -73,6 +73,9 @@ extern "C"
      *  this operation.
      * @param[out] minimum_reply_size Minimum size of the reply buffer for this
      *  operation.
+     * @param[out] async Indicates whether the operation is asynchronous.
+     * @param[out] privileged Indicates whether the operation requires
+     *  privileged access.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_SUPPORTED The operation id is not valid.
      */
@@ -81,7 +84,8 @@ extern "C"
         ebpf_operation_id_t operation_id,
         _Out_ size_t* minimum_request_size,
         _Out_ size_t* minimum_reply_size,
-        _Out_ bool* async);
+        _Out_ bool* async,
+        _Out_ bool* privileged);
 
     /**
      * @brief Cancel an async protocol operation that returned EBPF_PENDING from ebpf_core_invoke_protocol_handler.

--- a/libs/execution_context/ebpf_native.h
+++ b/libs/execution_context/ebpf_native.h
@@ -130,7 +130,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_native_authorize_module(_In_ const uint8_t* module_hash);
+    ebpf_native_authorize_module(_In_ const GUID* module_id, _In_ const uint8_t* module_hash);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -557,5 +557,6 @@ typedef struct _ebpf_operation_program_set_flags_request
 typedef struct _ebpf_operation_authorize_native_module_request
 {
     struct _ebpf_operation_header header;
+    GUID module_id;
     uint8_t module_hash[32]; // SHA256 hash of the native module.
 } ebpf_operation_authorize_native_module_request_t;

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -481,7 +481,7 @@ ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* 
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_authorize_native_module(HANDLE native_image_handle) noexcept
+ebpf_authorize_native_module(_In_ GUID* module_id, _In_ HANDLE native_image_handle) noexcept
 {
     EBPF_LOG_ENTRY();
 
@@ -524,6 +524,7 @@ ebpf_authorize_native_module(HANDLE native_image_handle) noexcept
         std::copy(sha256_hash.begin(), sha256_hash.end(), request.module_hash);
         request.header.id = ebpf_operation_id_t::EBPF_OPERATION_AUTHORIZE_NATIVE_MODULE;
         request.header.length = static_cast<uint16_t>(sizeof(request));
+        request.module_id = *module_id;
     } catch (const std::bad_alloc&) {
         result = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -433,7 +433,55 @@ Exit:
 #endif
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_authorize_native_module(_In_ HANDLE native_image_handle) noexcept
+ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* file_handle) noexcept
+{
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+    try {
+        std::wstring file_path_wide;
+        int file_path_length = MultiByteToWideChar(CP_UTF8, 0, file_path, -1, nullptr, 0);
+        if (file_path_length <= 0) {
+            result = win32_error_code_to_ebpf_result(GetLastError());
+            EBPF_LOG_MESSAGE_ERROR(
+                EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "MultiByteToWideChar failed", result);
+            EBPF_RETURN_RESULT(result);
+        }
+        file_path_wide.resize(file_path_length);
+
+        if (MultiByteToWideChar(CP_UTF8, 0, file_path, -1, file_path_wide.data(), file_path_length) <= 0) {
+            result = win32_error_code_to_ebpf_result(GetLastError());
+            EBPF_LOG_MESSAGE_ERROR(
+                EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "MultiByteToWideChar failed", result);
+            EBPF_RETURN_RESULT(result);
+        }
+
+        // FUTURE: Use WinVerifyTrustEx to verify the signature of the file.
+
+        *file_handle = CreateFileW(
+            file_path_wide.c_str(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_DELETE,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS,
+            nullptr);
+
+        if (*file_handle == INVALID_HANDLE_VALUE) {
+            result = win32_error_code_to_ebpf_result(GetLastError());
+            EBPF_LOG_MESSAGE_ERROR(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "CreateFileW failed", result);
+            EBPF_RETURN_RESULT(result);
+        }
+
+        EBPF_RETURN_RESULT(EBPF_SUCCESS);
+    } catch (const std::bad_alloc&) {
+        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
+    } catch (const std::exception&) {
+        EBPF_RETURN_RESULT(EBPF_FAILED);
+    }
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_authorize_native_module(HANDLE native_image_handle) noexcept
 {
     EBPF_LOG_ENTRY();
 
@@ -444,12 +492,12 @@ ebpf_authorize_native_module(_In_ HANDLE native_image_handle) noexcept
     ebpf_operation_authorize_native_module_request_t request;
     uint32_t error = ERROR_SUCCESS;
 
-    file_mapping_handle = CreateFileMappingA(native_image_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    file_mapping_handle = CreateFileMappingW(native_image_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
 
     if (file_mapping_handle == NULL) {
         result = win32_error_code_to_ebpf_result(GetLastError());
         EBPF_LOG_MESSAGE_ERROR(
-            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "CreateFileMappingA failed", result);
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "CreateFileMappingW failed", result);
         goto Done;
     }
 

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -6,6 +6,7 @@
 #include "device_helper.hpp"
 #include "ebpf_protocol.h"
 #include "ebpf_shared_framework.h"
+#include "hash.h"
 #include "map_descriptors.hpp"
 #include "platform.h"
 extern "C"
@@ -430,6 +431,73 @@ Exit:
 }
 
 #endif
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_authorize_native_module(_In_ HANDLE native_image_handle) noexcept
+{
+    EBPF_LOG_ENTRY();
+
+    ebpf_result_t result = EBPF_SUCCESS;
+    HANDLE file_mapping_handle = NULL;
+    void* file_mapping_view = nullptr;
+    size_t file_size = 0;
+    ebpf_operation_authorize_native_module_request_t request;
+    uint32_t error = ERROR_SUCCESS;
+
+    file_mapping_handle = CreateFileMappingA(native_image_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
+
+    if (file_mapping_handle == NULL) {
+        result = win32_error_code_to_ebpf_result(GetLastError());
+        EBPF_LOG_MESSAGE_ERROR(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "CreateFileMappingA failed", result);
+        goto Done;
+    }
+
+    file_size = GetFileSize(native_image_handle, nullptr);
+
+    if (file_size == INVALID_FILE_SIZE) {
+        result = win32_error_code_to_ebpf_result(GetLastError());
+        EBPF_LOG_MESSAGE_ERROR(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "GetFileSize failed", result);
+        goto Done;
+    }
+
+    file_mapping_view = MapViewOfFile(file_mapping_handle, FILE_MAP_READ, 0, 0, file_size);
+
+    if (file_mapping_view == nullptr) {
+        result = win32_error_code_to_ebpf_result(GetLastError());
+        EBPF_LOG_MESSAGE_ERROR(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "MapViewOfFile failed", result);
+        goto Done;
+    }
+
+    try {
+        // Compute the SHA256 hash of the file.
+        hash_t hash("SHA256");
+        auto sha256_hash = hash.hash_byte_ranges({{(uint8_t*)file_mapping_view, file_size}});
+        std::copy(sha256_hash.begin(), sha256_hash.end(), request.module_hash);
+        request.header.id = ebpf_operation_id_t::EBPF_OPERATION_AUTHORIZE_NATIVE_MODULE;
+        request.header.length = static_cast<uint16_t>(sizeof(request));
+    } catch (const std::bad_alloc&) {
+        result = EBPF_NO_MEMORY;
+        goto Done;
+    }
+
+    error = invoke_ioctl(request);
+    if (error != ERROR_SUCCESS) {
+        result = win32_error_code_to_ebpf_result(error);
+        EBPF_LOG_MESSAGE_ERROR(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "invoke_ioctl failed", result);
+        goto Done;
+    }
+
+Done:
+    if (file_mapping_view) {
+        UnmapViewOfFile(file_mapping_view);
+    }
+    if (file_mapping_handle != INVALID_HANDLE_VALUE && file_mapping_handle != 0) {
+        CloseHandle(file_mapping_handle);
+    }
+
+    EBPF_RETURN_RESULT(result);
+}
 
 uint32_t
 ebpf_service_initialize() noexcept

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -26,12 +26,13 @@ ebpf_verify_and_load_program(
 /**
  * @brief Authorize a native module to be loaded.
  *
+ * @param[in] module_id GUID of the module to authorize.
  * @param[in] native_image_handle Handle to native image.
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_authorize_native_module(HANDLE native_image_handle) EBPF_NO_EXCEPT;
+ebpf_authorize_native_module(_In_ GUID* module_id, _In_ HANDLE native_image_handle) EBPF_NO_EXCEPT;
 
 /**
  * @brief Verify the signature of a file and open it.

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -23,6 +23,16 @@ ebpf_verify_and_load_program(
     _Outptr_result_maybenull_z_ const char** error_message,
     _Out_ uint32_t* error_message_size) noexcept;
 
+/**
+ * @brief Authorize a native module to be loaded.
+ *
+ * @param[in] native_image_handle Handle to native image.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY Out of memory.
+ */
+_Must_inspect_result_ ebpf_result_t
+ebpf_authorize_native_module(_In_ HANDLE native_image_handle) EBPF_NO_EXCEPT;
+
 uint32_t
 ebpf_service_initialize() noexcept;
 

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -31,7 +31,19 @@ ebpf_verify_and_load_program(
  * @retval EBPF_NO_MEMORY Out of memory.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_authorize_native_module(_In_ HANDLE native_image_handle) EBPF_NO_EXCEPT;
+ebpf_authorize_native_module(HANDLE native_image_handle) EBPF_NO_EXCEPT;
+
+/**
+ * @brief Verify the signature of a file and open it.
+ *
+ * @param[in] file_path Path to the file to open.
+ * @param[out] file_handle Handle to the opened file.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY Out of memory.
+ * @retval EBPF_INVALID_ARGUMENT Invalid file path.
+ */
+_Must_inspect_result_ ebpf_result_t
+ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* file_handle) noexcept;
 
 uint32_t
 ebpf_service_initialize() noexcept;

--- a/libs/service/service.vcxproj
+++ b/libs/service/service.vcxproj
@@ -142,12 +142,15 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\shared\hash.cpp" />
     <ClCompile Include="api_service.cpp" />
     <ClCompile Include="verifier_service.cpp" />
     <ClCompile Include="windows_platform_service.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\shared\hash.h" />
     <ClInclude Include="api_service.h" />
+    <ClInclude Include="..\hash.h" />
     <ClInclude Include="tlv.h" />
     <ClInclude Include="verifier_service.h" />
     <ClInclude Include="windows_platform_service.hpp" />

--- a/libs/service/service.vcxproj.filters
+++ b/libs/service/service.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="api_service.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\shared\hash.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="tlv.h">
@@ -34,6 +37,10 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="api_service.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hash.h" />
+    <ClInclude Include="..\shared\hash.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libs/service/service.vcxproj.filters
+++ b/libs/service/service.vcxproj.filters
@@ -39,8 +39,10 @@
     <ClInclude Include="api_service.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\hash.h" />
     <ClInclude Include="..\shared\hash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hash.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -223,7 +223,7 @@ ebpf_rpc_load_program(
 #endif
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_rpc_authorize_native_module(_In_z_ const char* image_path)
+ebpf_rpc_authorize_native_module(_In_ GUID* module_id, _In_z_ const char* image_path)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     HANDLE image_handle = INVALID_HANDLE_VALUE;
@@ -233,7 +233,7 @@ ebpf_rpc_authorize_native_module(_In_z_ const char* image_path)
         return result;
     }
 
-    result = ebpf_authorize_native_module(image_handle);
+    result = ebpf_authorize_native_module(module_id, image_handle);
     CloseHandle(image_handle);
     return result;
 }

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -1,9 +1,7 @@
 // Copyright (c) eBPF for Windows contributors
 // SPDX-License-Identifier: MIT
 
-#if !defined(CONFIG_BPF_JIT_DISABLED) || !defined(CONFIG_BPF_INTERPRETER_DISABLED)
 #include "api_service.h"
-#endif
 #include "ebpf_api.h"
 #include "mock.h"
 #if !defined(CONFIG_BPF_JIT_DISABLED) || !defined(CONFIG_BPF_INTERPRETER_DISABLED)
@@ -223,3 +221,18 @@ ebpf_rpc_load_program(
     return result;
 }
 #endif
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_rpc_authorize_native_module(_In_z_ const char* image_path)
+{
+    HANDLE image_handle =
+        CreateFileA(image_path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (image_handle == INVALID_HANDLE_VALUE) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    ebpf_result_t result = ebpf_authorize_native_module(image_handle);
+
+    CloseHandle(image_handle);
+    return result;
+}

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -225,14 +225,15 @@ ebpf_rpc_load_program(
 _Must_inspect_result_ ebpf_result_t
 ebpf_rpc_authorize_native_module(_In_z_ const char* image_path)
 {
-    HANDLE image_handle =
-        CreateFileA(image_path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (image_handle == INVALID_HANDLE_VALUE) {
-        return EBPF_INVALID_ARGUMENT;
+    ebpf_result_t result = EBPF_SUCCESS;
+    HANDLE image_handle = INVALID_HANDLE_VALUE;
+
+    result = ebpf_verify_signature_and_open_file(image_path, &image_handle);
+    if (result != EBPF_SUCCESS) {
+        return result;
     }
 
-    ebpf_result_t result = ebpf_authorize_native_module(image_handle);
-
+    result = ebpf_authorize_native_module(image_handle);
     CloseHandle(image_handle);
     return result;
 }

--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -67,5 +67,5 @@ import "wtypes.idl";
             [ out, ref ] uint32_t * logs_size,
             [ out, size_is(, *logs_size), ref ] char** logs);
 
-        ebpf_result_t verify_and_authorize_native_image([ in, string ] char* image_path);
+        ebpf_result_t verify_and_authorize_native_image([in] GUID * module_id, [ in, string ] char* image_path);
     }

--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -66,4 +66,6 @@ import "wtypes.idl";
             [ in, ref ] ebpf_program_load_info * info,
             [ out, ref ] uint32_t * logs_size,
             [ out, size_is(, *logs_size), ref ] char** logs);
+
+        ebpf_result_t verify_and_authorize_native_image([ in, string ] char* image_path);
     }

--- a/scripts/check_binary_dependencies_ebpfapi_dll_nativeonly_release.txt
+++ b/scripts/check_binary_dependencies_ebpfapi_dll_nativeonly_release.txt
@@ -29,4 +29,6 @@ KERNEL32.dll
 api-ms-win-core-memory-l1-1-0.dll
 api-ms-win-core-string-l1-1-0.dll
 api-ms-win-crt-math-l1-1-0.dll
-bcrypt.dll
+api-ms-win-core-heap-l2-1-0.dll
+api-ms-win-core-libraryloader-l1-2-0.dll
+ADVAPI32.dll

--- a/scripts/check_binary_dependencies_ebpfsvc_exe_regular_debug.txt
+++ b/scripts/check_binary_dependencies_ebpfsvc_exe_regular_debug.txt
@@ -32,3 +32,4 @@ api-ms-win-core-interlocked-l1-1-0.dll
 api-ms-win-core-heap-l1-1-0.dll
 api-ms-win-core-memory-l1-1-0.dll
 kernel32.dll
+bcrypt.dll

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -347,7 +347,7 @@ typedef class _ip_in_ip_packet : public ip_packet_t
 #define TEST_IFINDEX 17
 
 static ebpf_result_t
-ebpf_authorize_native_module_wrapper(const char* filename)
+ebpf_authorize_native_module_wrapper(_In_z_ const char* filename)
 {
     HANDLE file_handle = CreateFileA(
         filename,

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -5,6 +5,7 @@
 
 #include "api_common.hpp"
 #include "api_internal.h"
+#include "api_service.h"
 #include "bpf/bpf.h"
 #include "bpf/libbpf.h"
 #include "bpf2c.h"
@@ -344,6 +345,26 @@ typedef class _ip_in_ip_packet : public ip_packet_t
 
 #define SAMPLE_PATH ""
 #define TEST_IFINDEX 17
+
+static ebpf_result_t
+ebpf_authorize_native_module_wrapper(const char* filename)
+{
+    HANDLE file_handle = CreateFileA(
+        filename,
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+    if (file_handle == INVALID_HANDLE_VALUE) {
+        return win32_error_code_to_ebpf_result(GetLastError());
+    }
+
+    ebpf_result_t result = ebpf_authorize_native_module(file_handle);
+    CloseHandle(file_handle);
+    return result;
+}
 
 int
 ebpf_program_load(
@@ -3148,7 +3169,7 @@ TEST_CASE("load_native_program_negative4", "[end-to-end]")
     _create_service_helper(
         L"test_sample_ebpf_um.dll", NATIVE_DRIVER_SERVICE_NAME, &provider_module_id, &service_handle);
 
-    REQUIRE(ebpf_authorize_native_module("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
+    REQUIRE(ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
 
     // Load native module. It should succeed.
     service_path = service_path + NATIVE_DRIVER_SERVICE_NAME;
@@ -3214,7 +3235,7 @@ TEST_CASE("load_native_program_negative6", "[end-to-end]")
     _create_service_helper(
         L"test_sample_ebpf_um.dll", NATIVE_DRIVER_SERVICE_NAME, &provider_module_id, &service_handle);
 
-    REQUIRE(ebpf_authorize_native_module("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
+    REQUIRE(ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
 
     // Load native module. It should succeed.
     service_path = service_path + NATIVE_DRIVER_SERVICE_NAME;
@@ -3263,7 +3284,7 @@ TEST_CASE("native_module_handle_test_negative", "[end-to-end]")
     _create_service_helper(
         L"test_sample_ebpf_um.dll", NATIVE_DRIVER_SERVICE_NAME, &provider_module_id, &service_handle);
 
-    REQUIRE(ebpf_authorize_native_module("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
+    REQUIRE(ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
 
     // Load native module. It should succeed.
     service_path = service_path + NATIVE_DRIVER_SERVICE_NAME;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -347,7 +347,7 @@ typedef class _ip_in_ip_packet : public ip_packet_t
 #define TEST_IFINDEX 17
 
 static ebpf_result_t
-ebpf_authorize_native_module_wrapper(_In_z_ const char* filename)
+ebpf_authorize_native_module_wrapper(_In_ GUID* module_id, _In_z_ const char* filename)
 {
     HANDLE file_handle = CreateFileA(
         filename,
@@ -361,7 +361,7 @@ ebpf_authorize_native_module_wrapper(_In_z_ const char* filename)
         return win32_error_code_to_ebpf_result(GetLastError());
     }
 
-    ebpf_result_t result = ebpf_authorize_native_module(file_handle);
+    ebpf_result_t result = ebpf_authorize_native_module(module_id, file_handle);
     CloseHandle(file_handle);
     return result;
 }
@@ -3169,7 +3169,7 @@ TEST_CASE("load_native_program_negative4", "[end-to-end]")
     _create_service_helper(
         L"test_sample_ebpf_um.dll", NATIVE_DRIVER_SERVICE_NAME, &provider_module_id, &service_handle);
 
-    REQUIRE(ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
+    REQUIRE(ebpf_authorize_native_module_wrapper(&provider_module_id, "test_sample_ebpf_um.dll") == EBPF_SUCCESS);
 
     // Load native module. It should succeed.
     service_path = service_path + NATIVE_DRIVER_SERVICE_NAME;
@@ -3235,7 +3235,7 @@ TEST_CASE("load_native_program_negative6", "[end-to-end]")
     _create_service_helper(
         L"test_sample_ebpf_um.dll", NATIVE_DRIVER_SERVICE_NAME, &provider_module_id, &service_handle);
 
-    REQUIRE(ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
+    REQUIRE(ebpf_authorize_native_module_wrapper(&provider_module_id, "test_sample_ebpf_um.dll") == EBPF_SUCCESS);
 
     // Load native module. It should succeed.
     service_path = service_path + NATIVE_DRIVER_SERVICE_NAME;
@@ -3284,7 +3284,7 @@ TEST_CASE("native_module_handle_test_negative", "[end-to-end]")
     _create_service_helper(
         L"test_sample_ebpf_um.dll", NATIVE_DRIVER_SERVICE_NAME, &provider_module_id, &service_handle);
 
-    REQUIRE(ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll") == EBPF_SUCCESS);
+    REQUIRE(ebpf_authorize_native_module_wrapper(&provider_module_id, "test_sample_ebpf_um.dll") == EBPF_SUCCESS);
 
     // Load native module. It should succeed.
     service_path = service_path + NATIVE_DRIVER_SERVICE_NAME;

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -466,6 +466,7 @@ GlueDeviceIoControl(
     size_t minimum_request_size = 0;
     size_t minimum_reply_size = 0;
     bool async = false;
+    bool privileged = false;
     unsigned long sharedBufferSize = (input_buffer_size > output_buffer_size) ? input_buffer_size : output_buffer_size;
     const void* local_input_buffer = nullptr;
     void* local_output_buffer = nullptr;
@@ -488,7 +489,8 @@ GlueDeviceIoControl(
 
     (*sharedBuffer).resize(sharedBufferSize);
 
-    result = ebpf_core_get_protocol_handler_properties(request_id, &minimum_request_size, &minimum_reply_size, &async);
+    result = ebpf_core_get_protocol_handler_properties(
+        request_id, &minimum_request_size, &minimum_reply_size, &async, &privileged);
     if (result != EBPF_SUCCESS) {
         goto Fail;
     }

--- a/tests/libfuzzer/execution_context/libfuzz_harness.cpp
+++ b/tests/libfuzzer/execution_context/libfuzz_harness.cpp
@@ -466,6 +466,7 @@ fuzz_ioctl(std::vector<uint8_t>& random_buffer)
 {
     fuzz_wrapper fuzz_state;
     bool async = false;
+    bool privileged = false;
     std::vector<uint8_t> request;
     std::vector<uint8_t> reply;
     uint16_t reply_buffer_length = 0;
@@ -501,8 +502,8 @@ fuzz_ioctl(std::vector<uint8_t>& random_buffer)
     size_t minimum_request_size;
     size_t minimum_reply_size;
 
-    ebpf_result_t result =
-        ebpf_core_get_protocol_handler_properties(operation_id, &minimum_request_size, &minimum_reply_size, &async);
+    ebpf_result_t result = ebpf_core_get_protocol_handler_properties(
+        operation_id, &minimum_request_size, &minimum_reply_size, &async, &privileged);
     if (result != EBPF_SUCCESS) {
         return;
     }

--- a/tests/stress/um/ebpf_stress_tests_um.vcxproj
+++ b/tests/stress/um/ebpf_stress_tests_um.vcxproj
@@ -150,13 +150,13 @@
     <ProjectReference Include="..\..\..\libs\runtime\user\platform_user.vcxproj">
       <Project>{c26cb6a9-158c-4a9e-a243-755ddd98e5fe}</Project>
     </ProjectReference>
-    <ProjectReference Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'" Include="..\..\..\libs\service\service.vcxproj">
+    <ProjectReference Include="..\..\..\libs\service\service.vcxproj">
       <Project>{af85c549-57cc-40a5-bdfc-dcf1998de80f}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\..\libs\shared\user\shared_user.vcxproj">
       <Project>{9388dd45-7941-45d7-b4ff-bc00f550af17}</Project>
     </ProjectReference>
-    <ProjectReference Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'" Include="..\..\..\libs\ubpf\user\ubpf_user.vcxproj">
+    <ProjectReference Include="..\..\..\libs\ubpf\user\ubpf_user.vcxproj">
       <Project>{245f0ec7-1ebc-4d68-8b1f-f758ea9196ae}</Project>
     </ProjectReference>
     <ProjectReference Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'" Include="..\..\..\rpc_interface\rpc_interface.vcxproj">

--- a/tests/unit/test.vcxproj
+++ b/tests/unit/test.vcxproj
@@ -93,7 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>mincore.lib;ubpf_user.lib;service.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -122,7 +122,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>mincore.lib;ubpf_user.lib;service.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -137,7 +137,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>mincore.lib;ubpf_user.lib;service.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -190,8 +190,14 @@
     <ProjectReference Include="..\..\libs\runtime\user\platform_user.vcxproj">
       <Project>{c26cb6a9-158c-4a9e-a243-755ddd98e5fe}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\libs\service\service.vcxproj">
+      <Project>{af85c549-57cc-40a5-bdfc-dcf1998de80f}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\libs\shared\user\shared_user.vcxproj">
       <Project>{9388dd45-7941-45d7-b4ff-bc00f550af17}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libs\ubpf\user\ubpf_user.vcxproj">
+      <Project>{245f0ec7-1ebc-4d68-8b1f-f758ea9196ae}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\rpc_interface\rpc_interface.vcxproj">
       <Project>{1423245d-0249-40fc-a077-ff7780acfe3f}</Project>


### PR DESCRIPTION
Part of #4427

## Description
Store module hashes keyed on module id to allow for duplicate hashes and remove hash entries when the associated module loads.

## Testing

CI/CD

## Documentation

No

## Installation

No
