### PR TITLE
Apply asan mitigations to the asan test pass (not the regular one)

### DIFF
--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -80,10 +80,7 @@ jobs:
         parameters:
           name: unit_tests
           pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-          # Exclude [processes] test that ASAN can't work with.
-           # Exclude ~printk, ~recursive_tail_call, and ~sequential_tail_call tests as they don't work with ASAN due to
-          # as usersim is linked with static CRT libraries which breaks stdout redirection.
-          test_command: '.\unit_tests.exe -d yes ~[processes] ~printk ~recursive_tail_call ~sequential_tail_call'
+          test_command: '.\unit_tests.exe -d yes ~[processes]'
           dependency: regular
           build_artifact: Build
           environment: windows-2022
@@ -322,7 +319,9 @@ jobs:
         parameters:
           name: sanitize_unit_tests
           # Exclude [processes] test that ASAN can't work with.
-          test_command: '.\unit_tests.exe -d yes ~[processes]'
+          # Exclude ~printk, ~recursive_tail_call, and ~sequential_tail_call tests as they don't work with ASAN due as
+          # usersim is linked with static CRT libraries which breaks stdout redirection.
+          test_command: '.\unit_tests.exe -d yes ~[processes] ~printk ~recursive_tail_call ~sequential_tail_call'
           dependency: sanitize
           build_artifact: Build-Sanitize
           environment: windows-2022


### PR DESCRIPTION
## Description

ASAN mitigations were applied to the regular unit_test pass rather than the ASAN test pass. Fix is to apply the mitigations to the correct test pass.

Resolves: #4624

## Testing

CI/CD

## Documentation

No.

## Installation

No.
