### PR TITLE
Update to latest WDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,6 +82,10 @@
   <PropertyGroup Condition="'$(Fuzzer)'!='True' And '$(Configuration)'!='FuzzerDebug'">
     <SpectreMitigation>Spectre</SpectreMitigation>
   </PropertyGroup>
+  <!-- Workaround for issue with WDK nuget package -->
+  <PropertyGroup>
+    <DriverCatalog_Enable>true</DriverCatalog_Enable>
+  </PropertyGroup>
   <!-- Select the best version of clang available. -->
   <!-- If $(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe exists, set ClangExe to that value -->
   <PropertyGroup Condition="Exists('$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe')">

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -4,11 +4,11 @@
   SPDX-License-Identifier: MIT
 -->
 <packages>
-  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.3323" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.3323" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.3323" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.3323" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.3323" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.3323" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.3323" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.4204" targetFramework="native" />
 </packages>

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion>10.0.26100.3323</WDKVersion>
+    <WDKVersion>10.0.26100.4204</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion>10.0.26100.3323</WDKVersion>
+    <WDKVersion>10.0.26100.4204</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/wdk.props
+++ b/wdk.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <HostPlatform Condition="'$(HostPlatform)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
-    <WDKVersion>10.0.26100.3323</WDKVersion>
+    <WDKVersion>10.0.26100.4204</WDKVersion>
   </PropertyGroup>
   <!-- Log the WDK version -->
   <Target Name="LogWDKVersion" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
## Description

Resolves: #4497 

Update to the latest WDK

## Testing

CI/CD

## Documentation

No

## Installation

No.

This pull request updates the Windows SDK and WDK versions across multiple configuration files to ensure compatibility with the latest version. The updates primarily involve changing the version from `10.0.26100.3323` to `10.0.26100.4204`.

### Updates to SDK and WDK versions:

* [`scripts/setup_build/packages.config`](diffhunk://#diff-802912bfde6b8ea411619105236cbcca7a2452e26911bc02617e5a4476da2c28L7-R13): Updated all package references for `Microsoft.Windows.SDK.CPP` and `Microsoft.Windows.WDK` to version `10.0.26100.4204`.
* [`tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj`](diffhunk://#diff-fc796b56abadfe08981eff727a9493359dbc2084b95990a738e9b0ed83d1f885L8-R8): Updated the `WDKVersion` property to `10.0.26100.4204`.
* [`tools/bpf2c/templates/user_mode_bpf2c.vcxproj`](diffhunk://#diff-448d7df5def64aa8987f23fe49f3739c3d0cf62d06fd70e8fe93fbc14dae757cL8-R8): Updated the `WDKVersion` property to `10.0.26100.4204`.
* [`wdk.props`](diffhunk://#diff-495df965b3e771fdb5967162d00ea1db561789398bddb53465aef374a22cbd42L10-R10): Updated the `WDKVersion` property to `10.0.26100.4204`.
