### PR TITLE
Address YAML validation warnings

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -160,7 +160,7 @@ jobs:
       test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-ARM64-native-only
       environment: '["windows-11-arm"]'
-      code_coverage: false # No code coverage on ARM64.
+      code_coverage: false  # No code coverage on ARM64.
       gather_dumps: true
       capture_etw: true
       leak_detection: true

--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863  # v2.12.1
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f  # v4.2.2
 
       - name: Validate YAML
         run: yamllint .


### PR DESCRIPTION
## Description

E.g., see Annotations in
https://github.com/microsoft/ebpf-for-windows/actions/runs/15713391279/job/44277006424

Each comment at the end of a line should have at least 2 spaces before the #

Most files already do this throughout, but three exceptions remained which this PR fixes.

## Testing

CI/CD

## Documentation

No impact.

## Installation

No impact.
