### PR TITLE
use allocate with tags for hash table.

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1056,7 +1056,7 @@ _create_hash_map_internal(
         .minimum_bucket_count = local_map->ebpf_map_definition.max_entries,
         .max_entries = fixed_size_map ? local_map->ebpf_map_definition.max_entries : EBPF_HASH_TABLE_NO_LIMIT,
         .extract_function = extract_function,
-        .allocate_tag = EBPF_POOL_TAG_MAP,
+        .allocation_tag = EBPF_POOL_TAG_MAP,
         .supplemental_value_size = supplemental_value_size,
         .notification_context = local_map,
         .notification_callback = notification_callback,

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1056,6 +1056,7 @@ _create_hash_map_internal(
         .minimum_bucket_count = local_map->ebpf_map_definition.max_entries,
         .max_entries = fixed_size_map ? local_map->ebpf_map_definition.max_entries : EBPF_HASH_TABLE_NO_LIMIT,
         .extract_function = extract_function,
+        .allocate_tag = EBPF_POOL_TAG_MAP,
         .supplemental_value_size = supplemental_value_size,
         .notification_context = local_map,
         .notification_callback = notification_callback,

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1026,7 +1026,8 @@ ebpf_native_initiate()
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(GUID),
         .value_size = sizeof(ebpf_native_module_t*),
-        .allocate = ebpf_allocate,
+        .allocate = ebpf_allocate_with_tag,
+        .allocate_tag = EBPF_POOL_TAG_NATIVE,
         .free = ebpf_free,
     };
 
@@ -1042,7 +1043,8 @@ ebpf_native_initiate()
         &(const ebpf_hash_table_creation_options_t){
             .key_size = sizeof(GUID),
             .value_size = sizeof(ebpf_native_authorized_module_entry_t),
-            .allocate = ebpf_allocate,
+            .allocate = ebpf_allocate_with_tag,
+            .allocate_tag = EBPF_POOL_TAG_NATIVE,
             .free = ebpf_free,
         });
     if (return_value != EBPF_SUCCESS) {
@@ -2454,7 +2456,7 @@ _ebpf_native_authorized_module_cleanup_work_item_callback(_Inout_opt_ void* cont
 
     uint64_t current_time = cxplat_query_time_since_boot_approximate(false) * EBPF_NS_PER_FILETIME;
 
-    // Iterate through the authorized module table and remove entries that have not been used for more than
+    // Iterate through the authorized module table and remove entries that have not been used for
     // EBPF_NATIVE_AUTHORIZE_MODULE_ENTRY_TIMEOUT_NANOSECONDS.
     GUID previous_key = {0};
     GUID next_key = {0};

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1027,7 +1027,7 @@ ebpf_native_initiate()
         .key_size = sizeof(GUID),
         .value_size = sizeof(ebpf_native_module_t*),
         .allocate = ebpf_allocate_with_tag,
-        .allocate_tag = EBPF_POOL_TAG_NATIVE,
+        .allocation_tag = EBPF_POOL_TAG_NATIVE,
         .free = ebpf_free,
     };
 
@@ -1044,7 +1044,7 @@ ebpf_native_initiate()
             .key_size = sizeof(GUID),
             .value_size = sizeof(ebpf_native_authorized_module_entry_t),
             .allocate = ebpf_allocate_with_tag,
-            .allocate_tag = EBPF_POOL_TAG_NATIVE,
+            .allocation_tag = EBPF_POOL_TAG_NATIVE,
             .free = ebpf_free,
         });
     if (return_value != EBPF_SUCCESS) {

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -65,7 +65,7 @@ struct _ebpf_hash_table
     ebpf_hash_table_allocate allocate; // Function to allocate memory.
     ebpf_hash_table_free free;         // Function to free memory.
     ebpf_hash_table_extract_function extract; // Function to extract bytes to hash from key.
-    uint32_t allocate_tag;                    // Pool tag to use for allocations.
+    uint32_t allocation_tag;                  // Pool tag to use for allocations.
 
     void* notification_context; //< Context to pass to notification functions.
     ebpf_hash_table_notification_function notification_callback;
@@ -408,7 +408,7 @@ _ebpf_hash_table_bucket_insert(
     }
 
     // Allocate new bucket.
-    local_new_bucket = hash_table->allocate(new_bucket_size, hash_table->allocate_tag);
+    local_new_bucket = hash_table->allocate(new_bucket_size, hash_table->allocation_tag);
     if (!local_new_bucket) {
         result = EBPF_NO_MEMORY;
         goto Done;
@@ -416,7 +416,7 @@ _ebpf_hash_table_bucket_insert(
 
     // Allocate a new backup bucket.
     if (old_bucket_size) {
-        backup_bucket = hash_table->allocate(old_bucket_size, hash_table->allocate_tag);
+        backup_bucket = hash_table->allocate(old_bucket_size, hash_table->allocation_tag);
         if (!backup_bucket) {
             result = EBPF_NO_MEMORY;
             goto Done;
@@ -552,7 +552,7 @@ _ebpf_hash_table_bucket_update(
     ebpf_hash_bucket_header_t* local_new_bucket = NULL;
 
     // Allocate new bucket.
-    local_new_bucket = hash_table->allocate(old_bucket_size, hash_table->allocate_tag);
+    local_new_bucket = hash_table->allocate(old_bucket_size, hash_table->allocation_tag);
     if (!local_new_bucket) {
         result = EBPF_NO_MEMORY;
         goto Done;
@@ -610,7 +610,7 @@ _ebpf_hash_table_replace_bucket(
     // Make a copy of the value to insert.
     if (operation != EBPF_HASH_BUCKET_OPERATION_DELETE) {
         new_data = hash_table->allocate(
-            hash_table->value_size + hash_table->supplemental_value_size, hash_table->allocate_tag);
+            hash_table->value_size + hash_table->supplemental_value_size, hash_table->allocation_tag);
         if (!new_data) {
             result = EBPF_NO_MEMORY;
             goto Done;
@@ -724,7 +724,7 @@ ebpf_hash_table_create(_Out_ ebpf_hash_table_t** hash_table, _In_ const ebpf_has
         options->minimum_bucket_count ? options->minimum_bucket_count : EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT;
     ebpf_hash_table_allocate allocate = options->allocate ? options->allocate : ebpf_epoch_allocate_with_tag;
     ebpf_hash_table_free free = options->free ? options->free : ebpf_epoch_free;
-    uint32_t allocate_tag = options->allocate_tag ? options->allocate_tag : EBPF_POOL_TAG_EPOCH;
+    uint32_t allocation_tag = options->allocation_tag ? options->allocation_tag : EBPF_POOL_TAG_EPOCH;
 
     // Increase bucket_count to next power of 2.
     unsigned long msb_index;
@@ -743,7 +743,7 @@ ebpf_hash_table_create(_Out_ ebpf_hash_table_t** hash_table, _In_ const ebpf_has
         goto Done;
     }
 
-    table = allocate(table_size, allocate_tag);
+    table = allocate(table_size, allocation_tag);
     if (table == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -753,7 +753,7 @@ ebpf_hash_table_create(_Out_ ebpf_hash_table_t** hash_table, _In_ const ebpf_has
     table->value_size = options->value_size;
     table->allocate = allocate;
     table->free = free;
-    table->allocate_tag = allocate_tag;
+    table->allocation_tag = allocation_tag;
     table->bucket_count = bucket_count;
     table->bucket_count_mask = bucket_count - 1;
     table->entry_count = 0;

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -60,7 +60,8 @@ extern "C"
         // Optional fields.
         ebpf_hash_table_extract_function extract_function; //< Function to extract key from stored value.
         ebpf_hash_table_allocate allocate; //< Function to allocate memory - defaults to ebpf_epoch_allocate_with_tag.
-        uint32_t allocate_tag;             //< Pool tag to use for allocations - defaults to EBPF_POOL_TAG_EPOCH.
+        uint32_t allocation_tag;           //< Pool tag to use for allocations - if set to 0 or unspecified, defaults to
+                                           // EBPF_POOL_TAG_EPOCH.
         ebpf_hash_table_free free;         //< Function to free memory - defaults to ebpf_epoch_free.
         size_t minimum_bucket_count;       //< Minimum number of buckets to use - defaults to
                                            // EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT.

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -34,7 +34,10 @@ extern "C"
         _In_ const uint8_t* key,
         _Inout_ uint8_t* value);
 
-    typedef _Must_inspect_result_ _Ret_writes_maybenull_(size) void* (*ebpf_hash_table_allocate)(size_t size);
+    // Allocation callback for the hash table. The tag parameter allows callers to
+    // specify a pool tag for the allocation.
+    typedef _Must_inspect_result_
+        _Ret_writes_maybenull_(size) void* (*ebpf_hash_table_allocate)(size_t size, uint32_t tag);
 
     typedef void (*ebpf_hash_table_free)(_Frees_ptr_opt_ void* memory);
 
@@ -56,7 +59,8 @@ extern "C"
         size_t value_size; //< Size of value in bytes.
         // Optional fields.
         ebpf_hash_table_extract_function extract_function; //< Function to extract key from stored value.
-        ebpf_hash_table_allocate allocate; //< Function to allocate memory - defaults to ebpf_epoch_allocate.
+        ebpf_hash_table_allocate allocate; //< Function to allocate memory - defaults to ebpf_epoch_allocate_with_tag.
+        uint32_t allocate_tag;             //< Pool tag to use for allocations - defaults to EBPF_POOL_TAG_EPOCH.
         ebpf_hash_table_free free;         //< Function to free memory - defaults to ebpf_epoch_free.
         size_t minimum_bucket_count;       //< Minimum number of buckets to use - defaults to
                                            // EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT.

--- a/libs/runtime/ebpf_pinning_table.c
+++ b/libs/runtime/ebpf_pinning_table.c
@@ -54,7 +54,7 @@ ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t return_value;
-    *pinning_table = ebpf_allocate(sizeof(ebpf_pinning_table_t));
+    *pinning_table = ebpf_allocate_with_tag(sizeof(ebpf_pinning_table_t), EBPF_POOL_TAG_PINNING);
     if (*pinning_table == NULL) {
         return_value = EBPF_NO_MEMORY;
         goto Done;
@@ -68,7 +68,8 @@ ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
         .key_size = sizeof(cxplat_utf8_string_t*),
         .value_size = sizeof(ebpf_pinning_entry_t*),
         .extract_function = _ebpf_pinning_table_extract,
-        .allocate = ebpf_allocate,
+        .allocate = ebpf_allocate_with_tag,
+        .allocate_tag = EBPF_POOL_TAG_PINNING,
         .free = ebpf_free,
     };
 
@@ -135,7 +136,7 @@ ebpf_pinning_table_insert(
         }
     }
 
-    new_pinning_entry = ebpf_allocate(sizeof(ebpf_pinning_entry_t));
+    new_pinning_entry = ebpf_allocate_with_tag(sizeof(ebpf_pinning_entry_t), EBPF_POOL_TAG_PINNING);
     if (!new_pinning_entry) {
         return_value = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/runtime/ebpf_pinning_table.c
+++ b/libs/runtime/ebpf_pinning_table.c
@@ -69,7 +69,7 @@ ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
         .value_size = sizeof(ebpf_pinning_entry_t*),
         .extract_function = _ebpf_pinning_table_extract,
         .allocate = ebpf_allocate_with_tag,
-        .allocate_tag = EBPF_POOL_TAG_PINNING,
+        .allocation_tag = EBPF_POOL_TAG_PINNING,
         .free = ebpf_free,
     };
 

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -233,17 +233,26 @@ TEST_CASE("hash_table_test", "[platform]")
         v = static_cast<uint8_t>(ebpf_random_uint32());
     }
 
-    const ebpf_hash_table_creation_options_t options = {
+    ebpf_hash_table_creation_options_t options = {
         .key_size = key_1.size(),
         .value_size = data_1.size(),
         .allocate = ebpf_allocate_with_tag,
-        .allocate_tag = EBPF_POOL_TAG_DEFAULT,
         .free = ebpf_free,
         .minimum_bucket_count = 1,
     };
 
     ebpf_hash_table_t* raw_ptr = nullptr;
-    REQUIRE(ebpf_hash_table_create(&raw_ptr, &options) == EBPF_SUCCESS);
+    // Allocate using default allocation tag.
+    REQUIRE(
+        ebpf_hash_table_create(&raw_ptr, const_cast<const ebpf_hash_table_creation_options_t*>(&options)) ==
+        EBPF_SUCCESS);
+    ebpf_hash_table_destroy(raw_ptr);
+
+    // Allocate using EBPF_POOL_TAG_DEFAULT.
+    options.allocation_tag = EBPF_POOL_TAG_DEFAULT;
+    REQUIRE(
+        ebpf_hash_table_create(&raw_ptr, const_cast<const ebpf_hash_table_creation_options_t*>(&options)) ==
+        EBPF_SUCCESS);
     ebpf_hash_table_ptr table(raw_ptr);
 
     // Insert first

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -236,7 +236,8 @@ TEST_CASE("hash_table_test", "[platform]")
     const ebpf_hash_table_creation_options_t options = {
         .key_size = key_1.size(),
         .value_size = data_1.size(),
-        .allocate = ebpf_allocate,
+        .allocate = ebpf_allocate_with_tag,
+        .allocate_tag = EBPF_POOL_TAG_DEFAULT,
         .free = ebpf_free,
         .minimum_bucket_count = 1,
     };

--- a/libs/shared/ebpf_shared_framework.h
+++ b/libs/shared/ebpf_shared_framework.h
@@ -51,6 +51,7 @@ typedef enum _ebpf_pool_tag
     EBPF_POOL_TAG_LINK = 'knle',
     EBPF_POOL_TAG_MAP = 'pame',
     EBPF_POOL_TAG_NATIVE = 'vtne',
+    EBPF_POOL_TAG_PINNING = 'nipe',
     EBPF_POOL_TAG_PROGRAM = 'grpe',
     EBPF_POOL_TAG_RANDOM = 'gnre',
     EBPF_POOL_TAG_RING_BUFFER = 'fbre',


### PR DESCRIPTION
## Description

This PR fixes #4125 by associating an allocation tag with ebpf hashtable allocation functions.

## Testing

No new tests are needed.

## Documentation

No impact on documentation.

## Installation

No installer imapct.
