### PR TITLE
fix bpf-conformance version path for onebranch

### DIFF
--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -126,7 +126,7 @@ jobs:
       - template: ./reusable-test.yml
         parameters:
           name: bpf2c_conformance
-          pre_test: 'powershell.exe $version = Get-Content .github/bpf-conformance-version.txt -Raw; Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/$version/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe'
+          pre_test: 'powershell.exe $version = Get-Content $(Build.SourcesDirectory)\$(PROJECT_NAME)\.github\bpf-conformance-version.txt -Raw; Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/$version/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe'
           test_command: '.\bpf_conformance_runner.exe --test_file_directory $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v3 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include $(Build.SourcesDirectory)\$(PROJECT_NAME)\include"'
           dependency: regular
           build_artifact: Build


### PR DESCRIPTION
## Description

Adds path to bpf-conformance-version file to onebranch pipeline yaml.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
