### PR TITLE
Remove deprecated internal API ebpf_allocate()

### DIFF
--- a/ebpfapi/rpc_client.cpp
+++ b/ebpfapi/rpc_client.cpp
@@ -193,7 +193,7 @@ clean_up_rpc_binding()
 _Must_inspect_result_ _Ret_maybenull_
 _Post_writable_byte_size_(size) void* __RPC_USER MIDL_user_allocate(_In_ size_t size)
 {
-    return ebpf_allocate(size);
+    return ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT);
 }
 
 void __RPC_USER

--- a/ebpfsvc/rpc_util.cpp
+++ b/ebpfsvc/rpc_util.cpp
@@ -117,7 +117,7 @@ Exit:
 _Must_inspect_result_ _Ret_maybenull_
 _Post_writable_byte_size_(size) void* __RPC_USER MIDL_user_allocate(_In_ size_t size)
 {
-    return ebpf_allocate(size);
+    return ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT);
 }
 
 void __RPC_USER

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -326,7 +326,7 @@ load_byte_code(
         }
 
         for (auto& raw_program : raw_programs) {
-            program = (ebpf_program_t*)ebpf_allocate(sizeof(ebpf_program_t));
+            program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t, EBPF_POOL_TAG_DEFAULT));
             if (program == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -348,7 +348,7 @@ load_byte_code(
                 goto Exit;
             }
             size_t ebpf_bytes = instruction_count * sizeof(ebpf_inst);
-            program->instructions = (ebpf_inst*)ebpf_allocate(ebpf_bytes);
+            program->instructions = (ebpf_inst*)ebpf_allocate_with_tag(ebpf_bytes, EBPF_POOL_TAG_DEFAULT);
             if (program->instructions == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -405,7 +405,7 @@ load_byte_code(
                 goto Exit;
             }
 
-            map = (ebpf_map_t*)ebpf_allocate(sizeof(ebpf_map_t));
+            map = (ebpf_map_t*)ebpf_allocate_with_tag(sizeof(ebpf_map_t, EBPF_POOL_TAG_DEFAULT));
             if (map == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -435,7 +435,7 @@ load_byte_code(
     } catch (std::runtime_error& err) {
         auto message = err.what();
         auto message_length = strlen(message) + 1;
-        char* error = reinterpret_cast<char*>(ebpf_allocate(message_length + 1));
+        char* error = reinterpret_cast<char*>(ebpf_allocate_with_tag(message_length + 1, EBPF_POOL_TAG_DEFAULT));
         if (error) {
             strcpy_s(error, message_length, message);
         }
@@ -468,7 +468,7 @@ Exit:
 static void
 _ebpf_add_stat(_Inout_ ebpf_api_program_info_t* info, std::string key, int value) noexcept(false)
 {
-    ebpf_stat_t* stat = (ebpf_stat_t*)ebpf_allocate(sizeof(*stat));
+    ebpf_stat_t* stat = (ebpf_stat_t*)ebpf_allocate_with_tag(sizeof(*stat, EBPF_POOL_TAG_DEFAULT));
     if (stat == nullptr) {
         throw std::runtime_error("Out of memory");
     }
@@ -503,7 +503,7 @@ ebpf_api_elf_enumerate_programs(
     try {
         auto raw_programs = read_elf(file, section ? std::string(section) : std::string(), verifier_options, platform);
         for (const auto& raw_program : raw_programs) {
-            info = (ebpf_api_program_info_t*)ebpf_allocate(sizeof(*info));
+            info = (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info, EBPF_POOL_TAG_DEFAULT));
             if (info == nullptr) {
                 throw std::runtime_error("Out of memory");
             }
@@ -548,7 +548,7 @@ ebpf_api_elf_enumerate_programs(
             info->offset_in_section = raw_program.insn_off;
             std::vector<uint8_t> raw_data = convert_ebpf_program_to_bytes(raw_program.prog);
             info->raw_data_size = raw_data.size();
-            info->raw_data = (char*)ebpf_allocate(info->raw_data_size);
+            info->raw_data = (char*)ebpf_allocate_with_tag(info->raw_data_size, EBPF_POOL_TAG_DEFAULT);
             if (info->raw_data == nullptr) {
                 throw std::runtime_error("Out of memory");
             }

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -326,7 +326,7 @@ load_byte_code(
         }
 
         for (auto& raw_program : raw_programs) {
-            program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t, EBPF_POOL_TAG_DEFAULT));
+            program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t), EBPF_POOL_TAG_DEFAULT);
             if (program == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -405,7 +405,7 @@ load_byte_code(
                 goto Exit;
             }
 
-            map = (ebpf_map_t*)ebpf_allocate_with_tag(sizeof(ebpf_map_t, EBPF_POOL_TAG_DEFAULT));
+            map = (ebpf_map_t*)ebpf_allocate_with_tag(sizeof(ebpf_map_t), EBPF_POOL_TAG_DEFAULT);
             if (map == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -468,7 +468,7 @@ Exit:
 static void
 _ebpf_add_stat(_Inout_ ebpf_api_program_info_t* info, std::string key, int value) noexcept(false)
 {
-    ebpf_stat_t* stat = (ebpf_stat_t*)ebpf_allocate_with_tag(sizeof(*stat, EBPF_POOL_TAG_DEFAULT));
+    ebpf_stat_t* stat = (ebpf_stat_t*)ebpf_allocate_with_tag(sizeof(*stat), EBPF_POOL_TAG_DEFAULT);
     if (stat == nullptr) {
         throw std::runtime_error("Out of memory");
     }
@@ -503,7 +503,7 @@ ebpf_api_elf_enumerate_programs(
     try {
         auto raw_programs = read_elf(file, section ? std::string(section) : std::string(), verifier_options, platform);
         for (const auto& raw_program : raw_programs) {
-            info = (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info, EBPF_POOL_TAG_DEFAULT));
+            info = (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info), EBPF_POOL_TAG_DEFAULT);
             if (info == nullptr) {
                 throw std::runtime_error("Out of memory");
             }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2759,7 +2759,7 @@ _ebpf_pe_add_section(
     std::string elf_section_name = pe_context->section_names[pe_section_name];
     std::string program_name = pe_context->program_names[pe_section_name];
 
-    ebpf_api_program_info_t* info = (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info, EBPF_POOL_TAG_DEFAULT));
+    ebpf_api_program_info_t* info = (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info), EBPF_POOL_TAG_DEFAULT);
     if (info == nullptr) {
         pe_context->result = EBPF_NO_MEMORY;
         return_value = 1;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1483,8 +1483,8 @@ ebpf_program_query_info(
 
     size_t file_name_length = reply->section_name_offset - reply->file_name_offset;
     size_t section_name_length = reply->header.length - reply->section_name_offset;
-    char* local_file_name = reinterpret_cast<char*>(ebpf_allocate(file_name_length + 1));
-    char* local_section_name = reinterpret_cast<char*>(ebpf_allocate(section_name_length + 1));
+    char* local_file_name = reinterpret_cast<char*>(ebpf_allocate_with_tag(file_name_length + 1, EBPF_POOL_TAG_DEFAULT));
+    char* local_section_name = reinterpret_cast<char*>(ebpf_allocate_with_tag(section_name_length + 1, EBPF_POOL_TAG_DEFAULT));
 
     if (!local_file_name || !local_section_name) {
         ebpf_free(local_file_name);
@@ -1656,7 +1656,7 @@ ebpf_program_attach(
 
     ebpf_assert(program);
 
-    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate(sizeof(ebpf_link_t));
+    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate_with_tag(sizeof(ebpf_link_t, EBPF_POOL_TAG_DEFAULT));
     if (new_link == nullptr) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
@@ -1712,7 +1712,7 @@ ebpf_program_attach_by_fd(
     EBPF_LOG_ENTRY();
     ebpf_assert(link);
 
-    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate(sizeof(ebpf_link_t));
+    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate_with_tag(sizeof(ebpf_link_t, EBPF_POOL_TAG_DEFAULT));
     if (new_link == nullptr) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
@@ -2286,7 +2286,7 @@ _initialize_ebpf_object_from_native_file(
     object.execution_type = EBPF_EXECUTION_NATIVE;
 
     for (ebpf_api_program_info_t* info = infos; info; info = info->next) {
-        program = (ebpf_program_t*)ebpf_allocate(sizeof(ebpf_program_t));
+        program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t, EBPF_POOL_TAG_DEFAULT));
         if (program == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -2580,7 +2580,7 @@ _ebpf_pe_get_map_definitions(
                     break;
                 }
 
-                map = (ebpf_map_t*)ebpf_allocate(sizeof(ebpf_map_t));
+                map = (ebpf_map_t*)ebpf_allocate_with_tag(sizeof(ebpf_map_t, EBPF_POOL_TAG_DEFAULT));
                 if (map == nullptr) {
                     goto Error;
                 }
@@ -2759,7 +2759,7 @@ _ebpf_pe_add_section(
     std::string elf_section_name = pe_context->section_names[pe_section_name];
     std::string program_name = pe_context->program_names[pe_section_name];
 
-    ebpf_api_program_info_t* info = (ebpf_api_program_info_t*)ebpf_allocate(sizeof(*info));
+    ebpf_api_program_info_t* info = (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info, EBPF_POOL_TAG_DEFAULT));
     if (info == nullptr) {
         pe_context->result = EBPF_NO_MEMORY;
         return_value = 1;
@@ -2785,7 +2785,7 @@ _ebpf_pe_add_section(
     info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
 
     info->raw_data_size = section_header.Misc.VirtualSize;
-    info->raw_data = (char*)ebpf_allocate(section_header.Misc.VirtualSize);
+    info->raw_data = (char*)ebpf_allocate_with_tag(section_header.Misc.VirtualSize, EBPF_POOL_TAG_DEFAULT);
     if (info->raw_data == nullptr || info->section_name == nullptr) {
         pe_context->result = EBPF_NO_MEMORY;
         return_value = 1;
@@ -3633,7 +3633,7 @@ _load_native_programs(
     size_t buffer_size = offsetof(ebpf_operation_load_native_programs_reply_t, data) + handles_size;
 
     if (count_of_maps > 0) {
-        *map_handles = (ebpf_handle_t*)ebpf_allocate(map_handles_size);
+        *map_handles = (ebpf_handle_t*)ebpf_allocate_with_tag(map_handles_size, EBPF_POOL_TAG_DEFAULT);
         if (*map_handles == nullptr) {
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR,
@@ -3645,7 +3645,7 @@ _load_native_programs(
     }
 
     if (count_of_programs > 0) {
-        *program_handles = (ebpf_handle_t*)ebpf_allocate(program_handles_size);
+        *program_handles = (ebpf_handle_t*)ebpf_allocate_with_tag(program_handles_size, EBPF_POOL_TAG_DEFAULT);
         if (*program_handles == nullptr) {
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR,

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1656,7 +1656,7 @@ ebpf_program_attach(
 
     ebpf_assert(program);
 
-    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate_with_tag(sizeof(ebpf_link_t, EBPF_POOL_TAG_DEFAULT));
+    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate_with_tag(sizeof(ebpf_link_t), EBPF_POOL_TAG_DEFAULT);
     if (new_link == nullptr) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
@@ -1712,7 +1712,7 @@ ebpf_program_attach_by_fd(
     EBPF_LOG_ENTRY();
     ebpf_assert(link);
 
-    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate_with_tag(sizeof(ebpf_link_t, EBPF_POOL_TAG_DEFAULT));
+    ebpf_link_t* new_link = (ebpf_link_t*)ebpf_allocate_with_tag(sizeof(ebpf_link_t), EBPF_POOL_TAG_DEFAULT);
     if (new_link == nullptr) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
@@ -2286,7 +2286,7 @@ _initialize_ebpf_object_from_native_file(
     object.execution_type = EBPF_EXECUTION_NATIVE;
 
     for (ebpf_api_program_info_t* info = infos; info; info = info->next) {
-        program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t, EBPF_POOL_TAG_DEFAULT));
+        program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t), EBPF_POOL_TAG_DEFAULT);
         if (program == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -2580,7 +2580,7 @@ _ebpf_pe_get_map_definitions(
                     break;
                 }
 
-                map = (ebpf_map_t*)ebpf_allocate_with_tag(sizeof(ebpf_map_t, EBPF_POOL_TAG_DEFAULT));
+                map = (ebpf_map_t*)ebpf_allocate_with_tag(sizeof(ebpf_map_t), EBPF_POOL_TAG_DEFAULT);
                 if (map == nullptr) {
                     goto Error;
                 }

--- a/libs/api/libbpf_link.cpp
+++ b/libs/api/libbpf_link.cpp
@@ -20,7 +20,7 @@ bpf_link__open(const char* path)
         return nullptr;
     }
 
-    link = (struct bpf_link*)ebpf_allocate_with_tag(sizeof(struct bpf_link, EBPF_POOL_TAG_DEFAULT));
+    link = (struct bpf_link*)ebpf_allocate_with_tag(sizeof(struct bpf_link), EBPF_POOL_TAG_DEFAULT);
     if (!link) {
         (void)ebpf_close_fd(link_fd);
         libbpf_err(-ENOMEM);

--- a/libs/api/libbpf_link.cpp
+++ b/libs/api/libbpf_link.cpp
@@ -20,7 +20,7 @@ bpf_link__open(const char* path)
         return nullptr;
     }
 
-    link = (struct bpf_link*)ebpf_allocate(sizeof(struct bpf_link));
+    link = (struct bpf_link*)ebpf_allocate_with_tag(sizeof(struct bpf_link, EBPF_POOL_TAG_DEFAULT));
     if (!link) {
         (void)ebpf_close_fd(link_fd);
         libbpf_err(-ENOMEM);

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -21,7 +21,7 @@ allocate_string(const std::string& string, uint32_t* length) noexcept
 {
     char* new_string;
     size_t string_length = string.size() + 1;
-    new_string = (char*)ebpf_allocate(string_length);
+    new_string = (char*)ebpf_allocate_with_tag(string_length, EBPF_POOL_TAG_DEFAULT);
     if (new_string != nullptr) {
         strcpy_s(new_string, string_length, string.c_str());
         if (length != nullptr) {

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -210,7 +210,7 @@ initialize_async_ioctl_operation(
     *async_ioctl_completion = nullptr;
 
     async_ioctl_completion_context_t* local_async_ioctl_completion =
-        (async_ioctl_completion_context_t*)ebpf_allocate_with_tag(sizeof(async_ioctl_completion_context_t, EBPF_POOL_TAG_DEFAULT));
+        (async_ioctl_completion_context_t*)ebpf_allocate_with_tag(sizeof(async_ioctl_completion_context_t), EBPF_POOL_TAG_DEFAULT);
     if (local_async_ioctl_completion == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -210,7 +210,7 @@ initialize_async_ioctl_operation(
     *async_ioctl_completion = nullptr;
 
     async_ioctl_completion_context_t* local_async_ioctl_completion =
-        (async_ioctl_completion_context_t*)ebpf_allocate(sizeof(async_ioctl_completion_context_t));
+        (async_ioctl_completion_context_t*)ebpf_allocate_with_tag(sizeof(async_ioctl_completion_context_t, EBPF_POOL_TAG_DEFAULT));
     if (local_async_ioctl_completion == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -164,7 +164,7 @@ _ebpf_store_load_program_type_descriptor(
 
     // Allocate the program type descriptor.
     local_program_type_descriptor =
-        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (local_program_type_descriptor == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -197,7 +197,7 @@ _ebpf_store_load_program_type_descriptor(
     }
 
     // Allocate and read context descriptor.
-    context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+    context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (context_descriptor == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -276,7 +276,7 @@ _ebpf_store_load_program_information(
     }
 
     // Allocate the program information struct.
-    program_information = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t, EBPF_POOL_TAG_DEFAULT));
+    program_information = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t), EBPF_POOL_TAG_DEFAULT);
     if (program_information == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -289,7 +289,7 @@ _ebpf_store_load_program_information(
     }
 
     // Allocate and read the program type GUID.
-    program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t, EBPF_POOL_TAG_DEFAULT));
+    program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t), EBPF_POOL_TAG_DEFAULT);
     if (program_type == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -353,7 +353,7 @@ _ebpf_store_load_program_information(
         }
 
         ebpf_helper_function_prototype_t* helper_prototype =
-            (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_count * sizeof(ebpf_helper_function_prototype_t, EBPF_POOL_TAG_DEFAULT));
+            (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_count * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_DEFAULT);
         if (helper_prototype == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -363,7 +363,7 @@ _ebpf_store_load_program_information(
         // Add space for null terminator.
         max_helper_name_size += 1;
 
-        helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
+        helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
         if (helper_name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -544,13 +544,13 @@ _load_section_data_information(
             goto Exit;
         }
 
-        program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t, EBPF_POOL_TAG_DEFAULT));
+        program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t), EBPF_POOL_TAG_DEFAULT);
         if (program_type == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
 
-        attach_type = (ebpf_attach_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_attach_type_t, EBPF_POOL_TAG_DEFAULT));
+        attach_type = (ebpf_attach_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_attach_type_t), EBPF_POOL_TAG_DEFAULT);
         if (attach_type == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -594,7 +594,7 @@ _load_section_data_information(
             goto Exit;
         }
 
-        section_information = (ebpf_section_definition_t*)ebpf_allocate_with_tag(sizeof(ebpf_section_definition_t, EBPF_POOL_TAG_DEFAULT));
+        section_information = (ebpf_section_definition_t*)ebpf_allocate_with_tag(sizeof(ebpf_section_definition_t), EBPF_POOL_TAG_DEFAULT);
         if (section_information == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -794,14 +794,14 @@ ebpf_store_load_global_helper_information(
     // Add space for null terminator.
     max_helper_name_size += 1;
 
-    helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
+    helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
     if (helper_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
 
     helper_prototype =
-        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(max_helpers_count * sizeof(ebpf_helper_function_prototype_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(max_helpers_count * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_DEFAULT);
     if (helper_prototype == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -164,7 +164,7 @@ _ebpf_store_load_program_type_descriptor(
 
     // Allocate the program type descriptor.
     local_program_type_descriptor =
-        (ebpf_program_type_descriptor_t*)ebpf_allocate(sizeof(ebpf_program_type_descriptor_t));
+        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     if (local_program_type_descriptor == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -197,7 +197,7 @@ _ebpf_store_load_program_type_descriptor(
     }
 
     // Allocate and read context descriptor.
-    context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate(sizeof(ebpf_context_descriptor_t));
+    context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     if (context_descriptor == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -276,7 +276,7 @@ _ebpf_store_load_program_information(
     }
 
     // Allocate the program information struct.
-    program_information = (ebpf_program_info_t*)ebpf_allocate(sizeof(ebpf_program_info_t));
+    program_information = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t, EBPF_POOL_TAG_DEFAULT));
     if (program_information == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -289,7 +289,7 @@ _ebpf_store_load_program_information(
     }
 
     // Allocate and read the program type GUID.
-    program_type = (ebpf_program_type_t*)ebpf_allocate(sizeof(ebpf_program_type_t));
+    program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t, EBPF_POOL_TAG_DEFAULT));
     if (program_type == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -353,7 +353,7 @@ _ebpf_store_load_program_information(
         }
 
         ebpf_helper_function_prototype_t* helper_prototype =
-            (ebpf_helper_function_prototype_t*)ebpf_allocate(helper_count * sizeof(ebpf_helper_function_prototype_t));
+            (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_count * sizeof(ebpf_helper_function_prototype_t, EBPF_POOL_TAG_DEFAULT));
         if (helper_prototype == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -363,7 +363,7 @@ _ebpf_store_load_program_information(
         // Add space for null terminator.
         max_helper_name_size += 1;
 
-        helper_name = (wchar_t*)ebpf_allocate(max_helper_name_size * sizeof(wchar_t));
+        helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
         if (helper_name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -486,7 +486,7 @@ ebpf_store_load_program_data(
         if (program_info_array.size() > 0) {
             // Copy the vector data to a new array.
             auto size = program_info_array.size() * sizeof(ebpf_program_info_t*);
-            *program_info = (ebpf_program_info_t**)ebpf_allocate(size);
+            *program_info = (ebpf_program_info_t**)ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT);
             if (*program_info == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -544,13 +544,13 @@ _load_section_data_information(
             goto Exit;
         }
 
-        program_type = (ebpf_program_type_t*)ebpf_allocate(sizeof(ebpf_program_type_t));
+        program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t, EBPF_POOL_TAG_DEFAULT));
         if (program_type == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
 
-        attach_type = (ebpf_attach_type_t*)ebpf_allocate(sizeof(ebpf_attach_type_t));
+        attach_type = (ebpf_attach_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_attach_type_t, EBPF_POOL_TAG_DEFAULT));
         if (attach_type == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -594,7 +594,7 @@ _load_section_data_information(
             goto Exit;
         }
 
-        section_information = (ebpf_section_definition_t*)ebpf_allocate(sizeof(ebpf_section_definition_t));
+        section_information = (ebpf_section_definition_t*)ebpf_allocate_with_tag(sizeof(ebpf_section_definition_t, EBPF_POOL_TAG_DEFAULT));
         if (section_information == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -691,7 +691,7 @@ ebpf_store_load_section_information(
         if (section_info_array.size() > 0) {
             // Copy the vector data to a new array.
             auto size = section_info_array.size() * sizeof(ebpf_section_definition_t*);
-            *section_info = (ebpf_section_definition_t**)ebpf_allocate(size);
+            *section_info = (ebpf_section_definition_t**)ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT);
             if (*section_info == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -794,14 +794,14 @@ ebpf_store_load_global_helper_information(
     // Add space for null terminator.
     max_helper_name_size += 1;
 
-    helper_name = (wchar_t*)ebpf_allocate(max_helper_name_size * sizeof(wchar_t));
+    helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
     if (helper_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
 
     helper_prototype =
-        (ebpf_helper_function_prototype_t*)ebpf_allocate(max_helpers_count * sizeof(ebpf_helper_function_prototype_t));
+        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(max_helpers_count * sizeof(ebpf_helper_function_prototype_t, EBPF_POOL_TAG_DEFAULT));
     if (helper_prototype == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -158,7 +158,7 @@ _get_program_descriptor_from_info(
             goto Exit;
         }
         type->name = std::string(name);
-        type->context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+        type->context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
         if (type->context_descriptor == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -167,7 +167,7 @@ _get_program_descriptor_from_info(
             (void*)type->context_descriptor,
             info->program_type_descriptor->context_descriptor,
             sizeof(ebpf_context_descriptor_t));
-        ebpf_program_type_t* program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t, EBPF_POOL_TAG_DEFAULT));
+        ebpf_program_type_t* program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t), EBPF_POOL_TAG_DEFAULT);
         if (program_type == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -158,7 +158,7 @@ _get_program_descriptor_from_info(
             goto Exit;
         }
         type->name = std::string(name);
-        type->context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate(sizeof(ebpf_context_descriptor_t));
+        type->context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
         if (type->context_descriptor == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -167,7 +167,7 @@ _get_program_descriptor_from_info(
             (void*)type->context_descriptor,
             info->program_type_descriptor->context_descriptor,
             sizeof(ebpf_context_descriptor_t));
-        ebpf_program_type_t* program_type = (ebpf_program_type_t*)ebpf_allocate(sizeof(ebpf_program_type_t));
+        ebpf_program_type_t* program_type = (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t, EBPF_POOL_TAG_DEFAULT));
         if (program_type == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -535,7 +535,7 @@ _update_global_helpers_for_program_information(
             goto Exit;
         }
         total_helper_size = total_helper_count * sizeof(ebpf_helper_function_prototype_t);
-        new_helpers = (ebpf_helper_function_prototype_t*)ebpf_allocate(total_helper_size);
+        new_helpers = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(total_helper_size, EBPF_POOL_TAG_DEFAULT);
         if (new_helpers == nullptr) {
             result = EBPF_NO_MEMORY;
             break;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1161,7 +1161,7 @@ _ebpf_core_protocol_program_test_run(
         goto Done;
     }
 
-    options = (ebpf_program_test_run_options_t*)ebpf_allocate(sizeof(ebpf_program_test_run_options_t));
+    options = (ebpf_program_test_run_options_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_test_run_options_t, EBPF_POOL_TAG_DEFAULT));
     if (!options) {
         retval = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1161,7 +1161,7 @@ _ebpf_core_protocol_program_test_run(
         goto Done;
     }
 
-    options = (ebpf_program_test_run_options_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_test_run_options_t, EBPF_POOL_TAG_DEFAULT));
+    options = (ebpf_program_test_run_options_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_test_run_options_t), EBPF_POOL_TAG_DEFAULT);
     if (!options) {
         retval = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1950,8 +1950,8 @@ _ebpf_native_load_programs(_Inout_ ebpf_native_module_instance_t* instance)
 
         ebpf_native_helper_address_changed_context_t* context = NULL;
 
-        context = (ebpf_native_helper_address_changed_context_t*)ebpf_allocate(
-            sizeof(ebpf_native_helper_address_changed_context_t));
+        context = (ebpf_native_helper_address_changed_context_t*)ebpf_allocate_with_tag(
+            sizeof(ebpf_native_helper_address_changed_context_t), EBPF_POOL_TAG_DEFAULT);
 
         if (context == NULL) {
             result = EBPF_NO_MEMORY;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1236,14 +1236,14 @@ _ebpf_program_update_jit_helpers(
         }
 
         total_helper_function_addresses =
-            (ebpf_helper_function_addresses_t*)ebpf_allocate(sizeof(ebpf_helper_function_addresses_t));
+            (ebpf_helper_function_addresses_t*)ebpf_allocate_with_tag(sizeof(ebpf_helper_function_addresses_t, EBPF_POOL_TAG_DEFAULT));
         if (total_helper_function_addresses == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
         }
         total_helper_function_addresses->helper_function_count = (uint32_t)total_helper_count;
         total_helper_function_addresses->helper_function_address =
-            (uint64_t*)ebpf_allocate(sizeof(uint64_t) * total_helper_count);
+            (uint64_t*)ebpf_allocate_with_tag(sizeof(uint64_t, EBPF_POOL_TAG_DEFAULT) * total_helper_count);
         if (total_helper_function_addresses->helper_function_address == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
@@ -1258,7 +1258,7 @@ _ebpf_program_update_jit_helpers(
         }
 
         __analysis_assume(total_helper_count > 0);
-        total_helper_function_ids = (uint32_t*)ebpf_allocate(sizeof(uint32_t) * total_helper_count);
+        total_helper_function_ids = (uint32_t*)ebpf_allocate_with_tag(sizeof(uint32_t, EBPF_POOL_TAG_DEFAULT) * total_helper_count);
         if (total_helper_function_ids == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
@@ -2380,7 +2380,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
         goto Exit;
     }
 
-    *hash = (uint8_t*)ebpf_allocate(*hash_length);
+    *hash = (uint8_t*)ebpf_allocate_with_tag(*hash_length, EBPF_POOL_TAG_DEFAULT);
     if (*hash == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1236,14 +1236,14 @@ _ebpf_program_update_jit_helpers(
         }
 
         total_helper_function_addresses =
-            (ebpf_helper_function_addresses_t*)ebpf_allocate_with_tag(sizeof(ebpf_helper_function_addresses_t, EBPF_POOL_TAG_DEFAULT));
+            (ebpf_helper_function_addresses_t*)ebpf_allocate_with_tag(sizeof(ebpf_helper_function_addresses_t), EBPF_POOL_TAG_DEFAULT);
         if (total_helper_function_addresses == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
         }
         total_helper_function_addresses->helper_function_count = (uint32_t)total_helper_count;
         total_helper_function_addresses->helper_function_address =
-            (uint64_t*)ebpf_allocate_with_tag(sizeof(uint64_t, EBPF_POOL_TAG_DEFAULT) * total_helper_count);
+            (uint64_t*)ebpf_allocate_with_tag(sizeof(uint64_t) * total_helper_count, EBPF_POOL_TAG_DEFAULT);
         if (total_helper_function_addresses->helper_function_address == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
@@ -1258,7 +1258,7 @@ _ebpf_program_update_jit_helpers(
         }
 
         __analysis_assume(total_helper_count > 0);
-        total_helper_function_ids = (uint32_t*)ebpf_allocate_with_tag(sizeof(uint32_t, EBPF_POOL_TAG_DEFAULT) * total_helper_count);
+        total_helper_function_ids = (uint32_t*)ebpf_allocate_with_tag(sizeof(uint32_t) * total_helper_count, EBPF_POOL_TAG_DEFAULT);
         if (total_helper_function_ids == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/runtime/ebpf_crypto_hash.c
+++ b/libs/runtime/ebpf_crypto_hash.c
@@ -22,7 +22,7 @@ ebpf_cryptographic_hash_create(_In_ const cxplat_utf8_string_t* algorithm, _Outp
     NTSTATUS nt_status;
     wchar_t* algorithm_unicode_string = NULL;
     ebpf_cryptographic_hash_t* local_hash =
-        (ebpf_cryptographic_hash_t*)ebpf_allocate_with_tag(sizeof(ebpf_cryptographic_hash_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_cryptographic_hash_t*)ebpf_allocate_with_tag(sizeof(ebpf_cryptographic_hash_t), EBPF_POOL_TAG_DEFAULT);
     if (local_hash == NULL) {
         result = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/runtime/ebpf_crypto_hash.c
+++ b/libs/runtime/ebpf_crypto_hash.c
@@ -22,7 +22,7 @@ ebpf_cryptographic_hash_create(_In_ const cxplat_utf8_string_t* algorithm, _Outp
     NTSTATUS nt_status;
     wchar_t* algorithm_unicode_string = NULL;
     ebpf_cryptographic_hash_t* local_hash =
-        (ebpf_cryptographic_hash_t*)ebpf_allocate(sizeof(ebpf_cryptographic_hash_t));
+        (ebpf_cryptographic_hash_t*)ebpf_allocate_with_tag(sizeof(ebpf_cryptographic_hash_t, EBPF_POOL_TAG_DEFAULT));
     if (local_hash == NULL) {
         result = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -478,7 +478,7 @@ ebpf_epoch_free_cache_aligned(_Frees_ptr_opt_ void* memory)
 ebpf_epoch_work_item_t*
 ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ const void (*callback)(_Inout_ void* context))
 {
-    ebpf_epoch_work_item_t* work_item = ebpf_allocate(sizeof(ebpf_epoch_work_item_t));
+    ebpf_epoch_work_item_t* work_item = ebpf_allocate_with_tag(sizeof(ebpf_epoch_work_item_t, EBPF_POOL_TAG_DEFAULT));
     if (!work_item) {
         return NULL;
     }

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -478,7 +478,7 @@ ebpf_epoch_free_cache_aligned(_Frees_ptr_opt_ void* memory)
 ebpf_epoch_work_item_t*
 ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ const void (*callback)(_Inout_ void* context))
 {
-    ebpf_epoch_work_item_t* work_item = ebpf_allocate_with_tag(sizeof(ebpf_epoch_work_item_t, EBPF_POOL_TAG_DEFAULT));
+    ebpf_epoch_work_item_t* work_item = ebpf_allocate_with_tag(sizeof(ebpf_epoch_work_item_t), EBPF_POOL_TAG_DEFAULT);
     if (!work_item) {
         return NULL;
     }

--- a/libs/runtime/ebpf_pinning_table.c
+++ b/libs/runtime/ebpf_pinning_table.c
@@ -268,7 +268,7 @@ ebpf_pinning_table_enumerate_entries(
     }
 
     // Allocate the output array for storing the pinning entries.
-    local_pinning_entries = (ebpf_pinning_entry_t*)ebpf_allocate_with_tag(sizeof(ebpf_pinning_entry_t, EBPF_POOL_TAG_DEFAULT) * entries_array_length);
+    local_pinning_entries = (ebpf_pinning_entry_t*)ebpf_allocate_with_tag(sizeof(ebpf_pinning_entry_t) * entries_array_length, EBPF_POOL_TAG_DEFAULT);
     if (local_pinning_entries == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/runtime/ebpf_pinning_table.c
+++ b/libs/runtime/ebpf_pinning_table.c
@@ -268,7 +268,7 @@ ebpf_pinning_table_enumerate_entries(
     }
 
     // Allocate the output array for storing the pinning entries.
-    local_pinning_entries = (ebpf_pinning_entry_t*)ebpf_allocate(sizeof(ebpf_pinning_entry_t) * entries_array_length);
+    local_pinning_entries = (ebpf_pinning_entry_t*)ebpf_allocate_with_tag(sizeof(ebpf_pinning_entry_t, EBPF_POOL_TAG_DEFAULT) * entries_array_length);
     if (local_pinning_entries == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -165,7 +165,7 @@ ebpf_get_execution_context_state(_Out_ ebpf_execution_context_state_t* state)
 _Must_inspect_result_ ebpf_result_t
 ebpf_semaphore_create(_Outptr_ KSEMAPHORE** semaphore, int initial_count, int maximum_count)
 {
-    *semaphore = (KSEMAPHORE*)ebpf_allocate_with_tag(sizeof(KSEMAPHORE, EBPF_POOL_TAG_DEFAULT));
+    *semaphore = (KSEMAPHORE*)ebpf_allocate_with_tag(sizeof(KSEMAPHORE), EBPF_POOL_TAG_DEFAULT);
     if (*semaphore == NULL) {
         return EBPF_NO_MEMORY;
     }
@@ -236,7 +236,7 @@ _Ret_maybenull_ ebpf_process_state_t*
 ebpf_allocate_process_state()
 {
     // Skipping fault injection as call to ebpf_allocate_with_tag(, EBPF_POOL_TAG_DEFAULT) covers it.
-    ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate_with_tag(sizeof(ebpf_process_state_t, EBPF_POOL_TAG_DEFAULT));
+    ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate_with_tag(sizeof(ebpf_process_state_t), EBPF_POOL_TAG_DEFAULT);
     return state;
 }
 
@@ -336,7 +336,7 @@ ebpf_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ wch
         return EBPF_INVALID_ARGUMENT;
     }
 
-    unicode_string = (wchar_t*)ebpf_allocate_with_tag(unicode_byte_count + sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
+    unicode_string = (wchar_t*)ebpf_allocate_with_tag(unicode_byte_count + sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
     if (unicode_string == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -464,7 +464,7 @@ ebpf_allocate_timer_work_item(
     _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
     _Inout_opt_ void* work_item_context)
 {
-    *timer_work_item = (ebpf_timer_work_item_t*)ebpf_allocate_with_tag(sizeof(ebpf_timer_work_item_t, EBPF_POOL_TAG_DEFAULT));
+    *timer_work_item = (ebpf_timer_work_item_t*)ebpf_allocate_with_tag(sizeof(ebpf_timer_work_item_t), EBPF_POOL_TAG_DEFAULT);
     if (*timer_work_item == NULL) {
         return EBPF_NO_MEMORY;
     }

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -165,7 +165,7 @@ ebpf_get_execution_context_state(_Out_ ebpf_execution_context_state_t* state)
 _Must_inspect_result_ ebpf_result_t
 ebpf_semaphore_create(_Outptr_ KSEMAPHORE** semaphore, int initial_count, int maximum_count)
 {
-    *semaphore = (KSEMAPHORE*)ebpf_allocate(sizeof(KSEMAPHORE));
+    *semaphore = (KSEMAPHORE*)ebpf_allocate_with_tag(sizeof(KSEMAPHORE, EBPF_POOL_TAG_DEFAULT));
     if (*semaphore == NULL) {
         return EBPF_NO_MEMORY;
     }
@@ -235,8 +235,8 @@ ebpf_platform_detach_process(_In_ ebpf_process_state_t* state)
 _Ret_maybenull_ ebpf_process_state_t*
 ebpf_allocate_process_state()
 {
-    // Skipping fault injection as call to ebpf_allocate() covers it.
-    ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate(sizeof(ebpf_process_state_t));
+    // Skipping fault injection as call to ebpf_allocate_with_tag(, EBPF_POOL_TAG_DEFAULT) covers it.
+    ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate_with_tag(sizeof(ebpf_process_state_t, EBPF_POOL_TAG_DEFAULT));
     return state;
 }
 
@@ -336,7 +336,7 @@ ebpf_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ wch
         return EBPF_INVALID_ARGUMENT;
     }
 
-    unicode_string = (wchar_t*)ebpf_allocate(unicode_byte_count + sizeof(wchar_t));
+    unicode_string = (wchar_t*)ebpf_allocate_with_tag(unicode_byte_count + sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
     if (unicode_string == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -371,7 +371,7 @@ Done:
 long
 ebpf_platform_printk(_In_z_ const char* format, va_list arg_list)
 {
-    char* output = (char*)ebpf_allocate(MAX_PRINTK_STRING_SIZE);
+    char* output = (char*)ebpf_allocate_with_tag(MAX_PRINTK_STRING_SIZE, EBPF_POOL_TAG_DEFAULT);
     if (output == NULL) {
         return -1;
     }
@@ -464,7 +464,7 @@ ebpf_allocate_timer_work_item(
     _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
     _Inout_opt_ void* work_item_context)
 {
-    *timer_work_item = (ebpf_timer_work_item_t*)ebpf_allocate(sizeof(ebpf_timer_work_item_t));
+    *timer_work_item = (ebpf_timer_work_item_t*)ebpf_allocate_with_tag(sizeof(ebpf_timer_work_item_t, EBPF_POOL_TAG_DEFAULT));
     if (*timer_work_item == NULL) {
         return EBPF_NO_MEMORY;
     }

--- a/libs/runtime/ebpf_trampoline.c
+++ b/libs/runtime/ebpf_trampoline.c
@@ -32,7 +32,7 @@ ebpf_allocate_trampoline_table(size_t entry_count, _Outptr_ ebpf_trampoline_tabl
     ebpf_result_t return_value;
     ebpf_trampoline_table_t* local_trampoline_table = NULL;
 
-    local_trampoline_table = ebpf_allocate(sizeof(ebpf_trampoline_table_t));
+    local_trampoline_table = ebpf_allocate_with_tag(sizeof(ebpf_trampoline_table_t, EBPF_POOL_TAG_DEFAULT));
     if (!local_trampoline_table) {
         return_value = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/runtime/ebpf_trampoline.c
+++ b/libs/runtime/ebpf_trampoline.c
@@ -32,7 +32,7 @@ ebpf_allocate_trampoline_table(size_t entry_count, _Outptr_ ebpf_trampoline_tabl
     ebpf_result_t return_value;
     ebpf_trampoline_table_t* local_trampoline_table = NULL;
 
-    local_trampoline_table = ebpf_allocate_with_tag(sizeof(ebpf_trampoline_table_t, EBPF_POOL_TAG_DEFAULT));
+    local_trampoline_table = ebpf_allocate_with_tag(sizeof(ebpf_trampoline_table_t), EBPF_POOL_TAG_DEFAULT);
     if (!local_trampoline_table) {
         return_value = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -33,7 +33,7 @@ ebpf_timed_work_queue_create(
     ebpf_timed_work_queue_t* local_work_queue = NULL;
     ebpf_result_t return_value;
 
-    local_work_queue = ebpf_allocate(sizeof(ebpf_timed_work_queue_t));
+    local_work_queue = ebpf_allocate_with_tag(sizeof(ebpf_timed_work_queue_t, EBPF_POOL_TAG_DEFAULT));
     if (!local_work_queue) {
         return_value = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -33,7 +33,7 @@ ebpf_timed_work_queue_create(
     ebpf_timed_work_queue_t* local_work_queue = NULL;
     ebpf_result_t return_value;
 
-    local_work_queue = ebpf_allocate_with_tag(sizeof(ebpf_timed_work_queue_t, EBPF_POOL_TAG_DEFAULT));
+    local_work_queue = ebpf_allocate_with_tag(sizeof(ebpf_timed_work_queue_t), EBPF_POOL_TAG_DEFAULT);
     if (!local_work_queue) {
         return_value = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -27,7 +27,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     EBPF_LOG_ENTRY();
     NTSTATUS status;
 
-    ebpf_ring_descriptor_t* ring_descriptor = ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+    ebpf_ring_descriptor_t* ring_descriptor = ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     MDL* source_mdl = NULL;
     MDL* kernel_mdl = NULL;
 

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -27,7 +27,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     EBPF_LOG_ENTRY();
     NTSTATUS status;
 
-    ebpf_ring_descriptor_t* ring_descriptor = ebpf_allocate(sizeof(ebpf_ring_descriptor_t));
+    ebpf_ring_descriptor_t* ring_descriptor = ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     MDL* source_mdl = NULL;
     MDL* kernel_mdl = NULL;
 

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -789,7 +789,7 @@ TEST_CASE("serialize_map_test", "[platform]")
         EBPF_INSUFFICIENT_BUFFER);
 
     {
-        uint8_t* buffer = static_cast<uint8_t*>(ebpf_allocate(required_length));
+        uint8_t* buffer = static_cast<uint8_t*>(ebpf_allocate_with_tag(required_length, EBPF_POOL_TAG_DEFAULT));
         if (buffer == nullptr) {
             REQUIRE(false);
         }
@@ -862,7 +862,7 @@ TEST_CASE("serialize_program_info_test", "[platform]")
         ebpf_serialize_program_info(&in_program_info, nullptr, buffer_length, &serialized_length, &required_length));
 
     {
-        uint8_t* buffer = static_cast<uint8_t*>(ebpf_allocate(required_length));
+        uint8_t* buffer = static_cast<uint8_t*>(ebpf_allocate_with_tag(required_length, EBPF_POOL_TAG_DEFAULT));
         if (buffer == nullptr) {
             REQUIRE(false);
         }

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -100,7 +100,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
 
     size_t total_mapped_size = header_length + length * 2;
 
-    ebpf_ring_descriptor_t* descriptor = (ebpf_ring_descriptor_t*)ebpf_allocate(sizeof(ebpf_ring_descriptor_t));
+    ebpf_ring_descriptor_t* descriptor = (ebpf_ring_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     if (!descriptor) {
         goto Exit;
     }

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -100,7 +100,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
 
     size_t total_mapped_size = header_length + length * 2;
 
-    ebpf_ring_descriptor_t* descriptor = (ebpf_ring_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+    ebpf_ring_descriptor_t* descriptor = (ebpf_ring_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (!descriptor) {
         goto Exit;
     }

--- a/libs/runtime/user/kernel_um.cpp
+++ b/libs/runtime/user/kernel_um.cpp
@@ -342,7 +342,7 @@ ExAllocatePoolUninitialized(_In_ POOL_TYPE pool_type, _In_ size_t number_of_byte
 {
     UNREFERENCED_PARAMETER(pool_type);
     UNREFERENCED_PARAMETER(tag);
-    return ebpf_allocate(number_of_bytes);
+    return ebpf_allocate_with_tag(number_of_bytes, EBPF_POOL_TAG_DEFAULT);
 }
 
 void
@@ -381,7 +381,7 @@ IoAllocateMdl(
     UNREFERENCED_PARAMETER(charge_quota);
     UNREFERENCED_PARAMETER(irp);
 
-    mdl = reinterpret_cast<MDL*>(ebpf_allocate(sizeof(MDL)));
+    mdl = reinterpret_cast<MDL*>(ebpf_allocate_with_tag(sizeof(MDL, EBPF_POOL_TAG_DEFAULT)));
     if (mdl == NULL) {
         return mdl;
     }
@@ -408,7 +408,7 @@ PIO_WORKITEM
 IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
 {
     // Skip Fault Injection as it is already added in ebpf_allocate.
-    auto work_item = reinterpret_cast<IO_WORKITEM*>(ebpf_allocate(sizeof(IO_WORKITEM)));
+    auto work_item = reinterpret_cast<IO_WORKITEM*>(ebpf_allocate_with_tag(sizeof(IO_WORKITEM, EBPF_POOL_TAG_DEFAULT)));
     if (!work_item) {
         return nullptr;
     }

--- a/libs/runtime/user/kernel_um.cpp
+++ b/libs/runtime/user/kernel_um.cpp
@@ -381,7 +381,7 @@ IoAllocateMdl(
     UNREFERENCED_PARAMETER(charge_quota);
     UNREFERENCED_PARAMETER(irp);
 
-    mdl = reinterpret_cast<MDL*>(ebpf_allocate_with_tag(sizeof(MDL, EBPF_POOL_TAG_DEFAULT)));
+    mdl = reinterpret_cast<MDL*>(ebpf_allocate_with_tag(sizeof(MDL), EBPF_POOL_TAG_DEFAULT));
     if (mdl == NULL) {
         return mdl;
     }
@@ -408,7 +408,7 @@ PIO_WORKITEM
 IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
 {
     // Skip Fault Injection as it is already added in ebpf_allocate.
-    auto work_item = reinterpret_cast<IO_WORKITEM*>(ebpf_allocate_with_tag(sizeof(IO_WORKITEM, EBPF_POOL_TAG_DEFAULT)));
+    auto work_item = reinterpret_cast<IO_WORKITEM*>(ebpf_allocate_with_tag(sizeof(IO_WORKITEM), EBPF_POOL_TAG_DEFAULT));
     if (!work_item) {
         return nullptr;
     }

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -481,7 +481,7 @@ ebpf_deserialize_program_info(
     ebpf_helper_function_prototype_t* local_helper_prototype_array;
 
     // Allocate output program info.
-    local_program_info = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t, EBPF_POOL_TAG_DEFAULT));
+    local_program_info = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t), EBPF_POOL_TAG_DEFAULT);
     if (local_program_info == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -492,7 +492,7 @@ ebpf_deserialize_program_info(
 
     // Allocate and deserialize program type descriptor.
     local_program_type_descriptor =
-        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (local_program_type_descriptor == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -514,7 +514,7 @@ ebpf_deserialize_program_info(
 
     // Allocate and deserialize context_descriptor, if present.
     if (serialized_program_type_descriptor->context_descriptor.size != 0) {
-        local_context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+        local_context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
         if (local_context_descriptor == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -170,7 +170,7 @@ ebpf_deserialize_map_info_array(
         goto Exit;
     }
 
-    out_map_info = (ebpf_map_info_t*)ebpf_allocate(out_map_size);
+    out_map_info = (ebpf_map_info_t*)ebpf_allocate_with_tag(out_map_size, EBPF_POOL_TAG_DEFAULT);
     if (out_map_info == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -226,7 +226,7 @@ ebpf_deserialize_map_info_array(
         if (source->pin_path_length > 0) {
             // Allocate the buffer to hold the pin path in destination map info structure.
             destination_pin_path_length = ((size_t)source->pin_path_length) + 1;
-            destination->pin_path = ebpf_allocate(destination_pin_path_length);
+            destination->pin_path = ebpf_allocate_with_tag(destination_pin_path_length, EBPF_POOL_TAG_DEFAULT);
             if (destination->pin_path == NULL) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -481,7 +481,7 @@ ebpf_deserialize_program_info(
     ebpf_helper_function_prototype_t* local_helper_prototype_array;
 
     // Allocate output program info.
-    local_program_info = (ebpf_program_info_t*)ebpf_allocate(sizeof(ebpf_program_info_t));
+    local_program_info = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t, EBPF_POOL_TAG_DEFAULT));
     if (local_program_info == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -492,7 +492,7 @@ ebpf_deserialize_program_info(
 
     // Allocate and deserialize program type descriptor.
     local_program_type_descriptor =
-        (ebpf_program_type_descriptor_t*)ebpf_allocate(sizeof(ebpf_program_type_descriptor_t));
+        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     if (local_program_type_descriptor == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -514,7 +514,7 @@ ebpf_deserialize_program_info(
 
     // Allocate and deserialize context_descriptor, if present.
     if (serialized_program_type_descriptor->context_descriptor.size != 0) {
-        local_context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate(sizeof(ebpf_context_descriptor_t));
+        local_context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
         if (local_context_descriptor == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -543,7 +543,7 @@ ebpf_deserialize_program_info(
     }
 
     // Allocate and deserialize program type descriptor name.
-    local_program_type_descriptor_name = (char*)ebpf_allocate(serialized_program_type_descriptor->name_length + 1);
+    local_program_type_descriptor_name = (char*)ebpf_allocate_with_tag(serialized_program_type_descriptor->name_length + 1, EBPF_POOL_TAG_DEFAULT);
     if (local_program_type_descriptor_name == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -601,7 +601,7 @@ ebpf_deserialize_program_info(
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }
-    local_helper_prototype_array = (ebpf_helper_function_prototype_t*)ebpf_allocate(helper_prototype_array_size);
+    local_helper_prototype_array = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_prototype_array_size, EBPF_POOL_TAG_DEFAULT);
     if (local_helper_prototype_array == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -643,7 +643,7 @@ ebpf_deserialize_program_info(
         }
 
         // Allocate buffer and serialize helper function name.
-        local_helper_function_name = (char*)ebpf_allocate(serialized_helper_prototype->name_length + 1);
+        local_helper_function_name = (char*)ebpf_allocate_with_tag(serialized_helper_prototype->name_length + 1, EBPF_POOL_TAG_DEFAULT);
         if (local_helper_function_name == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/shared/ebpf_shared_framework.h
+++ b/libs/shared/ebpf_shared_framework.h
@@ -58,18 +58,6 @@ typedef enum _ebpf_pool_tag
     EBPF_POOL_TAG_STATE = 'atse',
 } ebpf_pool_tag_t;
 
-/**
- * @brief Allocate memory.
- * @deprecated Use ebpf_allocate_with_tag() instead.
- * @param[in] size Size of memory to allocate.
- * @param[in] tag Pool tag to use.
- * @returns Pointer to zero-initialized memory block allocated, or null on failure.
- */
-__forceinline __drv_allocatesMem(Mem) _Must_inspect_result_
-    _Ret_writes_maybenull_(size) void* ebpf_allocate(size_t size)
-{
-    return cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, size, EBPF_POOL_TAG_DEFAULT);
-}
 
 __forceinline void
 ebpf_free(_Frees_ptr_opt_ void* pointer)

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -348,7 +348,7 @@ _duplicate_program_descriptor(
     ebpf_context_descriptor_t* context_descriptor_copy = NULL;
 
     program_type_descriptor_copy =
-        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (program_type_descriptor_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -368,7 +368,7 @@ _duplicate_program_descriptor(
         goto Exit;
     }
 
-    context_descriptor_copy = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
+    context_descriptor_copy = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (context_descriptor_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -407,7 +407,7 @@ _duplicate_helper_function_prototype_array(
     helper_prototype_size = EBPF_PAD_8(helper_prototype_array[0].header.size);
 
     local_helper_prototype_array =
-        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(count * sizeof(ebpf_helper_function_prototype_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(count * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_DEFAULT);
     if (local_helper_prototype_array == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -481,7 +481,7 @@ ebpf_duplicate_program_info(_In_ const ebpf_program_info_t* info, _Outptr_ ebpf_
 
     EBPF_LOG_ENTRY();
 
-    program_info = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t, EBPF_POOL_TAG_DEFAULT));
+    program_info = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t), EBPF_POOL_TAG_DEFAULT);
     if (program_info == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -547,7 +547,7 @@ _duplicate_helper_function_addresses(
     *new_helper_function_addresses = NULL;
 
     helper_function_addresses_copy =
-        (ebpf_helper_function_addresses_t*)ebpf_allocate_with_tag(sizeof(ebpf_helper_function_addresses_t, EBPF_POOL_TAG_DEFAULT));
+        (ebpf_helper_function_addresses_t*)ebpf_allocate_with_tag(sizeof(ebpf_helper_function_addresses_t), EBPF_POOL_TAG_DEFAULT);
     if (helper_function_addresses_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -559,7 +559,7 @@ _duplicate_helper_function_addresses(
     helper_function_addresses_copy->header.total_size = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_TOTAL_SIZE;
 
     helper_function_addresses_copy->helper_function_address =
-        (uint64_t*)ebpf_allocate_with_tag(helper_function_addresses->helper_function_count * sizeof(uint64_t, EBPF_POOL_TAG_DEFAULT));
+        (uint64_t*)ebpf_allocate_with_tag(helper_function_addresses->helper_function_count * sizeof(uint64_t), EBPF_POOL_TAG_DEFAULT);
     if (helper_function_addresses_copy->helper_function_address == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -603,7 +603,7 @@ ebpf_duplicate_program_data(
 
     EBPF_LOG_ENTRY();
 
-    program_data_copy = (ebpf_program_data_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_data_t, EBPF_POOL_TAG_DEFAULT));
+    program_data_copy = (ebpf_program_data_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_data_t), EBPF_POOL_TAG_DEFAULT);
     if (program_data_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -348,7 +348,7 @@ _duplicate_program_descriptor(
     ebpf_context_descriptor_t* context_descriptor_copy = NULL;
 
     program_type_descriptor_copy =
-        (ebpf_program_type_descriptor_t*)ebpf_allocate(sizeof(ebpf_program_type_descriptor_t));
+        (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     if (program_type_descriptor_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -368,7 +368,7 @@ _duplicate_program_descriptor(
         goto Exit;
     }
 
-    context_descriptor_copy = (ebpf_context_descriptor_t*)ebpf_allocate(sizeof(ebpf_context_descriptor_t));
+    context_descriptor_copy = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t, EBPF_POOL_TAG_DEFAULT));
     if (context_descriptor_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -407,7 +407,7 @@ _duplicate_helper_function_prototype_array(
     helper_prototype_size = EBPF_PAD_8(helper_prototype_array[0].header.size);
 
     local_helper_prototype_array =
-        (ebpf_helper_function_prototype_t*)ebpf_allocate(count * sizeof(ebpf_helper_function_prototype_t));
+        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(count * sizeof(ebpf_helper_function_prototype_t, EBPF_POOL_TAG_DEFAULT));
     if (local_helper_prototype_array == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -481,7 +481,7 @@ ebpf_duplicate_program_info(_In_ const ebpf_program_info_t* info, _Outptr_ ebpf_
 
     EBPF_LOG_ENTRY();
 
-    program_info = (ebpf_program_info_t*)ebpf_allocate(sizeof(ebpf_program_info_t));
+    program_info = (ebpf_program_info_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_info_t, EBPF_POOL_TAG_DEFAULT));
     if (program_info == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -547,7 +547,7 @@ _duplicate_helper_function_addresses(
     *new_helper_function_addresses = NULL;
 
     helper_function_addresses_copy =
-        (ebpf_helper_function_addresses_t*)ebpf_allocate(sizeof(ebpf_helper_function_addresses_t));
+        (ebpf_helper_function_addresses_t*)ebpf_allocate_with_tag(sizeof(ebpf_helper_function_addresses_t, EBPF_POOL_TAG_DEFAULT));
     if (helper_function_addresses_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -559,7 +559,7 @@ _duplicate_helper_function_addresses(
     helper_function_addresses_copy->header.total_size = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_TOTAL_SIZE;
 
     helper_function_addresses_copy->helper_function_address =
-        (uint64_t*)ebpf_allocate(helper_function_addresses->helper_function_count * sizeof(uint64_t));
+        (uint64_t*)ebpf_allocate_with_tag(helper_function_addresses->helper_function_count * sizeof(uint64_t, EBPF_POOL_TAG_DEFAULT));
     if (helper_function_addresses_copy->helper_function_address == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -603,7 +603,7 @@ ebpf_duplicate_program_data(
 
     EBPF_LOG_ENTRY();
 
-    program_data_copy = (ebpf_program_data_t*)ebpf_allocate(sizeof(ebpf_program_data_t));
+    program_data_copy = (ebpf_program_data_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_data_t, EBPF_POOL_TAG_DEFAULT));
     if (program_data_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -130,7 +130,7 @@ ebpf_read_registry_value_string(
         return result;
     }
 
-    string_value = (wchar_t*)ebpf_allocate_with_tag((value_size + sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT)));
+    string_value = (wchar_t*)ebpf_allocate_with_tag((value_size + sizeof(wchar_t)), EBPF_POOL_TAG_DEFAULT);
     if (string_value == nullptr) {
         return EBPF_NO_MEMORY;
     }

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -24,7 +24,7 @@ wchar_t*
 ebpf_get_wstring_from_string(_In_ const char* text)
 {
     int length = MultiByteToWideChar(CP_UTF8, 0, text, -1, nullptr, 0);
-    wchar_t* wide = (wchar_t*)ebpf_allocate(length * sizeof(wchar_t));
+    wchar_t* wide = (wchar_t*)ebpf_allocate_with_tag(length * sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
     if (wide == nullptr) {
         return nullptr;
     }
@@ -130,7 +130,7 @@ ebpf_read_registry_value_string(
         return result;
     }
 
-    string_value = (wchar_t*)ebpf_allocate((value_size + sizeof(wchar_t)));
+    string_value = (wchar_t*)ebpf_allocate_with_tag((value_size + sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT)));
     if (string_value == nullptr) {
         return EBPF_NO_MEMORY;
     }

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -24,7 +24,7 @@ wchar_t*
 ebpf_get_wstring_from_string(_In_ const char* text)
 {
     int length = MultiByteToWideChar(CP_UTF8, 0, text, -1, nullptr, 0);
-    wchar_t* wide = (wchar_t*)ebpf_allocate_with_tag(length * sizeof(wchar_t, EBPF_POOL_TAG_DEFAULT));
+    wchar_t* wide = (wchar_t*)ebpf_allocate_with_tag(length * sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
     if (wide == nullptr) {
         return nullptr;
     }

--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -16,8 +16,8 @@
 
 #include <stdlib.h>
 
-#define malloc(X) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT))
-#define calloc(X, Y) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT) * (Y))
+#define malloc(X) ebpf_allocate_with_tag((X), EBPF_POOL_TAG_DEFAULT)
+#define calloc(X, Y) ebpf_allocate_with_tag(((X) * (Y)), EBPF_POOL_TAG_DEFAULT)
 #define free(X) ebpf_free(X)
 
 #include <endian.h>

--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -16,8 +16,8 @@
 
 #include <stdlib.h>
 
-#define malloc(X) ebpf_allocate((X))
-#define calloc(X, Y) ebpf_allocate((X) * (Y))
+#define malloc(X) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT))
+#define calloc(X, Y) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT) * (Y))
 #define free(X) ebpf_free(X)
 
 #include <endian.h>

--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -20,8 +20,8 @@
 
 #include <stdlib.h>
 
-#define malloc(X) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT))
-#define calloc(X, Y) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT) * (Y))
+#define malloc(X) ebpf_allocate_with_tag((X), EBPF_POOL_TAG_DEFAULT)
+#define calloc(X, Y) ebpf_allocate_with_tag(((X) * (Y)), EBPF_POOL_TAG_DEFAULT)
 #define free(X) ebpf_free(X)
 
 #pragma warning(push)

--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -20,8 +20,8 @@
 
 #include <stdlib.h>
 
-#define malloc(X) ebpf_allocate((X))
-#define calloc(X, Y) ebpf_allocate((X) * (Y))
+#define malloc(X) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT))
+#define calloc(X, Y) ebpf_allocate_with_tag((X, EBPF_POOL_TAG_DEFAULT) * (Y))
 #define free(X) ebpf_free(X)
 
 #pragma warning(push)

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -798,7 +798,7 @@ _ebpf_bind_context_create(
     *context = nullptr;
     bind_md_t* bind_context = nullptr;
     bind_context_header_t* bind_context_header =
-        reinterpret_cast<bind_context_header_t*>(ebpf_allocate(sizeof(bind_context_header_t)));
+        reinterpret_cast<bind_context_header_t*>(ebpf_allocate_with_tag(sizeof(bind_context_header_t, EBPF_POOL_TAG_DEFAULT)));
     if (bind_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -933,7 +933,7 @@ _ebpf_sock_addr_context_create(
 
     bpf_sock_addr_t* sock_addr_context = nullptr;
     sock_addr_context_header_t* sock_addr_context_header =
-        reinterpret_cast<sock_addr_context_header_t*>(ebpf_allocate(sizeof(sock_addr_context_header_t)));
+        reinterpret_cast<sock_addr_context_header_t*>(ebpf_allocate_with_tag(sizeof(sock_addr_context_header_t, EBPF_POOL_TAG_DEFAULT)));
     if (sock_addr_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -1058,7 +1058,7 @@ _ebpf_sock_ops_context_create(
 
     bpf_sock_ops_t* sock_ops_context = nullptr;
     sock_ops_context_header_t* sock_ops_context_header =
-        reinterpret_cast<sock_ops_context_header_t*>(ebpf_allocate(sizeof(sock_ops_context_header_t)));
+        reinterpret_cast<sock_ops_context_header_t*>(ebpf_allocate_with_tag(sizeof(sock_ops_context_header_t, EBPF_POOL_TAG_DEFAULT)));
     if (sock_ops_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -798,7 +798,7 @@ _ebpf_bind_context_create(
     *context = nullptr;
     bind_md_t* bind_context = nullptr;
     bind_context_header_t* bind_context_header =
-        reinterpret_cast<bind_context_header_t*>(ebpf_allocate_with_tag(sizeof(bind_context_header_t, EBPF_POOL_TAG_DEFAULT)));
+        reinterpret_cast<bind_context_header_t*>(ebpf_allocate_with_tag(sizeof(bind_context_header_t), EBPF_POOL_TAG_DEFAULT));
     if (bind_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -933,7 +933,7 @@ _ebpf_sock_addr_context_create(
 
     bpf_sock_addr_t* sock_addr_context = nullptr;
     sock_addr_context_header_t* sock_addr_context_header =
-        reinterpret_cast<sock_addr_context_header_t*>(ebpf_allocate_with_tag(sizeof(sock_addr_context_header_t, EBPF_POOL_TAG_DEFAULT)));
+        reinterpret_cast<sock_addr_context_header_t*>(ebpf_allocate_with_tag(sizeof(sock_addr_context_header_t), EBPF_POOL_TAG_DEFAULT));
     if (sock_addr_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -1058,7 +1058,7 @@ _ebpf_sock_ops_context_create(
 
     bpf_sock_ops_t* sock_ops_context = nullptr;
     sock_ops_context_header_t* sock_ops_context_header =
-        reinterpret_cast<sock_ops_context_header_t*>(ebpf_allocate_with_tag(sizeof(sock_ops_context_header_t, EBPF_POOL_TAG_DEFAULT)));
+        reinterpret_cast<sock_ops_context_header_t*>(ebpf_allocate_with_tag(sizeof(sock_ops_context_header_t), EBPF_POOL_TAG_DEFAULT));
     if (sock_ops_context_header == nullptr) {
         retval = EBPF_NO_MEMORY;
         goto Done;


### PR DESCRIPTION
## Summary
Removes the deprecated internal API `ebpf_allocate()` as requested in issue #4674.

## Changes Made
- **API Migration**: Replaced all calls to `ebpf_allocate(size)` with `ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT)`
- **Function Removal**: Removed the deprecated `ebpf_allocate()` function definition from `ebpf_shared_framework.h`
- **Codebase Wide**: Updated all callers across 29 files to use the non-deprecated API

## Files Modified
The changes span across the entire eBPF codebase including:
- API layers (`ebpfapi/`, `libs/api/`)
- Runtime components (`libs/runtime/`, `libs/execution_context/`)
- Shared utilities (`libs/shared/`, `libs/api_common/`)
- Test utilities (`tests/end_to_end/`)

## Behavior
- **Functionality**: No functional changes - all allocations still use the same pool tag (`EBPF_POOL_TAG_DEFAULT`)
- **Compatibility**: Maintains existing behavior while using the recommended API
- **Code Quality**: Eliminates deprecated API usage warnings

## Testing
- All existing functionality preserved since `ebpf_allocate()` was just a wrapper around `ebpf_allocate_with_tag()` with the default tag
- No behavioral changes expected as the underlying allocation mechanism remains identical

This cleanup addresses the technical debt identified in the codebase and ensures all memory allocations use the recommended tagged allocation API.

Fixes #4674