### PR TITLE
Remove deprecated ebpf_* APIs

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -102,11 +102,8 @@ EXPORTS
     bpf_xdp_detach
     bpf_xdp_query_id
     ebpf_api_elf_disassemble_program
-    ebpf_api_elf_disassemble_section
     ebpf_api_elf_verify_program_from_file
     ebpf_api_elf_verify_program_from_memory
-    ebpf_api_elf_verify_section_from_file
-    ebpf_api_elf_verify_section_from_memory
     ebpf_api_close_handle
     ebpf_api_get_pinned_map_info
     ebpf_api_map_info_free
@@ -114,9 +111,7 @@ EXPORTS
     ebpf_close_fd
     ebpf_duplicate_fd
     ebpf_enumerate_programs
-    ebpf_enumerate_sections = ebpf_enumerate_programs
     ebpf_free_programs
-    ebpf_free_sections = ebpf_free_programs
     ebpf_free_string
     ebpf_get_attach_type_name
     ebpf_get_bpf_attach_type
@@ -124,7 +119,6 @@ EXPORTS
     ebpf_get_ebpf_attach_type
     ebpf_get_ebpf_program_type
     ebpf_get_next_pinned_object_path
-    ebpf_get_next_pinned_program_path
     ebpf_get_program_info_from_verifier
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -66,18 +66,14 @@ extern "C"
         size_t offset_in_section; // Byte offset of program in section.
     } ebpf_api_program_info_t;
 
-// The type ebpf_section_info_t was replaced by ebpf_api_program_info_t
-// which also added the offset_in_section field at the end.
-#define ebpf_section_info_t ebpf_api_program_info_t
-
     /**
--     * @brief Get list of programs and stats in an eBPF file.
--     * @param[in] file Name of file containing eBPF programs.
--     * @param[in] verbose Obtain additional info about the programs.
--     * @param[out] infos On success points to a list of eBPF programs.
+      * @brief Get list of programs and stats in an eBPF file.
+      * @param[in] file Name of file containing eBPF programs.
+      * @param[in] verbose Obtain additional info about the programs.
+      * @param[out] infos On success points to a list of eBPF programs.
       * The caller is responsible for freeing the list via ebpf_free_programs().
--     * @param[out] error_message On failure points to a text description of
--     *  the error.
+      * @param[out] error_message On failure points to a text description of
+      *  the error.
       */
     _Must_inspect_result_ ebpf_result_t
     ebpf_enumerate_programs(
@@ -87,36 +83,11 @@ extern "C"
         _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
     /**
-     * @brief Get list of sections and stats in an eBPF file.
-     * @param[in] file Name of file containing eBPF program sections.
-     * @param[in] verbose Obtain additional info about the program sections.
-     * @param[out] infos On success points to a list of eBPF program sections.
-     * The caller is responsible for freeing the list via ebpf_free_sections().
-     * @param[out] error_message On failure points to a text description of
-     *  the error.
-     * @deprecated Use ebpf_enumerate_programs() instead.
-     */
-    __declspec(deprecated("Use ebpf_enumerate_programs() instead.")) _Must_inspect_result_ ebpf_result_t
-    ebpf_enumerate_sections(
-        _In_z_ const char* file,
-        bool verbose,
-        _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
-
-    /**
      * @brief Free memory returned from \ref ebpf_enumerate_programs.
      * @param[in] data Memory to free.
      */
     void
     ebpf_free_programs(_In_opt_ _Post_invalid_ ebpf_api_program_info_t* infos) EBPF_NO_EXCEPT;
-
-    /**
-     * @brief Free memory returned from \ref ebpf_enumerate_sections.
-     * @param[in] data Memory to free.
-     * @deprecated Use ebpf_free_programs() instead.
-     */
-    __declspec(deprecated("Use ebpf_free_programs() instead.")) void
-    ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos) EBPF_NO_EXCEPT;
 
     /**
      * @brief Convert an eBPF program to human readable byte code.
@@ -134,21 +105,6 @@ extern "C"
         _In_z_ const char* file,
         _In_opt_z_ const char* section_name,
         _In_opt_z_ const char* program_name,
-        _Outptr_result_maybenull_z_ const char** disassembly,
-        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
-
-    /**
-     * @brief Convert an eBPF program to human readable byte code.
-     * @param[in] file Name of ELF file containing eBPF program.
-     * @param[in] section The name of the section to disassemble.
-     * @param[out] disassembly On success points text version of the program.
-     * @param[out] error_message On failure points to a text description of
-     *  the error.
-     */
-    __declspec(deprecated("Use ebpf_api_elf_disassemble_program() instead.")) uint32_t
-    ebpf_api_elf_disassemble_section(
-        _In_z_ const char* file,
-        _In_z_ const char* section,
         _Outptr_result_maybenull_z_ const char** disassembly,
         _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
@@ -196,31 +152,6 @@ extern "C"
 
     /**
      * @brief Verify that the program is safe to execute.
-     * @param[in] file Name of ELF file containing eBPF program.
-     * @param[in] section The name of the section to verify.
-     * @param[in] program_type Optional program type.
-     *  If NULL, the program type is derived from the section name.
-     * @param[in] verbosity How much additional info about the programs to obtain.
-     * @param[out] report Points to a text section describing why the program
-     *  failed verification.
-     * @param[out] error_message On failure points to a text description of
-     *  the error.
-     * @param[out] stats If non-NULL, returns verification statistics.
-     * @retval 0 Verification succeeded.
-     * @retval 1 Verification failed.
-     */
-    __declspec(deprecated("Use ebpf_api_elf_verify_program_from_file() instead.")) _Success_(return == 0) uint32_t
-        ebpf_api_elf_verify_section_from_file(
-            _In_z_ const char* file,
-            _In_z_ const char* section,
-            _In_opt_ const ebpf_program_type_t* program_type,
-            ebpf_verification_verbosity_t verbosity,
-            _Outptr_result_maybenull_z_ const char** report,
-            _Outptr_result_maybenull_z_ const char** error_message,
-            _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
-
-    /**
-     * @brief Verify that the program is safe to execute.
      * @param[in] data Memory containing the ELF file containing eBPF program.
      * @param[in] data_length Length of data.
      * @param[in] section_name The name of the section in which the program exists.
@@ -248,33 +179,6 @@ extern "C"
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
         _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
-
-    /**
-     * @brief Verify that the program is safe to execute.
-     * @param[in] data Memory containing the ELF file containing eBPF program.
-     * @param[in] data_length Length of data.
-     * @param[in] section_name The name of the section to verify.
-     * @param[in] program_type Optional program type.
-     *  If NULL, the program type is derived from the section name.
-     * @param[in] verbosity How much additional info about the programs to obtain.
-     * @param[out] report Points to a text section describing why the program
-     *  failed verification.
-     * @param[out] error_message On failure points to a text description of
-     *  the error.
-     * @param[out] stats If non-NULL, returns verification statistics.
-     * @retval 0 Verification succeeded.
-     * @retval 1 Verification failed.
-     */
-    __declspec(deprecated("Use ebpf_api_elf_verify_program_from_memory() instead.")) _Success_(return == 0) uint32_t
-        ebpf_api_elf_verify_section_from_memory(
-            _In_reads_(data_length) const char* data,
-            size_t data_length,
-            _In_z_ const char* section_name,
-            _In_opt_ const ebpf_program_type_t* program_type,
-            ebpf_verification_verbosity_t verbosity,
-            _Outptr_result_maybenull_z_ const char** report,
-            _Outptr_result_maybenull_z_ const char** error_message,
-            _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
 
     /**
      * @brief Free memory for a string returned from an eBPF API.
@@ -588,20 +492,6 @@ extern "C"
      */
     _Ret_maybenull_z_ const char*
     ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) EBPF_NO_EXCEPT;
-
-    /**
-     * @brief Gets the next pinned program after a given path.
-     *
-     * @param[in] start_path Path to look for an entry greater than.
-     * @param[out] next_path Returns the next path, if one exists.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MORE_KEYS No more entries found.
-     * @deprecated Use ebpf_get_next_pinned_object_path() instead.
-     */
-    __declspec(deprecated("Use ebpf_get_next_pinned_object_path() instead.")) _Must_inspect_result_ ebpf_result_t
-    ebpf_get_next_pinned_program_path(
-        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) EBPF_NO_EXCEPT;
 
     /**
      * @brief Retrieve the next pinned path of an eBPF object.

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -626,16 +626,6 @@ ebpf_api_elf_disassemble_program(
     return 0;
 }
 
-uint32_t
-ebpf_api_elf_disassemble_section(
-    _In_z_ const char* file,
-    _In_z_ const char* section,
-    _Outptr_result_maybenull_z_ const char** disassembly,
-    _Outptr_result_maybenull_z_ const char** error_message) noexcept
-{
-    return ebpf_api_elf_disassemble_program(file, section, {}, disassembly, error_message);
-}
-
 static _Success_(return == 0) uint32_t _ebpf_api_elf_verify_program_from_stream(
     std::istream& stream,
     _In_z_ const char* stream_name,
@@ -798,19 +788,6 @@ _Success_(return == 0) uint32_t ebpf_api_elf_verify_program_from_file(
         data, file, section_name, program_name, program_type, verbosity, report, error_message, stats);
 }
 
-_Success_(return == 0) uint32_t ebpf_api_elf_verify_section_from_file(
-    _In_z_ const char* file,
-    _In_z_ const char* section,
-    _In_opt_ const ebpf_program_type_t* program_type,
-    ebpf_verification_verbosity_t verbosity,
-    _Outptr_result_maybenull_z_ const char** report,
-    _Outptr_result_maybenull_z_ const char** error_message,
-    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
-{
-    return ebpf_api_elf_verify_program_from_file(
-        file, section, {}, program_type, verbosity, report, error_message, stats);
-}
-
 _Success_(return == 0) uint32_t ebpf_api_elf_verify_program_from_memory(
     _In_reads_(data_length) const char* data,
     size_t data_length,
@@ -832,18 +809,4 @@ _Success_(return == 0) uint32_t ebpf_api_elf_verify_program_from_memory(
         report,
         error_message,
         stats);
-}
-
-_Success_(return == 0) uint32_t ebpf_api_elf_verify_section_from_memory(
-    _In_reads_(data_length) const char* data,
-    size_t data_length,
-    _In_z_ const char* section,
-    _In_opt_ const ebpf_program_type_t* program_type,
-    ebpf_verification_verbosity_t verbosity,
-    _Outptr_result_maybenull_z_ const char** report,
-    _Outptr_result_maybenull_z_ const char** error_message,
-    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
-{
-    return ebpf_api_elf_verify_program_from_memory(
-        data, data_length, section, {}, program_type, verbosity, report, error_message, stats);
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4247,15 +4247,6 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) NO_EXCEPT_TRY
 CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_get_next_pinned_program_path(
-    _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) NO_EXCEPT_TRY
-{
-    ebpf_object_type_t type = EBPF_OBJECT_PROGRAM;
-    return ebpf_get_next_pinned_object_path(start_path, next_path, EBPF_MAX_PIN_PATH_LENGTH, &type);
-}
-CATCH_NO_MEMORY_EBPF_RESULT
-
-_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_pinned_object_path(
     _In_z_ const char* start_path,
     _Out_writes_z_(next_path_len) char* next_path,

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -916,35 +916,6 @@ TEST_CASE("enum programs", "[end_to_end]")
     ebpf_free_string(error_message);
 }
 
-TEST_CASE("verify section", "[end_to_end][deprecated]")
-{
-    _test_helper_end_to_end test_helper;
-    test_helper.initialize();
-
-    const char* error_message = nullptr;
-    const char* report = nullptr;
-    uint32_t result;
-    program_info_provider_t sample_test_program_info;
-    REQUIRE(sample_test_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
-
-    ebpf_api_verifier_stats_t stats;
-#pragma warning(suppress : 4996) // deprecated
-    REQUIRE(
-        (result = ebpf_api_elf_verify_section_from_file(
-             SAMPLE_PATH "test_sample_ebpf.o",
-             "sample_ext",
-             nullptr,
-             EBPF_VERIFICATION_VERBOSITY_NORMAL,
-             &report,
-             &error_message,
-             &stats),
-         ebpf_free_string(error_message),
-         error_message = nullptr,
-         result == 0));
-    REQUIRE(report != nullptr);
-    ebpf_free_string(report);
-}
-
 TEST_CASE("verify program", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;


### PR DESCRIPTION
## Description

Remove deprecated APIs before 1.0 release.

Fixes #4673

## Testing

Updated tests.

## Documentation

No impact.

## Installation

No impact.