### PR TITLE
Miscellaneous changes to kernel driver test CICD jobs.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -246,6 +246,7 @@ jobs:
     if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-test.yml
     strategy:
+      fail-fast: false
       matrix:
         image:
           - 'server2022'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -187,6 +187,7 @@ jobs:
 
       - name: Cache nuget packages
         if: steps.skip_check.outputs.should_skip != 'true'
+        continue-on-error: true
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         env:
           cache-name: cache-nuget-modules

--- a/docs/remote-vm-setup.md
+++ b/docs/remote-vm-setup.md
@@ -1,10 +1,10 @@
-# Running Scripts on a Remote VM
+# Running CI/CD Scripts on a Remote VM
 
-This guide explains how to set up and run eBPF for Windows CI/CD scripts on a remote VM.
+This guide explains how to set up and run eBPF for Windows CI/CD scripts on a remote VM using [WinRM](https://learn.microsoft.com/en-us/windows/win32/winrm/portal).
 
 ---
 
-## 1. Prepare the Remote VM
+## Prepare the Remote VM
 
 Set the execution policy and run the setup script as Administrator:
 
@@ -12,10 +12,16 @@ Set the execution policy and run the setup script as Administrator:
 Set-ExecutionPolicy Unrestricted -Force
 .\setup_remote_vm.ps1
 ```
+Post reboot run `winrm quickconfig` and take a snapshot of the VM.
 
 ---
 
-## 2. Ensure Remote VM is Reachable
+## Start WinRM service on the local host
+```cmd
+sc.exe start winrm
+```
+
+## Ensure Remote VM is Reachable
 
 On your host machine, verify that the remote VM is reachable and that WinRM is running by executing:
 
@@ -23,11 +29,11 @@ On your host machine, verify that the remote VM is reachable and that WinRM is r
 Test-WSMan <remote-vm-ip>
 ```
 
-If this command fails, ensure the VM is powered on, network connectivity is working, and WinRM is enabled. Running `winrm quickconfig` on the remote VM can help identify and fix common WinRM setup issues.
+If this command fails, ensure the VM is powered on, network connectivity is working, and WinRM is enabled.
 
 ---
 
-## 2.1. Add Remote VM to Trusted Hosts
+## Add Remote VM to Trusted Hosts
 
 On your host machine, allow connections to the remote VM by adding its IP address to the list of trusted hosts:
 
@@ -36,7 +42,7 @@ Set-Item WSMan:\localhost\Client\TrustedHosts -Value "<remote-vm-ip>"
 ```
 ---
 
-## 3. Store VM Credentials on the Host
+## Store VM Credentials on the Host
 
 On your host machine, save the VM administrator and standard user credentials using the `CredentialManager` module:
 
@@ -52,7 +58,7 @@ New-StoredCredential -Target TEST_VM_STANDARD -Username <VM Standard User Name> 
 
 ---
 
-## 4. Prepare the Build Artifacts
+## Prepare the Build Artifacts
 
 1. **Navigate to the Build Directory**
 
@@ -62,7 +68,7 @@ New-StoredCredential -Target TEST_VM_STANDARD -Username <VM Standard User Name> 
    cd .\x64\Release
    ```
 
-2. **Edit `test_execution.json`**
+1. **Edit `test_execution.json`**
 
    Update the `VMMap` section to specify your test VM.
    Example:
@@ -86,7 +92,7 @@ New-StoredCredential -Target TEST_VM_STANDARD -Username <VM Standard User Name> 
 
 ---
 
-## 5. Run the CI/CD Setup Script
+## Run the CI/CD Setup Script
 
 1. **Run the Setup Script**
 
@@ -94,7 +100,7 @@ New-StoredCredential -Target TEST_VM_STANDARD -Username <VM Standard User Name> 
    .\setup_ebpf_cicd_tests.ps1 -VMIsRemote
    ```
 
-3. **Run the Test Execution Script**
+1. **Run the Test Execution Script**
 
    ```powershell
    .\execute_ebpf_cicd_tests.ps1 -VMIsRemote

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -145,7 +145,7 @@ function Stop-DriverWithTimeout {
 }
 
 # This function specifically tests that all eBPF drivers and services can be stopped.
-function Stop-eBPFComponents {
+function Stop-eBPFServiceAndDrivers {
     param([parameter(Mandatory=$false)] [bool] $GranularTracing = $false)
 
     if ($GranularTracing) {
@@ -348,11 +348,11 @@ function Install-eBPFComponents
     if (Test-Path -Path "export_program_info_sample.exe") {
         $TestCommand = "$pwd\PsExec64.exe"
         $Arguments = "-accepteula -nobanner -s -w `"$pwd`" `"$pwd\export_program_info_sample.exe`""
-        Start-Process -NoNewWindow -Wait "$TestCommand" -ArgumentList "$Arguments"
-        if ($LASTEXITCODE -ne 0) {
-            throw ("Failed to run 'export_program_info_sample.exe as SYSTEM'.");
+        $PsExecProc = Start-Process -Wait -PassThru -FilePath "$TestCommand" -ArgumentList $Arguments
+        if ($PsExecProc.ExitCode -ne 0) {
+            throw ("Running 'export_program_info_sample.exe' as SYSTEM failed with exit code $($PsExecProc.ExitCode).");
         } else {
-            Write-Log "'export_program_info_sample.exe' succeeded." -ForegroundColor Green
+            Write-Log "Running 'export_program_info_sample.exe' as SYSTEM succeeded." -ForegroundColor Green
         }
     }
 

--- a/scripts/setup_ebpf_cicd_tests.ps1
+++ b/scripts/setup_ebpf_cicd_tests.ps1
@@ -1,16 +1,16 @@
 # Copyright (c) eBPF for Windows contributors
 # SPDX-License-Identifier: MIT
 
-param ([parameter(Mandatory=$false)][string] $Target = "TEST_VM",
-       [parameter(Mandatory=$false)][bool] $KmTracing = $true,
-       [parameter(Mandatory=$false)][string] $KmTraceType = "file",
-       [parameter(Mandatory=$false)][string] $TestMode = "CI/CD",
-       [parameter(Mandatory=$false)][string] $LogFileName = "TestLog.log",
-       [parameter(Mandatory=$false)][string] $WorkingDirectory = $pwd.ToString(),
-       [parameter(Mandatory=$false)][string] $RegressionArtifactsVersion = "",
-       [parameter(Mandatory=$false)][string] $RegressionArtifactsConfiguration = "",
-       [parameter(Mandatory=$false)][string] $TestExecutionJsonFileName = "test_execution.json",
-       [parameter(Mandatory=$false)][string] $SelfHostedRunnerName = [System.Net.Dns]::GetHostName(),
+param ([parameter(Mandatory = $false)][string] $Target = "TEST_VM",
+       [parameter(Mandatory = $false)][bool] $KmTracing = $true,
+       [parameter(Mandatory = $false)][string] $KmTraceType = "file",
+       [parameter(Mandatory = $false)][string] $TestMode = "CI/CD",
+       [parameter(Mandatory = $false)][string] $LogFileName = "TestLog.log",
+       [parameter(Mandatory = $false)][string] $WorkingDirectory = $pwd.ToString(),
+       [parameter(Mandatory = $false)][string] $RegressionArtifactsVersion = "",
+       [parameter(Mandatory = $false)][string] $RegressionArtifactsConfiguration = "",
+       [parameter(Mandatory = $false)][string] $TestExecutionJsonFileName = "test_execution.json",
+       [parameter(Mandatory = $false)][string] $SelfHostedRunnerName = [System.Net.Dns]::GetHostName(),
        [Parameter(Mandatory = $false)][int] $TestJobTimeout = (30*60),
        [Parameter(Mandatory = $false)][string] $EnableHVCI = "Off",
        [Parameter(Mandatory = $false)][switch] $ExecuteOnHost,
@@ -28,26 +28,31 @@ Push-Location $WorkingDirectory
 # Load other utility modules.
 Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName) -WarningAction SilentlyContinue
 
+Write-Log "ExecuteOnHost: $ExecuteOnHost"
+Write-Log "ExecuteOnVM: $ExecuteOnVM"
+Write-Log "VMIsRemote: $VMIsRemote"
+Write-Log "TestMode: $TestMode"
+Write-Log "KmTracing: $KmTracing"
+Write-Log "KmTraceType: $KmTraceType"
+Write-Log "EnableHVCI: $EnableHVCI"
+Write-Log "GranularTracing: $GranularTracing"
+Write-Log "Architecture: $Architecture"
+
+# Read the test execution json.
+$Config = Get-Content ("{0}\{1}" -f $PSScriptRoot, $TestExecutionJsonFileName) | ConvertFrom-Json
+
 if ($ExecuteOnVM) {
     if ($SelfHostedRunnerName -eq "1ESRunner") {
         $TestVMCredential = Retrieve-StoredCredential -Target $Target
     } else {
         $TestVMCredential = Get-StoredCredential -Target $Target -ErrorAction Stop
     }
-
-    $UserName = $TestVMCredential.UserName
-    $Password = $TestVMCredential.Password
 } else {
     # Username and password are not used when running on host - use empty but non-null values.
     $UserName = $env:USERNAME
     $Password = ConvertTo-SecureString -String 'empty' -AsPlainText -Force
     $TestVMCredential = New-Object System.Management.Automation.PSCredential($UserName, $Password)
 }
-
-Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($UserName, $Password, $WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
-
-# Read the test execution json.
-$Config = Get-Content ("{0}\{1}" -f $PSScriptRoot, $TestExecutionJsonFileName) | ConvertFrom-Json
 
 # Delete old log files if any.
 Remove-Item "$env:TEMP\$LogFileName" -ErrorAction SilentlyContinue
@@ -59,166 +64,140 @@ if ($TestMode -eq "Regression") {
     Get-RegressionTestArtifacts -ArtifactVersion $RegressionArtifactsVersion -Configuration $RegressionArtifactsConfiguration
 }
 
-if ($TestMode -eq "CI/CD" -or $TestMode -eq "Regression") {
-
-    # Download the release artifacts for legacy regression tests.
-    Get-LegacyRegressionTestArtifacts
-}
-
 Get-CoreNetTools -Architecture $Architecture
 Get-PSExec
 
-if ($ExecuteOnVM -and $VMIsRemote) {
-    # Setup for remote machine execution.
-    $VMList = $Config.VMMap.$SelfHostedRunnerName
+$Job = Start-Job -ScriptBlock {
+    param (
+        [Parameter(Mandatory = $true)] [PSCredential] $TestVMCredential,
+        [Parameter(Mandatory = $true)] [PSCustomObject] $Config,
+        [Parameter(Mandatory = $true)] [string] $SelfHostedRunnerName,
+        [parameter(Mandatory = $true)] [string] $TestMode,
+        [parameter(Mandatory = $true)] [string] $LogFileName,
+        [parameter(Mandatory = $true)] [string] $WorkingDirectory = $pwd.ToString(),
+        [parameter(Mandatory = $true)] [bool] $KmTracing,
+        [parameter(Mandatory = $true)] [string] $KmTraceType,
+        [parameter(Mandatory = $true)] [string] $EnableHVCI,
+        [parameter(Mandatory = $true)] [bool] $ExecuteOnVM,
+        [parameter(Mandatory = $true)] [bool] $VMIsRemote,
+        [parameter(Mandatory = $true)] [bool] $GranularTracing
+    )
+    Push-Location $WorkingDirectory
 
-    # Export build artifacts to the remote machine(s).
-    Export-BuildArtifactsToVMs -VMList $VMList -VMIsRemote:$VMIsRemote -ErrorAction Stop
+    # Load other utility modules.
+    Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName) -WarningAction SilentlyContinue
+    Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($TestVMCredential.UserName, $TestVMCredential.Password, $WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
 
-    # Configure network adapters on remote machine(s).
-    Initialize-NetworkInterfaces `
-        -ExecuteOnHost $false `
-        -ExecuteOnVM $true `
-        -VMList $VMList `
-        -TestWorkingDirectory "C:\ebpf" `
-        -VMIsRemote:$VMIsRemote `
-        -ErrorAction Stop
-
-    # Install eBPF Components on the remote machine(s).
-    foreach($VM in $VMList) {
-        $VMName = $VM.Name
-        Install-eBPFComponentsOnVM -VMName $VMName -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -VMIsRemote:$VMIsRemote -GranularTracing:$GranularTracing -ErrorAction Stop
+    if  ($ExecuteOnVM) {
+        $VMList = $Config.VMMap.$SelfHostedRunnerName
+        if (-not $VMIsRemote) {
+            # Get all local VMs to ready state.
+            Initialize-AllVMs -VMList $VMList -ErrorAction Stop
+        }
+    } else {
+        Import-Module .\install_ebpf.psm1 -Force -ArgumentList ($WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
+        $VMList = @()
     }
 
-    Pop-Location
-}
-elseif ($ExecuteOnVM) {
-    $Job = Start-Job -ScriptBlock {
-        param (
-            [Parameter(Mandatory = $true)] [PSCredential] $TestVMCredential,
-            [Parameter(Mandatory = $true)] [PSCustomObject] $Config,
-            [Parameter(Mandatory = $true)] [string] $SelfHostedRunnerName,
-            [parameter(Mandatory = $true)] [string] $TestMode,
-            [parameter(Mandatory = $true)] [string] $LogFileName,
-            [parameter(Mandatory = $true)] [string] $WorkingDirectory = $pwd.ToString(),
-            [parameter(Mandatory = $true)] [bool] $KmTracing,
-            [parameter(Mandatory = $true)] [string] $KmTraceType,
-            [parameter(Mandatory = $true)] [string] $EnableHVCI,
-            [parameter(Mandatory = $true)] [bool] $GranularTracing
-        )
-        Push-Location $WorkingDirectory
-
-        # Load other utility modules.
-        Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName) -WarningAction SilentlyContinue
-
-        Import-Module .\config_test_vm.psm1 -Force -ArgumentList ($TestVMCredential.UserName, $TestVMCredential.Password, $WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
-
-        $VMList = $Config.VMMap.$SelfHostedRunnerName
-
-        # Get all VMs to ready state.
-        Initialize-AllVMs -VMList $VMList -ErrorAction Stop
-
+    if ($ExecuteOnVM) {
         # Export build artifacts to the test VMs. Attempt with a few retries.
         $MaxRetryCount = 5
         for ($i = 0; $i -lt $MaxRetryCount; $i += 1) {
             try {
-                Export-BuildArtifactsToVMs -VMList $VMList -ErrorAction Stop
+                Export-BuildArtifactsToVMs -VMList $VMList -VMIsRemote $VMIsRemote -ErrorAction Stop
                 break
-            } catch {
-                if ($i -eq $MaxRetryCount) {
-                    Write-Log "Export-BuildArtifactsToVMs failed after $MaxRetryCount attempts."
-                    throw
-                }
+            } catch [System.Exception] {
+                Write-Log "Export-BuildArtifactsToVMs failed: $_"
                 Write-Log "Export-BuildArtifactsToVMs failed. Retrying..."
             }
         }
 
-        # Configure network adapters.
-        Initialize-NetworkInterfaces `
-            -ExecuteOnHost $false `
-            -ExecuteOnVM $true `
-            -VMList $VMList `
-            -TestWorkingDirectory "C:\ebpf" `
-            -ErrorAction Stop
-
         # Enable HVCI on the test VMs if specified.
-        Write-Log "EnableHVCI: $EnableHVCI"
-
         if ($EnableHVCI -eq "On") {
             Write-Log "Enabling HVCI on test VMs..."
             # Enable HVCI on the test VM.
             foreach($VM in $VMList) {
                 $VMName = $VM.Name
-                Enable-HVCIOnVM -VMName $VMName -ErrorAction Stop
+                Enable-HVCIOnVM -VMName $VMName -VMIsRemote:$VMIsRemote -ErrorAction Stop
             }
-        } else {
-            Write-Log "HVCI is not enabled on test VMs."
         }
-
-        # Install eBPF Components on the test VM.
-        foreach($VM in $VMList) {
-            $VMName = $VM.Name
-            Install-eBPFComponentsOnVM -VMName $VMname -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -GranularTracing:$GranularTracing -ErrorAction Stop
-        }
-
-        # Log OS build information on the test VM.
-        foreach($VM in $VMList) {
-            $VMName = $VM.Name
-            Log-OSBuildInformationOnVM -VMName $VMName -ErrorAction Stop
-        }
-
-        Pop-Location
-    }  -ArgumentList (
-        $TestVMCredential,
-        $Config,
-        $SelfHostedRunnerName,
-        $TestMode,
-        $LogFileName,
-        $WorkingDirectory,
-        $KmTracing,
-        $KmTraceType,
-        $EnableHVCI,
-        $GranularTracing)
-
-    # Wait for the job to complete.
-    $JobTimedOut = `
-        Wait-TestJobToComplete -Job $Job `
-        -Config $Config `
-        -SelfHostedRunnerName $SelfHostedRunnerName `
-        -TestJobTimeout $TestJobTimeout `
-        -CheckpointPrefix "Setup" `
-        -ExecuteOnHost $ExecuteOnHost `
-        -ExecuteOnVM $ExecuteOnVM `
-        -AdminTestVMCredential $TestVMCredential `
-        -StandardUserTestVMCredential $TestVMCredential `
-        -VMIsRemote $VMIsRemote `
-        -TestWorkingDirectory $(if ($ExecuteOnVM) { "C:\ebpf" } else { $WorkingDirectory }) `
-        -LogFileName $LogFileName `
-        -TestMode $TestMode `
-        -Options @("None") `
-        -TestHangTimeout (10*60) `
-        -UserModeDumpFolder "C:\Dumps"
-
-    # Clean up.
-    Remove-Job -Job $Job -Force
-
-    Pop-Location
-
-    if ($JobTimedOut) {
-        exit 1
     }
-} else {
+
+    # Configure network adapters on test VMs or host.
     Initialize-NetworkInterfaces `
-        -ExecuteOnHost $true `
-        -ExecuteOnVM $false `
-        -VMList @() `
-        -TestWorkingDirectory $WorkingDirectory `
+        -ExecuteOnVM $ExecuteOnVM `
+        -VMList $VMList `
+        -TestWorkingDirectory $(if ($ExecuteOnVM) { "C:\ebpf" } else { $WorkingDirectory }) `
+        -VMIsRemote:$VMIsRemote `
         -ErrorAction Stop
 
-    # Install eBPF components but skip anything that requires reboot.
-    # Note that installing ebpf components requires psexec which does not run in a powershell job.
-    Import-Module .\install_ebpf.psm1 -Force -ArgumentList ($WorkingDirectory, $LogFileName) -WarningAction SilentlyContinue
-    Install-eBPFComponents -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -SkipRebootOperations -GranularTracing:$GranularTracing
+    Write-Log "Network interfaces initialized"
+
+    $ExecuteOnHost = -not $ExecuteOnVM
+    if  ($ExecuteOnHost) {
+        # Install eBPF components on host, but skip anything that requires reboot.
+        # Note that installing ebpf components requires psexec which does not run in a powershell job.
+        Write-Log "Installing eBPF components on host"
+        Install-eBPFComponents -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -SkipRebootOperations -GranularTracing:$GranularTracing
+        return
+    }
+
+    # The rest of the script runs only if executing on VM.
+    if (-not $ExecuteOnVM) {
+        throw "Assertion failed: ExecuteOnVM must be true."
+    }
+
+    # Install eBPF Components on the test VM.
+    foreach($VM in $VMList) {
+        $VMName = $VM.Name
+        Install-eBPFComponentsOnVM -VMName $VMName -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -VMIsRemote:$VMIsRemote -GranularTracing:$GranularTracing -ErrorAction Stop
+    }
+
+    # Log OS build information on the test VMs.
+    foreach($VM in $VMList) {
+        $VMName = $VM.Name
+        Log-OSBuildInformationOnVM -VMName $VMName -VMIsRemote:$VMIsRemote -ErrorAction Stop
+    }
 
     Pop-Location
+}  -ArgumentList (
+    $TestVMCredential,
+    $Config,
+    $SelfHostedRunnerName,
+    $TestMode,
+    $LogFileName,
+    $WorkingDirectory,
+    $KmTracing,
+    $KmTraceType,
+    $EnableHVCI,
+    $ExecuteOnVM,
+    $VMIsRemote,
+    $GranularTracing)
+
+# Wait for the job to complete.
+$JobTimedOut = `
+    Wait-TestJobToComplete -Job $Job `
+    -Config $Config `
+    -SelfHostedRunnerName $SelfHostedRunnerName `
+    -TestJobTimeout $TestJobTimeout `
+    -CheckpointPrefix "Setup" `
+    -ExecuteOnHost $ExecuteOnHost `
+    -ExecuteOnVM $ExecuteOnVM `
+    -AdminTestVMCredential $TestVMCredential `
+    -StandardUserTestVMCredential $TestVMCredential `
+    -VMIsRemote $VMIsRemote `
+    -TestWorkingDirectory $(if ($ExecuteOnVM) { "C:\ebpf" } else { $WorkingDirectory }) `
+    -LogFileName $LogFileName `
+    -TestMode $TestMode `
+    -Options @("None") `
+    -TestHangTimeout (10*60) `
+    -UserModeDumpFolder "C:\Dumps"
+
+# Clean up.
+Remove-Job -Job $Job -Force
+
+Pop-Location
+
+if ($JobTimedOut) {
+    exit 1
 }

--- a/scripts/tracing_utils.psm1
+++ b/scripts/tracing_utils.psm1
@@ -53,12 +53,12 @@ function Start-WPRTrace {
         if ($TraceType -eq "file") {
             $profileName = "$TracingProfileName-File"
             Write-Log "Executing: wpr.exe -start `"$wprpProfilePath!$profileName`" -filemode"
-            wpr.exe -start "$wprpProfilePath!$profileName" -filemode
+            $null = wpr.exe -start "$wprpProfilePath!$profileName" -filemode 2>&1
             $exitCode = $LASTEXITCODE
         } else {
             $profileName = "$TracingProfileName-Memory"
             Write-Log "Executing: wpr.exe -start `"$wprpProfilePath!$profileName`""
-            wpr.exe -start "$wprpProfilePath!$profileName"
+            $null = wpr.exe -start "$wprpProfilePath!$profileName" 2>&1
             $exitCode = $LASTEXITCODE
         }
 


### PR DESCRIPTION
## Description

This PR makes the following changes:

* Change the setup script to enable HVCI _before_ installing duonic. Empirical evidence suggests that duonic installation was failing post enabling HVCI. No causality has been established. This is merely a workaround to make forward progress.
* It sets `fail-fast: false` for the native only tests strategy matrix, so that failure in one flavor does not cancel the other.
* It re-enables XDP tests to be run conditionally.
* Refactor some functions so that setup/execution on local host, VM and remote VM share maximum code.
* Removes some dead code from the scripts.
* Additional logging.

## Testing

This makes changes to the kernel driver test jobs.

## Documentation

No documentation changes.

## Installation

No installation changes.