### PR TITLE
Remove UBPF_STACK_SIZE definition

### DIFF
--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -17,7 +17,6 @@
 #pragma warning(disable : 4267)
 
 #include <endian.h>
-#define UBPF_STACK_SIZE 512
 
 #include <stdlib.h>
 


### PR DESCRIPTION
Removed the UBPF_STACK_SIZE definition from ubpf_user.c.

## Description

Closes #202 

## Testing

Covered with existing test

## Documentation

No

## Installation

No
