### PR TITLE
Refine issue prioritization criteria in Governance.md

### DIFF
--- a/docs/Governance.md
+++ b/docs/Governance.md
@@ -131,12 +131,11 @@ In the weekly triage meetings, new issues should be added to a milestone followi
 
 To help prioritize issues, the triage drivers and maintainers MUST use *special labels* to prioritize issues as follows:
 ### P1:
-This label represents highest priority. This label should be used for bugs impacting users, new features, or enhancements that are urgently
-requested by users. `P1` issues MUST be set to the *current milestone*.
+This label represents highest priority. This label should ONLY be applied to bugs or features with quantifiable business impact. Quantifiable business impact may include number of users, business blocked, or deployment blocked. Bugs with only qualitative impact (descriptions without numbers) will be ranked lower than quantifiable P1 bugs. `P1` issues MUST be set to the *current milestone*.
 ### P2:
-This label is used for the next level of priority. Issues marked as `P2` can be set to the current milestone or to a future milestones (preferred).
+This label is used for the next level of priority. Issues marked as `P2` will be set future milestones (preferred).
 ### P3:
-This label is used for low priority issues. Issues marked as `P3` can be set to any future milestone or the `Backlog` milestone.
+This label is used for low priority issues. Issues marked as `P3` can be set to future milestones beyond 3 month or the `Backlog` milestone.
 
 ## Milestone Issues Limit
 Triage managers need to ensure that the number of issues in a milestone does not exceed the capacity of the contributors


### PR DESCRIPTION
Clarify criteria for P1, P2, and P3 issue labels regarding business impact and milestone settings.

## Description

Changing the definition of P1 bugs as our team and partners grow in size.
This will trigger a revisit of bugs currently tagged as P1. If quantifiable business impact is available, they need to be added for bugs to remain as P1. Ming can provide assistance for potential tough cuts.

## Testing

No

## Documentation

Changing the definition of P1 bugs.

## Installation

No
