### PR TITLE
Fix flow deletion

### DIFF
--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1113,7 +1113,7 @@ sock_ops_thread_function(
         result = helper->test_sock_ops_v4(parameters, &flow_id);
 
         sock_ops_test_action_t iteration_action = _get_sock_ops_action(action, port_number);
-        if (iteration_action != SOCK_OPS_TEST_ACTION_FAILURE) {
+        if (iteration_action != SOCK_OPS_TEST_ACTION_FAILURE && flow_id != 0) {
             // Create a list of flow context ids to delete after timeout. Flow context is created only if the invocation
             // is successful.
             flow_ids.push_back(flow_id);


### PR DESCRIPTION
## Description

In the sock_ops_thread_function when fault injection is enabled, test_sock_ops_v4 can fail and flow_id will not be set. In this case 0 gets added to the flow_ids list which leads to assertion failure when test_sock_ops_v4_remove_flow_context is called later on.  

- Fix:
  * In `sock_ops_thread_function`, updated the condition to only add `flow_id` to `flow_ids` if `iteration_action` is not `SOCK_OPS_TEST_ACTION_FAILURE` and `flow_id` is not zero, ensuring only valid flow IDs are tracked for deletion.

## Testing

Ran netebpfext_unit twice on local vm with fault injection enabled

## Documentation

NA

## Installation

NA