### PR TITLE
Fix indentation of "pinned" parameter help text in netsh ebpf add program

### DIFF
--- a/tools/netsh/ebpfnetsh.rc
+++ b/tools/netsh/ebpfnetsh.rc
@@ -82,7 +82,7 @@ BEGIN
 \n                    specified for program types other than CGROUP_SOCK_ADDR.\
 \n      pinned      - One of the following values:\
 \n                     none: Load all programs without pinning any.\
-\n                   first: Pin the first program in the file.\
+\n                     first: Pin the first program in the file.\
 \n                     all: Pin all programs in the file.\
 \n      execution   - One of the following values:\
 \n                     jit: Convert the program to machine code.\


### PR DESCRIPTION
…gram

## Description

This PR fixes the indentation of the pinned parameter help text in the netsh ebpf add program command. The previous formatting was misaligned, making the help output harder to read.

Fixes #4580 

## Testing

No functional changes, so existing tests remain unaffected.

## Documentation
Improves help text formatting for better readability.

## Installation
No impact on installation; this is a documentation/UX improvement only.
