### PR TITLE
Modify link behavior to hold reference on program

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -12,6 +12,7 @@ EXPORTS
     bpf_link__destroy
     bpf_link__disconnect
     bpf_link__fd
+    bpf_link__open
     bpf_link__pin
     bpf_link__unpin
     bpf_link_detach
@@ -128,6 +129,7 @@ EXPORTS
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name
     ebpf_link_close
+    ebpf_link_mark_as_legacy_mode
     ebpf_map_set_wait_handle
     ebpf_object_get
     ebpf_object_get_execution_type

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -906,6 +906,18 @@ extern "C"
         _In_opt_ void* ctx,
         _In_opt_ const struct ebpf_perf_buffer_opts* opts) EBPF_NO_EXCEPT;
 
+    /**
+     * @brief Mark a link as operating in legacy mode, which means it doesn't detach
+     * automatically when last user mode reference is closed.
+     * This is used by bpf_prog_attach and related APIs to implement legacy behavior.
+     *
+     * @param[in] link File descriptor for the link.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_link_mark_as_legacy_mode(fd_t link) EBPF_NO_EXCEPT;
 #ifdef __cplusplus
 }
 #endif

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -5233,8 +5233,8 @@ ebpf_link_mark_as_legacy_mode(fd_t link_fd) NO_EXCEPT_TRY
         result = EBPF_INVALID_FD;
         EBPF_RETURN_RESULT(result);
     }
-    ebpf_operation_link_legacy_mode_request_t request{
-        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_LINK_LEGACY_MODE, link_handle};
+    ebpf_operation_link_set_legacy_mode_request_t request{
+        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_LINK_SET_LEGACY_MODE, link_handle};
     result = win32_error_code_to_ebpf_result(invoke_ioctl(request));
     EBPF_RETURN_RESULT(result);
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -5222,3 +5222,20 @@ ebpf_map_set_wait_handle(fd_t map_fd, uint64_t index, ebpf_handle_t handle) NO_E
     EBPF_RETURN_RESULT(result);
 }
 CATCH_NO_MEMORY_EBPF_RESULT
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_link_mark_as_legacy_mode(fd_t link_fd) NO_EXCEPT_TRY
+{
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_handle_t link_handle = _get_handle_from_file_descriptor(link_fd);
+    if (link_handle == ebpf_handle_invalid) {
+        result = EBPF_INVALID_FD;
+        EBPF_RETURN_RESULT(result);
+    }
+    ebpf_operation_link_legacy_mode_request_t request{
+        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_LINK_LEGACY_MODE, link_handle};
+    result = win32_error_code_to_ebpf_result(invoke_ioctl(request));
+    EBPF_RETURN_RESULT(result);
+}
+CATCH_NO_MEMORY_EBPF_RESULT

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -272,6 +272,10 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
     }
 
     ebpf_assert(link != nullptr);
+    // Mark the link as legacy mode to avoid it being deleted when the program is closed.
+    // The caller is responsible for managing the link's lifetime.
+    (void)ebpf_link_mark_as_legacy_mode(link->fd);
+
     bpf_link__disconnect(link);
     bpf_link__destroy(link);
 
@@ -637,6 +641,10 @@ __bpf_set_link_xdp_fd_replace(int ifindex, int fd, int old_fd, __u32 flags)
         struct bpf_link* link = nullptr;
         result = ebpf_program_attach_by_fd(fd, &EBPF_ATTACH_TYPE_XDP, &ifindex, sizeof(ifindex), &link);
         if (result == EBPF_SUCCESS) {
+            // Mark the link as legacy mode to avoid it being deleted when the program is closed.
+            // The caller is responsible for managing the link's lifetime.
+            (void)ebpf_link_mark_as_legacy_mode(link->fd);
+
             // Disconnect and destroy the link object.
             bpf_link__disconnect(link);
             bpf_link__destroy(link);

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2185,7 +2185,7 @@ _ebpf_core_protocol_epoch_synchronize(
 }
 
 static ebpf_result_t
-_ebpf_core_protocol_link_legacy_mode(_In_ const ebpf_operation_link_legacy_mode_request_t* request)
+_ebpf_core_protocol_link_set_legacy_mode(_In_ const ebpf_operation_link_set_legacy_mode_request_t* request)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result;
@@ -2196,7 +2196,7 @@ _ebpf_core_protocol_link_legacy_mode(_In_ const ebpf_operation_link_legacy_mode_
         goto Done;
     }
 
-    result = ebpf_link_legacy_mode(link);
+    result = ebpf_link_set_legacy_mode(link);
 
 Done:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)link);
@@ -2900,7 +2900,7 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(ring_buffer_map_map_buffer, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(ring_buffer_map_unmap_buffer, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY_ASYNC(epoch_synchronize, PROTOCOL_ALL_MODES),
-    DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(link_legacy_mode, PROTOCOL_ALL_MODES),
+    DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(link_set_legacy_mode, PROTOCOL_ALL_MODES),
 };
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -343,6 +343,8 @@ ebpf_core_terminate()
         _ebpf_global_helper_function_nmr_binding_handle = NULL;
     }
 
+    ebpf_link_terminate();
+
     ebpf_program_terminate();
 
     ebpf_handle_table_terminate();

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2182,6 +2182,25 @@ _ebpf_core_protocol_epoch_synchronize(
     EBPF_RETURN_RESULT(result);
 }
 
+static ebpf_result_t
+_ebpf_core_protocol_link_legacy_mode(_In_ const ebpf_operation_link_legacy_mode_request_t* request)
+{
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result;
+    ebpf_link_t* link = NULL;
+
+    result = EBPF_OBJECT_REFERENCE_BY_HANDLE(request->link_handle, EBPF_OBJECT_LINK, (ebpf_core_object_t**)&link);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    result = ebpf_link_legacy_mode(link);
+
+Done:
+    EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)link);
+    EBPF_RETURN_RESULT(result);
+}
+
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
@@ -2879,6 +2898,7 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_FIXED_REPLY(ring_buffer_map_map_buffer, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(ring_buffer_map_unmap_buffer, PROTOCOL_ALL_MODES),
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY_ASYNC(epoch_synchronize, PROTOCOL_ALL_MODES),
+    DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_NO_REPLY(link_legacy_mode, PROTOCOL_ALL_MODES),
 };
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -642,7 +642,7 @@ _Requires_lock_held_(link->lock) static void _ebpf_link_set_state(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_link_legacy_mode(_Inout_ ebpf_link_t* link)
+ebpf_link_set_legacy_mode(_Inout_ ebpf_link_t* link)
 {
     ebpf_result_t return_value = EBPF_SUCCESS;
     ebpf_lock_state_t state;

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -649,7 +649,7 @@ ebpf_link_set_legacy_mode(_Inout_ ebpf_link_t* link)
     state = ebpf_lock_lock(&link->lock);
 
     if (link->state != EBPF_LINK_STATE_ATTACHED) {
-        return_value = EBPF_INVALID_ARGUMENT;
+        return_value = EBPF_INVALID_STATE;
     } else {
         link->in_legacy_mode = true;
         return_value = EBPF_SUCCESS;

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -20,21 +20,16 @@
  * 1. EBPF_LINK_STATE_INITIAL -> EBPF_LINK_STATE_ATTACHING - Program is being attached to a provider.
  * 2. EBPF_LINK_STATE_ATTACHING -> EBPF_LINK_STATE_ATTACHED - NmrRegisterClient returns success.
  * 3. EBPF_LINK_STATE_ATTACHING -> EBPF_LINK_STATE_DETACHING - Provider failed to attach.
- * 4. EBPF_LINK_STATE_ATTACHED -> EBPF_LINK_STATE_LEGACY_MODE - Link is operating in legacy mode which prevents the link
- * from detaching after the last user mode reference is released.
- * 5. EBPF_LINK_STATE_LEGACY_MODE -> EBPF_LINK_STATE_DETACHING - Program is being detached from a provider.
- * 6. EBPF_LINK_STATE_ATTACHED -> EBPF_LINK_STATE_DETACHING - Program is being detached from a provider.
- * 7. EBPF_LINK_STATE_DETACHING -> EBPF_LINK_STATE_DETACHED - NmrDeregisterClient returns success.
+ * 4. EBPF_LINK_STATE_ATTACHED -> EBPF_LINK_STATE_DETACHING - Program is being detached from a provider.
+ * 5. EBPF_LINK_STATE_DETACHING -> EBPF_LINK_STATE_DETACHED - NmrDeregisterClient returns success.
  */
 typedef enum _ebpf_link_state
 {
-    EBPF_LINK_STATE_INITIAL,     ///< Program is not attached to any provider.
-    EBPF_LINK_STATE_ATTACHING,   ///< Program is being attached to a provider.
-    EBPF_LINK_STATE_ATTACHED,    ///< Program is attached to a provider.
-    EBPF_LINK_STATE_LEGACY_MODE, ///< Link is operating in legacy mode. This prevents the link from detaching after the
-                                 ///< last user mode reference is released.
-    EBPF_LINK_STATE_DETACHING,   ///< Program is being detached from a provider.
-    EBPF_LINK_STATE_DETACHED,    ///< Program is detached from a provider.
+    EBPF_LINK_STATE_INITIAL,   ///< Program is not attached to any provider.
+    EBPF_LINK_STATE_ATTACHING, ///< Program is being attached to a provider.
+    EBPF_LINK_STATE_ATTACHED,  ///< Program is attached to a provider.
+    EBPF_LINK_STATE_DETACHING, ///< Program is being detached from a provider.
+    EBPF_LINK_STATE_DETACHED,  ///< Program is detached from a provider.
 } ebpf_link_state_t;
 
 typedef struct _ebpf_link
@@ -52,6 +47,7 @@ typedef struct _ebpf_link
     _Guarded_by_(lock) HANDLE nmr_client_handle;
     _Guarded_by_(lock) bool provider_attached;
     _Guarded_by_(lock) ebpf_link_state_t state;
+    _Guarded_by_(lock) bool in_legacy_mode;
 } ebpf_link_t;
 
 static NPI_CLIENT_ATTACH_PROVIDER_FN _ebpf_link_client_attach_provider;
@@ -237,7 +233,7 @@ _ebpf_link_notify_reference_count_zeroed(_In_opt_ _Post_invalid_ ebpf_core_objec
 
     bool detach_required = false;
     ebpf_lock_state_t state = ebpf_lock_lock(&link->lock);
-    ebpf_assert(link->state != EBPF_LINK_STATE_LEGACY_MODE);
+    ebpf_assert(link->in_legacy_mode == false);
     detach_required = (link->state == EBPF_LINK_STATE_ATTACHED);
     ebpf_lock_unlock(&link->lock, state);
     if (detach_required) {
@@ -443,13 +439,14 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     state = ebpf_lock_lock(&link->lock);
     lock_held = true;
 
-    if (link->state != EBPF_LINK_STATE_ATTACHED && link->state != EBPF_LINK_STATE_LEGACY_MODE) {
+    if (link->state != EBPF_LINK_STATE_ATTACHED) {
         EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_LINK, "Link is not attached to a program.");
         goto Done;
     }
 
-    if (link->state == EBPF_LINK_STATE_LEGACY_MODE) {
+    if (link->in_legacy_mode) {
         link_disconnected = true;
+        link->in_legacy_mode = false;
     }
 
     _ebpf_link_set_state(link, EBPF_LINK_STATE_DETACHING);
@@ -630,17 +627,11 @@ _Requires_lock_held_(link->lock) static void _ebpf_link_set_state(
         ebpf_assert(old_state == EBPF_LINK_STATE_ATTACHING);
         break;
     case EBPF_LINK_STATE_DETACHING:
-        ebpf_assert(
-            old_state == EBPF_LINK_STATE_ATTACHED || old_state == EBPF_LINK_STATE_ATTACHING ||
-            old_state == EBPF_LINK_STATE_LEGACY_MODE);
+        ebpf_assert(old_state == EBPF_LINK_STATE_ATTACHED || old_state == EBPF_LINK_STATE_ATTACHING);
         break;
     case EBPF_LINK_STATE_DETACHED:
         // Program is unlinked from a provider.
         ebpf_assert(old_state == EBPF_LINK_STATE_DETACHING);
-        break;
-    case EBPF_LINK_STATE_LEGACY_MODE:
-        // User disconnected the link.
-        ebpf_assert(old_state == EBPF_LINK_STATE_ATTACHED);
         break;
     default:
         ebpf_assert(!"Invalid link state");
@@ -660,10 +651,35 @@ ebpf_link_legacy_mode(_Inout_ ebpf_link_t* link)
     if (link->state != EBPF_LINK_STATE_ATTACHED) {
         return_value = EBPF_INVALID_ARGUMENT;
     } else {
-        _ebpf_link_set_state(link, EBPF_LINK_STATE_LEGACY_MODE);
+        link->in_legacy_mode = true;
         return_value = EBPF_SUCCESS;
+        // Add a reference to the link to account for legacy mode.
         EBPF_OBJECT_ACQUIRE_REFERENCE(&link->object);
     }
     ebpf_lock_unlock(&link->lock, state);
     EBPF_RETURN_RESULT(return_value);
+}
+
+void
+ebpf_link_terminate()
+{
+    EBPF_LOG_ENTRY();
+
+    // Enumerate all links and issue a detach on them.
+
+    ebpf_core_object_t* object = NULL;
+
+    for (;;) {
+        EBPF_OBJECT_REFERENCE_NEXT_OBJECT(object, EBPF_OBJECT_LINK, &object);
+
+        if (object == NULL) {
+            break;
+        }
+
+        ebpf_link_t* link = (ebpf_link_t*)object;
+        ebpf_link_detach_program(link);
+        EBPF_OBJECT_RELEASE_REFERENCE(object);
+    }
+
+    EBPF_LOG_EXIT();
 }

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -77,7 +77,7 @@ extern "C"
      * @param[in] link The link object to mark as legacy mode.
      *
      * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_INVALID_ARGUMENT The link is NULL or already disconnected.
+     * @retval EBPF_INVALID_STATE The link is not in the attached state.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_link_set_legacy_mode(_Inout_ ebpf_link_t* link);

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -81,6 +81,12 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_link_legacy_mode(_Inout_ ebpf_link_t* link);
+
+    /**
+     * @brief Clean up the link module.
+     */
+    void
+    ebpf_link_terminate();
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -70,6 +70,17 @@ extern "C"
         _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
         _Inout_ uint16_t* info_size);
 
+    /**
+     * @brief Mark the link as operating in legacy mode, which means that it doesn't
+     * detach when the last user mode reference to the link is closed.
+     *
+     * @param[in] link The link object to mark as legacy mode.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT The link is NULL or already disconnected.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_link_legacy_mode(_Inout_ ebpf_link_t* link);
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -80,7 +80,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT The link is NULL or already disconnected.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_link_legacy_mode(_Inout_ ebpf_link_t* link);
+    ebpf_link_set_legacy_mode(_Inout_ ebpf_link_t* link);
 
     /**
      * @brief Clean up the link module.

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -91,7 +91,6 @@ typedef struct _ebpf_program
     // Lock protecting the fields below.
     ebpf_lock_t lock;
 
-    _Guarded_by_(lock) ebpf_list_entry_t links;
     _Guarded_by_(lock) uint32_t link_count;
     _Guarded_by_(lock) ebpf_map_t** maps;
     _Guarded_by_(lock) uint32_t count_of_maps;
@@ -203,29 +202,6 @@ ebpf_program_initiate()
 void
 ebpf_program_terminate()
 {
-}
-
-_Requires_lock_not_held_(program->lock) static void _ebpf_program_detach_links(_Inout_ ebpf_program_t* program)
-{
-    EBPF_LOG_ENTRY();
-    ebpf_lock_state_t state;
-    state = ebpf_lock_lock(&program->lock);
-    while (!ebpf_list_is_empty(&program->links)) {
-        ebpf_list_entry_t* entry = program->links.Flink;
-        ebpf_core_object_t* object = CONTAINING_RECORD(entry, ebpf_core_object_t, object_list_entry);
-        // Acquire a reference on the object to prevent it from going away.
-        EBPF_OBJECT_ACQUIRE_REFERENCE(object);
-
-        // Release the lock before calling detach.
-        ebpf_lock_unlock(&program->lock, state);
-        ebpf_link_detach_program((ebpf_link_t*)object);
-
-        EBPF_OBJECT_RELEASE_REFERENCE(object);
-        state = ebpf_lock_lock(&program->lock);
-    }
-    ebpf_lock_unlock(&program->lock, state);
-
-    EBPF_RETURN_VOID();
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_program_information_hash(
@@ -658,10 +634,6 @@ _ebpf_program_notify_reference_count_zeroed(_In_opt_ _Post_invalid_ ebpf_core_ob
         EBPF_RETURN_VOID();
     }
 
-    // Detach from all the attach points.
-    _ebpf_program_detach_links(program);
-    ebpf_assert(ebpf_list_is_empty(&program->links));
-
     for (index = 0; index < program->count_of_maps; index++) {
         EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)program->maps[index]);
     }
@@ -808,7 +780,6 @@ ebpf_program_create(_In_ const ebpf_program_parameters_t* program_parameters, _O
         goto Done;
     }
 
-    ebpf_list_initialize(&local_program->links);
     ebpf_lock_create(&local_program->lock);
 
     local_program->bpf_prog_type = BPF_PROG_TYPE_UNSPEC;
@@ -2059,34 +2030,28 @@ ebpf_program_free_program_info(_In_opt_ _Post_invalid_ ebpf_program_info_t* prog
 }
 
 void
-ebpf_program_attach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link)
+ebpf_program_attach_link(_Inout_ ebpf_program_t* program)
 {
     EBPF_LOG_ENTRY();
-    // Acquire "attach" reference on the link object.
-    EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)link);
+    EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)program);
 
-    // Insert the link in the attach list.
     ebpf_lock_state_t state;
     state = ebpf_lock_lock(&program->lock);
-    ebpf_list_insert_tail(&program->links, &((ebpf_core_object_t*)link)->object_list_entry);
     program->link_count++;
     ebpf_lock_unlock(&program->lock, state);
     EBPF_RETURN_VOID();
 }
 
 void
-ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link)
+ebpf_program_detach_link(_Inout_ ebpf_program_t* program)
 {
     EBPF_LOG_ENTRY();
-    // Remove the link from the attach list.
     ebpf_lock_state_t state;
     state = ebpf_lock_lock(&program->lock);
-    ebpf_list_remove_entry(&((ebpf_core_object_t*)link)->object_list_entry);
     program->link_count--;
     ebpf_lock_unlock(&program->lock, state);
 
-    // Release the "attach" reference.
-    EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)link);
+    EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)program);
     EBPF_RETURN_VOID();
 }
 

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -271,22 +271,20 @@ extern "C"
     ebpf_program_set_program_info_hash(_Inout_ ebpf_program_t* program);
 
     /**
-     * @brief Attach a link object to an eBPF program.
+     * @brief Notify the program that a link object has been attached to it.
      *
      * @param[in, out] program Program to attach to the link object.
-     * @param[in, out] link The link object.
      */
     void
-    ebpf_program_attach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link);
+    ebpf_program_attach_link(_Inout_ ebpf_program_t* program);
 
     /**
-     * @brief Detach a link object from the eBPF program it is attached to.
+     * @brief Notify the program that a link object has been detached from it.
      *
-     * @param[in, out] program Program to detach to the link object from.
-     * @param[in, out] link The link object.
+     * @param[in, out] program Program to detach from the link object.
      */
     void
-    ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link);
+    ebpf_program_detach_link(_Inout_ ebpf_program_t* program);
 
     /**
      * @brief Store the pointer to the program to execute on tail call.

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -54,7 +54,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_RING_BUFFER_MAP_MAP_BUFFER,
     EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER,
     EBPF_OPERATION_EPOCH_SYNCHRONIZE,
-    EBPF_OPERATION_LINK_LEGACY_MODE,
+    EBPF_OPERATION_LINK_SET_LEGACY_MODE,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -616,8 +616,8 @@ typedef struct _ebpf_operation_epoch_synchronize_request
     struct _ebpf_operation_header header;
 } ebpf_operation_epoch_synchronize_request_t;
 
-typedef struct _ebpf_operation_link_legacy_mode_request
+typedef struct _ebpf_operation_link_set_legacy_mode_request
 {
     struct _ebpf_operation_header header;
     ebpf_handle_t link_handle;
-} ebpf_operation_link_legacy_mode_request_t;
+} ebpf_operation_link_set_legacy_mode_request_t;

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -54,6 +54,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_RING_BUFFER_MAP_MAP_BUFFER,
     EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER,
     EBPF_OPERATION_EPOCH_SYNCHRONIZE,
+    EBPF_OPERATION_LINK_LEGACY_MODE,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -614,3 +615,9 @@ typedef struct _ebpf_operation_epoch_synchronize_request
 {
     struct _ebpf_operation_header header;
 } ebpf_operation_epoch_synchronize_request_t;
+
+typedef struct _ebpf_operation_link_legacy_mode_request
+{
+    struct _ebpf_operation_header header;
+    ebpf_handle_t link_handle;
+} ebpf_operation_link_legacy_mode_request_t;

--- a/libs/execution_context/unit/execution_context_unit_test_jit.h
+++ b/libs/execution_context/unit/execution_context_unit_test_jit.h
@@ -21,7 +21,8 @@ template <typename T> class ebpf_object_deleter
     void
     operator()(T* object)
     {
-        ebpf_object_release_reference(reinterpret_cast<ebpf_core_object_t*>(object), EBPF_FILE_ID_EXECUTION_CONTEXT_UNIT_TESTS, __LINE__);
+        ebpf_object_release_reference(
+            reinterpret_cast<ebpf_core_object_t*>(object), EBPF_FILE_ID_EXECUTION_CONTEXT_UNIT_TESTS, __LINE__);
     }
 };
 
@@ -65,7 +66,7 @@ typedef class _ebpf_async_wrapper
   private:
     static void
     completion_callback(_In_ void* context, size_t reply_size, ebpf_result_t result);
-    
+
     ebpf_result_t _result = EBPF_SUCCESS;
     size_t _reply_size = 0;
     bool _completed = false;
@@ -169,8 +170,8 @@ extern "C"
 #define TOTAL_HELPER_COUNT 3
 
 #if defined(CONFIG_BPF_JIT_DISABLED) || defined(CONFIG_BPF_INTERPRETER_DISABLED)
-void
-test_blocked_by_policy(ebpf_operation_id_t operation);
+    void
+    test_blocked_by_policy(ebpf_operation_id_t operation);
 #endif
 
 #ifdef __cplusplus

--- a/libs/execution_context/user/execution_context_user.vcxproj.filters
+++ b/libs/execution_context/user/execution_context_user.vcxproj.filters
@@ -40,6 +40,9 @@
     <ClCompile Include="..\ebpf_native.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_strings.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ebpf_core.h">
@@ -64,6 +67,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\ebpf_native.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ebpf_strings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/api_test/api_test.vcxproj
+++ b/tests/api_test/api_test.vcxproj
@@ -173,7 +173,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="api_test_jit.h" /> 
+    <ClInclude Include="api_test_jit.h" />
     <ClInclude Include="header.h" />
     <ClInclude Include="rpc_client.h" />
   </ItemGroup>

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -86,17 +86,15 @@ typedef struct _ebpf_free_memory
 
 typedef std::unique_ptr<uint8_t, ebpf_free_memory_t> ebpf_memory_t;
 
+int
+bpf_link__destroy(bpf_link* link);
+
 typedef struct _close_bpf_link
 {
     void
     operator()(_In_opt_ _Post_invalid_ bpf_link* link)
     {
-        if (link != nullptr) {
-            if (ebpf_link_detach(link) != EBPF_SUCCESS) {
-                throw std::runtime_error("ebpf_link_detach failed");
-            }
-            ebpf_link_close(link);
-        }
+        bpf_link__destroy(link);
     }
 } close_bpf_link_t;
 

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -86,6 +86,7 @@ typedef struct _ebpf_free_memory
 
 typedef std::unique_ptr<uint8_t, ebpf_free_memory_t> ebpf_memory_t;
 
+// Prototype added as the libbpf headers cause conflicts with the execution context headers.
 int
 bpf_link__destroy(bpf_link* link);
 

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -31,7 +31,6 @@ class _test_helper_netsh
     initialize();
 
   private:
-    bool initialized = false;
     _test_helper_libbpf test_helper_libbpf;
 };
 
@@ -40,25 +39,10 @@ _test_helper_netsh::_test_helper_netsh() { _ebpf_netsh_objects.clear(); }
 _test_helper_netsh::~_test_helper_netsh()
 {
     if (cxplat_fault_injection_is_enabled()) {
-        if (initialized) {
-            for (auto& object : _ebpf_netsh_objects) {
-                bpf_object__close(object);
-            }
-            _ebpf_netsh_objects.clear();
-
-            // Detach all bpf links
-            uint32_t link_id;
-            while (bpf_link_get_next_id(0, &link_id) == 0) {
-                fd_t link_fd = bpf_link_get_fd_by_id(link_id);
-                if (link_fd < 0) {
-                    break;
-                }
-                bpf_link_detach(link_fd);
-                if (link_fd >= 0) {
-                    Platform::_close(link_fd);
-                }
-            }
+        for (auto& object : _ebpf_netsh_objects) {
+            bpf_object__close(object);
         }
+        _ebpf_netsh_objects.clear();
     }
     REQUIRE(_ebpf_netsh_objects.size() == 0);
 }
@@ -67,7 +51,6 @@ void
 _test_helper_netsh::initialize()
 {
     test_helper_libbpf.initialize();
-    initialized = true;
 }
 
 std::string

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -6,6 +6,9 @@
 #include "misc_helper.h"
 #include "native_helper.hpp"
 
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <io.h>
 #include <rpc.h>
 
 // We cannot use REQUIRE from a constructor.  Anything that can fail should be here in initialize().
@@ -20,6 +23,19 @@ _native_module_helper::initialize(
 #else
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_ANY;
 #endif
+    // Cleanup any previous state.
+    // Detach all bpf links
+    uint32_t link_id;
+    while (bpf_link_get_next_id(0, &link_id) == 0) {
+        fd_t link_fd = bpf_link_get_fd_by_id(link_id);
+        if (link_fd < 0) {
+            break;
+        }
+        bpf_link_detach(link_fd);
+        if (link_fd >= 0) {
+            _close(link_fd);
+        }
+    }
 
     // Set _is_main_thread before any REQUIRE is invoked.
     _is_main_thread = is_main_thread;

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -24,7 +24,7 @@ _native_module_helper::initialize(
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_ANY;
 #endif
     // Clean up any previous state.
-    // Detach all bpf links
+    // Detach all bpf links.
     uint32_t link_id;
     while (bpf_link_get_next_id(0, &link_id) == 0) {
         fd_t link_fd = bpf_link_get_fd_by_id(link_id);

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -23,7 +23,7 @@ _native_module_helper::initialize(
 #else
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_ANY;
 #endif
-    // Cleanup any previous state.
+    // Clean up any previous state.
     // Detach all bpf links
     uint32_t link_id;
     while (bpf_link_get_next_id(0, &link_id) == 0) {

--- a/tests/unit/libbpf_test_jit.cpp
+++ b/tests/unit/libbpf_test_jit.cpp
@@ -117,7 +117,8 @@ ebpf_test_tail_call(_In_z_ const char* filename, uint32_t expected_result)
 }
 
 #if !defined(CONFIG_BPF_JIT_DISABLED)
-void test_libbpf_load_program()
+void
+test_libbpf_load_program()
 {
     _test_helper_libbpf test_helper;
     test_helper.initialize();
@@ -133,10 +134,7 @@ void test_libbpf_load_program()
 }
 
 // Only run the test if JIT is enabled.
-TEST_CASE("libbpf load program", "[libbpf][deprecated]")
-{
-    test_libbpf_load_program();
-}
+TEST_CASE("libbpf load program", "[libbpf][deprecated]") { test_libbpf_load_program(); }
 
 void
 test_libbpf_prog_test_run()
@@ -222,10 +220,7 @@ test_libbpf_prog_test_run()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf prog test run", "[libbpf][deprecated]")
-{
-    test_libbpf_prog_test_run();   
-}
+TEST_CASE("libbpf prog test run", "[libbpf][deprecated]") { test_libbpf_prog_test_run(); }
 #endif
 
 #if !defined(CONFIG_BPF_JIT_DISABLED)
@@ -277,7 +272,7 @@ test_valid_bpf_load_program()
 }
 
 void
-test_valid_bpf_prog_load() 
+test_valid_bpf_prog_load()
 {
     _test_helper_libbpf test_helper;
     test_helper.initialize();
@@ -343,25 +338,15 @@ test_valid_bpf_load_program_xattr()
     Platform::_close(program_fd);
 }
 
-TEST_CASE("valid bpf_load_program", "[libbpf][deprecated]")
-{
-    test_valid_bpf_load_program();
-}
+TEST_CASE("valid bpf_load_program", "[libbpf][deprecated]") { test_valid_bpf_load_program(); }
 
-TEST_CASE("valid bpf_prog_load", "[libbpf]")
-{
-    test_valid_bpf_load_program();
-}
+TEST_CASE("valid bpf_prog_load", "[libbpf]") { test_valid_bpf_load_program(); }
 
-TEST_CASE("valid bpf_load_program_xattr", "[libbpf][deprecated]")
-{
-    test_valid_bpf_load_program_xattr();
-}
+TEST_CASE("valid bpf_load_program_xattr", "[libbpf][deprecated]") { test_valid_bpf_load_program_xattr(); }
 #endif
 
 // Define macros that appear in the Linux man page to values in ebpf_vm_isa.h.
-#define BPF_LD_MAP_FD(reg, fd) \
-    {INST_OP_LDDW_IMM, (reg), 1, 0, (fd)}, { 0 }
+#define BPF_LD_MAP_FD(reg, fd) {INST_OP_LDDW_IMM, (reg), 1, 0, (fd)}, {0}
 #define BPF_ALU64_IMM(op, reg, imm) {INST_CLS_ALU64 | INST_SRC_IMM | ((op) << 4), (reg), 0, 0, (imm)}
 #define BPF_MOV64_IMM(reg, imm) {INST_CLS_ALU64 | INST_SRC_IMM | 0xb0, (reg), 0, 0, (imm)}
 #define BPF_MOV64_REG(dst, src) {INST_CLS_ALU64 | INST_SRC_REG | 0xb0, (dst), (src), 0, 0}
@@ -422,10 +407,7 @@ test_valid_bpf_load_program_with_map()
     Platform::_close(map_fd);
 }
 
-TEST_CASE("valid bpf_load_program with map", "[libbpf][deprecated]")
-{
-    test_valid_bpf_load_program_with_map();
-}
+TEST_CASE("valid bpf_load_program with map", "[libbpf][deprecated]") { test_valid_bpf_load_program_with_map(); }
 
 void
 test_libbpf_program()
@@ -477,10 +459,7 @@ test_libbpf_program()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf program", "[libbpf]")
-{
-    test_libbpf_program();
-}
+TEST_CASE("libbpf program", "[libbpf]") { test_libbpf_program(); }
 
 void
 test_libbpf_subprogram()
@@ -511,10 +490,7 @@ test_libbpf_subprogram()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf subprogram", "[libbpf]")
-{
-    test_libbpf_subprogram();
-}
+TEST_CASE("libbpf subprogram", "[libbpf]") { test_libbpf_subprogram(); }
 
 static void
 _test_program_autoload(ebpf_execution_type_t execution_type)
@@ -645,10 +621,7 @@ test_libbpf_program_pinning()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf program pinning", "[libbpf]")
-{
-    test_libbpf_program_pinning();
-}
+TEST_CASE("libbpf program pinning", "[libbpf]") { test_libbpf_program_pinning(); }
 
 void
 test_libbpf_program_attach()
@@ -697,10 +670,7 @@ test_libbpf_program_attach()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf program attach", "[libbpf]")
-{
-    test_libbpf_program_attach();
-}
+TEST_CASE("libbpf program attach", "[libbpf]") { test_libbpf_program_attach(); }
 #endif
 
 void
@@ -762,10 +732,7 @@ test_bpf_set_link_xdp_fd()
     bpf_object__close(object[1]);
 }
 
-TEST_CASE("bpf_set_link_xdp_fd", "[libbpf]")
-{
-   test_bpf_set_link_xdp_fd();
-}
+TEST_CASE("bpf_set_link_xdp_fd", "[libbpf]") { test_bpf_set_link_xdp_fd(); }
 
 void
 test_libbpf_map()
@@ -1012,10 +979,7 @@ test_libbpf_map()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf map", "[libbpf]")
-{
-    test_libbpf_map();
-}
+TEST_CASE("libbpf map", "[libbpf]") { test_libbpf_map(); }
 
 void
 test_libbpf_map_binding()
@@ -1075,10 +1039,7 @@ test_libbpf_map_binding()
     REQUIRE(bpf_map_get_fd_by_id(map_id) < 0);
 }
 
-TEST_CASE("libbpf map binding", "[libbpf]")
-{
-    test_libbpf_map_binding();
-}
+TEST_CASE("libbpf map binding", "[libbpf]") { test_libbpf_map_binding(); }
 
 void
 test_libbpf_map_pinning()
@@ -1181,10 +1142,7 @@ test_libbpf_map_pinning()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf map pinning", "[libbpf]")
-{
-    test_libbpf_map_pinning();
-}
+TEST_CASE("libbpf map pinning", "[libbpf]") { test_libbpf_map_pinning(); }
 
 void
 test_libbpf_obj_pinning()
@@ -1226,10 +1184,7 @@ test_libbpf_obj_pinning()
     bpf_object__close(object);
 }
 
-TEST_CASE("libbpf obj pinning", "[libbpf]")
-{
-   test_libbpf_obj_pinning();
-}
+TEST_CASE("libbpf obj pinning", "[libbpf]") { test_libbpf_obj_pinning(); }
 
 TEST_CASE("good_tail_call-jit", "[libbpf]")
 {
@@ -1338,10 +1293,7 @@ test_enumerate_link_IDs()
     REQUIRE(errno == ENOENT);
 }
 
-TEST_CASE("enumerate link IDs", "[libbpf]")
-{
-    test_enumerate_link_IDs();
-}
+TEST_CASE("enumerate link IDs", "[libbpf]") { test_enumerate_link_IDs(); }
 
 void
 test_enumerate_link_IDs_with_bpf()
@@ -1423,7 +1375,7 @@ test_enumerate_link_IDs_with_bpf()
     // Pin the detached link.
     memset(&attr, 0, sizeof(attr));
     attr.obj_pin.bpf_fd = fd1;
-    attr.obj_pin.pathname = (uintptr_t) "MyPath";
+    attr.obj_pin.pathname = (uintptr_t)"MyPath";
     REQUIRE(bpf(BPF_OBJ_PIN, &attr, sizeof(attr)) == 0);
 
     // Verify that bpf_fd must be 0 when calling BPF_OBJ_GET.
@@ -1464,10 +1416,7 @@ test_enumerate_link_IDs_with_bpf()
     Platform::_close(fd3);
 }
 
-TEST_CASE("enumerate link IDs with bpf", "[libbpf][bpf]")
-{
-    test_enumerate_link_IDs_with_bpf();   
-}
+TEST_CASE("enumerate link IDs with bpf", "[libbpf][bpf]") { test_enumerate_link_IDs_with_bpf(); }
 
 void
 test_bpf_prog_attach()
@@ -1502,14 +1451,12 @@ test_bpf_prog_attach()
     REQUIRE(link_fd >= 0);
     REQUIRE(bpf_link_detach(link_fd) == 0);
     REQUIRE(bpf_prog_attach(program_fd, program_fd, BPF_CGROUP_INET4_CONNECT, 0) == 0);
+    REQUIRE(bpf_prog_detach2(program_fd, program_fd, BPF_CGROUP_INET4_CONNECT) == 0);
 
     bpf_object__close(object);
 }
 
-TEST_CASE("bpf_prog_attach", "[libbpf]")
-{
-   test_bpf_prog_attach();
-}
+TEST_CASE("bpf_prog_attach", "[libbpf]") { test_bpf_prog_attach(); }
 
 void
 test_bpf_link_pin()
@@ -1529,9 +1476,6 @@ test_bpf_link_pin()
     REQUIRE(bpf_program__pin(program, program_pin_name) == 0);
     int program_fd = bpf_program__fd(program);
     REQUIRE(program_fd > 0);
-
-    // Verify we can't attach the program to a different attach type.
-    REQUIRE(bpf_prog_attach(program_fd, 0, BPF_CGROUP_INET4_CONNECT, 0) == -EINVAL);
 
     // Attach the program so we get a link object.
     bpf_link_ptr link(bpf_program__attach(program));
@@ -1559,10 +1503,7 @@ test_bpf_link_pin()
     bpf_object__close(object);
 }
 
-TEST_CASE("bpf_link__pin", "[libbpf]")
-{
-    test_bpf_link_pin();
-}
+TEST_CASE("bpf_link__pin", "[libbpf]") { test_bpf_link_pin(); }
 
 void
 test_bpf_obj_get_info_by_fd()
@@ -1751,10 +1692,7 @@ test_bpf_obj_get_info_by_fd()
     Platform::_close(link_fd);
 }
 
-TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
-{
-    test_bpf_obj_get_info_by_fd();
-}
+TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]") { test_bpf_obj_get_info_by_fd(); }
 
 void
 test_bpf_obj_get_info_by_fd_2()
@@ -1816,10 +1754,7 @@ test_bpf_obj_get_info_by_fd_2()
     Platform::_close(link_fd);
 }
 
-TEST_CASE("bpf_obj_get_info_by_fd_2", "[libbpf]")
-{
-    test_bpf_obj_get_info_by_fd_2();
-}
+TEST_CASE("bpf_obj_get_info_by_fd_2", "[libbpf]") { test_bpf_obj_get_info_by_fd_2(); }
 
 void
 test_bpf_object_load_with_o()
@@ -1884,12 +1819,9 @@ test_bpf_object_load_with_o()
     bpf_object__close(object);
 }
 
-TEST_CASE("bpf_object__load with .o", "[libbpf]")
-{
-    test_bpf_object_load_with_o();
-}
+TEST_CASE("bpf_object__load with .o", "[libbpf]") { test_bpf_object_load_with_o(); }
 
-void 
+void
 test_bpf_object_load_with_o_from_memory()
 {
     _test_helper_libbpf test_helper;
@@ -1963,10 +1895,7 @@ test_bpf_object_load_with_o_from_memory()
     bpf_object__close(object);
 }
 
-TEST_CASE("bpf_object__load with .o from memory", "[libbpf]")
-{
-    test_bpf_object_load_with_o_from_memory();
-}
+TEST_CASE("bpf_object__load with .o from memory", "[libbpf]") { test_bpf_object_load_with_o_from_memory(); }
 
 void
 test_bpf_backwards_compatibility()
@@ -2004,10 +1933,7 @@ test_bpf_backwards_compatibility()
 }
 
 // Test that bpf() accepts a smaller and a larger bpf_attr.
-TEST_CASE("bpf() backwards compatibility", "[libbpf][bpf]")
-{
-    test_bpf_backwards_compatibility();
-}
+TEST_CASE("bpf() backwards compatibility", "[libbpf][bpf]") { test_bpf_backwards_compatibility(); }
 
 void
 test_bpf_prog_bind_map_etc()
@@ -2159,10 +2085,7 @@ test_bpf_prog_bind_map_etc()
 // BPF_PROG_LOAD, BPF_OBJ_GET_INFO_BY_FD, BPF_PROG_GET_NEXT_ID,
 // BPF_MAP_CREATE, BPF_MAP_GET_NEXT_ID, BPF_PROG_BIND_MAP,
 // BPF_PROG_GET_FD_BY_ID, BPF_MAP_GET_FD_BY_ID, and BPF_MAP_GET_FD_BY_ID.
-TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf][bpf]")
-{
-    test_bpf_prog_bind_map_etc();
-}
+TEST_CASE("BPF_PROG_BIND_MAP etc.", "[libbpf][bpf]") { test_bpf_prog_bind_map_etc(); }
 
 void
 test_bpf_prog_attach_macro()
@@ -2215,10 +2138,7 @@ test_bpf_prog_attach_macro()
 
 // Test bpf() with the following command ids:
 //  BPF_PROG_ATTACH, BPF_PROG_DETACH
-TEST_CASE("BPF_PROG_ATTACH", "[libbpf][bpf]")
-{
-    test_bpf_prog_attach_macro();
-}
+TEST_CASE("BPF_PROG_ATTACH", "[libbpf][bpf]") { test_bpf_prog_attach_macro(); }
 #endif
 
 TEST_CASE("BPF_PROG_LOAD logging", "[libbpf][bpf]")


### PR DESCRIPTION
## Description

eBPF for Windows link behavior doesn't match Linux. Linux behavior is that an active link keeps the program object alive, so that the program is only unloaded when the last link is closed.

Resolves: #4135

## Testing

CI/CD - tests for new behavior

## Documentation

No.

## Installation

No.


This pull request introduces a new "legacy mode" for eBPF links, which changes how link lifetimes are managed: links marked as legacy will not be automatically detached when the last user-mode reference is closed. This is particularly important for compatibility with legacy APIs and tools. The implementation includes API additions, updates to core link state management, and changes to how links are handled in various attach/detach scenarios.

**Legacy Mode Support for Links**

* Added new API `ebpf_link_mark_as_legacy_mode` to allow marking a link as legacy mode, preventing automatic detachment when the last user-mode reference is closed (`include/ebpf_api.h`, `libs/api/ebpf_api.cpp`, `ebpfapi/Source.def`). [[1]](diffhunk://#diff-8b744ef020b2dae7afefac77b8d1d9664fa3d249c683b307cd393362da9f5e8bR909-R920) [[2]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeR5225-R5241) [[3]](diffhunk://#diff-2f82d1ff51a61fb435467ba5290591820cb88e359100a25e9b9a8e7913c6577cR132)
* Integrated legacy mode marking into program attach workflows in `libbpf_program.cpp` and `ebpfnetsh/programs.cpp`, ensuring links created by legacy APIs/tools are managed correctly (`libs/api/libbpf_program.cpp`, `libs/ebpfnetsh/programs.cpp`). [[1]](diffhunk://#diff-780511a42f3cac926001942e228bf075fec98dafebcbef6f1c6f5ce257068839R275-R278) [[2]](diffhunk://#diff-9ebbb96ca59e504fcf42e194b161976b696a71ad048cbe73e587a78e084c7a90R277-R283) [[3]](diffhunk://#diff-9ebbb96ca59e504fcf42e194b161976b696a71ad048cbe73e587a78e084c7a90R483-R485)

**Core Link State Machine Changes**

* Introduced `EBPF_LINK_STATE_LEGACY_MODE` and updated the link state machine and transition logic to support legacy mode, including new state assertions and transition handling (`libs/execution_context/ebpf_link.c`). [[1]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L23-R35) [[2]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L603-R669)
* Modified link detachment logic to handle legacy mode: links in legacy mode are not detached on last reference, and reference counting is adjusted accordingly (`libs/execution_context/ebpf_link.c`). [[1]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L416-R454) [[2]](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L448-L462)

**Protocol and Internal API Updates**

* Added protocol handler for legacy mode requests, and implemented core protocol logic for handling legacy mode transitions (`libs/execution_context/ebpf_core.c`, `libs/execution_context/ebpf_link.h`). [[1]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R2185-R2203) [[2]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R2901) [[3]](diffhunk://#diff-c95db721601463a10df0c794b291aa672574629c1e475bda87b78b575c36b626R73-R83)

**libbpf API Extension**

* Added `bpf_link__open` to allow opening a link from a pinned path, supporting legacy workflows (`libs/api/libbpf_link.cpp`, `ebpfapi/Source.def`). [[1]](diffhunk://#diff-53a4b543c99db504ac2e4b6d03900b3665bfa5886700f1e8dec406becbbdd3bcR10-R42) [[2]](diffhunk://#diff-2f82d1ff51a61fb435467ba5290591820cb88e359100a25e9b9a8e7913c6577cR15)

These changes ensure better compatibility with legacy eBPF workflows and provide more explicit control over link lifetimes, especially when integrating with older APIs and tools.