### PR TITLE
Disable regression tests for breaking changes.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -291,7 +291,8 @@ jobs:
     # Always run this job.
     # Only run this on repos that have self-host runners.
     needs: regular
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+    # Disabled for now for pull_request, merge_group, and push until in-progress breaking changes are completed.
+    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: .\setup_ebpf_cicd_tests.ps1 -TestMode "Regression" -RegressionArtifactsVersion "0.21.0" -GranularTracing


### PR DESCRIPTION
## Description

Disables regression tests while we make breaking changes prior to the v1.0 release.

Should be followed by a PR for #4664 after these breaking changes and the release are completed.

Closes #4671 

## Testing

Only prevents regression tests from automatically running for PRs.

## Documentation

N/A

## Installation

N/A
