### PR TITLE
_ebpf_object_load_native: wait until service is deleted on error

### DIFF
--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -17,8 +17,8 @@ std::function<decltype(DuplicateHandle)> duplicate_handle_handler;
 std::function<decltype(DeviceIoControl)> device_io_control_handler;
 std::function<decltype(_get_osfhandle)> get_osfhandle_handler;
 std::function<decltype(_open_osfhandle)> open_osfhandle_handler;
-std::function<decltype(_create_service)> create_service_handler;
-std::function<decltype(_delete_service)> delete_service_handler;
+std::function<decltype(Platform::_create_service)> create_service_handler;
+std::function<decltype(Platform::_delete_service)> delete_service_handler;
 
 namespace Platform {
 bool
@@ -180,13 +180,10 @@ _query_service_status(SC_HANDLE service_handle, _Inout_ SERVICE_STATUS* status)
 }
 
 uint32_t
-_stop_service(SC_HANDLE service_handle)
+_stop_and_delete_service(SC_HANDLE service_handle, const wchar_t* service_name)
 {
-    // TODO: (Issue# 852) Just a stub currently in order to compile.
-    // Will be replaced by a proper mock.
-
-    UNREFERENCED_PARAMETER(service_handle);
-    return ERROR_SUCCESS;
+    UNREFERENCED_PARAMETER(service_name);
+    return _delete_service(service_handle);
 }
 
 } // namespace Platform

--- a/libs/thunk/mock/mock.h
+++ b/libs/thunk/mock/mock.h
@@ -6,11 +6,15 @@
 #include <functional>
 #include <io.h>
 
+namespace Platform {
+
 uint32_t
 _create_service(_In_z_ const wchar_t* service_name, _In_z_ const wchar_t* file_path, _Out_ SC_HANDLE* service_handle);
 
 uint32_t
 _delete_service(SC_HANDLE service_handle);
+
+} // namespace Platform
 
 extern std::function<decltype(_close)> close_handler;
 extern std::function<decltype(_dup)> dup_handler;
@@ -21,5 +25,5 @@ extern std::function<decltype(DuplicateHandle)> duplicate_handle_handler;
 extern std::function<decltype(DeviceIoControl)> device_io_control_handler;
 extern std::function<decltype(_get_osfhandle)> get_osfhandle_handler;
 extern std::function<decltype(_open_osfhandle)> open_osfhandle_handler;
-extern std::function<decltype(_create_service)> create_service_handler;
-extern std::function<decltype(_delete_service)> delete_service_handler;
+extern std::function<decltype(Platform::_create_service)> create_service_handler;
+extern std::function<decltype(Platform::_delete_service)> delete_service_handler;

--- a/libs/thunk/platform.h
+++ b/libs/thunk/platform.h
@@ -79,7 +79,7 @@ uint32_t
 _delete_service(SC_HANDLE service_handle);
 
 uint32_t
-_stop_service(SC_HANDLE service_handle);
+_stop_and_delete_service(SC_HANDLE service_handle, const wchar_t* service_name);
 
 bool
 _query_service_status(SC_HANDLE service_handle, _Inout_ SERVICE_STATUS* status);

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1641,6 +1641,40 @@ TEST_CASE("prog_array_map_user_reference-native", "[user_reference]")
     _test_prog_array_map_user_reference(EBPF_EXECUTION_NATIVE);
 }
 
+TEST_CASE("native_load_retry_after_insufficient_buffers", "[native_tests]")
+{
+    native_module_helper_t native_helper;
+    native_helper.initialize("bindmonitor", EBPF_EXECUTION_NATIVE);
+
+    std::vector<fd_t> map_fds(3, ebpf_fd_invalid);
+    std::vector<fd_t> program_fds(1, ebpf_fd_invalid);
+    size_t count_of_maps = 0;
+    size_t count_of_programs = 0;
+
+    ebpf_result_t result = ebpf_object_load_native_by_fds(
+        native_helper.get_file_name().c_str(), &count_of_maps, nullptr, &count_of_programs, nullptr);
+
+    REQUIRE(result == EBPF_NO_MEMORY);
+    REQUIRE(count_of_maps == map_fds.size());
+    REQUIRE(count_of_programs == program_fds.size());
+
+    result = ebpf_object_load_native_by_fds(
+        native_helper.get_file_name().c_str(), &count_of_maps, map_fds.data(), &count_of_programs, program_fds.data());
+
+    REQUIRE(result == EBPF_SUCCESS);
+    REQUIRE(count_of_maps == map_fds.size());
+    REQUIRE(count_of_programs == program_fds.size());
+
+    for (auto fd : map_fds) {
+        REQUIRE(fd != ebpf_fd_invalid);
+        _close(fd);
+    }
+    for (auto fd : program_fds) {
+        REQUIRE(fd != ebpf_fd_invalid);
+        _close(fd);
+    }
+}
+
 TEST_CASE("load_all_sample_programs", "[native_tests]")
 {
     struct _ebpf_program_load_test_parameters test_parameters[] = {


### PR DESCRIPTION
ebpf-go loads native images via ebpf_object_load_native_by_fds. Contrary to ebpf_object_load_native this function requires the caller to provide memory for map and program fds. If the caller doesn't provide enough space, EBPF_NO_MEMORY is returned along with a sizing hint. The caller is expected to retry with a larger buffer.

This behaviour currently breaks for two reasons: first, the error recovery path of _ebpf_object_load_native stops and deletes the service, but does not wait for deletion to complete. This is a problem because each native image can currently only be loaded once. This causes an error when ebpf-go retries the load with larger buffers. Second, the check which issues the EBPF_NO_MEMORY result happens at a point where we can't reliably delete the service since we don't know its name.

Fix this by waiting for a service to be deleted on the error path and by pushing the EBPF_NO_MEMORY condition down into _ebpf_object_load_native. The latter requires some creative semantics for count_of_maps and count_of_programs: they now specify the maximum number the caller is willing to accept.
