### PR TITLE
Remove XDP tests

### DIFF
--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -485,9 +485,6 @@ function Run-KernelTests {
     Write-Log "Finished Invoke-OnHostOrVM for Run-KernelTests"
 
     if (($script:TestMode -eq "CI/CD") -or ($script:TestMode -eq "Regression")) {
-        Write-Log "Running XDP tests"
-        Invoke-XDPTests -Interfaces $Config.Interfaces -LogFileName $script:LogFileName
-        Write-Log "XDP tests completed"
         Write-Log "Running Connect Redirect tests"
         Invoke-ConnectRedirectTestHelper -Interfaces $Config.Interfaces -ConnectRedirectTestConfig $Config.ConnectRedirectTest -UserType "Administrator" -LogFileName $script:LogFileName
         Add-StandardUser -UserName $script:StandardUser -Password $script:StandardUserPassword


### PR DESCRIPTION
## Description
There are a few primary motivations for removing the XDP tests:
1 - The XDP tests have been intermittently failing (See issue #4470).
2 - The XDP tests are utilizing a 'xdp_test' hook, which was created during previously development, but is not the actual production XDP hook, and is not needed.
3 - The XDP test hook should eventually be removed from netebpfext (See issue #2974).

For all of the above reasons, this PR removes the invocation of XDP tests. Note that the rest of the test code and scripts still exist, and can be fully removed when we complete issue #2974.

## Testing
Removes the XDP tests from our kernel test suite.

## Documentation
n/a

## Installation
n/a