### PR TITLE
Disable scheduled regression tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -291,8 +291,8 @@ jobs:
     # Always run this job.
     # Only run this on repos that have self-host runners.
     needs: regular
-    # Disabled for now for pull_request, merge_group, and push until in-progress breaking changes are completed.
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    # Disabled for now for schedule, pull_request, merge_group, and push until in-progress breaking changes are completed.
+    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: .\setup_ebpf_cicd_tests.ps1 -TestMode "Regression" -RegressionArtifactsVersion "0.21.0" -GranularTracing


### PR DESCRIPTION
## Description

Extends #4663 to disable scheduled regression tests so scheduled pipelines can also be kept green through our breaking changes.

Completes #4671


## Testing

Disables tests for breaking changes

## Documentation

N/A

## Installation

N/A
