### PR TITLE
Remove UBPF_STACK_SIZE definition

### DIFF
--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -29,8 +29,6 @@ extern "C"
 {
 #endif
 
-#define UBPF_STACK_SIZE 512
-
 #define IMMEDIATE(X) (int32_t)X
 #define OFFSET(X) (int16_t)X
 #define POINTER(X) (uint64_t)(X)


### PR DESCRIPTION
Removed the UBPF_STACK_SIZE definition from bpf2c.h.

## Description

Closes #202 

## Testing

Covered with existing test

## Documentation

No

## Installation

No
