### PR TITLE
Add workflow to require linked issue on pull requests

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -2,7 +2,7 @@ name: Require Linked Issue
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Description

Add workflow for requiring a valid, linked issue for PRs. Ensures at least one valid issue is linked. If not, adds a comment if not already added. Once a valid issue is added, any previously added comment is removed.

Related to #4726

## Testing

Tested in my personal github repo as I don't have permissions to modify rulesets here.