### PR TITLE
Mitigate code scanner alerts

### DIFF
--- a/.azure/reusable-test.yml
+++ b/.azure/reusable-test.yml
@@ -100,7 +100,7 @@ jobs:
         displayName: 'Shallow Checkout Repo'
 
       - bash: |
-          choco install -y procdump --version 11.0
+          choco install -y --requirechecksum=true --checksum=d58e81b96d53ded74570ad028d605fcfa1bfcc2e7cb2f5ab24bd64901b0c8783 --checksum-type=sha256 procdump --version=11.0
           where procdump.exe
         condition: eq('${{parameters.gather_dumps}}', 'true')
         name: install_procdump

--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -33,7 +33,6 @@ permissions:
   id-token: write  # Required to log in to Azure.
   contents: read
   checks: read  # Required by reusable-test.yml to check build status.
-  security-events: write  # Required by codeql task.
   issues: write  # Required to create issues.
 
 jobs:
@@ -286,6 +285,8 @@ jobs:
 
   codeql:
     uses: ./.github/workflows/reusable-build.yml
+  permissions:
+    security-events: write  # Required by codeql task.
     with:
       ref: ${{ github.ref }}
       repository: ${{ github.repository }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,7 +18,6 @@ concurrency:
 permissions:
   contents: read
   checks: read  # Required by reusable-test.yml to check build status.
-  security-events: write  # Required by codeql task.
   issues: write  # Required to create issues.
 
 jobs:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -71,7 +71,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write  # Required by codeql task
 
 jobs:
   build:
@@ -354,6 +353,20 @@ jobs:
           path: c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
           retention-days: 10
 
+  codeql:
+    needs: build
+    if: ${{ needs.build.outputs.should_skip != 'true' && inputs.build_codeql == true }}
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ${{ inputs.architecture == 'x64' && 'windows-2022' || 'windows-11-arm' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{inputs.repository}}
+          submodules: 'recursive'
+          ref: ${{inputs.ref}}
+
       - name: Perform CodeQL Analysis
-        if: inputs.build_codeql == true && steps.skip_check.outputs.should_skip != 'true'
-        uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b
+        uses: github/codeql-action/analyze@39edc492dbe16b1465b0cafca41432d857bdb31a

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -159,7 +159,7 @@ jobs:
         id: install_procdump
         if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
         run: |
-          choco install -y procdump --version 11.0
+          choco install -y --requirechecksum=true --checksum=d58e81b96d53ded74570ad028d605fcfa1bfcc2e7cb2f5ab24bd64901b0c8783 --checksum-type=sha256 procdump --version=11.0
           where procdump.exe
 
       - name: Set up OpenCppCoverage and add to PATH


### PR DESCRIPTION
## Description

This fixes #4455 by making changes to the various workflow files to mitigate the code scanner warnings. The changes were around lowering token permissions and specifying file hash for downloading tools using choco.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CI/CD is adequate.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.
