### PR TITLE
Fix scorecard workflow

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -43,6 +43,7 @@ jobs:
             www.bestpractices.dev:443
             github.com:443
             api.deps.dev:443
+            fulcio.sigstore.dev:443
 
       - name: "Checkout code"
         if: github.ref_name == 'main'


### PR DESCRIPTION
## Description

https://github.com/microsoft/ebpf-for-windows/security/code-scanning shows "Scorecard is reporting errors" and the code scanning alerts are old (April 1st) and out of date.  Diving into the errors link there, we find that https://github.com/microsoft/ebpf-for-windows/actions/runs/17113111801/job/48538627679 shows:

2025/08/20 23:52:20 error signing scorecard results: getting key from Fulcio: retrieving cert: client: Post "https://fulcio.sigstore.dev/api/v1/signingCert": dial tcp 54.185.253.63:443: connect: connection refused

This is because fulcio.sigstore.dev is not in the permitted domains for the job.

This PR corrects that so github code scanning will work again.
Fixes #4593

## Testing

Must be tested by github.

## Documentation

No impact.

## Installation

No impact.