### PR TITLE
Remove ebpf_link_mark_as_legacy_mode

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -129,7 +129,6 @@ EXPORTS
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name
     ebpf_link_close
-    ebpf_link_mark_as_legacy_mode
     ebpf_map_set_wait_handle
     ebpf_object_get
     ebpf_object_get_execution_type

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -433,7 +433,8 @@ extern "C"
      * @param[in] attach_parameters Optionally, attach parameters. This is an
      *  opaque flat buffer containing the attach parameters which is interpreted
      *  by the extension provider.
-     * @param[out] link Pointer to ebpf_link structure.
+     * @param[out] link Pointer to ebpf_link structure or NULL if the caller is not
+     * interested in the link.
      *
      * @retval EBPF_SUCCESS The operation was successful.
      */
@@ -443,7 +444,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
         size_t attach_params_size,
-        _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
+        _Outptr_opt_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Attach an eBPF program by program file descriptor.
@@ -457,7 +458,8 @@ extern "C"
      * @param[in] attach_parameters Optionally, attach parameters. This is an
      *  opaque flat buffer containing the attach parameters which is interpreted
      *  by the extension provider.
-     * @param[out] link Pointer to ebpf_link structure.
+     * @param[out] link Pointer to ebpf_link structure or NULL if the caller is not
+     * interested in the link.
      *
      * @retval EBPF_SUCCESS The operation was successful.
      */
@@ -467,7 +469,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
         size_t attach_parameters_size,
-        _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
+        _Outptr_opt_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Attach an eBPF program by program file descriptor and return
@@ -483,7 +485,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
         size_t attach_parameters_size,
-        _Out_ fd_t* link) EBPF_NO_EXCEPT;
+        _Out_opt_ fd_t* link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Detach an eBPF program from an attach point represented by
@@ -906,18 +908,6 @@ extern "C"
         _In_opt_ void* ctx,
         _In_opt_ const struct ebpf_perf_buffer_opts* opts) EBPF_NO_EXCEPT;
 
-    /**
-     * @brief Mark a link as operating in legacy mode, which means it doesn't detach
-     * automatically when last user mode reference is closed.
-     * This is used by bpf_prog_attach and related APIs to implement legacy behavior.
-     *
-     * @param[in] link File descriptor for the link.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_link_mark_as_legacy_mode(fd_t link) EBPF_NO_EXCEPT;
 #ifdef __cplusplus
 }
 #endif

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -257,12 +257,11 @@ _does_attach_type_support_attachable_fd(enum bpf_attach_type type)
 int
 bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsigned int flags)
 {
-    bpf_link* link = nullptr;
     ebpf_result_t result = EBPF_SUCCESS;
 
     if (_does_attach_type_support_attachable_fd(type) && (flags == 0)) {
         result = ebpf_program_attach_by_fd(
-            prog_fd, get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), &link);
+            prog_fd, get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), nullptr);
     } else {
         result = EBPF_OPERATION_NOT_SUPPORTED;
     }
@@ -270,14 +269,6 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
     if (result != EBPF_SUCCESS) {
         return libbpf_result_err(result);
     }
-
-    ebpf_assert(link != nullptr);
-    // Mark the link as legacy mode to avoid it being deleted when the program is closed.
-    // The caller is responsible for managing the link's lifetime.
-    (void)ebpf_link_mark_as_legacy_mode(link->fd);
-
-    bpf_link__disconnect(link);
-    bpf_link__destroy(link);
 
     return 0;
 }
@@ -638,17 +629,7 @@ __bpf_set_link_xdp_fd_replace(int ifindex, int fd, int old_fd, __u32 flags)
 
     if (fd != ebpf_fd_invalid) {
         // Link the new program fd to the specified ifindex.
-        struct bpf_link* link = nullptr;
-        result = ebpf_program_attach_by_fd(fd, &EBPF_ATTACH_TYPE_XDP, &ifindex, sizeof(ifindex), &link);
-        if (result == EBPF_SUCCESS) {
-            // Mark the link as legacy mode to avoid it being deleted when the program is closed.
-            // The caller is responsible for managing the link's lifetime.
-            (void)ebpf_link_mark_as_legacy_mode(link->fd);
-
-            // Disconnect and destroy the link object.
-            bpf_link__disconnect(link);
-            bpf_link__destroy(link);
-        }
+        result = ebpf_program_attach_by_fd(fd, &EBPF_ATTACH_TYPE_XDP, &ifindex, sizeof(ifindex), nullptr);
     }
     if (result != EBPF_SUCCESS) {
         return libbpf_result_err(result);


### PR DESCRIPTION
## Description

Resolves: #4675 
Modify ebpf_program_atttach* APIs so they can emulate the old libbpf attach (with out links) as well as the new libbpf attach style (with links).
Removed temporary ebpf_link_mark_as_legacy_mode API.

## Testing

CI/CD

## Documentation

Updated API doxygen.

## Installation

No.

This pull request refactors the eBPF user-mode API to simplify program attachment workflows and management of link lifetimes. The main change is to make the output link pointer optional in program attach APIs, and to internalize legacy mode handling so callers no longer need to manually mark links as legacy. Several APIs and internal functions are updated to reflect these changes, and related cleanup is performed in both the API and sample code.

### API and Function Signature Changes

* Made the output link pointer (`struct bpf_link** link`) and link file descriptor (`fd_t* link`) parameters optional in all eBPF program attach APIs (`ebpf_program_attach`, `ebpf_program_attach_by_fd`, `ebpf_program_attach_by_fds`), by changing them to use `_Outptr_opt_` and `_Out_opt_` annotations. This allows callers to pass `nullptr` if they do not need the link object or fd. (`[[1]](diffhunk://#diff-8b744ef020b2dae7afefac77b8d1d9664fa3d249c683b307cd393362da9f5e8bL446-R447)`, `[[2]](diffhunk://#diff-8b744ef020b2dae7afefac77b8d1d9664fa3d249c683b307cd393362da9f5e8bL470-R472)`, `[[3]](diffhunk://#diff-8b744ef020b2dae7afefac77b8d1d9664fa3d249c683b307cd393362da9f5e8bL486-R488)`)
* Updated internal implementations in `ebpf_api.cpp` to handle optional link outputs, including allocation and assignment logic, and to avoid assertions on non-null output pointers. (`[[1]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1610-R1625)`, `[[2]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1653-R1707)`, `[[3]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1683-L1686)`, `[[4]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1710-R1765)`)

### Link Legacy Mode Handling

* Removed the public API `ebpf_link_mark_as_legacy_mode` and replaced it with an internal function `_ebpf_link_mark_as_legacy_mode`. Legacy mode is now set automatically if the caller does not request a link or fd, so callers do not need to manage this explicitly. (`[[1]](diffhunk://#diff-2f82d1ff51a61fb435467ba5290591820cb88e359100a25e9b9a8e7913c6577cL132)`, `[[2]](diffhunk://#diff-8b744ef020b2dae7afefac77b8d1d9664fa3d249c683b307cd393362da9f5e8bL909-L920)`, `[[3]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL5226-L5235)`)
* Updated program attach logic to internally mark links as legacy when neither link nor fd is requested, and to clean up handles appropriately. (`[libs/api/ebpf_api.cppL1629-R1663](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1629-R1663)`)

### Cleanup and Refactoring in Sample and Helper Code

* Removed manual legacy mode marking and link cleanup from sample code and helper functions, including `bpf_prog_attach` and `__bpf_set_link_xdp_fd_replace` in `libbpf_program.cpp`, and from Netsh sample code in `programs.cpp`. This simplifies usage and reduces risk of resource leaks. (`[[1]](diffhunk://#diff-780511a42f3cac926001942e228bf075fec98dafebcbef6f1c6f5ce257068839L260-R264)`, `[[2]](diffhunk://#diff-780511a42f3cac926001942e228bf075fec98dafebcbef6f1c6f5ce257068839L274-L281)`, `[[3]](diffhunk://#diff-780511a42f3cac926001942e228bf075fec98dafebcbef6f1c6f5ce257068839L641-R632)`, `[[4]](diffhunk://#diff-9ebbb96ca59e504fcf42e194b161976b696a71ad048cbe73e587a78e084c7a90L266-L283)`, `[[5]](diffhunk://#diff-9ebbb96ca59e504fcf42e194b161976b696a71ad048cbe73e587a78e084c7a90L478-R457)`)
* Removed the `_link_deleter` struct from Netsh sample code, as manual link cleanup is no longer needed. (`[libs/ebpfnetsh/programs.cppL112-L122](diffhunk://#diff-9ebbb96ca59e504fcf42e194b161976b696a71ad048cbe73e587a78e084c7a90L112-L122)`)

### Minor Code Formatting

* Improved code formatting for readability in several places, such as buffer allocation and struct initialization. (`[[1]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL1486-R1492)`, `[[2]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL2762-R2800)`)

---

These changes streamline eBPF program attachment by making link management more automatic and reducing the burden on callers, while improving code clarity and safety.