### PR TITLE
Add Concurrency tests for sock ops

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -97,8 +97,8 @@ The following steps need to be executed *once* before the first build on a new c
 
 To build with the specific compile time options for disabling JIT compiler and/or the Interpreter, append "`/p:<option>=True`". Available options are:
 
-1. `DisableJIT` - Compile eBPF's *Execution Context* without support for eBPF JIT compiler.
-1. `DisableInterpreter` - Compile eBPF's *Execution Context* without support for eBPF interpreter.
+1. `DisableJIT` - Compile eBPF's *execution context* without support for eBPF JIT compiler.
+1. `DisableInterpreter` - Compile eBPF's *execution context* without support for eBPF interpreter.
 
 Both options are set when compiling with the "NativeOnlyDebug" or "NativeOnlyRelease" configurations.
 
@@ -116,8 +116,8 @@ To build with the specific compile time options for disabling JIT compiler and/o
 1. Navigate to "`C/C++`" -> "`Preprocessor`" -> "`Preprocessor Definitions`"
 1. Click the "`V`" combobox arrow and then "`Edit`" for adding the option(s) to the list of preprocessor options. Available options are:
 
-   *  `CONFIG_BPF_JIT_DISABLED` - Compile eBPF's *Execution Context* without support for the eBPF JIT compiler.
-   *  `CONFIG_BPF_INTERPRETER_DISABLED` - Compile eBPF's *Execution Context* without support for the eBPF interpreter.
+   *  `CONFIG_BPF_JIT_DISABLED` - Compile eBPF's *execution context* without support for the eBPF JIT compiler.
+   *  `CONFIG_BPF_INTERPRETER_DISABLED` - Compile eBPF's *execution context* without support for the eBPF interpreter.
 
       >*Note for Linux users*: this option is similar to the `CONFIG_BPF_JIT_ALWAYS_ON` which, as documented
 [here](https://googleprojectzero.blogspot.com/2018/01/reading-privileged-memory-with-side.html), is used to disable support for the interpreter.

--- a/docs/NativeCodeGeneration.md
+++ b/docs/NativeCodeGeneration.md
@@ -276,7 +276,7 @@ address of the start of the map data into the address_of_map_value field.
 
 ## Loading an eBPF program from a PE .sys file
 
-The process of loading an eBPF program is a series of interactions between the eBPF Execution Context and the generated
+The process of loading an eBPF program is a series of interactions between the eBPF execution context and the generated
 .sys file, and is summarized in the following diagram:
 
 ![Native Driver Architecture](ArchitectureDiagram.svg)

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -126,8 +126,8 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         (void)helper.test_cgroup_inet6_connect(&parameters);
         break;
     case BPF_PROG_TYPE_SOCK_OPS:
-        (void)helper.test_sock_ops_v4(&parameters);
-        (void)helper.test_sock_ops_v6(&parameters);
+        (void)helper.test_sock_ops_v4(&parameters, nullptr);
+        (void)helper.test_sock_ops_v6(&parameters, nullptr);
         break;
     // Explicitly ignore all other program types.
     default:

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -81,10 +81,22 @@ typedef class _netebpf_ext_helper
     }
 
     FWP_ACTION_TYPE
-    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters) { return usersim_fwp_sock_ops_v4(parameters); }
+    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id)
+    {
+        return usersim_fwp_sock_ops_v4(parameters, flow_id);
+    }
 
     FWP_ACTION_TYPE
-    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters) { return usersim_fwp_sock_ops_v6(parameters); }
+    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id)
+    {
+        return usersim_fwp_sock_ops_v6(parameters, flow_id);
+    }
+
+    void
+    test_sock_ops_v4_remove_flow_context(uint64_t flow_id)
+    {
+        usersim_fwp_sock_ops_v4_remove_flow_context(flow_id);
+    }
 
   private:
     bool trace_initiated = false;

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -81,13 +81,13 @@ typedef class _netebpf_ext_helper
     }
 
     FWP_ACTION_TYPE
-    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id)
+    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ uint64_t* flow_id)
     {
         return usersim_fwp_sock_ops_v4(parameters, flow_id);
     }
 
     FWP_ACTION_TYPE
-    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id)
+    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ uint64_t* flow_id)
     {
         return usersim_fwp_sock_ops_v6(parameters, flow_id);
     }

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1100,6 +1100,8 @@ sock_ops_thread_function(
         flow_ids.push_back(flow_id);
         auto expected_result = _get_fwp_sock_ops_action(port_number);
 
+        count++;
+
         if (result != expected_result) {
             if (fault_injection_enabled) {
                 continue;
@@ -1107,9 +1109,7 @@ sock_ops_thread_function(
             (*failure_count)++;
             break;
         }
-        count++;
     }
-
     // Sleep for the specified flow duration before removing flow contexts.
     std::this_thread::sleep_for(std::chrono::seconds(flow_duration_seconds));
     for (auto id : flow_ids) {

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1064,7 +1064,7 @@ TEST_CASE("sock_ops_context", "[netebpfext]")
 void
 sock_ops_thread_function(
     std::stop_token token,
-    _In_ const netebpf_ext_helper_t* helper,
+    _In_ netebpf_ext_helper_t* helper,
     _In_ fwp_classify_parameters_t* parameters,
     std::atomic<size_t>* failure_count,
     size_t iteration_count,

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -942,7 +942,7 @@ netebpfext_unit_invoke_sock_ops_program(
     int action = client_context->sock_ops_action;
 
     if (action == SOCK_OPS_TEST_ACTION_ROUND_ROBIN) {
-        // If the action is round robin, decide the action based on the locsl port number.
+        // If the action is round robin, decide the action based on the local port number.
         bpf_sock_ops_t* sock_ops_context = (bpf_sock_ops_t*)context;
         action = _get_sock_ops_action(sock_ops_context->local_port);
     }

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1103,7 +1103,8 @@ sock_ops_thread_function(
         count++;
 
         if (result != expected_result) {
-            if (fault_injection_enabled) {
+            // If fault injection is enabled, then id can be 0 and lead to crash when trying to remove the flow context.
+            if (fault_injection_enabled && flow_id == 0) {
                 continue;
             }
             (*failure_count)++;
@@ -1113,6 +1114,10 @@ sock_ops_thread_function(
     // Sleep for the specified flow duration before removing flow contexts.
     std::this_thread::sleep_for(std::chrono::seconds(flow_duration_seconds));
     for (auto id : flow_ids) {
+        // If fault injection is enabled, then id can be 0 and lead to crash when trying to remove the flow context.
+        if (fault_injection_enabled && id == 0) {
+            continue;
+        }
         helper->test_sock_ops_v4_remove_flow_context(id);
     }
 }

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1064,7 +1064,7 @@ TEST_CASE("sock_ops_context", "[netebpfext]")
 void
 sock_ops_thread_function(
     std::stop_token token,
-    _In_ netebpf_ext_helper_t* helper,
+    _In_ const netebpf_ext_helper_t* helper,
     _In_ fwp_classify_parameters_t* parameters,
     std::atomic<size_t>* failure_count,
     size_t iteration_count,


### PR DESCRIPTION
## Description

Added concurrency tests for sock ops.
Added calls to flow_context deletion test api that will be added to usersim with [this pr](https://github.com/microsoft/usersim/pull/263).

Currently flow_context deletion is only triggered when client is detached. According to [this page](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/fwpsk/nc-fwpsk-fwps_callout_flow_delete_notify_fn0) , flowDeleteFn  is called when flow terminates. This is not being tested.
The added test cases add coverage for deletion of flow context before client detach. 
Closes #2082 

Note: build will fail until the usersim changes get merged.

## Testing

Tested unit test locally.

## Documentation

NA

## Installation

NA