### PR TITLE
Mark load_all_sample_programs as mandatory

### DIFF
--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -126,6 +126,7 @@ _test_multiple_programs_load(
         fd_t program_fd;
 
         result = program_load_helper(file_name, program_type, execution_type, &object, &program_fd);
+        CAPTURE(file_name);
         REQUIRE(expected_load_result == result);
         if (expected_load_result == 0) {
             REQUIRE(program_fd > 0);


### PR DESCRIPTION
## Description

Resolves #4840 

Marking `load_all_sample_programs` as mandatory. This failure is no longer being hit in pipeline runs and the failure has also been unable to be reproduced locally. This test will continue to be monitored to make sure that failure does not reappear.  

## Testing

No

## Documentation

No

## Installation

No
