### PR TITLE
Remove UBPF_STACK_SIZE definition

### DIFF
--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -61,8 +61,6 @@ place_holder_errno()
     return -1;
 }
 
-#define UBPF_STACK_SIZE 512
-
 static enum Registers
 map_register(int r)
 {


### PR DESCRIPTION
Removed the UBPF_STACK_SIZE definition from ubpf_kernel.c.

## Description

Closes #202 

## Testing

Covered with existing test

## Documentation

No

## Installation

No