### PR TITLE
Skip address sanitizer tests that depend on stdio redirection in ADO pipeline

### DIFF
--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -80,7 +80,10 @@ jobs:
         parameters:
           name: unit_tests
           pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-          test_command: '.\unit_tests.exe -d yes ~[processes]'
+          # Exclude [processes] test that ASAN can't work with.
+           # Exclude ~printk, ~recursive_tail_call, and ~sequential_tail_call tests as they don't work with ASAN due to
+          # as usersim is linked with static CRT libraries which breaks stdout redirection.
+          test_command: '.\unit_tests.exe -d yes ~[processes] ~printk ~recursive_tail_call ~sequential_tail_call'
           dependency: regular
           build_artifact: Build
           environment: windows-2022


### PR DESCRIPTION
## Description

Address sanitizer tests are not compatible with stdout redirection, which causes the unit tests that rely on this to fail. The GitHub pipeline skips printk, recursive_tail_call, and recursive_tail_call, but the ADO pipeline wasn't updated.
Resolves: #4624

## Testing

CI/CD

## Documentation

No

## Installation

No
