### PR TITLE
Make map helper functions const correct

### DIFF
--- a/include/bpf_helper_defs.h
+++ b/include/bpf_helper_defs.h
@@ -14,7 +14,7 @@
  * @param[in] key Key to use when searching map.
  * @return Pointer to the value if found or NULL.
  */
-EBPF_HELPER(void*, bpf_map_lookup_elem, (void* map, void* key));
+EBPF_HELPER(void*, bpf_map_lookup_elem, (void* map, const void* key));
 #ifndef __doxygen
 #define bpf_map_lookup_elem ((bpf_map_lookup_elem_t)BPF_FUNC_map_lookup_elem)
 #endif
@@ -30,7 +30,7 @@ EBPF_HELPER(void*, bpf_map_lookup_elem, (void* map, void* key));
  * @retval -EBPF_NO_MEMORY Unable to allocate resources for this
  *  entry.
  */
-EBPF_HELPER(int64_t, bpf_map_update_elem, (void* map, void* key, void* value, uint64_t flags));
+EBPF_HELPER(int64_t, bpf_map_update_elem, (void* map, const void* key, const void* value, uint64_t flags));
 #ifndef __doxygen
 #define bpf_map_update_elem ((bpf_map_update_elem_t)BPF_FUNC_map_update_elem)
 #endif
@@ -43,7 +43,7 @@ EBPF_HELPER(int64_t, bpf_map_update_elem, (void* map, void* key, void* value, ui
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval -EBPF_INVALID_ARGUMENT One or more parameters are invalid.
  */
-EBPF_HELPER(int64_t, bpf_map_delete_elem, (void* map, void* key));
+EBPF_HELPER(int64_t, bpf_map_delete_elem, (void* map, const void* key));
 #ifndef __doxygen
 #define bpf_map_delete_elem ((bpf_map_delete_elem_t)BPF_FUNC_map_delete_elem)
 #endif
@@ -55,7 +55,7 @@ EBPF_HELPER(int64_t, bpf_map_delete_elem, (void* map, void* key));
  * @param[in] key Key to use when searching map.
  * @return Pointer to the value if found or NULL.
  */
-EBPF_HELPER(void*, bpf_map_lookup_and_delete_elem, (void* map, void* key));
+EBPF_HELPER(void*, bpf_map_lookup_and_delete_elem, (void* map, const void* key));
 #ifndef __doxygen
 #define bpf_map_lookup_and_delete_elem ((bpf_map_lookup_and_delete_elem_t)BPF_FUNC_map_lookup_and_delete_elem)
 #endif
@@ -69,7 +69,7 @@ EBPF_HELPER(void*, bpf_map_lookup_and_delete_elem, (void* map, void* key));
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval -EBPF_INVALID_ARGUMENT One or more parameters are invalid.
  */
-EBPF_HELPER(int64_t, bpf_tail_call, (void* ctx, void* prog_array_map, uint32_t index));
+EBPF_HELPER(int64_t, bpf_tail_call, (const void* ctx, const void* prog_array_map, uint32_t index));
 #ifndef __doxygen
 #define bpf_tail_call ((bpf_tail_call_t)BPF_FUNC_tail_call)
 #endif
@@ -126,7 +126,7 @@ EBPF_HELPER(uint64_t, bpf_ktime_get_ns, ());
  *
  * @returns The checksum delta on success, or <0 on failure.
  */
-EBPF_HELPER(int, bpf_csum_diff, (void* from, int from_size, void* to, int to_size, int seed));
+EBPF_HELPER(int, bpf_csum_diff, (const void* from, int from_size, const void* to, int to_size, int seed));
 #ifndef __doxygen
 #define bpf_csum_diff ((bpf_csum_diff_t)BPF_FUNC_csum_diff)
 #endif
@@ -140,7 +140,7 @@ EBPF_HELPER(int, bpf_csum_diff, (void* from, int from_size, void* to, int to_siz
  * @param[in] flags Flags indicating if notification for new data availability should be sent.
  * @returns 0 on success and a negative value on error.
  */
-EBPF_HELPER(int, bpf_ringbuf_output, (void* ring_buffer, void* data, uint64_t size, uint64_t flags));
+EBPF_HELPER(int, bpf_ringbuf_output, (void* ring_buffer, const void* data, uint64_t size, uint64_t flags));
 #ifndef __doxygen
 #define bpf_ringbuf_output ((bpf_ringbuf_output_t)BPF_FUNC_ringbuf_output)
 #endif
@@ -264,7 +264,7 @@ bpf_printk(const char* fmt, ...);
  *  entry.
  * @retval -EBPF_OUT_OF_SPACE Map is full and BPF_EXIST was not supplied.
  */
-EBPF_HELPER(int64_t, bpf_map_push_elem, (void* map, void* value, uint64_t flags));
+EBPF_HELPER(int64_t, bpf_map_push_elem, (void* map, const void* value, uint64_t flags));
 #ifndef __doxygen
 #define bpf_map_push_elem ((bpf_map_push_elem_t)BPF_FUNC_map_push_elem)
 #endif
@@ -526,7 +526,10 @@ EBPF_HELPER(uint64_t, bpf_ktime_get_ms, ());
  *  entry.
  * @retval -EBPF_OUT_OF_SPACE Map is full.
  */
-EBPF_HELPER(int, bpf_perf_event_output, (void* ctx, void* perf_event_array, uint64_t flags, void* data, uint64_t size));
+EBPF_HELPER(
+    int,
+    bpf_perf_event_output,
+    (const void* ctx, void* perf_event_array, uint64_t flags, const void* data, uint64_t size));
 #ifndef __doxygen
 #define bpf_perf_event_output ((bpf_perf_event_output_t)BPF_FUNC_perf_event_output)
 #endif
@@ -551,5 +554,6 @@ EBPF_HELPER(uint64_t, bpf_get_current_process_start_key, ());
  */
 EBPF_HELPER(int64_t, bpf_get_current_thread_create_time, ());
 #ifndef __doxygen
-#define bpf_get_current_thread_create_time ((bpf_get_current_thread_create_time_t)BPF_FUNC_get_current_thread_create_time)
+#define bpf_get_current_thread_create_time \
+    ((bpf_get_current_thread_create_time_t)BPF_FUNC_get_current_thread_create_time)
 #endif


### PR DESCRIPTION
## Description

This pull request updates several helper function definitions in `include/bpf_helper_defs.h` to improve type safety and clarity. The main change is adding `const` qualifiers to pointer parameters where the data is not modified, ensuring better correctness and compatibility with modern C standards.

Type safety improvements for BPF helper functions:

* Added `const` qualifiers to pointer parameters in map-related helpers (`bpf_map_lookup_elem`, `bpf_map_update_elem`, `bpf_map_delete_elem`, `bpf_map_lookup_and_delete_elem`, `bpf_map_push_elem`) to indicate keys and values are not modified. [[1]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L17-R17) [[2]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L33-R33) [[3]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L46-R46) [[4]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L58-R58) [[5]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L267-R267)
* Added `const` qualifiers to pointer parameters in context and data for helpers (`bpf_tail_call`, `bpf_csum_diff`, `bpf_ringbuf_output`, `bpf_perf_event_output`) to clarify that input buffers are read-only. [[1]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L72-R72) [[2]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L129-R129) [[3]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L143-R143) [[4]](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293L529-R532)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
