### PR TITLE
Added -g option to clang compile commands

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -237,7 +237,7 @@ On the attacker machine, do the following:
 1. Compile `droppacket.c`:
 
    ```cmd
-   clang -target bpf -O2 -Werror -c droppacket.c -o droppacket.o
+   clang -target bpf -O2 -g -Werror -c droppacket.c -o droppacket.o
    ```
 
 1. Show eBPF byte code for `droppacket.o`:
@@ -272,7 +272,7 @@ On the attacker machine, do the following:
 1. Compile `droppacket.c`:
 
    ```cmd
-   clang -target bpf -O2 -Werror -c droppacket.c -o droppacket.o
+   clang -target bpf -O2 -g -Werror -c droppacket.c -o droppacket.o
    ```
 
 1. Show that the verifier rejects the code:


### PR DESCRIPTION
## Description

Fixes: [#4429](https://github.com/microsoft/ebpf-for-windows/issues/4429)
This change adds the `-g` option to the clang compile commands in the `GettingStarted.md` instructions. This option is necessary to include since the generated elf file is subsequently disassembled and verified using `netsh ebpf` commands. The `-g` option includes debug symbols and other debugging information in the generated elf file, which is required for the disassembly and verification process.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
No new tests are needed.

## Documentation

_Is there any documentation impact for this change?_
This change is solely a documentation impact.

## Installation

_Is there any installer impact for this change?_
No.
