### PR TITLE
Require Microsoft Corporation eBPF Verification issuer and EKU

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -37,7 +37,7 @@ const NPI_MODULEID ebpf_general_helper_function_module_id = {
 static ebpf_pinning_table_t* _ebpf_core_map_pinning_table = NULL;
 
 // Assume enabled until we can query it.
-static bool _ebpf_platform_hyper_visor_code_integrity_enabled = true;
+static bool _ebpf_platform_hypervisor_code_integrity_enabled = true;
 static bool _ebpf_platform_test_signing_enabled = true;
 
 static void*
@@ -301,7 +301,7 @@ ebpf_core_initiate()
     }
 
     return_value = ebpf_get_code_integrity_state(
-        &_ebpf_platform_test_signing_enabled, &_ebpf_platform_hyper_visor_code_integrity_enabled);
+        &_ebpf_platform_test_signing_enabled, &_ebpf_platform_hypervisor_code_integrity_enabled);
 
 Done:
     if (return_value != EBPF_SUCCESS) {
@@ -404,7 +404,7 @@ _ebpf_core_protocol_load_code(_In_ const ebpf_operation_load_code_request_t* req
     }
 
     if (request->code_type == EBPF_CODE_JIT) {
-        if (_ebpf_platform_hyper_visor_code_integrity_enabled) {
+        if (_ebpf_platform_hypervisor_code_integrity_enabled) {
             retval = EBPF_BLOCKED_BY_POLICY;
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR,
@@ -2299,7 +2299,7 @@ _ebpf_core_protocol_get_code_integrity_state(
     EBPF_LOG_ENTRY();
     UNREFERENCED_PARAMETER(request);
     ebpf_result_t result = EBPF_SUCCESS;
-    reply->hypervisor_code_integrity_enabled = _ebpf_platform_hyper_visor_code_integrity_enabled;
+    reply->hypervisor_code_integrity_enabled = _ebpf_platform_hypervisor_code_integrity_enabled;
     reply->test_signing_enabled = _ebpf_platform_test_signing_enabled;
     EBPF_RETURN_RESULT(result);
 }
@@ -2898,7 +2898,7 @@ ebpf_core_get_protocol_handler_properties(
 
 #if !defined(CONFIG_BPF_JIT_DISABLED)
     // JIT is permitted only if HVCI is off.
-    bool jit_permitted = !_ebpf_platform_hyper_visor_code_integrity_enabled;
+    bool jit_permitted = !_ebpf_platform_hypervisor_code_integrity_enabled;
 #endif
 
     // Interpret is only permitted if CONFIG_BPF_INTERPRETER_DISABLED is not set.

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -37,7 +37,8 @@ const NPI_MODULEID ebpf_general_helper_function_module_id = {
 static ebpf_pinning_table_t* _ebpf_core_map_pinning_table = NULL;
 
 // Assume enabled until we can query it.
-static ebpf_code_integrity_state_t _ebpf_core_code_integrity_state = EBPF_CODE_INTEGRITY_HYPERVISOR_KERNEL_MODE;
+static bool _ebpf_platform_hyper_visor_code_integrity_enabled = true;
+static bool _ebpf_platform_test_signing_enabled = true;
 
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key);
@@ -299,7 +300,8 @@ ebpf_core_initiate()
         goto Done;
     }
 
-    return_value = ebpf_get_code_integrity_state(&_ebpf_core_code_integrity_state);
+    return_value = ebpf_get_code_integrity_state(
+        &_ebpf_platform_test_signing_enabled, &_ebpf_platform_hyper_visor_code_integrity_enabled);
 
 Done:
     if (return_value != EBPF_SUCCESS) {
@@ -402,12 +404,12 @@ _ebpf_core_protocol_load_code(_In_ const ebpf_operation_load_code_request_t* req
     }
 
     if (request->code_type == EBPF_CODE_JIT) {
-        if (_ebpf_core_code_integrity_state == EBPF_CODE_INTEGRITY_HYPERVISOR_KERNEL_MODE) {
+        if (_ebpf_platform_hyper_visor_code_integrity_enabled) {
             retval = EBPF_BLOCKED_BY_POLICY;
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR,
                 EBPF_TRACELOG_KEYWORD_CORE,
-                "code_type == EBPF_CODE_JIT blocked by EBPF_CODE_INTEGRITY_HYPERVISOR_KERNEL_MODE");
+                "code_type == EBPF_CODE_JIT blocked by Hyper-V Code Integrity policy");
             goto Done;
         }
     }
@@ -2289,6 +2291,19 @@ _ebpf_core_protocol_authorize_native_module(_In_ const ebpf_operation_authorize_
     EBPF_RETURN_RESULT(result);
 }
 
+static ebpf_result_t
+_ebpf_core_protocol_get_code_integrity_state(
+    _In_ const ebpf_operation_get_code_integrity_state_request_t* request,
+    _Out_ ebpf_operation_get_code_integrity_state_reply_t* reply)
+{
+    EBPF_LOG_ENTRY();
+    UNREFERENCED_PARAMETER(request);
+    ebpf_result_t result = EBPF_SUCCESS;
+    reply->hypervisor_code_integrity_enabled = _ebpf_platform_hyper_visor_code_integrity_enabled;
+    reply->test_signing_enabled = _ebpf_platform_test_signing_enabled;
+    EBPF_RETURN_RESULT(result);
+}
+
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
@@ -2866,6 +2881,8 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
         get_next_pinned_object_path, start_path, next_path, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(
         authorize_native_module, PROTOCOL_NATIVE_MODE | PROTOCOL_PRIVILEGED_OPERATION),
+    DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(
+        get_code_integrity_state, PROTOCOL_ALL_MODES | PROTOCOL_PRIVILEGED_OPERATION),
 };
 
 _Must_inspect_result_ ebpf_result_t
@@ -2881,7 +2898,7 @@ ebpf_core_get_protocol_handler_properties(
 
 #if !defined(CONFIG_BPF_JIT_DISABLED)
     // JIT is permitted only if HVCI is off.
-    bool jit_permitted = (_ebpf_core_code_integrity_state == EBPF_CODE_INTEGRITY_DEFAULT) ? true : false;
+    bool jit_permitted = !_ebpf_platform_hyper_visor_code_integrity_enabled;
 #endif
 
     // Interpret is only permitted if CONFIG_BPF_INTERPRETER_DISABLED is not set.

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -49,6 +49,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_PROGRAM_SET_FLAGS,
     EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH,
     EBPF_OPERATION_AUTHORIZE_NATIVE_MODULE,
+    EBPF_OPERATION_GET_CODE_INTEGRITY_STATE,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -560,3 +561,15 @@ typedef struct _ebpf_operation_authorize_native_module_request
     GUID module_id;
     uint8_t module_hash[32]; // SHA256 hash of the native module.
 } ebpf_operation_authorize_native_module_request_t;
+
+typedef struct _ebpf_operation_get_code_integrity_state_request
+{
+    struct _ebpf_operation_header header;
+} ebpf_operation_get_code_integrity_state_request_t;
+
+typedef struct _ebpf_operation_get_code_integrity_state_reply
+{
+    struct _ebpf_operation_header header;
+    bool hypervisor_code_integrity_enabled;
+    bool test_signing_enabled;
+} ebpf_operation_get_code_integrity_state_reply_t;

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -178,10 +178,10 @@ extern "C"
 
     /**
      * @brief Get the code integrity state from the platform.
-     * @param[out] test_signing_enabled Pointer to a boolean that will be set to
-     * true if test signing is enabled, false otherwise.
-     * @param[out] hypervisor_kernel_mode_enabled Pointer to a boolean that will be set
-     * true if hypervisor kernel mode is enabled, false otherwise.
+     * @param[out] test_signing_enabled Pointer to a boolean that will be set to true if test signing is enabled, to
+     * false otherwise.
+     * @param[out] hypervisor_kernel_mode_enabled Pointer to a boolean that will be set to true if hypervisor kernel
+     * mode is enabled, to false otherwise.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_SUPPORTED Unable to obtain state from platform.
      */

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -38,12 +38,6 @@ extern "C"
 #define EBPF_NS_PER_FILETIME 100
 #define EBPF_FILETIME_PER_MS 10000
 
-    typedef enum _ebpf_code_integrity_state
-    {
-        EBPF_CODE_INTEGRITY_DEFAULT = 0,
-        EBPF_CODE_INTEGRITY_HYPERVISOR_KERNEL_MODE = 1
-    } ebpf_code_integrity_state_t;
-
     typedef struct _ebpf_timer_work_item ebpf_timer_work_item_t;
     typedef struct _ebpf_helper_function_prototype ebpf_helper_function_prototype_t;
 
@@ -184,12 +178,15 @@ extern "C"
 
     /**
      * @brief Get the code integrity state from the platform.
-     * @param[out] state The code integrity state being enforced.
+     * @param[out] test_signing_enabled Pointer to a boolean that will be set to
+     * true if test signing is enabled, false otherwise.
+     * @param[out] hypervisor_kernel_mode_enabled Pointer to a boolean that will be set
+     * true if hypervisor kernel mode is enabled, false otherwise.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_SUPPORTED Unable to obtain state from platform.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state);
+    ebpf_get_code_integrity_state(_Out_ bool* test_signing_enabled, _Out_ bool* hypervisor_kernel_mode_enabled);
 
     /**
      * @brief Create an instance of a lock.

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -145,7 +145,7 @@ typedef struct _SYSTEM_CODEINTEGRITY_INFORMATION
     unsigned long Length;
     unsigned long CodeIntegrityOptions;
 } SYSTEM_CODEINTEGRITY_INFORMATION, *PSYSTEM_CODEINTEGRITY_INFORMATION;
-#define CODEINTEGRITY_OPTION_TESTSIGN 0x02
+#define CODEINTEGRITY_OPTION_TEST_SIGN 0x02
 #define CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED 0x400
 NTSTATUS
 NtQuerySystemInformation(
@@ -165,7 +165,7 @@ ebpf_get_code_integrity_state(_Out_ bool* test_signing_enabled, _Out_ bool* hype
     status = NtQuerySystemInformation(
         SystemCodeIntegrityInformation, &code_integrity_information, system_information_length, &returned_length);
     if (NT_SUCCESS(status)) {
-        if ((code_integrity_information.CodeIntegrityOptions & CODEINTEGRITY_OPTION_TESTSIGN) != 0) {
+        if ((code_integrity_information.CodeIntegrityOptions & CODEINTEGRITY_OPTION_TEST_SIGN) != 0) {
             EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Test signing enabled");
             *test_signing_enabled = true;
         } else {

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -145,6 +145,7 @@ typedef struct _SYSTEM_CODEINTEGRITY_INFORMATION
     unsigned long Length;
     unsigned long CodeIntegrityOptions;
 } SYSTEM_CODEINTEGRITY_INFORMATION, *PSYSTEM_CODEINTEGRITY_INFORMATION;
+#define CODEINTEGRITY_OPTION_TESTSIGN 0x02
 #define CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED 0x400
 NTSTATUS
 NtQuerySystemInformation(
@@ -155,7 +156,7 @@ NtQuerySystemInformation(
 // End code pulled from winternl.h.
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state)
+ebpf_get_code_integrity_state(_Out_ bool* test_signing_enabled, _Out_ bool* hypervisor_kernel_mode_enabled)
 {
     NTSTATUS status;
     SYSTEM_CODEINTEGRITY_INFORMATION code_integrity_information = {sizeof(SYSTEM_CODEINTEGRITY_INFORMATION), 0};
@@ -164,12 +165,18 @@ ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state)
     status = NtQuerySystemInformation(
         SystemCodeIntegrityInformation, &code_integrity_information, system_information_length, &returned_length);
     if (NT_SUCCESS(status)) {
+        if ((code_integrity_information.CodeIntegrityOptions & CODEINTEGRITY_OPTION_TESTSIGN) != 0) {
+            EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Test signing enabled");
+            *test_signing_enabled = true;
+        } else {
+            *test_signing_enabled = false;
+        }
         if ((code_integrity_information.CodeIntegrityOptions & CODEINTEGRITY_OPTION_HVCI_KMCI_ENABLED) != 0) {
             EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Code integrity enabled");
-            *state = EBPF_CODE_INTEGRITY_HYPERVISOR_KERNEL_MODE;
+            *hypervisor_kernel_mode_enabled = true;
         } else {
             EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Code integrity disabled");
-            *state = EBPF_CODE_INTEGRITY_DEFAULT;
+            *hypervisor_kernel_mode_enabled = false;
         }
         return EBPF_SUCCESS;
     } else {

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -20,21 +20,29 @@
 #include <vector>
 
 // Global variables used to override behavior for testing.
-// Permit the test to simulate both Hyper-V Code Integrity.
+// Permit the test to simulate both Hyper-V Code Integrity and Test Signing
+// being enabled or disabled.
 bool _ebpf_platform_code_integrity_enabled = false;
+bool _ebpf_platform_code_integrity_test_signing_enabled = true;
 
 extern "C" size_t ebpf_fuzzing_memory_limit = MAXSIZE_T;
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state)
+ebpf_get_code_integrity_state(_Out_ bool* test_signing_enabled, _Out_ bool* hypervisor_kernel_mode_enabled)
 {
     EBPF_LOG_ENTRY();
+    if (_ebpf_platform_code_integrity_test_signing_enabled) {
+        EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Test signing enabled");
+        *test_signing_enabled = true;
+    } else {
+        *test_signing_enabled = false;
+    }
     if (_ebpf_platform_code_integrity_enabled) {
         EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Code integrity enabled");
-        *state = EBPF_CODE_INTEGRITY_HYPERVISOR_KERNEL_MODE;
+        *hypervisor_kernel_mode_enabled = true;
     } else {
         EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, "Code integrity disabled");
-        *state = EBPF_CODE_INTEGRITY_DEFAULT;
+        *hypervisor_kernel_mode_enabled = false;
     }
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -20,7 +20,17 @@ extern "C"
 #include "windows_platform.hpp"
 
 #include <map>
+#include <set>
+#include <softpub.h>
 #include <stdexcept>
+#include <string>
+#include <wintrust.h>
+
+// Include wintrust.lib
+#pragma comment(lib, "wintrust.lib")
+
+static bool _ebpf_service_test_signing_enabled = false;
+static bool _ebpf_service_hypervisor_kernel_mode_code_enforcement_enabled = false;
 
 #if !defined(CONFIG_BPF_JIT_DISABLED) || !defined(CONFIG_BPF_INTERPRETER_DISABLED)
 
@@ -432,6 +442,206 @@ Exit:
 
 #endif
 
+class WinVerifyTrustHelper
+{
+  public:
+    WinVerifyTrustHelper(const wchar_t* path)
+    {
+        win_trust_data.cbStruct = sizeof(WINTRUST_DATA);
+        win_trust_data.dwStateAction = WTD_STATEACTION_VERIFY;
+        win_trust_data.dwUIChoice = WTD_UI_NONE;
+        win_trust_data.fdwRevocationChecks = WTD_REVOKE_NONE;
+        win_trust_data.dwUnionChoice = WTD_CHOICE_FILE;
+
+        file_info.cbStruct = sizeof(WINTRUST_FILE_INFO);
+        file_info.pcwszFilePath = path;
+
+        win_trust_data.pFile = &file_info;
+
+        signature_settings.cbStruct = sizeof(WINTRUST_SIGNATURE_SETTINGS);
+        signature_settings.dwFlags = WSS_VERIFY_SPECIFIC | WSS_GET_SECONDARY_SIG_COUNT;
+        signature_settings.dwIndex = 0;
+
+        win_trust_data.pSignatureSettings = &signature_settings;
+
+        // Query the number of signatures.
+        DWORD error = WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
+        if (error != ERROR_SUCCESS) {
+            EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, WinVerifyTrust);
+            cleanup_win_verify_trust();
+            throw std::runtime_error("WinVerifyTrust failed");
+        }
+    }
+
+    ~WinVerifyTrustHelper() { cleanup_win_verify_trust(); }
+
+    DWORD
+    cert_count()
+    {
+        // The number of signatures is stored in the dwIndex field.
+        return signature_settings.cSecondarySigs + 1;
+    }
+
+    CRYPT_PROVIDER_CERT*
+    get_cert(DWORD index)
+    {
+        // Check if the context currently points to the correct index.
+        if (signature_settings.dwIndex != index) {
+            cleanup_win_verify_trust();
+
+            win_trust_data.dwStateAction = WTD_STATEACTION_VERIFY;
+            win_trust_data.pSignatureSettings->dwIndex = index;
+
+            DWORD error = WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
+            if (error != ERROR_SUCCESS) {
+                EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, WinVerifyTrust);
+                throw std::runtime_error("WinVerifyTrust failed");
+            }
+        }
+
+        CRYPT_PROVIDER_DATA* provider_data = WTHelperProvDataFromStateData(win_trust_data.hWVTStateData);
+        CRYPT_PROVIDER_SGNR* provider_signer = WTHelperGetProvSignerFromChain(provider_data, 0, FALSE, 0);
+        CRYPT_PROVIDER_CERT* cert = WTHelperGetProvCertFromChain(provider_signer, 0);
+
+        if (cert == nullptr) {
+            EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, WTHelperGetProvCertFromChain);
+            throw std::runtime_error("WTHelperGetProvCertFromChain failed");
+        }
+        return cert;
+    }
+
+  private:
+    void
+    cleanup_win_verify_trust()
+    {
+        if (win_trust_data.hWVTStateData) {
+            win_trust_data.dwStateAction = WTD_STATEACTION_CLOSE;
+            WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
+            win_trust_data.hWVTStateData = nullptr;
+        }
+    }
+
+    GUID generic_action_code = WINTRUST_ACTION_GENERIC_VERIFY_V2;
+    WINTRUST_DATA win_trust_data = {};
+    WINTRUST_FILE_INFO file_info = {};
+    WINTRUST_SIGNATURE_SETTINGS signature_settings = {};
+};
+
+static std::set<std::string>
+_ebpf_extract_eku(_In_ CRYPT_PROVIDER_CERT* cert)
+{
+    std::set<std::string> eku_set;
+    DWORD cb_usage = 0;
+    if (!CertGetEnhancedKeyUsage(cert->pCert, 0, nullptr, &cb_usage)) {
+        return eku_set;
+    }
+    std::vector<uint8_t> usage(cb_usage);
+
+    if (!CertGetEnhancedKeyUsage(cert->pCert, 0, reinterpret_cast<PCERT_ENHKEY_USAGE>(usage.data()), &cb_usage)) {
+        return eku_set;
+    }
+    auto pusage = reinterpret_cast<PCERT_ENHKEY_USAGE>(usage.data());
+    for (size_t index = 0; index < pusage->cUsageIdentifier; index++) {
+        eku_set.insert(pusage->rgpszUsageIdentifier[index]);
+    }
+    return eku_set;
+}
+
+static std::string
+_ebpf_extract_issuer(_In_ CRYPT_PROVIDER_CERT* cert)
+{
+    DWORD name_cb =
+        CertGetNameStringA(cert->pCert, CERT_KEY_PROV_INFO_PROP_ID, CERT_NAME_ISSUER_FLAG, nullptr, nullptr, 0);
+
+    std::vector<char> issuer(name_cb);
+    if (CertGetNameStringA(
+            cert->pCert, CERT_KEY_PROV_INFO_PROP_ID, CERT_NAME_ISSUER_FLAG, nullptr, issuer.data(), name_cb) == 0) {
+        return std::string();
+    }
+    return std::string(issuer.data());
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_verify_sys_file_signature(
+    _In_z_ const wchar_t* file_name,
+    _In_z_ const char* issuer_name,
+    _In_ size_t eku_count,
+    _In_reads_(eku_count) const char** eku_list)
+{
+    ebpf_result_t result = EBPF_OBJECT_NOT_FOUND;
+    EBPF_LOG_ENTRY();
+    std::string required_issuer(issuer_name);
+    std::set<std::string> required_eku_set;
+
+    if (_ebpf_service_test_signing_enabled) {
+        // Test signing is enabled, so we don't verify the signature.
+        EBPF_RETURN_RESULT(EBPF_SUCCESS);
+    }
+
+    for (size_t i = 0; i < eku_count; i++) {
+        required_eku_set.insert(eku_list[i]);
+    }
+
+    try {
+        WinVerifyTrustHelper wrapper(file_name);
+
+        for (DWORD i = 0; i < wrapper.cert_count(); i++) {
+
+            std::set<std::string> eku_set = _ebpf_extract_eku(wrapper.get_cert(i));
+            std::string issuer = _ebpf_extract_issuer(wrapper.get_cert(i));
+
+            if (issuer != required_issuer) {
+                EBPF_LOG_MESSAGE_STRING(
+                    EBPF_TRACELOG_LEVEL_ERROR,
+                    EBPF_TRACELOG_KEYWORD_API,
+                    "Certificate issuer mismatch",
+                    issuer.c_str());
+                continue;
+            }
+
+            std::set<std::string> eku_intersection;
+            std::set_intersection(
+                eku_set.begin(),
+                eku_set.end(),
+                required_eku_set.begin(),
+                required_eku_set.end(),
+                std::inserter(eku_intersection, eku_intersection.begin()));
+
+            if (eku_intersection.size() != required_eku_set.size()) {
+                EBPF_LOG_MESSAGE_STRING(
+                    EBPF_TRACELOG_LEVEL_ERROR,
+                    EBPF_TRACELOG_KEYWORD_API,
+                    "Certificate EKU mismatch",
+                    "Required EKUs not found in certificate");
+                continue;
+            }
+
+            // The certificate is valid and has the required EKUs.
+            result = EBPF_SUCCESS;
+            break;
+        }
+    } catch (const std::bad_alloc&) {
+        result = EBPF_NO_MEMORY;
+        EBPF_LOG_MESSAGE_ERROR(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_API,
+            "Memory allocation failed during signature verification",
+            result);
+    } catch (const std::runtime_error&) {
+        result = EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, WinVerifyTrust);
+    }
+
+    EBPF_RETURN_RESULT(result);
+}
+
+static const char* _ebpf_required_issuer =
+    "US, Washington, Redmond, Microsoft Corporation, Microsoft Corporation eBPF Verification";
+static const char* _ebpf_required_eku_list[] = {
+    "1.3.6.1.5.5.7.3.3",     // Code Signing
+    "1.3.6.1.4.1.311.133.1", // eBPF Verification
+};
+
 _Must_inspect_result_ ebpf_result_t
 ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* file_handle) noexcept
 {
@@ -455,8 +665,6 @@ ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* 
             EBPF_RETURN_RESULT(result);
         }
 
-        // FUTURE: Use WinVerifyTrustEx to verify the signature of the file.
-
         *file_handle = CreateFileW(
             file_path_wide.c_str(),
             GENERIC_READ,
@@ -472,7 +680,15 @@ ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* 
             EBPF_RETURN_RESULT(result);
         }
 
-        EBPF_RETURN_RESULT(EBPF_SUCCESS);
+        // Note: Signature verification is done after the file is opened to ensure that the file exists and can not be
+        // modified.
+        result = ebpf_verify_sys_file_signature(
+            file_path_wide.c_str(),
+            _ebpf_required_issuer,
+            sizeof(_ebpf_required_eku_list) / sizeof(_ebpf_required_eku_list[0]),
+            _ebpf_required_eku_list);
+
+        EBPF_RETURN_RESULT(result);
     } catch (const std::bad_alloc&) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     } catch (const std::exception&) {
@@ -548,6 +764,39 @@ Done:
     EBPF_RETURN_RESULT(result);
 }
 
+/**
+ * @brief Initialize the test signing state.
+ *
+ * @retval EBPF_SUCCESS on success, or an error code on failure.
+ * @retval EBPF_INVALID_ARGUMENT if the operation ID in the reply is not as expected.
+ * @retval EBPF_NO_MEMORY if memory allocation fails.
+ */
+static _Must_inspect_result_ ebpf_result_t
+_initialize_test_signing_state()
+{
+    _ebpf_service_test_signing_enabled = false;
+    _ebpf_service_hypervisor_kernel_mode_code_enforcement_enabled = false;
+
+    ebpf_operation_get_code_integrity_state_request_t request{
+        sizeof(ebpf_operation_get_code_integrity_state_request_t),
+        ebpf_operation_id_t::EBPF_OPERATION_GET_CODE_INTEGRITY_STATE};
+    ebpf_operation_get_code_integrity_state_reply_t reply;
+
+    uint32_t error = invoke_ioctl(request, reply);
+    if (error != ERROR_SUCCESS) {
+        return win32_error_code_to_ebpf_result(error);
+    }
+
+    if (reply.header.id != ebpf_operation_id_t::EBPF_OPERATION_GET_CODE_INTEGRITY_STATE) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    _ebpf_service_test_signing_enabled = reply.test_signing_enabled;
+    _ebpf_service_hypervisor_kernel_mode_code_enforcement_enabled = reply.hypervisor_code_integrity_enabled;
+
+    return EBPF_SUCCESS;
+}
+
 uint32_t
 ebpf_service_initialize() noexcept
 {
@@ -556,6 +805,11 @@ ebpf_service_initialize() noexcept
     // This is needed to ensure the service can successfully start
     // even if the driver is not installed.
     (void)initialize_async_device_handle();
+
+    ebpf_result_t result = _initialize_test_signing_state();
+    if (result != EBPF_SUCCESS) {
+        return ERROR_NOT_ENOUGH_MEMORY;
+    }
 
     return ERROR_SUCCESS;
 }

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -467,6 +467,7 @@ class WinVerifyTrustHelper
         // Query the number of signatures.
         DWORD error = WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
         if (error != ERROR_SUCCESS) {
+            SetLastError(error);
             EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, WinVerifyTrust);
             clean_up_win_verify_trust();
             throw std::runtime_error("WinVerifyTrust failed");
@@ -495,6 +496,7 @@ class WinVerifyTrustHelper
 
             DWORD error = WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
             if (error != ERROR_SUCCESS) {
+                SetLastError(error);
                 EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, WinVerifyTrust);
                 throw std::runtime_error("WinVerifyTrust failed");
             }
@@ -517,7 +519,8 @@ class WinVerifyTrustHelper
     {
         if (win_trust_data.hWVTStateData) {
             win_trust_data.dwStateAction = WTD_STATEACTION_CLOSE;
-            WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
+            // Ignore the return value of WinVerifyTrust on close.
+            (void)WinVerifyTrust(nullptr, &generic_action_code, &win_trust_data);
             win_trust_data.hWVTStateData = nullptr;
         }
     }

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -551,12 +551,15 @@ _ebpf_extract_eku(_In_ CRYPT_PROVIDER_CERT* cert)
 static std::string
 _ebpf_extract_issuer(_In_ const CRYPT_PROVIDER_CERT* cert)
 {
-    DWORD name_cb =
-        CertGetNameStringA(cert->pCert, CERT_KEY_PROV_INFO_PROP_ID, CERT_NAME_ISSUER_FLAG, nullptr, nullptr, 0);
+    DWORD name_cb = CertGetNameStringA(cert->pCert, CERT_NAME_RDN_TYPE, CERT_NAME_ISSUER_FLAG, nullptr, nullptr, 0);
+
+    if (name_cb == 0) {
+        return std::string();
+    }
 
     std::vector<char> issuer(name_cb);
-    if (CertGetNameStringA(
-            cert->pCert, CERT_KEY_PROV_INFO_PROP_ID, CERT_NAME_ISSUER_FLAG, nullptr, issuer.data(), name_cb) == 0) {
+    if (CertGetNameStringA(cert->pCert, CERT_NAME_RDN_TYPE, CERT_NAME_ISSUER_FLAG, nullptr, issuer.data(), name_cb) ==
+        0) {
         return std::string();
     }
     return std::string(issuer.data());
@@ -808,7 +811,14 @@ ebpf_service_initialize() noexcept
 
     ebpf_result_t result = _initialize_test_signing_state();
     if (result != EBPF_SUCCESS) {
-        return ERROR_NOT_ENOUGH_MEMORY;
+        switch (result) {
+        case EBPF_NO_MEMORY:
+            return ERROR_NOT_ENOUGH_MEMORY;
+        case EBPF_INVALID_ARGUMENT:
+            return ERROR_INVALID_PARAMETER;
+        default:
+            return ERROR_NOT_SUPPORTED;
+        }
     }
 
     return ERROR_SUCCESS;

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -46,6 +46,26 @@ ebpf_authorize_native_module(_In_ const GUID* module_id, _In_ HANDLE native_imag
 _Must_inspect_result_ ebpf_result_t
 ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* file_handle) noexcept;
 
+/**
+ * @brief Verify the signature of a system file.
+ *
+ * @param file_name The name of the file to verify.
+ * @param issuer_name The name of the issuer to check against.
+ * @param eku_count The number of EKUs to check.
+ * @param eku_list The list of EKUs to check against.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_OBJECT_NOT_FOUND The file does not have the expected signature.
+ * @retval EBPF_INVALID_ARGUMENT The file name or issuer name is invalid.
+ * @retval EBPF_NO_MEMORY Out of memory.
+ * @retval EBPF_FAILED A failure occurred during the verification process.
+ */
+_Must_inspect_result_ ebpf_result_t
+ebpf_verify_sys_file_signature(
+    _In_z_ const wchar_t* file_name,
+    _In_z_ const char* issuer_name,
+    _In_ size_t eku_count,
+    _In_reads_(eku_count) const char** eku_list);
+
 uint32_t
 ebpf_service_initialize() noexcept;
 

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -49,10 +49,10 @@ ebpf_verify_signature_and_open_file(_In_z_ const char* file_path, _Out_ HANDLE* 
 /**
  * @brief Verify the signature of a system file.
  *
- * @param file_name The name of the file to verify.
- * @param issuer_name The name of the issuer to check against.
- * @param eku_count The number of EKUs to check.
- * @param eku_list The list of EKUs to check against.
+ * @param[in] file_name The name of the file to verify.
+ * @param[in] issuer_name The name of the issuer to check against.
+ * @param[in] eku_count The number of EKUs to check.
+ * @param[in] eku_list The list of EKUs to check against.
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_OBJECT_NOT_FOUND The file does not have the expected signature.
  * @retval EBPF_INVALID_ARGUMENT The file name or issuer name is invalid.
@@ -63,7 +63,7 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_verify_sys_file_signature(
     _In_z_ const wchar_t* file_name,
     _In_z_ const char* issuer_name,
-    _In_ size_t eku_count,
+    size_t eku_count,
     _In_reads_(eku_count) const char** eku_list);
 
 uint32_t
@@ -71,3 +71,8 @@ ebpf_service_initialize() noexcept;
 
 void
 ebpf_service_cleanup() noexcept;
+
+#define EBPF_REQUIRED_ISSUER "US, Washington, Redmond, Microsoft Corporation, Microsoft Corporation eBPF Verification"
+#define EBPF_CODE_SIGNING_EKU "1.3.6.1.5.5.7.3.3"
+#define EBPF_VERIFICATION_EKU "1.3.6.1.4.1.311.133.1"
+#define EBPF_WINDOWS_COMPONENT_EKU "1.3.6.1.4.1.311.10.3.6"

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -72,7 +72,22 @@ ebpf_service_initialize() noexcept;
 void
 ebpf_service_cleanup() noexcept;
 
+/**
+ * @brief This macro defines the required issuer for eBPF verification.
+ * The issuer must match the one used for signing eBPF programs.
+ */
 #define EBPF_REQUIRED_ISSUER "US, Washington, Redmond, Microsoft Corporation, Microsoft Corporation eBPF Verification"
+
+/**
+ * @brief This macro defines the EKU for code signing.
+ */
 #define EBPF_CODE_SIGNING_EKU "1.3.6.1.5.5.7.3.3"
+/**
+ * @brief This macro defines the EKU used by eBPF to denote that a BPF program has been verified using the eBPF
+ * verification process.
+ */
 #define EBPF_VERIFICATION_EKU "1.3.6.1.4.1.311.133.1"
+/**
+ * @brief This macro defines the EKU used to denote that a driver is a Windows component.
+ */
 #define EBPF_WINDOWS_COMPONENT_EKU "1.3.6.1.4.1.311.10.3.6"

--- a/scripts/check_binary_dependencies_ebpfsvc_exe_regular_debug.txt
+++ b/scripts/check_binary_dependencies_ebpfsvc_exe_regular_debug.txt
@@ -30,7 +30,9 @@ api-ms-win-service-management-l1-1-0.dll
 api-ms-win-service-management-l2-1-0.dll
 api-ms-win-service-winsvc-l1-1-0.dll
 bcrypt.dll
+crypt32.dll
 dbghelp.dll
 kernel32.dll
 RPCRT4.dll
 ucrtbased.dll
+wintrust.dll

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -3302,11 +3302,13 @@ extern bool _ebpf_platform_code_integrity_test_signing_enabled;
 TEST_CASE("load_native_program_negative8", "[end-to-end]")
 {
     _test_helper_end_to_end test_helper;
+    GUID provider_module_id;
     _ebpf_platform_code_integrity_test_signing_enabled = false;
     test_helper.initialize();
     _ebpf_platform_code_integrity_test_signing_enabled = true;
 
-    ebpf_result_t result = ebpf_authorize_native_module_wrapper("test_sample_ebpf_um.dll");
+    REQUIRE(UuidCreate(&provider_module_id) == RPC_S_OK);
+    ebpf_result_t result = ebpf_authorize_native_module_wrapper(&provider_module_id, "test_sample_ebpf_um.dll");
 
     REQUIRE(result != EBPF_SUCCESS);
 }

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -4276,7 +4276,6 @@ TEST_CASE("signature_checking", "[end_to_end]")
     REQUIRE(result == EBPF_SUCCESS);
 }
 
-extern bool _ebpf_platform_code_integrity_test_signing_enabled;
 TEST_CASE("signature_checking_negative", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -4255,8 +4255,8 @@ TEST_CASE("signature_checking", "[end_to_end]")
     _ebpf_platform_code_integrity_test_signing_enabled = true;
 
     const char* eku_list[] = {
-        "1.3.6.1.5.5.7.3.3",      // Code signing
-        "1.3.6.1.4.1.311.10.3.6", // Windows System Component Verification
+        EBPF_CODE_SIGNING_EKU,
+        EBPF_WINDOWS_COMPONENT_EKU,
     };
     const char* issuer_production =
         "US, Washington, Redmond, Microsoft Corporation, Microsoft Windows Production PCA 2011";
@@ -4285,10 +4285,10 @@ TEST_CASE("signature_checking_negative", "[end_to_end]")
     _ebpf_platform_code_integrity_test_signing_enabled = true;
 
     const char* eku_list[] = {
-        "1.3.6.1.5.5.7.3.3",     // Code signing
-        "1.3.6.1.4.1.311.133.1", // eBPF Verification
+        EBPF_CODE_SIGNING_EKU,
+        EBPF_VERIFICATION_EKU,
     };
-    const char* issuer = "US, Washington, Redmond, Microsoft Corporation, Microsoft Corporation eBPF Verification";
+    const char* issuer = EBPF_REQUIRED_ISSUER;
 
     std::wstring test_file = L"%windir%\\system32\\drivers\\tcpip.sys";
 

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -3,6 +3,7 @@
 
 #include "api_common.hpp"
 #include "api_internal.h"
+#include "api_service.h"
 #include "bpf/bpf.h"
 #include "bpf2c.h"
 #include "cxplat_fault_injection.h"
@@ -727,6 +728,7 @@ _test_helper_end_to_end::initialize()
     ec_initialized = true;
     REQUIRE(ebpf_api_initiate() == EBPF_SUCCESS);
     api_initialized = true;
+    REQUIRE(ebpf_service_initialize() == EBPF_SUCCESS);
 }
 
 _test_handle_helper::~_test_handle_helper()
@@ -759,6 +761,8 @@ clear_program_info_cache();
 _test_helper_end_to_end::~_test_helper_end_to_end()
 {
     try {
+        ebpf_service_cleanup();
+
         _rundown_osfhandles();
 
         // Run down duplicate handles, if any.

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -729,6 +729,7 @@ _test_helper_end_to_end::initialize()
     REQUIRE(ebpf_api_initiate() == EBPF_SUCCESS);
     api_initialized = true;
     REQUIRE(ebpf_service_initialize() == EBPF_SUCCESS);
+    service_initialized = true;
 }
 
 _test_handle_helper::~_test_handle_helper()
@@ -761,7 +762,9 @@ clear_program_info_cache();
 _test_helper_end_to_end::~_test_helper_end_to_end()
 {
     try {
-        ebpf_service_cleanup();
+        if (service_initialized) {
+            ebpf_service_cleanup();
+        }
 
         _rundown_osfhandles();
 

--- a/tests/end_to_end/test_helper.hpp
+++ b/tests/end_to_end/test_helper.hpp
@@ -13,6 +13,7 @@ class _test_helper_end_to_end
   private:
     bool ec_initialized = false;
     bool api_initialized = false;
+    bool service_initialized = false;
 };
 
 class _program_info_provider;


### PR DESCRIPTION
## Description

Resolves: #4427
This pull request introduces significant changes to the eBPF platform's code integrity handling and signature verification mechanisms. The updates replace the previous `ebpf_code_integrity_state_t` enumeration with separate boolean flags for Hyper-V Code Integrity and Test Signing states, expand the protocol to query these states, and implement a robust file signature verification process using Windows Trust APIs.

### Code Integrity State Updates:
* Replaced `ebpf_code_integrity_state_t` with two boolean flags: `_ebpf_platform_hyper_visor_code_integrity_enabled` and `_ebpf_platform_test_signing_enabled` to track Hyper-V Code Integrity and Test Signing states. [[1]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L40-R41) [[2]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7L41-L46)
* Updated `ebpf_get_code_integrity_state` function to return these flags instead of the deprecated enumeration. [[1]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7L187-R189) [[2]](diffhunk://#diff-86ad2329b975e7c7a873e33a2f2e00ed7130fdf4ddbe4e08b49470a746c4cba6L158-R159)

### Protocol Enhancements:
* Added a new protocol operation (`EBPF_OPERATION_GET_CODE_INTEGRITY_STATE`) to query the code integrity state, including Hyper-V Code Integrity and Test Signing flags. [[1]](diffhunk://#diff-8ed704d86d8cbd581386c6cb0486d2f594cb73c97b06864425f673cc0e4a1f00R52) [[2]](diffhunk://#diff-8ed704d86d8cbd581386c6cb0486d2f594cb73c97b06864425f673cc0e4a1f00R563-R574) [[3]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R2294-R2306) [[4]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R2884-R2885)

### Signature Verification:
* Implemented a comprehensive signature verification mechanism using `WinVerifyTrust`, including support for Enhanced Key Usage (EKU) and issuer validation. [[1]](diffhunk://#diff-4b05db47f30b730880202628e554484a25835ea2ef9c897e50dbfabe67538b85R445-R644) [[2]](diffhunk://#diff-4b05db47f30b730880202628e554484a25835ea2ef9c897e50dbfabe67538b85L458-L459) [[3]](diffhunk://#diff-4b05db47f30b730880202628e554484a25835ea2ef9c897e50dbfabe67538b85L475-R691)
* Added helper functions to extract EKU and issuer information from certificates for validation.

### Service Initialization:
* Integrated code integrity state initialization into the `ebpf_service_initialize` function to ensure proper setup of the Test Signing and Hyper-V Code Integrity flags during service startup. [[1]](diffhunk://#diff-4b05db47f30b730880202628e554484a25835ea2ef9c897e50dbfabe67538b85R766-R798) [[2]](diffhunk://#diff-4b05db47f30b730880202628e554484a25835ea2ef9c897e50dbfabe67538b85R808-R812)

### Miscellaneous Changes:
* Updated logging and error handling to reflect the new code integrity and signature verification logic. [[1]](diffhunk://#diff-86ad2329b975e7c7a873e33a2f2e00ed7130fdf4ddbe4e08b49470a746c4cba6R168-R179) [[2]](diffhunk://#diff-20b5fd970c548fe85017a765358e1c10c4c66e68ecee00954927a767bbe9a70eL23-R45)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
