### PR TITLE
Update procDump checksum

### DIFF
--- a/.azure/reusable-test.yml
+++ b/.azure/reusable-test.yml
@@ -100,7 +100,7 @@ jobs:
         displayName: 'Shallow Checkout Repo'
 
       - bash: |
-          choco install -y --requirechecksum=true --checksum=d58e81b96d53ded74570ad028d605fcfa1bfcc2e7cb2f5ab24bd64901b0c8783 --checksum-type=sha256 procdump --version=11.0
+          choco install -y --requirechecksum=true --checksum=863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4 --checksum-type=sha256 procdump --version=11.0
           where procdump.exe
         condition: eq('${{parameters.gather_dumps}}', 'true')
         name: install_procdump

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -159,7 +159,7 @@ jobs:
         id: install_procdump
         if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
         run: |
-          choco install -y --requirechecksum=true --checksum=d58e81b96d53ded74570ad028d605fcfa1bfcc2e7cb2f5ab24bd64901b0c8783 --checksum-type=sha256 procdump --version=11.0
+          choco install -y --requirechecksum=true --checksum=863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4 --checksum-type=sha256 procdump --version=11.0
           where procdump.exe
 
       - name: Set up OpenCppCoverage and add to PATH


### PR DESCRIPTION
## Description

The checksum for procdump has changed which is causing installation to fail in the pipelines.
The necessary checksum is displayed when trying to run the existing command:
```
choco install -y --requirechecksum=true --checksum=d58e81b96d53ded74570ad028d605fcfa1bfcc2e7cb2f5ab24bd64901b0c8783 --checksum-type=sha256 procdump --version=11.0
Chocolatey v2.3.0
Installing the following packages:
procdump
By installing, you accept licenses for the packages.
Downloading package from source 'https://community.chocolatey.org/api/v2/'
Progress: Downloading procdump 11.0... 100%

procdump v11.0.0 [Approved]
procdump package files install completed. Performing other installation steps.
File appears to be downloaded already. Verifying with package checksum to determine if it needs to be redownloaded.
Error - hashes do not match. Actual value was '863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4'.
Downloading procdump
  from 'https://download.sysinternals.com/files/Procdump.zip'
Progress: 100% - Completed download of C:\Users\lakshkotian\AppData\Local\Temp\chocolatey\procdump\11.0.0\Procdump.zip (1.17 MB).
Download of Procdump.zip (1.17 MB) completed.
Error - hashes do not match. Actual value was '863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4'.

```

Switched the checksum to the 'actual value' from above output

closes #4827 
## Testing

CI/CD

## Documentation

NA

## Installation

NA