### PR TITLE
Add proposal for adding a listen hook

### DIFF
--- a/docs/ListenHook.md
+++ b/docs/ListenHook.md
@@ -386,7 +386,6 @@ This section documents alignment with and divergences from the Linux `BPF_CGROUP
 | `compartment_id` | Absent | Present | Windows networking concept |
 | `interface_luid` | Absent | Present | Windows networking concept |
 | `ipv6_flowinfo` | Present | Absent | Not available from WFP |
-| `ipv6_scope_id` | Present | Could be supported | Derivable from `interface_luid` via NSI APIs |
 | Return values | 0 (deny) / 1 (allow) | 3-value verdict enum | Pre-existing Windows design choice |
 | Address rewriting | Supported (local address) | Not supported for listen | WFP ALE_AUTH_LISTEN does not support address modification |
 


### PR DESCRIPTION
## Description

Add a design proposal for eBPF listen hook functionality on Windows, enabling interception and control of socket listen operations through the Windows Filtering Platform (WFP) ALE Authorization Listen layers.

The proposal reuses the existing `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` program type with two new attach types (`BPF_CGROUP_INET4_LISTEN` / `BPF_CGROUP_INET6_LISTEN`), aligning with the Linux kernel's equivalent attach types. The hook uses the existing `bpf_sock_addr_t` context structure with both `msg_src_*` and `user_*` fields populated with the local listen address, matching Linux `struct bpf_sock_addr` semantics.

Key design points:
- Reuses existing `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` program type (no new program type)
- Integrates with WFP `FWPM_LAYER_ALE_AUTH_LISTEN_V4/V6` layers
- Context field semantics match Linux for portability
- Verdict-based control (reject, proceed soft/hard) over listen operations
- Enables port access control, process whitelisting, network monitoring, and resource management

Resolves: #4480

## Testing

N/A - design document only.

## Documentation

Yes - adds `docs/ListenHook.md` with full design proposal including Linux compatibility analysis.

## Installation

N/A