### PR TITLE
Prevent NULL filename in verify_and_authorize_native_image

### DIFF
--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -64,8 +64,8 @@ import "wtypes.idl";
 
         ebpf_result_t verify_and_load_program(
             [ in, ref ] ebpf_program_load_info * info,
-            [ out, ref ] uint32_t * logs_size,
+            [ out, ref ] uint32_t* logs_size,
             [ out, size_is(, *logs_size), ref ] char** logs);
 
-        ebpf_result_t verify_and_authorize_native_image([in] GUID * module_id, [ in, string ] char* image_path);
+        ebpf_result_t verify_and_authorize_native_image([in] GUID * module_id, [ in, ref, string ] char* image_path);
     }


### PR DESCRIPTION
## Description

Mark the filename parameter to the RPC method as required (cannot be null).

## Testing

CI/CD

## Documentation

No.

## Installation

No.
