### PR TITLE
Fix sock_ops code flow and test

### DIFF
--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1123,22 +1123,20 @@ sock_ops_thread_function(
         count++;
 
         if (result != expected_result) {
-            // If fault injection is enabled, results can be different.
-            if (fault_injection_enabled) {
+            // If fault injection is enabled, FwpsFlowAssociateContext can fail in which case the sock_ops classifyfn
+            // will return FWP_ACTION_PERMIT.
+            if (fault_injection_enabled && result == FWP_ACTION_PERMIT) {
                 continue;
             }
             (*failure_count)++;
             break;
         }
     }
-    // If fault injection is enabled, it is possible that the context has not been created.
-    // Trying to delete flow context in this case can lead to a crash.
-    if (!fault_injection_enabled) {
-        // Sleep for the specified flow duration before removing flow contexts.
-        std::this_thread::sleep_for(std::chrono::seconds(flow_duration_seconds));
-        for (auto id : flow_ids) {
-            helper->test_sock_ops_v4_remove_flow_context(id);
-        }
+
+    // Sleep for the specified flow duration before removing flow contexts.
+    std::this_thread::sleep_for(std::chrono::seconds(flow_duration_seconds));
+    for (auto id : flow_ids) {
+        helper->test_sock_ops_v4_remove_flow_context(id);
     }
 }
 

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1123,22 +1123,22 @@ sock_ops_thread_function(
         count++;
 
         if (result != expected_result) {
-            // If fault injection is enabled, then id can be 0 and lead to crash when trying to remove the flow context.
-            if (fault_injection_enabled && flow_id == 0) {
+            // If fault injection is enabled, results can be different.
+            if (fault_injection_enabled) {
                 continue;
             }
             (*failure_count)++;
             break;
         }
     }
-    // Sleep for the specified flow duration before removing flow contexts.
-    std::this_thread::sleep_for(std::chrono::seconds(flow_duration_seconds));
-    for (auto id : flow_ids) {
-        // If fault injection is enabled, then id can be 0 and lead to crash when trying to remove the flow context.
-        if (fault_injection_enabled && id == 0) {
-            continue;
+    // If fault injection is enabled, it is possible that the context has not been created.
+    // Trying to delete flow context in this case can lead to a crash.
+    if (!fault_injection_enabled) {
+        // Sleep for the specified flow duration before removing flow contexts.
+        std::this_thread::sleep_for(std::chrono::seconds(flow_duration_seconds));
+        for (auto id : flow_ids) {
+            helper->test_sock_ops_v4_remove_flow_context(id);
         }
-        helper->test_sock_ops_v4_remove_flow_context(id);
     }
 }
 


### PR DESCRIPTION
## Description

- Currently the sock_ops classifyfn invokes the attached bpf program even if FwpsFlowAssociateContext0 has failed. Changed the logic to exit when FwpsFlowAssociateContext0 fails.

- When fault injection is enabled calls to FwpsFlowAssociateContext0 can fail. When this happens a call to test_sock_ops_v4_remove_flow_context will trigger an assert. [This pr](https://github.com/microsoft/usersim/pull/272) in usersim updates remove_flow_context and now it only deletes flow context if it exists. Bumping usersim to include this change

Closes #4584 


## Testing

CICD
## Documentation

NA
## Installation

NA