### PR TITLE
Add negative lookup tests for inner map in hash_of_map test case

### DIFF
--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -4052,6 +4052,19 @@ _hash_of_map_initial_value_test(ebpf_execution_type_t execution_type)
 
     // Verify that the id of the inner map matches the id in the outer map.
     REQUIRE(inner_map_id == info.id);
+
+    // Lookup in the inner map with a non-zero key should fail.
+    uint32_t non_zero_key = 1;
+    uint32_t value = 0;
+    int result = bpf_map_lookup_elem(inner_map_fd, &non_zero_key, &value);
+    REQUIRE(result != 0);
+    REQUIRE(errno == ENOENT);
+
+    // Lookup in the inner map with a clearly nonexistent key should also fail.
+    uint32_t nonexistent_key = 12345;
+    result = bpf_map_lookup_elem(inner_map_fd, &nonexistent_key, &value);
+    REQUIRE(result != 0);
+    REQUIRE(errno == ENOENT);
 }
 
 TEST_CASE("hash_of_map", "[libbpf]")


### PR DESCRIPTION
## Description
Description
This PR enhances the hash_of_map test case in libbpf_test.cpp by adding additional negative tests for inner map lookups. Specifically, it verifies that:

Looking up a non-zero key in the inner map fails as expected.
Looking up a clearly nonexistent key in the inner map also fails as expected.
These checks help ensure the correctness and robustness of map-in-map behavior, particularly for static initializers in native execution mode.

Fixes #3219 

Changes
Updated _hash_of_map_initial_value_test to include:
A lookup with a non-zero key (1) in the inner map, asserting failure and errno == ENOENT.
A lookup with a clearly nonexistent key (12345) in the inner map, asserting failure and errno == ENOENT.

Motivation
These additional tests improve coverage for negative scenarios and help catch regressions in map lookup behavior for nested maps.

## Testing
All existing and new tests pass locally.
No regressions observed in related test cases.

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
