### PR TITLE
models: add bounded TLA+ models + CI (TLC/TLATeX)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,9 @@
 *.sh                text eol=lf
 /scripts/**         text eol=lf
 
+# Generated TLATeX outputs should always have LFs (CI runs on Linux).
+models/**/tlatex/*.tex  text eol=lf
+
 # Windows build files should always have CRLFs.
 *.sln               text eol=crlf
 *.vcxproj           text eol=crlf

--- a/.github/workflows/tla-plus-epoch.yml
+++ b/.github/workflows/tla-plus-epoch.yml
@@ -1,0 +1,71 @@
+# Copyright (c) eBPF for Windows contributors
+# SPDX-License-Identifier: MIT
+
+---
+name: TLA+ Epoch Model
+
+on:
+  pull_request:
+    paths:
+      - 'models/epoch/**'
+      - 'libs/runtime/ebpf_epoch.c'
+      - 'libs/runtime/ebpf_epoch.h'
+      - '.github/workflows/tla-plus-epoch.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'models/epoch/**'
+      - 'libs/runtime/ebpf_epoch.c'
+      - 'libs/runtime/ebpf_epoch.h'
+      - '.github/workflows/tla-plus-epoch.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  tlc:
+    name: TLC model check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '21'
+
+      - name: Download tla2tools.jar
+        run: |
+          curl -fsSL -o tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/tla2tools.jar
+
+      - name: TLC fixed config must pass
+        run: |
+          java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC -workers auto \
+            -config models/epoch/EpochModel.cfg \
+            models/epoch/EpochModel.tla
+
+      - name: TLC buggy config must fail (find counterexample)
+        shell: bash
+        run: |
+          set +e
+          java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC -workers auto \
+            -config models/epoch/EpochModel_buggy.cfg \
+            models/epoch/EpochModel.tla \
+            > tlc-buggy.out 2>&1
+          status=$?
+          cat tlc-buggy.out
+
+          if [ "$status" -eq 0 ]; then
+            echo "Buggy model unexpectedly passed"
+            exit 1
+          fi
+
+          if ! grep -q "Invariant Safety is violated" tlc-buggy.out; then
+            echo "Buggy model failed, but did not report a Safety invariant violation"
+            exit 1
+          fi

--- a/.github/workflows/tla-plus-models.yml
+++ b/.github/workflows/tla-plus-models.yml
@@ -1,0 +1,127 @@
+# Copyright (c) eBPF for Windows contributors
+# SPDX-License-Identifier: MIT
+
+---
+name: TLA+ Models
+
+on:
+  pull_request:
+    paths:
+      - 'models/**'
+      - 'scripts/generate_tlatex.sh'
+      - 'scripts/generate_tlatex.ps1'
+      - '.github/workflows/tla-plus-models.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'models/**'
+      - 'scripts/generate_tlatex.sh'
+      - 'scripts/generate_tlatex.ps1'
+      - '.github/workflows/tla-plus-models.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  tlc:
+    name: TLC model check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '21'
+
+      - name: Download tla2tools.jar
+        run: |
+          curl -fsSL -o tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/tla2tools.jar
+
+      - name: Install LaTeX (for TLATeX)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y texlive-latex-base
+
+      - name: Generate TLATeX outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          TLA2TOOLS_JAR=./tla2tools.jar bash scripts/generate_tlatex.sh
+
+      - name: Verify TLATeX outputs are up to date
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --exit-code
+
+      - name: Run TLC for all models
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Convention:
+          # - any config named *_buggy*.cfg is expected to FAIL with an invariant violation
+          # - all other *.cfg are expected to PASS
+          # A model directory may contain one or more *.tla files. For each spec, we run any
+          # configs that match "<SpecRoot>*.cfg" (e.g., EpochModel.cfg and EpochModel_buggy.cfg).
+
+          shopt -s nullglob
+
+          for model_dir in models/*/ ; do
+            tla_files=("${model_dir}"*.tla)
+            if [ ${#tla_files[@]} -eq 0 ]; then
+              echo "Skipping ${model_dir}: no .tla files"
+              continue
+            fi
+
+            echo "=== Model: ${model_dir} (specs: ${#tla_files[@]}) ==="
+
+            for tla in "${tla_files[@]}" ; do
+              spec_root="$(basename "${tla}" .tla)"
+              spec_cfg_files=("${model_dir}${spec_root}"*.cfg)
+
+              if [ ${#spec_cfg_files[@]} -eq 0 ]; then
+                echo "Skipping spec ${tla}: no matching .cfg files"
+                continue
+              fi
+
+              echo "--- Spec: ${tla} ---"
+
+              for cfg in "${spec_cfg_files[@]}" ; do
+                echo "--- Config: ${cfg} ---"
+                out="${cfg}.out"
+
+                set +e
+                java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC -workers auto \
+                  -config "${cfg}" \
+                  "${tla}" \
+                  >"${out}" 2>&1
+                status=$?
+                set -e
+
+                cat "${out}"
+
+                if [[ "${cfg}" == *"_buggy"*".cfg" ]]; then
+                  if [ "$status" -eq 0 ]; then
+                    echo "Buggy config unexpectedly passed: ${cfg}"
+                    exit 1
+                  fi
+                  if ! grep -q "Invariant" "${out}"; then
+                    echo "Buggy config failed but did not report an invariant violation: ${cfg}"
+                    exit 1
+                  fi
+                else
+                  if [ "$status" -ne 0 ]; then
+                    echo "Config failed unexpectedly: ${cfg}"
+                    exit 1
+                  fi
+                fi
+              done
+            done
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ artifacts/
 
 # CodeQL temporary files.
 _codeql_detected_source_root
+
+states/**
+models/**/states/**

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,159 @@
+# Formal models (TLA+)
+
+This folder contains small **TLA+** models used to explore and verify correctness properties of selected eBPF-for-Windows components.
+
+These models are intentionally **bounded and executable** (checked with TLC) so we can:
+
+- catch concurrency / lifecycle hazards (e.g., use-after-free scenarios)
+- document critical invariants and assumptions in a precise way
+- provide “known-buggy” configurations that demonstrate why a fix matters
+
+These models are not meant to be a full formal specification of the entire project.
+
+## What is TLA+?
+
+TLA+ (Temporal Logic of Actions) is a specification language for describing system behavior over time.
+
+In this repo we use it pragmatically:
+
+- **State**: variables describe the system state (e.g., epochs, bucket pointers).
+- **Actions**: steps that transition state (e.g., reader enter/exit, writer update).
+- **Invariants**: properties that must always hold (e.g., “no reclaimed object is observed by an in-epoch reader”).
+- **Model checking (TLC)**: explores all behaviors within finite bounds and finds counterexamples when properties are violated.
+
+## How to run the models
+
+### Prerequisites
+
+- Java (JRE/JDK). On Windows you can install:
+  - `winget install Microsoft.OpenJDK.21`
+
+### TLC
+
+This repo does **not** vendor the TLA+ tools jar. It is downloaded from the official TLA+ releases by the GitHub workflows.
+
+#### Downloading `tla2tools.jar` locally
+
+1. Go to the official TLA+ GitHub releases: https://github.com/tlaplus/tlaplus/releases  
+2. Download the `tla2tools.jar` artifact for the desired version.  
+3. Place it at:
+
+   - `models/tla2tools.jar`
+
+With `tla2tools.jar` in place, you can run TLC from the repo root using the model’s `.cfg` file:
+
+```powershell
+java -cp models\tla2tools.jar tlc2.TLC -config models\<model>\<config>.cfg models\<model>\<spec>.tla
+```
+
+Many models also run faster with multiple workers:
+
+```powershell
+java -cp models\tla2tools.jar tlc2.TLC -workers 8 -terse -nowarning -config models\<model>\<config>.cfg models\<model>\<spec>.tla
+```
+
+TLC writes state exploration artifacts into `states/` folders next to the model by default.
+
+### TLATeX (LaTeX pretty-print)
+
+For a typeset (mathematically formatted) version of each model, this repo checks in the generated `.tex` output under:
+
+- `models/<model>/tlatex/<Spec>.tex`
+
+To regenerate them, you need Java and a LaTeX toolchain installed (because TLATeX runs `latex` to compute alignment). On Ubuntu, this is typically:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y texlive-latex-base
+```
+
+Then run:
+
+```bash
+TLA2TOOLS_JAR=./tla2tools.jar scripts/generate_tlatex.sh
+```
+
+On Windows, you can run the PowerShell version:
+
+```powershell
+pwsh -File scripts\generate_tlatex.ps1 -Tla2ToolsJar .\tla2tools.jar
+```
+
+### Generating PDFs on Windows (from TLATeX output)
+
+If you want a PDF rendering of a model, you can compile the generated TLATeX `.tex` file (for example `models\epoch\tlatex\EpochModel.tex`).
+
+One straightforward option is **MiKTeX**:
+
+```powershell
+winget install MiKTeX.MiKTeX
+```
+
+After installation, open a new terminal so PATH updates are picked up.
+
+Then, from the directory containing the `.tex` file:
+
+- Preferred (handles multiple passes automatically):
+
+```powershell
+latexmk -pdf -interaction=nonstopmode -file-line-error EpochModel.tex
+```
+
+Note: on Windows with MiKTeX, `latexmk` typically requires a Perl runtime (e.g., Strawberry Perl). If `latexmk` fails with “MiKTeX could not find the script engine 'perl'”, either install Perl or use the `pdflatex` fallback below.
+
+- If `latexmk` is not available, run `pdflatex` twice:
+
+```powershell
+pdflatex -interaction=nonstopmode -file-line-error EpochModel.tex
+pdflatex -interaction=nonstopmode -file-line-error EpochModel.tex
+```
+
+This will produce `EpochModel.pdf` next to the `.tex` file.
+
+The GitHub workflow `.github/workflows/tla-plus-models.yml` regenerates these files and fails the build if there are diffs.
+
+## Models in this repo
+
+- `models/epoch/`
+  - Models the epoch-based reclamation scheme and checks safety properties around published/released epochs.
+  - Includes “fixed” and “buggy” configurations to demonstrate the hazard.
+
+- `models/hash_table/`
+  - Models the runtime hash table’s immutable-bucket replacement pattern plus simplified epoch-based reclamation.
+  - Includes a “safe usage” configuration and a deliberately unsafe “use-after-exit” configuration that demonstrates a safety violation.
+
+- `models/ring_buffer/`
+  - Models core ring buffer producer/consumer behavior plus map async-query completion.
+  - Includes a “safe” configuration and a deliberately buggy “publish-before-lock” configuration that demonstrates a safety violation.
+
+- `models/object_array_map/`
+  - Models lock-free reads of object pointers stored in array map slots (prog array / array-of-maps) and the epoch-based lifetime contract that makes them safe.
+  - Includes a “safe” configuration and a deliberately buggy “read outside epoch” configuration that demonstrates a safety violation.
+
+- `models/extension_invoke/`
+  - Models the lock-free "extension still loaded?" check in the invoke fast path (`ReadPointerNoFence` on `program->extension_program_data`) and the ordering assumption that makes it safe.
+  - Includes a “safe” configuration and a deliberately buggy “epoch enter is not a barrier” configuration that demonstrates a safety violation.
+
+## Conformance to implementation
+
+Each model directory should include a short `CONFORMANCE.md` that maps model variables/actions to the corresponding implementation concepts and calls out simplifications.
+
+If you change the implementation in a way that affects:
+
+- memory ordering assumptions (acquire/release publish)
+- lifetime/reclamation semantics
+- API usage requirements (e.g., callers must hold an epoch)
+
+…please update the model and/or its `CONFORMANCE.md`.
+
+## Adding a new model
+
+Suggested structure:
+
+- `<ModelName>.tla`: the spec
+- `<ModelName>.cfg`: a configuration expected to pass
+- `<ModelName>_buggy*.cfg`: one or more configurations expected to fail (optional but encouraged)
+- `README.md`: how to run the model and what it checks
+- `CONFORMANCE.md`: mapping to code + key assumptions
+
+Note: new `.tla` and `.cfg` files should include the repo’s license header in the first lines (see other models for examples).

--- a/models/epoch/CONFORMANCE.md
+++ b/models/epoch/CONFORMANCE.md
@@ -1,0 +1,129 @@
+# Conformance: `libs/runtime/ebpf_epoch.c` vs `models/epoch/EpochModel.tla`
+
+This note explains how the TLA+ model in `models/epoch/EpochModel.tla` relates to the production implementation in `libs/runtime/ebpf_epoch.c`.
+
+The goal is not to claim the model is a line-by-line reproduction. The goal is to make the abstraction **explicit** so reviewers can tell whether the model still represents the same safety argument as the code.
+
+## What the model is proving
+
+The model checks a single core safety property:
+
+- **No reclamation while a reader can still hold a reference**.
+
+In the model this is expressed as `Safety`:
+
+- If `obj_state = "Reclaimed"` then for all CPUs `c`, `reader_holds[c] = FALSE`.
+
+In the implementation, the analogous claim is:
+
+- An allocation/work-item/synchronization entry on a per-CPU free list is only actually freed/queued/signaled once its stamped `freed_epoch` is `<= released_epoch`, and `released_epoch` is computed such that it lags behind the minimum epoch of any active thread.
+
+## Refinement mapping (implementation → model)
+
+This table is the intended mapping from concrete state to model state.
+
+| Model concept | TLA+ variable(s) | Implementation concept | C symbol(s) / mechanism |
+|---|---|---|---|
+| Globally published epoch | `published_epoch` | Global “source of truth” epoch used by readers and retire stamping | `_ebpf_epoch_published_current_epoch` read via `_ebpf_epoch_get_published_epoch()`; advanced by CPU0 with `InterlockedIncrement64(&_ebpf_epoch_published_current_epoch)` in `_ebpf_epoch_messenger_propose_release_epoch()` |
+| Per-CPU cached epoch | `cpu_epoch[c]` | Per-CPU epoch cache used for local tracking (may lag until it processes the propose message) | `_ebpf_epoch_cpu_table[c].current_epoch` set in `_ebpf_epoch_messenger_propose_release_epoch()` |
+| Reader “in epoch” flag | `reader_active[c]` | Thread is currently inside an epoch and is listed on a per-CPU active list | Membership of an `ebpf_epoch_state_t` in `_ebpf_epoch_cpu_table[c].epoch_state_list` (inserted by `ebpf_epoch_enter()`, removed by `ebpf_epoch_exit()`) |
+| Reader captured epoch | `reader_epoch[c]` | The epoch a thread recorded on entry | `epoch_state->epoch` set by `ebpf_epoch_enter()` to `_ebpf_epoch_get_published_epoch()` |
+| Reader currently “holds” object | `reader_holds[c]` | Abstract “the reader still has a reference to the to-be-freed object” | Not represented directly in C; in the implementation this corresponds to “a thread can still access memory that is protected by having entered the epoch and not yet exited” |
+| Retirement stamp (object’s freed_epoch) | `obj_freed_epoch` | When an entry is enqueued for deferred reclamation, it is stamped with an epoch | `header->freed_epoch` in `_ebpf_epoch_insert_in_free_list()`, set to `max(published_epoch, local_epoch)` |
+| Retirement stamp inputs (snapshotted at retirement time) | `retire_published_epoch`, `retire_cpu_epoch` | The values used to compute the retirement stamp at the moment of retirement | In `_ebpf_epoch_insert_in_free_list()`: `published_epoch = _ebpf_epoch_get_published_epoch()` and `local_epoch = cpu_entry->current_epoch` |
+| Release threshold | `released_epoch` | The newest epoch eligible for reclamation | Per-CPU `_ebpf_epoch_cpu_table[c].released_epoch`, computed in `_ebpf_epoch_messenger_commit_release_epoch()` as `message->...released_epoch - 1` |
+| Reclamation | `Reclaim` action | Actual free / queue work-item / signal event for eligible entries | `_ebpf_epoch_release_free_list()` drains entries with `header->freed_epoch <= released_epoch` |
+
+### Notes about the mapping
+
+- The model treats “readers” as CPU-indexed for simplicity (one conceptual reader per CPU). The implementation has many threads per CPU.
+- The implementation’s `released_epoch` is stored per-CPU, but the protocol is intended to make it converge to the same value on all CPUs each computation cycle. The model uses a single global `released_epoch`.
+
+## Key modeled protocol steps vs code
+
+### 1) Advance the published epoch
+
+- Model: `AdvanceEpoch` (CPU0 advances `published_epoch`, others may lag in `cpu_epoch[c]` until they process an update).
+- Code:
+  - CPU0 advances global published epoch in `_ebpf_epoch_messenger_propose_release_epoch()`:
+    - `InterlockedIncrement64(&_ebpf_epoch_published_current_epoch)`.
+  - CPU0 sets its local `current_epoch` and places it into the message.
+
+### 2) Propagate the new epoch to other CPUs
+
+- Model: `ProcessEpochUpdate(c)` updates `cpu_epoch[c]` from the published epoch.
+- Code:
+  - Non-zero CPUs set their local `current_epoch` from `message->message.propose_epoch.current_epoch` when processing `_ebpf_epoch_messenger_propose_release_epoch()`.
+
+### 3) Readers capture an epoch on enter
+
+- Model: `ReaderEnter(c)` sets `reader_epoch[c]` to either the published epoch (fixed) or the CPU-local epoch (buggy mode).
+- Code:
+  - `ebpf_epoch_enter()` stamps `epoch_state->epoch = _ebpf_epoch_get_published_epoch()` (fixed design behavior).
+
+### 4) Retirement stamping
+
+- Model: `Retire(c)` stamps `obj_freed_epoch` as either `Max2(published_epoch, cpu_epoch[c])` (fixed) or `cpu_epoch[c]` (buggy mode).
+- Code:
+  - `_ebpf_epoch_insert_in_free_list()` stamps `header->freed_epoch = max(published_epoch, local_epoch)`.
+
+This is the specific point that prevents the epoch-skew hazard:
+- a reader might have observed a newer published epoch,
+- while a CPU’s `current_epoch` lags,
+- so retirements must not be stamped “too old”.
+
+### 5) Compute and commit a release threshold
+
+- Model: `ComputeRelease` computes a `released_epoch` which never includes the current published epoch.
+- Code:
+  - `_ebpf_epoch_messenger_propose_release_epoch()` computes `minimum_epoch` across all active `epoch_state->epoch` values.
+  - `_ebpf_epoch_messenger_commit_release_epoch()` sets `cpu_entry->released_epoch = minimum_epoch - 1`.
+
+## Shared invariants worth keeping in sync
+
+These are implementation-design invariants that correspond directly to the model’s assumptions/checks.
+
+1) **No release of the current epoch**
+- Model: `released_epoch` is computed as at most `published_epoch - 1`.
+- Code: commit sets `released_epoch = minimum_epoch - 1`, and `minimum_epoch <= current_epoch == published_epoch`.
+
+2) **Eligibility check is epoch-based**
+- Model: `Reclaim` allowed only when `obj_freed_epoch <= released_epoch`.
+- Code: `_ebpf_epoch_release_free_list()` frees entries only when `header->freed_epoch <= released_epoch`.
+
+3) **Readers use the published epoch as source of truth**
+- Model: in the fixed config, `ReaderEnter` uses `published_epoch`.
+- Code: `ebpf_epoch_enter()` reads `_ebpf_epoch_get_published_epoch()`.
+
+4) **Retirements are stamped conservatively**
+- Model: in the fixed config, retirement stamping uses `max(published_epoch, cpu_epoch[c])`.
+- Code: `_ebpf_epoch_insert_in_free_list()` stamps `max(published_epoch, local_epoch)`.
+
+The model checks this stamping rule explicitly via the invariant:
+- `RetireStampIsMaxWhenEnabled`: when `UsePublishedEpochForRetire=TRUE`, the stamped `obj_freed_epoch` equals `Max(retire_published_epoch, retire_cpu_epoch)`.
+
+## Intentional simplifications (where the model does NOT match the code)
+
+These are the abstraction boundaries. If any of these change materially in the implementation, the model may need to be updated.
+
+- **One shared object**: the model tracks a single object; the implementation manages many allocations/work-items/synchronizations.
+- **Boolean “holds”**: the model’s `reader_holds[c]` is a single bit; the code has arbitrary memory accesses while in-epoch.
+- **One reader per CPU**: the model collapses many threads into one representative “reader” per CPU.
+- **Global release threshold**: the model uses one `released_epoch`; the implementation stores it per CPU and updates it via the commit message hop.
+- **Scheduling details omitted**: timers, DPCs, work-queues, and IRQL are not represented.
+- **CPU migration**: the implementation explicitly handles `ebpf_epoch_exit()` on a different CPU; the model does not.
+
+## Practical ways to keep them matched
+
+When changing `libs/runtime/ebpf_epoch.c`, update the model and this mapping if any of these change:
+
+- How `ebpf_epoch_enter()` chooses the epoch value to store.
+- How retirements are stamped (what epoch value is written into `freed_epoch`).
+- How the “release epoch” is computed/committed (especially whether it still lags the minimum active epoch).
+- The condition under which an item is reclaimed.
+
+Suggested review checklist for changes touching epochs:
+
+1) Does the change preserve the four “Shared invariants” above?
+2) Does `EpochModel.cfg` still pass and does `EpochModel_buggy.cfg` still find a counterexample?
+3) If the algorithmic intent changed, should the model be updated to represent the new intent?

--- a/models/epoch/EpochModel.cfg
+++ b/models/epoch/EpochModel.cfg
@@ -1,0 +1,15 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  NCPUS = 2
+  MaxEpoch = 4
+  UsePublishedEpochForReader = TRUE
+  UsePublishedEpochForRetire = TRUE
+
+INVARIANT TypeOK
+INVARIANT ReleaseNeverAhead
+INVARIANT RetireStampIsMaxWhenEnabled
+INVARIANT Safety

--- a/models/epoch/EpochModel.tla
+++ b/models/epoch/EpochModel.tla
@@ -1,0 +1,203 @@
+---------------------------- MODULE EpochModel ----------------------------
+EXTENDS Naturals, FiniteSets, TLC
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+(***************************************************************************
+A small model of the eBPF-for-Windows epoch reclamation protocol focused on
+safety (no reclamation while a reader may still hold a reference).
+
+This model is intentionally simple:
+- One shared object transitions Reachable -> Retired -> Reclaimed.
+- Each CPU has a cached epoch (cpu_epoch[c]) that may lag published_epoch.
+- Readers capture an epoch on entry and may "hold" the object if it was
+  reachable when they read it.
+- Retirement stamps obj_freed_epoch either from cpu_epoch (buggy) or using
+  the globally published epoch (fixed), mirroring the published-epoch fix.
+
+The key safety invariant is:
+  obj_state = "Reclaimed" => no reader_holds[c]
+
+Tune constants in the .cfg files in this folder.
+***************************************************************************)
+
+CONSTANTS
+    NCPUS,                      \* number of CPUs (>= 2 is interesting)
+    MaxEpoch,                   \* bound on epoch increments for finite state
+    UsePublishedEpochForReader, \* if TRUE: reader captures published_epoch
+    UsePublishedEpochForRetire  \* if TRUE: retire stamps Max(published, cpu)
+
+CPUS == 0 .. (NCPUS - 1)
+
+ObjStates == {"Reachable", "Retired", "Reclaimed"}
+
+VARIABLES
+    published_epoch,  \* global single source of truth epoch (monotonic)
+    cpu_epoch,        \* per-CPU cached epoch (may lag)
+    released_epoch,   \* globally computed safe-to-reclaim threshold
+
+    reader_active,    \* reader_active[c] is TRUE if a reader is in epoch on cpu c
+    reader_epoch,     \* reader_epoch[c] is the epoch captured on entry
+    reader_holds,     \* reader_holds[c] indicates the reader still holds the object
+
+    obj_state,        \* Reachable / Retired / Reclaimed
+    obj_freed_epoch,  \* epoch stamped at retirement
+    retire_published_epoch, \* published epoch value observed at retirement time
+    retire_cpu_epoch        \* per-CPU cached epoch value observed at retirement time
+
+vars == <<
+    published_epoch,
+    cpu_epoch,
+    released_epoch,
+    reader_active,
+    reader_epoch,
+    reader_holds,
+    obj_state,
+    obj_freed_epoch,
+    retire_published_epoch,
+    retire_cpu_epoch
+>>
+
+Max2(a, b) == IF a >= b THEN a ELSE b
+
+Min(S) == CHOOSE m \in S : \A x \in S : m <= x
+
+ActiveCPUs == { c \in CPUS : reader_active[c] }
+
+ActiveReaderEpochs == { reader_epoch[c] : c \in ActiveCPUs }
+
+TypeOK ==
+    /\ published_epoch \in 1..MaxEpoch
+    /\ released_epoch \in 0..MaxEpoch
+    /\ cpu_epoch \in [CPUS -> 1..MaxEpoch]
+    /\ reader_active \in [CPUS -> BOOLEAN]
+    /\ reader_epoch \in [CPUS -> 0..MaxEpoch]
+    /\ reader_holds \in [CPUS -> BOOLEAN]
+    /\ obj_state \in ObjStates
+    /\ obj_freed_epoch \in 0..MaxEpoch
+    /\ retire_published_epoch \in 0..MaxEpoch
+    /\ retire_cpu_epoch \in 0..MaxEpoch
+
+Init ==
+    /\ published_epoch = 1
+    /\ cpu_epoch = [c \in CPUS |-> 1]
+    /\ released_epoch = 0
+
+    /\ reader_active = [c \in CPUS |-> FALSE]
+    /\ reader_epoch = [c \in CPUS |-> 0]
+    /\ reader_holds = [c \in CPUS |-> FALSE]
+
+    /\ obj_state = "Reachable"
+    /\ obj_freed_epoch = 0
+    /\ retire_published_epoch = 0
+    /\ retire_cpu_epoch = 0
+
+(***************************************************************************
+Protocol steps
+***************************************************************************)
+
+\* CPU0 advances the global epoch; other CPUs lag until they process an update.
+AdvanceEpoch ==
+    /\ published_epoch < MaxEpoch
+    /\ published_epoch' = published_epoch + 1
+    /\ cpu_epoch' = [cpu_epoch EXCEPT ![0] = published_epoch']
+    /\ UNCHANGED << released_epoch, reader_active, reader_epoch, reader_holds, obj_state, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+\* A non-CPU0 core learns the current published epoch (delayed message processing).
+ProcessEpochUpdate(c) ==
+    /\ c \in CPUS \ {0}
+    /\ cpu_epoch' = [cpu_epoch EXCEPT ![c] = published_epoch]
+    /\ UNCHANGED << published_epoch, released_epoch, reader_active, reader_epoch, reader_holds, obj_state, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+\* Reader enters epoch on a CPU and captures an epoch value.
+ReaderEnter(c) ==
+    /\ c \in CPUS
+    /\ ~reader_active[c]
+    /\ reader_active' = [reader_active EXCEPT ![c] = TRUE]
+    /\ reader_epoch' = [reader_epoch EXCEPT ![c] = IF UsePublishedEpochForReader THEN published_epoch ELSE cpu_epoch[c]]
+    /\ reader_holds' = [reader_holds EXCEPT ![c] = FALSE]
+    /\ UNCHANGED << published_epoch, cpu_epoch, released_epoch, obj_state, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+\* While inside epoch, a reader may load and hold the object if it is reachable.
+ReaderRead(c) ==
+    /\ c \in CPUS
+    /\ reader_active[c]
+    /\ obj_state = "Reachable"
+    /\ reader_holds' = [reader_holds EXCEPT ![c] = TRUE]
+    /\ UNCHANGED << published_epoch, cpu_epoch, released_epoch, reader_active, reader_epoch, obj_state, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+\* Reader exits epoch and drops any reference.
+ReaderExit(c) ==
+    /\ c \in CPUS
+    /\ reader_active[c]
+    /\ reader_active' = [reader_active EXCEPT ![c] = FALSE]
+    /\ reader_holds' = [reader_holds EXCEPT ![c] = FALSE]
+    /\ UNCHANGED << published_epoch, cpu_epoch, released_epoch, reader_epoch, obj_state, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+\* Retire the shared object on some CPU.
+Retire(c) ==
+    /\ c \in CPUS
+    /\ obj_state = "Reachable"
+    /\ obj_state' = "Retired"
+    /\ retire_published_epoch' = published_epoch
+    /\ retire_cpu_epoch' = cpu_epoch[c]
+    /\ obj_freed_epoch' =
+        IF UsePublishedEpochForRetire
+            THEN Max2(published_epoch, cpu_epoch[c])
+            ELSE cpu_epoch[c]
+    /\ UNCHANGED << published_epoch, cpu_epoch, released_epoch, reader_active, reader_epoch, reader_holds >>
+
+\* CPU0 computes a safe release threshold.
+\* If there are active readers with captured epochs, we can only release epochs
+\* strictly less than the minimum active reader epoch.
+ComputeRelease ==
+    /\ LET candidate ==
+            IF ActiveReaderEpochs = {}
+                THEN published_epoch - 1
+                ELSE (Min(ActiveReaderEpochs) - 1)
+       IN released_epoch' = Max2(released_epoch, candidate)
+    /\ UNCHANGED << published_epoch, cpu_epoch, reader_active, reader_epoch, reader_holds, obj_state, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+\* Reclaim when the release threshold covers the object's retirement epoch.
+Reclaim ==
+    /\ obj_state = "Retired"
+    /\ obj_freed_epoch <= released_epoch
+    /\ obj_state' = "Reclaimed"
+    /\ UNCHANGED << published_epoch, cpu_epoch, released_epoch, reader_active, reader_epoch, reader_holds, obj_freed_epoch, retire_published_epoch, retire_cpu_epoch >>
+
+Next ==
+    \/ AdvanceEpoch
+    \/ \E c \in CPUS \ {0} : ProcessEpochUpdate(c)
+    \/ \E c \in CPUS : ReaderEnter(c)
+    \/ \E c \in CPUS : ReaderRead(c)
+    \/ \E c \in CPUS : ReaderExit(c)
+    \/ \E c \in CPUS : Retire(c)
+    \/ ComputeRelease
+    \/ Reclaim
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************
+Properties to check with TLC
+***************************************************************************)
+
+\* "No use-after-free": once reclaimed, no reader can still be holding it.
+Safety == (obj_state = "Reclaimed") => (\A c \in CPUS : ~reader_holds[c])
+
+\* When the published-epoch retirement behavior is enabled, the epoch stamped on
+\* the retired object equals the max() of the values observed at the moment of retirement.
+\* This corresponds to the implementation's:
+\*   header->freed_epoch = max(published_epoch, local_epoch)
+RetireStampIsMaxWhenEnabled ==
+    UsePublishedEpochForRetire =>
+        ((obj_state = "Reachable") =>
+            /\ obj_freed_epoch = 0
+            /\ retire_published_epoch = 0
+            /\ retire_cpu_epoch = 0)
+        /\ ((obj_state \in {"Retired", "Reclaimed"}) =>
+            obj_freed_epoch = Max2(retire_published_epoch, retire_cpu_epoch))
+
+\* Sanity: release should never exceed published.
+ReleaseNeverAhead == released_epoch <= published_epoch
+
+=============================================================================

--- a/models/epoch/EpochModel_buggy.cfg
+++ b/models/epoch/EpochModel_buggy.cfg
@@ -1,0 +1,22 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+\* This model intentionally reflects the pre-fix hazard:
+\* - readers capture per-CPU cached epoch (CPU0 may advance ahead)
+\* - retirement stamps using a potentially stale per-CPU cached epoch
+\*
+\* TLC should find a counterexample that violates Safety.
+\* (RetireStampIsMaxWhenEnabled is checked too, but is gated by UsePublishedEpochForRetire.)
+
+CONSTANTS
+  NCPUS = 2
+  MaxEpoch = 4
+  UsePublishedEpochForReader = FALSE
+  UsePublishedEpochForRetire = FALSE
+
+INVARIANT TypeOK
+INVARIANT ReleaseNeverAhead
+INVARIANT RetireStampIsMaxWhenEnabled
+INVARIANT Safety

--- a/models/epoch/README.md
+++ b/models/epoch/README.md
@@ -1,0 +1,65 @@
+# EpochModel (TLA+)
+
+This folder contains a small TLA+ model of the epoch reclamation protocol, focused on proving the key safety property:
+
+- **No reclamation while any reader can still hold a reference**
+
+Files:
+- `EpochModel.tla`: the TLA+ spec (module `EpochModel`).
+- `EpochModel.cfg`: TLC config for the **fixed** design (should PASS).
+- `EpochModel_buggy.cfg`: TLC config for the **buggy** design (should FAIL with a counterexample).
+- `CONFORMANCE.md`: mapping between the model and the implementation.
+
+## Run it (command line, Windows)
+
+### 1) Install prerequisites
+- Install a recent **Java** (JDK includes a JRE). Java 11+ is fine.
+  - Recommended (Microsoft OpenJDK 21): `winget install Microsoft.OpenJDK.21`
+  - After installing, open a **new terminal** and verify: `java -version`
+  - If `java` still isn't found, use the full path (example):
+    - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -version`
+- Download **TLA+ tools** (`tla2tools.jar`). Options:
+  - Install **TLA+ Toolbox** (recommended) from https://lamport.azurewebsites.net/tla/toolbox.html
+  - Or download `tla2tools.jar` from the TLA+ releases: https://github.com/tlaplus/tlaplus/releases
+
+### 2) Run TLC from the repo root
+
+From the repo root, run (replace the jar path with where you put it). If you already have `models\tla2tools.jar`, you can use that directly:
+
+- Fixed design (expected to PASS):
+  - `java -cp models\tla2tools.jar tlc2.TLC -workers auto -config models\epoch\EpochModel.cfg models\epoch\EpochModel.tla`
+
+- Buggy design (expected to FAIL with a counterexample):
+  - `java -cp models\tla2tools.jar tlc2.TLC -workers auto -config models\epoch\EpochModel_buggy.cfg models\epoch\EpochModel.tla`
+
+What you should see:
+- PASS case ends with `Model checking completed. No error has been found.`
+- Buggy case ends with an invariant violation (Safety), plus a trace you can replay.
+
+Invariants checked:
+- `Safety`: no reader can still hold the object once reclaimed.
+- `ReleaseNeverAhead`: release epoch never exceeds published epoch.
+- `RetireStampIsMaxWhenEnabled`: when `UsePublishedEpochForRetire=TRUE`, retirement stamping is `Max(published_epoch, cpu_epoch[c])` (the model equivalent of `max(published_epoch, local_epoch)`).
+
+## Run it (TLA+ Toolbox)
+
+1. Open TLA+ Toolbox.
+2. **File → Open Spec…**
+   - Point it at `models/epoch/EpochModel.tla`.
+3. Create a new model:
+   - **TLC Model Checker → New Model…**
+4. In the model:
+   - Set **Model Parameters → Spec** to `Spec` (default if the file is open).
+  - Add invariants: `TypeOK`, `ReleaseNeverAhead`, `RetireStampIsMaxWhenEnabled`, `Safety`.
+   - Set constants to match either config:
+     - Fixed: `NCPUS=2`, `MaxEpoch=4`, `UsePublishedEpochForReader=TRUE`, `UsePublishedEpochForRetire=TRUE`
+     - Buggy: same but both flags `FALSE`
+5. Click **Run TLC**.
+
+## Notes / How this relates to the implementation
+
+This model is designed to capture the specific failure mode that motivated the published-epoch fix:
+- CPU0 can hand out a newer epoch to readers while another CPU still uses a stale cached epoch for retirement stamping.
+- If retirement is stamped "too old", the global release computation can incorrectly permit reclamation while a reader still holds a reference.
+
+If you want this model to track the implementation more closely (e.g., explicit propose/commit message states, per-CPU free lists, multiple objects), we can incrementally refine it while keeping the safety invariant as the anchor.

--- a/models/epoch/tlatex/EpochModel.tex
+++ b/models/epoch/tlatex/EpochModel.tex
@@ -1,0 +1,1373 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\@x{}\moduleLeftDash\@xx{ {\MODULE} EpochModel}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals ,\, FiniteSets ,\, TLC}%
+\@x{}%
+\@y{\@s{0}%
+ Copyright (\ensuremath{c}) \ensuremath{eBPF} for Windows contributors
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{0}%
+ SPDX-License-Identifier: \ensuremath{MIT
+}}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+**************************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+A small model of the eBPF-for-Windows epoch reclamation protocol focused on
+ safety (no reclamation while a reader may still hold a reference).
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+This model is intentionally simple\ensuremath{\.{:}
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-}} One shared object transitions \ensuremath{Reachable
+ \.{\rightarrow} Retired \.{\rightarrow} Reclaimed}.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ - Each \ensuremath{CPU} has a cached epoch (\ensuremath{cpu\_epoch[c]}) that
+ may lag \ensuremath{published\_epoch}.
+\end{cpar}%
+\begin{cpar}{0}{T}{T}{0}{2.5}{%
+-}%
+Readers capture an epoch on entry and may ``hold'' the object if it was
+ reachable when they read it.
+\end{cpar}%
+\begin{cpar}{1}{T}{T}{0}{2.5}{%
+-}%
+ Retirement stamps \ensuremath{obj\_freed\_epoch} either from
+ \ensuremath{cpu\_epoch} (buggy) or using
+ the globally published epoch (fixed), mirroring the published-epoch fix.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{T}{F}{0}{5.0}{}%
+The key safety invariant is:
+ \ensuremath{obj\_state \.{=} \@w{Reclaimed} \.{\implies}} no
+ \ensuremath{reader\_holds[c]
+}%
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Tune constants in the \ensuremath{.cfg} files in this folder.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+**************************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ {\CONSTANTS}}%
+\@x{\@s{16.4} NCPUS ,\,\@s{93.03}}%
+\@y{\@s{0}%
+ number of \ensuremath{CPUs} (\ensuremath{\.{\geq} 2} is interesting)
+}%
+\@xx{}%
+\@x{\@s{16.4} MaxEpoch ,\,\@s{83.48}}%
+\@y{\@s{0}%
+ bound on epoch increments for finite state
+}%
+\@xx{}%
+\@x{\@s{16.4} UsePublishedEpochForReader ,\,}%
+\@y{\@s{0}%
+ if \ensuremath{{\TRUE}}: reader captures \ensuremath{published\_epoch
+}}%
+\@xx{}%
+\@x{\@s{16.4} UsePublishedEpochForRetire\@s{10.26}}%
+\@y{\@s{0}%
+ if \ensuremath{{\TRUE}}: retire stamps \ensuremath{Max(published,\, cpu)
+}}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ CPUS \.{\defeq} 0 \.{\dotdot} ( NCPUS \.{-} 1 )}%
+\@pvspace{8.0pt}%
+ \@x{ ObjStates \.{\defeq} \{\@w{Reachable} ,\,\@w{Retired} ,\,\@w{Reclaimed}
+ \}}%
+\@pvspace{8.0pt}%
+\@x{ {\VARIABLES}}%
+\@x{\@s{16.4} published\_epoch ,\,\@s{4.1}}%
+\@y{\@s{0}%
+ global single source of truth epoch (monotonic)
+}%
+\@xx{}%
+\@x{\@s{16.4} cpu\_epoch ,\,\@s{28.38}}%
+\@y{\@s{0}%
+ per-CPU cached epoch (may lag)
+}%
+\@xx{}%
+\@x{\@s{16.4} released\_epoch ,\,\@s{9.85}}%
+\@y{\@s{0}%
+ globally computed safe-to-reclaim threshold
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{\@s{16.4} reader\_active ,\,\@s{14.55}}%
+\@y{\@s{0}%
+ \ensuremath{reader\_active[c]} is \ensuremath{{\TRUE}} if a reader is in
+ epoch on cpu \ensuremath{c
+}}%
+\@xx{}%
+\@x{\@s{16.4} reader\_epoch ,\,\@s{16.32}}%
+\@y{\@s{0}%
+ \ensuremath{reader\_epoch[c]} is the epoch captured on entry
+}%
+\@xx{}%
+\@x{\@s{16.4} reader\_holds ,\,\@s{17.80}}%
+\@y{\@s{0}%
+ \ensuremath{reader\_holds[c]} indicates the reader still holds the object
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{\@s{16.4} obj\_state ,\,\@s{33.09}}%
+\@y{\@s{0}%
+ Reachable / \ensuremath{Retired} / \ensuremath{Reclaimed
+}}%
+\@xx{}%
+\@x{\@s{16.4} obj\_freed\_epoch ,\,\@s{4.41}}%
+\@y{\@s{0}%
+ epoch stamped at retirement
+}%
+\@xx{}%
+\@x{\@s{16.4} retire\_published\_epoch ,\,}%
+\@y{\@s{0}%
+ published epoch value observed at retirement time
+}%
+\@xx{}%
+\@x{\@s{16.4} retire\_cpu\_epoch\@s{30.39}}%
+\@y{\@s{0}%
+ per-CPU cached epoch value observed at retirement time
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ vars \.{\defeq} {\langle}}%
+\@x{\@s{16.4} published\_epoch ,\,}%
+\@x{\@s{16.4} cpu\_epoch ,\,}%
+\@x{\@s{16.4} released\_epoch ,\,}%
+\@x{\@s{16.4} reader\_active ,\,}%
+\@x{\@s{16.4} reader\_epoch ,\,}%
+\@x{\@s{16.4} reader\_holds ,\,}%
+\@x{\@s{16.4} obj\_state ,\,}%
+\@x{\@s{16.4} obj\_freed\_epoch ,\,}%
+\@x{\@s{16.4} retire\_published\_epoch ,\,}%
+\@x{\@s{16.4} retire\_cpu\_epoch}%
+\@x{ {\rangle}}%
+\@pvspace{8.0pt}%
+ \@x{ Max2 ( a ,\, b ) \.{\defeq} {\IF} a\@s{12.70} \.{\geq} b \.{\THEN} a
+ \.{\ELSE} b}%
+\@pvspace{8.0pt}%
+ \@x{ Min ( S ) \.{\defeq} {\CHOOSE} m \.{\in} S \.{:} \A\, x \.{\in} S \.{:}
+ m \.{\leq} x}%
+\@pvspace{8.0pt}%
+\@x{ ActiveCPUs \.{\defeq} \{ c \.{\in} CPUS \.{:} reader\_active [ c ] \}}%
+\@pvspace{8.0pt}%
+ \@x{ ActiveReaderEpochs \.{\defeq} \{ reader\_epoch [ c ] \.{:} c \.{\in}
+ ActiveCPUs \}}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq}}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} published\_epoch \.{\in} 1 \.{\dotdot}
+ MaxEpoch}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} released\_epoch \.{\in} 0 \.{\dotdot}
+ MaxEpoch}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} cpu\_epoch \.{\in} [ CPUS \.{\rightarrow} 1
+ \.{\dotdot} MaxEpoch ]}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} reader\_active \.{\in} [ CPUS
+ \.{\rightarrow} {\BOOLEAN} ]}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} reader\_epoch \.{\in} [ CPUS \.{\rightarrow}
+ 0 \.{\dotdot} MaxEpoch ]}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} reader\_holds\@s{1.47} \.{\in} [ CPUS
+ \.{\rightarrow} {\BOOLEAN} ]}%
+\@x{\@s{16.4} \.{\land}\@s{9.74} obj\_state \.{\in} ObjStates}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} obj\_freed\_epoch \.{\in} 0 \.{\dotdot}
+ MaxEpoch}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} retire\_published\_epoch \.{\in} 0
+ \.{\dotdot} MaxEpoch}%
+ \@x{\@s{16.4} \.{\land}\@s{9.74} retire\_cpu\_epoch \.{\in} 0 \.{\dotdot}
+ MaxEpoch}%
+\@pvspace{8.0pt}%
+\@x{ Init \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} published\_epoch \.{=} 1}%
+\@x{\@s{16.4} \.{\land} cpu\_epoch \.{=} [ c \.{\in} CPUS \.{\mapsto} 1 ]}%
+\@x{\@s{16.4} \.{\land} released\_epoch\@s{2.73} \.{=} 0}%
+\@pvspace{8.0pt}%
+ \@x{\@s{16.4} \.{\land} reader\_active \.{=} [ c \.{\in} CPUS \.{\mapsto}
+ {\FALSE} ]}%
+\@x{\@s{16.4} \.{\land} reader\_epoch \.{=} [ c \.{\in} CPUS \.{\mapsto} 0 ]}%
+ \@x{\@s{16.4} \.{\land} reader\_holds\@s{1.47} \.{=} [ c \.{\in} CPUS
+ \.{\mapsto} {\FALSE} ]}%
+\@pvspace{8.0pt}%
+\@x{\@s{16.4} \.{\land} obj\_state \.{=}\@w{Reachable}}%
+\@x{\@s{16.4} \.{\land} obj\_freed\_epoch \.{=} 0}%
+\@x{\@s{16.4} \.{\land} retire\_published\_epoch \.{=} 0}%
+\@x{\@s{16.4} \.{\land} retire\_cpu\_epoch \.{=} 0}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+**************************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Protocol steps
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+**************************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{}%
+\@y{\@s{0}%
+ \ensuremath{CPU0} advances the global epoch; other \ensuremath{CPUs} lag
+ until they process an update.
+}%
+\@xx{}%
+\@x{ AdvanceEpoch \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} published\_epoch \.{<} MaxEpoch}%
+ \@x{\@s{16.4} \.{\land} published\_epoch \.{'} \.{=} published\_epoch \.{+}
+ 1}%
+ \@x{\@s{16.4} \.{\land} cpu\_epoch \.{'} \.{=} [ cpu\_epoch {\EXCEPT} {\bang}
+ [ 0 ] \.{=} published\_epoch \.{'} ]}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} released\_epoch ,\,
+ reader\_active ,\, reader\_epoch ,\, reader\_holds ,\, obj\_state ,\,
+ obj\_freed\_epoch ,\, retire\_published\_epoch ,\, retire\_cpu\_epoch
+ {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ A non-CPU0 core learns the current published epoch (delayed message
+ processing).
+}%
+\@xx{}%
+\@x{ ProcessEpochUpdate ( c ) \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} c \.{\in} CPUS \.{\,\backslash\,} \{ 0 \}}%
+ \@x{\@s{16.4} \.{\land} cpu\_epoch \.{'} \.{=} [ cpu\_epoch {\EXCEPT} {\bang}
+ [ c ] \.{=} published\_epoch ]}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, reader\_active ,\, reader\_epoch ,\, reader\_holds ,\,
+ obj\_state ,\, obj\_freed\_epoch ,\, retire\_published\_epoch ,\,
+ retire\_cpu\_epoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Reader enters epoch on a \ensuremath{CPU} and captures an epoch value.
+}%
+\@xx{}%
+\@x{ ReaderEnter ( c ) \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} c \.{\in} CPUS}%
+\@x{\@s{16.4} \.{\land} {\lnot} reader\_active [ c ]}%
+ \@x{\@s{16.4} \.{\land} reader\_active \.{'} \.{=} [ reader\_active {\EXCEPT}
+ {\bang} [ c ] \.{=} {\TRUE} ]}%
+ \@x{\@s{16.4} \.{\land} reader\_epoch \.{'} \.{=} [ reader\_epoch {\EXCEPT}
+ {\bang} [ c ] \.{=} {\IF} UsePublishedEpochForReader \.{\THEN}
+ published\_epoch \.{\ELSE} cpu\_epoch [ c ] ]}%
+ \@x{\@s{16.4} \.{\land} reader\_holds \.{'}\@s{1.47} \.{=} [ reader\_holds
+ {\EXCEPT} {\bang} [ c ]\@s{1.47} \.{=} {\FALSE} ]}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ cpu\_epoch ,\, released\_epoch ,\, obj\_state ,\, obj\_freed\_epoch ,\,
+ retire\_published\_epoch ,\, retire\_cpu\_epoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ While inside epoch, a reader may load and hold the object if it is reachable.
+}%
+\@xx{}%
+\@x{ ReaderRead ( c ) \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} c \.{\in} CPUS}%
+\@x{\@s{16.4} \.{\land} reader\_active [ c ]}%
+\@x{\@s{16.4} \.{\land} obj\_state \.{=}\@w{Reachable}}%
+ \@x{\@s{16.4} \.{\land} reader\_holds \.{'} \.{=} [ reader\_holds {\EXCEPT}
+ {\bang} [ c ] \.{=} {\TRUE} ]}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ cpu\_epoch ,\, released\_epoch ,\, reader\_active ,\, reader\_epoch ,\,
+ obj\_state ,\, obj\_freed\_epoch ,\, retire\_published\_epoch ,\,
+ retire\_cpu\_epoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Reader exits epoch and drops any reference.
+}%
+\@xx{}%
+\@x{ ReaderExit ( c ) \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} c \.{\in} CPUS}%
+\@x{\@s{16.4} \.{\land} reader\_active [ c ]}%
+ \@x{\@s{16.4} \.{\land} reader\_active \.{'} \.{=} [ reader\_active {\EXCEPT}
+ {\bang} [ c ] \.{=} {\FALSE} ]}%
+ \@x{\@s{16.4} \.{\land} reader\_holds \.{'} \.{=} [ reader\_holds {\EXCEPT}
+ {\bang} [ c ] \.{=} {\FALSE} ]}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ cpu\_epoch ,\, released\_epoch ,\, reader\_epoch ,\, obj\_state ,\,
+ obj\_freed\_epoch ,\, retire\_published\_epoch ,\, retire\_cpu\_epoch
+ {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Retire the shared object on some \ensuremath{CPU}.
+}%
+\@xx{}%
+\@x{ Retire ( c ) \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} c \.{\in} CPUS}%
+\@x{\@s{16.4} \.{\land} obj\_state \.{=}\@w{Reachable}}%
+\@x{\@s{16.4} \.{\land} obj\_state \.{'} \.{=}\@w{Retired}}%
+ \@x{\@s{16.4} \.{\land} retire\_published\_epoch \.{'} \.{=}
+ published\_epoch}%
+\@x{\@s{16.4} \.{\land} retire\_cpu\_epoch \.{'} \.{=} cpu\_epoch [ c ]}%
+\@x{\@s{16.4} \.{\land} obj\_freed\_epoch \.{'} \.{=}}%
+\@x{\@s{31.61} {\IF} UsePublishedEpochForRetire}%
+\@x{\@s{47.86} \.{\THEN} Max2 ( published\_epoch ,\, cpu\_epoch [ c ] )}%
+\@x{\@s{47.86} \.{\ELSE} cpu\_epoch [ c ]}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ cpu\_epoch ,\, released\_epoch ,\, reader\_active ,\, reader\_epoch ,\,
+ reader\_holds {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ \ensuremath{CPU0} computes a safe release threshold.
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{0}%
+ If there are active readers with captured epochs, we can only release epochs
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{0}%
+ strictly less than the minimum active reader epoch.
+}%
+\@xx{}%
+\@x{ ComputeRelease \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} \.{\LET} candidate \.{\defeq}}%
+\@x{\@s{52.01} {\IF} ActiveReaderEpochs \.{=} \{ \}}%
+\@x{\@s{68.26} \.{\THEN} published\_epoch \.{-} 1}%
+\@x{\@s{68.26} \.{\ELSE} ( Min ( ActiveReaderEpochs ) \.{-} 1 )}%
+ \@x{\@s{27.51} \.{\IN} released\_epoch \.{'} \.{=} Max2 ( released\_epoch ,\,
+ candidate )}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ cpu\_epoch ,\, reader\_active ,\, reader\_epoch ,\, reader\_holds ,\,
+ obj\_state ,\, obj\_freed\_epoch ,\, retire\_published\_epoch ,\,
+ retire\_cpu\_epoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Reclaim when the release threshold covers the object\mbox{'}s retirement
+ epoch.
+}%
+\@xx{}%
+\@x{ Reclaim \.{\defeq}}%
+\@x{\@s{16.4} \.{\land} obj\_state \.{=}\@w{Retired}}%
+\@x{\@s{16.4} \.{\land} obj\_freed\_epoch \.{\leq} released\_epoch}%
+\@x{\@s{16.4} \.{\land} obj\_state \.{'} \.{=}\@w{Reclaimed}}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ cpu\_epoch ,\, released\_epoch ,\, reader\_active ,\, reader\_epoch ,\,
+ reader\_holds ,\, obj\_freed\_epoch ,\, retire\_published\_epoch ,\,
+ retire\_cpu\_epoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ Next \.{\defeq}}%
+\@x{\@s{16.4} \.{\lor} AdvanceEpoch}%
+ \@x{\@s{16.4} \.{\lor} \E\, c \.{\in} CPUS \.{\,\backslash\,} \{ 0 \} \.{:}
+ ProcessEpochUpdate ( c )}%
+\@x{\@s{16.4} \.{\lor} \E\, c \.{\in} CPUS \.{:} ReaderEnter ( c )}%
+\@x{\@s{16.4} \.{\lor} \E\, c \.{\in} CPUS \.{:} ReaderRead ( c )}%
+\@x{\@s{16.4} \.{\lor} \E\, c \.{\in} CPUS \.{:} ReaderExit ( c )}%
+\@x{\@s{16.4} \.{\lor} \E\, c \.{\in} CPUS \.{:} Retire ( c )}%
+\@x{\@s{16.4} \.{\lor} ComputeRelease}%
+\@x{\@s{16.4} \.{\lor} Reclaim}%
+\@pvspace{8.0pt}%
+\@x{ Spec \.{\defeq} Init \.{\land} {\Box} [ Next ]_{ vars}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+**************************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Properties to check with \ensuremath{TLC
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+**************************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{}%
+\@y{\@s{0}%
+ ``No use-after-free'': once reclaimed, no reader can still be holding it.
+}%
+\@xx{}%
+ \@x{ Safety \.{\defeq} ( obj\_state \.{=}\@w{Reclaimed} ) \.{\implies} ( \A\,
+ c \.{\in} CPUS \.{:} {\lnot} reader\_holds [ c ] )}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ When the published-epoch retirement behavior is enabled, the epoch stamped on
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{0}%
+ the retired object equals the \ensuremath{max()} of the values observed at
+ the moment of retirement.
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{0}%
+ This corresponds to the implementation\mbox{'}s:
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{5.0}%
+ header\ensuremath{\.{\rightarrow}freed\_epoch \.{=} max(published\_epoch,\,
+ local\_epoch)
+}}%
+\@xx{}%
+\@x{ RetireStampIsMaxWhenEnabled \.{\defeq}}%
+\@x{\@s{16.4} UsePublishedEpochForRetire \.{\implies}}%
+\@x{\@s{32.8} ( ( obj\_state \.{=}\@w{Reachable} ) \.{\implies}}%
+\@x{\@s{48.77} \.{\land} obj\_freed\_epoch \.{=} 0}%
+\@x{\@s{48.77} \.{\land} retire\_published\_epoch \.{=} 0}%
+\@x{\@s{48.77} \.{\land} retire\_cpu\_epoch \.{=} 0 )}%
+ \@x{\@s{32.8} \.{\land} ( ( obj\_state \.{\in} \{\@w{Retired}
+ ,\,\@w{Reclaimed} \} ) \.{\implies}}%
+ \@x{\@s{47.79} obj\_freed\_epoch \.{=} Max2 ( retire\_published\_epoch ,\,
+ retire\_cpu\_epoch ) )}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Sanity: release should never exceed published.
+}%
+\@xx{}%
+\@x{ ReleaseNeverAhead \.{\defeq} released\_epoch \.{\leq} published\_epoch}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/models/extension_invoke/CONFORMANCE.md
+++ b/models/extension_invoke/CONFORMANCE.md
@@ -1,0 +1,30 @@
+# Conformance notes: invoke fast-path loaded-check
+
+## What this model corresponds to
+
+This model captures the essence of the lock-free loaded-check in the invoke fast path:
+
+- In [libs/execution_context/ebpf_program.c](libs/execution_context/ebpf_program.c), `ebpf_program_invoke()` checks `program->extension_program_data` via `ReadPointerNoFence(...)` and bails out if it is `NULL`.
+- In [libs/execution_context/ebpf_link.c](libs/execution_context/ebpf_link.c), the link invoke path enters an epoch (`ebpf_epoch_enter(...)`) before calling `ebpf_program_invoke()`.
+- In [libs/execution_context/ebpf_program.c](libs/execution_context/ebpf_program.c), the program-information detach path clears `program->extension_program_data` and then calls `ebpf_epoch_synchronize()` when the program is visible to other threads.
+
+## Mapping of model state to implementation concepts
+
+- `ext_ptr` (0/1) represents `program->extension_program_data` being `NULL` or non-`NULL`.
+- `ext_alive` represents whether the memory reachable from `extension_program_data` is still valid (not yet freed).
+- `DetachClear` models setting `program->extension_program_data = NULL` under the lock/unlock barrier.
+- `DetachFree` models freeing the duplicated program data structure (via `ebpf_program_data_free(...)`) after epoch synchronization.
+
+Note: the real detach implementation’s ordering between clearing the pointer, freeing the duplicated program data, and synchronizing epochs is more detailed than this model. This model intentionally treats reclamation as happening only after epoch synchronization to isolate the memory-ordering hazard of a NoFence read without an epoch-enter barrier. If you want to validate use-after-free under a worst-case “detach can overlap invoke” schedule, the model should be extended to reflect the exact ordering and allowed concurrency.
+- `InvokerEnterEpoch` models the caller entering an epoch (`ebpf_epoch_enter(...)`).
+- `InvokerReadPointerNoFence` models `ReadPointerNoFence(&program->extension_program_data)`.
+  - If `EpochEnterIsBarrier=TRUE`, the read must see the current value.
+  - If `EpochEnterIsBarrier=FALSE`, the read may see a stale previous value.
+- `InvokerUse` abstracts any dereference/use of data reachable from the pointer.
+
+## Key assumption being validated
+
+The safety of using `ReadPointerNoFence` here depends on the documented property:
+- entering the epoch provides sufficient ordering so that a NoFence pointer read observes the up-to-date value (or otherwise cannot observe a freed object).
+
+The buggy configuration intentionally violates this assumption by setting `EpochEnterIsBarrier=FALSE`.

--- a/models/extension_invoke/ExtensionInvokeModel.cfg
+++ b/models/extension_invoke/ExtensionInvokeModel.cfg
@@ -1,0 +1,10 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT Safety
+
+CONSTANTS
+  EpochEnterIsBarrier = TRUE

--- a/models/extension_invoke/ExtensionInvokeModel.tla
+++ b/models/extension_invoke/ExtensionInvokeModel.tla
@@ -1,0 +1,145 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+---- MODULE ExtensionInvokeModel ----
+EXTENDS Naturals, TLC
+
+(*****************************************************************
+Bounded, executable TLA+ model of the lock-free "is the extension
+still loaded?" check in the invoke fast path.
+
+Source motivation:
+- ebpf_program_invoke() checks program->extension_program_data via
+  ReadPointerNoFence() and bails out if it's NULL.
+- The caller (e.g., ebpf_link invoke path) enters an epoch before
+  invoking; ebpf_epoch_enter is documented as a full memory barrier.
+- Detach/unload clears extension_program_data under a lock/unlock
+  barrier and then synchronizes epochs before proceeding.
+
+What this model focuses on:
+- Whether a NoFence pointer read is safe when ordered by an epoch-enter
+  barrier.
+
+This model is intentionally small and does not model:
+- NMR semantics, provider/client call ordering, or IRQL constraints
+- explicit rundown reference protection (ExAcquireRundownProtection)
+- multiple concurrent invokers
+- actual pointer values (uses 0/1) or program info contents
+*****************************************************************)
+
+CONSTANTS
+  EpochEnterIsBarrier \* BOOLEAN: if TRUE, entering an epoch provides a full barrier.
+
+ASSUME EpochEnterIsBarrier \in BOOLEAN
+
+Ptr == {0, 1}
+
+VARIABLES
+  ext_ptr,        \* 0 means NULL, 1 means non-NULL (loaded)
+  stale_ptr,      \* last seen value of ext_ptr (models a potentially stale cached value)
+  ext_alive,      \* TRUE if the pointed-to data is still valid (not freed)
+  inv_in_epoch,   \* invoker is executing inside an epoch
+  inv_barrier,    \* whether the invoker has executed an ordering barrier
+  inv_loaded_ptr, \* value read by ReadPointerNoFence
+  inv_using       \* invoker is using the extension program data
+
+Vars == <<ext_ptr, stale_ptr, ext_alive, inv_in_epoch, inv_barrier, inv_loaded_ptr, inv_using>>
+
+TypeOK ==
+  /\ ext_ptr \in Ptr
+  /\ stale_ptr \in Ptr
+  /\ ext_alive \in BOOLEAN
+  /\ inv_in_epoch \in BOOLEAN
+  /\ inv_barrier \in BOOLEAN
+  /\ inv_loaded_ptr \in Ptr
+  /\ inv_using \in BOOLEAN
+
+(*****************************************************************
+Initialization: extension is loaded and its program data is alive.
+*****************************************************************)
+Init ==
+  /\ ext_ptr = 1
+  /\ stale_ptr = 1
+  /\ ext_alive = TRUE
+  /\ inv_in_epoch = FALSE
+  /\ inv_barrier = FALSE
+  /\ inv_loaded_ptr = 0
+  /\ inv_using = FALSE
+
+(*****************************************************************
+Detach/unload actions.
+
+We model the "clear pointer" step and the "free program data" step.
+The free step is gated by "no invoker currently in an epoch", which is
+an abstraction of ebpf_epoch_synchronize().
+*****************************************************************)
+DetachClear ==
+  /\ ext_ptr = 1
+  /\ ext_ptr' = 0
+  /\ stale_ptr' = ext_ptr
+  /\ UNCHANGED <<ext_alive, inv_in_epoch, inv_barrier, inv_loaded_ptr, inv_using>>
+
+DetachFree ==
+  /\ ext_ptr = 0
+  /\ ext_alive = TRUE
+  /\ inv_in_epoch = FALSE
+  /\ ext_alive' = FALSE
+  /\ UNCHANGED <<ext_ptr, stale_ptr, inv_in_epoch, inv_barrier, inv_loaded_ptr, inv_using>>
+
+(*****************************************************************
+Invoker actions.
+
+The invoke fast path performs a NoFence read of ext_ptr.
+- If the invoker has a barrier (inv_barrier = TRUE), it must read the
+  current value of ext_ptr.
+- If the invoker does NOT have a barrier, it may read a stale value.
+
+The model then allows the invoker to "use" the data only if the loaded
+pointer is non-NULL.
+*****************************************************************)
+InvokerEnterEpoch ==
+  /\ inv_in_epoch = FALSE
+  /\ inv_in_epoch' = TRUE
+  /\ inv_barrier' = EpochEnterIsBarrier
+  /\ UNCHANGED <<ext_ptr, stale_ptr, ext_alive, inv_loaded_ptr, inv_using>>
+
+InvokerReadPointerNoFence ==
+  /\ inv_in_epoch = TRUE
+  /\ inv_loaded_ptr = 0
+  /\ inv_using = FALSE
+  /\ IF inv_barrier
+        THEN inv_loaded_ptr' = ext_ptr
+        ELSE inv_loaded_ptr' \in {ext_ptr, stale_ptr}
+  /\ UNCHANGED <<ext_ptr, stale_ptr, ext_alive, inv_in_epoch, inv_barrier, inv_using>>
+
+InvokerUse ==
+  /\ inv_in_epoch = TRUE
+  /\ inv_loaded_ptr = 1
+  /\ inv_using = FALSE
+  /\ inv_using' = TRUE
+  /\ UNCHANGED <<ext_ptr, stale_ptr, ext_alive, inv_in_epoch, inv_barrier, inv_loaded_ptr>>
+
+InvokerFinish ==
+  /\ inv_in_epoch = TRUE
+  /\ inv_using' = FALSE
+  /\ inv_loaded_ptr' = 0
+  /\ inv_in_epoch' = FALSE
+  /\ inv_barrier' = FALSE
+  /\ UNCHANGED <<ext_ptr, stale_ptr, ext_alive>>
+
+Next ==
+  DetachClear
+  \/ DetachFree
+  \/ InvokerEnterEpoch
+  \/ InvokerReadPointerNoFence
+  \/ InvokerUse
+  \/ InvokerFinish
+
+Spec == Init /\ [][Next]_Vars
+
+(*****************************************************************
+Safety property: the invoker must never use freed extension data.
+*****************************************************************)
+Safety == inv_using => ext_alive
+
+====

--- a/models/extension_invoke/ExtensionInvokeModel_buggy_epoch_enter_not_barrier.cfg
+++ b/models/extension_invoke/ExtensionInvokeModel_buggy_epoch_enter_not_barrier.cfg
@@ -1,0 +1,10 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT Safety
+
+CONSTANTS
+  EpochEnterIsBarrier = FALSE

--- a/models/extension_invoke/README.md
+++ b/models/extension_invoke/README.md
@@ -1,0 +1,40 @@
+# Invoke fast-path "extension still loaded?" TLA+ Model
+
+This folder contains a bounded TLA+ model of the lock-free loaded-check in the invoke fast path:
+
+- `ebpf_program_invoke()` checks `program->extension_program_data` via a `ReadPointerNoFence(...)` and returns `EBPF_EXTENSION_FAILED_TO_LOAD` if it is `NULL`.
+- The high-volume invoke callers (e.g., link invoke) enter an epoch before calling `ebpf_program_invoke()`.
+- The code comments rely on `ebpf_epoch_enter` being a full memory barrier, making the `ReadPointerNoFence` safe when performed after entering the epoch.
+
+## What the model checks
+
+Safety invariant (`Safety`):
+- The invoker must never use extension program data after it has been freed.
+
+The model demonstrates why the barrier property matters:
+- If epoch-enter is a real barrier, the NoFence read must observe the current pointer value.
+- If epoch-enter is *not* a barrier, the NoFence read may observe a stale non-`NULL` pointer even after unload has cleared the pointer and freed the data.
+
+## Files
+
+- `ExtensionInvokeModel.tla`: the model.
+- `ExtensionInvokeModel.cfg`: safe configuration (expected to pass).
+- `ExtensionInvokeModel_buggy_epoch_enter_not_barrier.cfg`: deliberately unsafe configuration (expected to fail `Safety`).
+
+## Running TLC locally
+
+From the repo root:
+
+- Safe model (expected PASS):
+  - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -cp models\tla2tools.jar tlc2.TLC -workers auto models\extension_invoke\ExtensionInvokeModel.tla -config models\extension_invoke\ExtensionInvokeModel.cfg`
+
+- Buggy model (expected FAIL):
+  - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -cp models\tla2tools.jar tlc2.TLC -workers auto models\extension_invoke\ExtensionInvokeModel.tla -config models\extension_invoke\ExtensionInvokeModel_buggy_epoch_enter_not_barrier.cfg`
+
+## Notes / limitations
+
+- Single invoker and a single extension program data pointer.
+- Abstracts pointer values to `0/1` and models "stale reads" as nondeterministically returning the last value.
+- Abstracts `ebpf_epoch_synchronize()` as "free is only allowed when no invoker is currently in an epoch".
+- The real detach path in the code does additional steps (lock/unlock barrier, rundown wait, etc.) and its exact free/clear ordering is not modeled here; this model is narrowly focused on the ordering requirement behind using `ReadPointerNoFence`.
+- Does not model rundown protection or NMR call ordering.

--- a/models/extension_invoke/tlatex/ExtensionInvokeModel.tex
+++ b/models/extension_invoke/tlatex/ExtensionInvokeModel.tex
@@ -1,0 +1,1218 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{\,\backslash\,}}* Copyright (c) \ensuremath{eBPF} for Windows
+ contributors
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{\,\backslash\,}}* SPDX-License-Identifier: \ensuremath{MIT
+}%
+\end{cpar}%
+\end{lcom}%
+ \@x{}\moduleLeftDash\@xx{ {\MODULE}
+ ExtensionInvokeModel}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals ,\, TLC}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Bounded, executable TLA+ model of the lock-free ``is the extension
+ still loaded\.{?}'' check in the invoke fast path.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+Source motivation:
+ - \ensuremath{ebpf\_program\_invoke()} checks
+ program\ensuremath{\.{\rightarrow}extension\_program\_data} via
+\end{cpar}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+\ensuremath{ReadPointerNoFence()} and bails out if it\mbox{'}s NULL.
+\end{cpar}%
+\begin{cpar}{1}{T}{T}{0}{2.5}{%
+-}%
+ The caller (\ensuremath{e.g}., \ensuremath{ebpf\_link} invoke path) enters an
+ epoch before
+ invoking; \ensuremath{ebpf\_epoch\_enter} is documented as a full memory
+ barrier.
+\end{cpar}%
+\begin{cpar}{1}{T}{T}{0}{2.5}{%
+-}%
+Detach/unload clears \ensuremath{extension\_program\_data} under a lock/unlock
+ barrier and then synchronizes epochs before proceeding.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+What this model focuses on:
+ - Whether a \ensuremath{NoFence} pointer read is safe when ordered by an
+ epoch-enter
+\end{cpar}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+barrier.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+This model is intentionally small and does not model:
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ - \ensuremath{NMR} semantics, provider/client call ordering, or
+ \ensuremath{IRQL} constraints
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ - explicit rundown reference protection
+ (\ensuremath{ExAcquireRundownProtection})
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+- multiple concurrent invokers
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+- actual pointer values (uses 0/1) or program info contents
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ {\CONSTANTS}}%
+\@x{\@s{8.2} EpochEnterIsBarrier}%
+\@y{\@s{0}%
+ \ensuremath{{\BOOLEAN}}: if \ensuremath{{\TRUE}}, entering an epoch provides
+ a full barrier.
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ {\ASSUME} EpochEnterIsBarrier \.{\in} {\BOOLEAN}}%
+\@pvspace{8.0pt}%
+\@x{ Ptr \.{\defeq} \{ 0 ,\, 1 \}}%
+\@pvspace{8.0pt}%
+\@x{ {\VARIABLES}}%
+\@x{\@s{8.2} ext\_ptr ,\,\@s{32.96}}%
+\@y{\@s{0}%
+ 0 means NULL, 1 means non-NULL (loaded)
+}%
+\@xx{}%
+\@x{\@s{8.2} stale\_ptr ,\,\@s{26.04}}%
+\@y{\@s{0}%
+ last seen value of \ensuremath{ext\_ptr} (models a potentially stale cached
+ value)
+}%
+\@xx{}%
+\@x{\@s{8.2} ext\_alive ,\,\@s{26.00}}%
+\@y{\@s{0}%
+ \ensuremath{{\TRUE}} if the pointed-to data is still valid (not freed)
+}%
+\@xx{}%
+\@x{\@s{8.2} inv\_in\_epoch ,\,\@s{7.60}}%
+\@y{\@s{0}%
+ invoker is executing inside an epoch
+}%
+\@xx{}%
+\@x{\@s{8.2} inv\_barrier ,\,\@s{15.24}}%
+\@y{\@s{0}%
+ whether the invoker has executed an ordering barrier
+}%
+\@xx{}%
+\@x{\@s{8.2} inv\_loaded\_ptr ,\,}%
+\@y{\@s{0}%
+ value read by \ensuremath{ReadPointerNoFence
+}}%
+\@xx{}%
+\@x{\@s{8.2} inv\_using\@s{28.31}}%
+\@y{\@s{0}%
+ invoker is using the extension program data
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+ \@x{ Vars \.{\defeq} {\langle} ext\_ptr ,\, stale\_ptr ,\, ext\_alive ,\,
+ inv\_in\_epoch ,\, inv\_barrier ,\, inv\_loaded\_ptr ,\, inv\_using
+ {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} ext\_ptr \.{\in} Ptr}%
+\@x{\@s{8.2} \.{\land} stale\_ptr\@s{0.03} \.{\in} Ptr}%
+\@x{\@s{8.2} \.{\land} ext\_alive \.{\in} {\BOOLEAN}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{\in} {\BOOLEAN}}%
+\@x{\@s{8.2} \.{\land} inv\_barrier \.{\in} {\BOOLEAN}}%
+\@x{\@s{8.2} \.{\land} inv\_loaded\_ptr \.{\in} Ptr}%
+\@x{\@s{8.2} \.{\land} inv\_using \.{\in} {\BOOLEAN}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Initialization: extension is loaded and its program data is alive.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ Init \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} ext\_ptr \.{=} 1}%
+\@x{\@s{8.2} \.{\land} stale\_ptr\@s{0.03} \.{=} 1}%
+\@x{\@s{8.2} \.{\land} ext\_alive \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} inv\_barrier \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} inv\_loaded\_ptr \.{=} 0}%
+\@x{\@s{8.2} \.{\land} inv\_using \.{=} {\FALSE}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Detach/unload actions.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+We model the ``clear pointer'' step and the ``free program data'' step.
+ The free step is gated by ``no invoker currently in an epoch'', which is
+ an abstraction of \ensuremath{ebpf\_epoch\_synchronize()}.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ DetachClear \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} ext\_ptr \.{=} 1}%
+\@x{\@s{8.2} \.{\land} ext\_ptr \.{'} \.{=} 0}%
+\@x{\@s{8.2} \.{\land} stale\_ptr \.{'} \.{=} ext\_ptr}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} ext\_alive ,\, inv\_in\_epoch
+ ,\, inv\_barrier ,\, inv\_loaded\_ptr ,\, inv\_using {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ DetachFree \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} ext\_ptr \.{=} 0}%
+\@x{\@s{8.2} \.{\land} ext\_alive \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} ext\_alive \.{'} \.{=} {\FALSE}}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} ext\_ptr ,\, stale\_ptr ,\,
+ inv\_in\_epoch ,\, inv\_barrier ,\, inv\_loaded\_ptr ,\, inv\_using
+ {\rangle}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Invoker actions.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ The invoke fast path performs a \ensuremath{NoFence} read of
+ \ensuremath{ext\_ptr}.
+ - If the invoker has a barrier (\ensuremath{inv\_barrier \.{=} {\TRUE}}), it
+ must read the
+\end{cpar}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+current value of \ensuremath{ext\_ptr}.
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+- If the invoker does NOT have a barrier, it may read a stale value.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+The model then allows the invoker to ``use'' the data only if the loaded
+ pointer is non-NULL.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ InvokerEnterEpoch \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{'} \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} inv\_barrier \.{'} \.{=} EpochEnterIsBarrier}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} ext\_ptr ,\, stale\_ptr ,\,
+ ext\_alive ,\, inv\_loaded\_ptr ,\, inv\_using {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ InvokerReadPointerNoFence \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} inv\_loaded\_ptr \.{=} 0}%
+\@x{\@s{8.2} \.{\land} inv\_using \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} {\IF} inv\_barrier}%
+\@x{\@s{31.46} \.{\THEN} inv\_loaded\_ptr \.{'} \.{=} ext\_ptr}%
+ \@x{\@s{31.46} \.{\ELSE} inv\_loaded\_ptr \.{'} \.{\in} \{ ext\_ptr ,\,
+ stale\_ptr \}}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} ext\_ptr ,\, stale\_ptr ,\,
+ ext\_alive ,\, inv\_in\_epoch ,\, inv\_barrier ,\, inv\_using {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ InvokerUse \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} inv\_loaded\_ptr \.{=} 1}%
+\@x{\@s{8.2} \.{\land} inv\_using \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} inv\_using \.{'} \.{=} {\TRUE}}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} ext\_ptr ,\, stale\_ptr ,\,
+ ext\_alive ,\, inv\_in\_epoch ,\, inv\_barrier ,\, inv\_loaded\_ptr
+ {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ InvokerFinish \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} inv\_using \.{'} \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} inv\_loaded\_ptr \.{'} \.{=} 0}%
+\@x{\@s{8.2} \.{\land} inv\_in\_epoch \.{'} \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} inv\_barrier \.{'} \.{=} {\FALSE}}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} ext\_ptr ,\, stale\_ptr ,\,
+ ext\_alive {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ Next \.{\defeq}}%
+\@x{\@s{8.2} DetachClear}%
+\@x{\@s{8.2} \.{\lor} DetachFree}%
+\@x{\@s{8.2} \.{\lor} InvokerEnterEpoch}%
+\@x{\@s{8.2} \.{\lor} InvokerReadPointerNoFence}%
+\@x{\@s{8.2} \.{\lor} InvokerUse}%
+\@x{\@s{8.2} \.{\lor} InvokerFinish}%
+\@pvspace{8.0pt}%
+\@x{ Spec \.{\defeq} Init \.{\land} {\Box} [ Next ]_{ Vars}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Safety property: the invoker must never use freed extension data.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ Safety \.{\defeq} inv\_using \.{\implies} ext\_alive}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/models/hash_table/CONFORMANCE.md
+++ b/models/hash_table/CONFORMANCE.md
@@ -1,0 +1,64 @@
+# Conformance notes: `HashTableModel.tla` vs `ebpf_hash_table.*`
+
+This document explains what `models/hash_table/HashTableModel.tla` is modeling from:
+
+- `libs/runtime/ebpf_hash_table.h`
+- `libs/runtime/ebpf_hash_table.c`
+
+and what it is intentionally simplifying.
+
+## What the model is capturing
+
+### Immutable buckets + pointer swap
+
+In `ebpf_hash_table.c`, writers build a replacement bucket and publish it with release semantics:
+
+- acquire read of current bucket pointer: `_ebpf_hash_table_get_bucket()`
+- release write of new bucket pointer: `_ebpf_hash_table_set_bucket()`
+- replacement operation under per-bucket lock: `_ebpf_hash_table_replace_bucket()`
+
+In the model:
+
+- `bucket_ptr[b]` corresponds to the published bucket pointer for bucket `b`.
+- `bucket_contents[bo]` is the immutable map “inside” a bucket object `bo`.
+- `WriterUpsert` / `WriterDelete` create a fresh bucket object and atomically update `bucket_ptr`.
+- `ReaderBeginFind` snapshots `bucket_ptr[b]` into `snapshot_bucket[c]`, then `ReaderFinishFind` reads the entry from that snapshot.
+
+### Epoch-based reclamation (simplified)
+
+The C implementation uses epoch-based reclamation by default (`ebpf_epoch_allocate_with_tag` / `ebpf_epoch_free`), and relies on:
+
+- publishing an epoch (global)
+- recording active reader epochs
+- advancing a released epoch
+- reclaiming retired allocations only once it is safe
+
+In the model:
+
+- `published_epoch`, `released_epoch`, `cpu_epoch[c]` are a simplified epoch mechanism.
+- buckets and value objects are “retired” on update/delete and later reclaimed by `ReclaimOne`.
+
+## Safety property being checked
+
+The invariant `Safety` checks:
+
+- if `cpu_epoch[c] != 0` (reader is inside an epoch), then anything it holds/dereferences (`held_bucket`, `held_obj`) must not be in state `"Freed"`.
+
+This corresponds to the intent that callers run hash-table reads under epoch protection so that `ebpf_epoch_free()` cannot reclaim memory out from under an active reader.
+
+## Intentional simplifications
+
+- No allocation failure paths (`EBPF_NO_MEMORY`), no notification callbacks, and no `supplemental_value_size` behavior.
+- No modeling of `backup_bucket` reuse; deletes/updates are represented as “allocate new bucket object”.
+- Not a full behavioral model of `ebpf_hash_table_iterate` / `*_next_key_*` APIs.
+- Bucket hashing is abstracted by the constant function `BucketOfKey`.
+- Writers are modeled as a single atomic action per operation; the real implementation uses an explicit per-bucket lock plus acquire/release pointer operations.
+
+## Key assumptions to keep in sync
+
+If the implementation changes, these are the assumptions the model is relying on:
+
+- Buckets are immutable after publication (readers never see in-place bucket mutation).
+- Publication is via a single pointer write with release semantics and read via acquire semantics.
+- Retired buckets and values are reclaimed through epoch-based mechanisms (or something with equivalent safety).
+- Read-side callers are expected to be under epoch protection for the lifetime of any returned pointer.

--- a/models/hash_table/HashTableModel.cfg
+++ b/models/hash_table/HashTableModel.cfg
@@ -1,0 +1,23 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  CPUs = {0, 1}
+  Keys = {1, 2}
+  Values = {0, 1}
+  BucketIds = {0}
+
+  ObjIds = {1, 2, 3}
+  BucketObjs = {1, 2, 3}
+
+  MaxEntries = 2
+  MaxEpoch = 3
+
+  ReadersUsePublishedEpoch = TRUE
+  RetireStampUsesPublishedEpoch = TRUE
+  AllowUseAfterExit = FALSE
+
+INVARIANT TypeOK
+INVARIANT Safety

--- a/models/hash_table/HashTableModel.tla
+++ b/models/hash_table/HashTableModel.tla
@@ -1,0 +1,412 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+---- MODULE HashTableModel ----
+EXTENDS Naturals, FiniteSets, TLC
+
+(*****************************************************************
+This is a bounded, executable TLA+ model of the key concurrency and
+lifetime aspects of libs/runtime/ebpf_hash_table.c.
+
+High-level intent:
+- Writers replace an immutable bucket by swapping a pointer.
+- Readers take a snapshot of the bucket pointer and then read entries.
+- Old buckets and old values are "retired" and later "reclaimed" via a
+  simplified epoch-based reclamation scheme.
+
+The model checks a core safety property:
+- While a reader is in an epoch, it must never observe a reclaimed
+  (Freed) bucket/value it is using.
+
+This is NOT a full linearizability model of all APIs (iterate/next_key,
+notifications, allocator failures, etc.). See CONFORMANCE.md.
+*****************************************************************)
+
+CONSTANTS
+  CPUs,              \* Finite set of reader CPUs/threads.
+  Keys,              \* Finite set of keys.
+  Values,            \* Finite set of values.
+  BucketIds,         \* Finite set of bucket indices.
+  ObjIds,            \* Finite set of value-object identifiers.
+  BucketObjs,        \* Finite set of bucket-object identifiers.
+  MaxEntries,        \* Nat, max #keys allowed in table.
+  MaxEpoch,          \* Nat, upper bound to keep TLC finite.
+
+  ReadersUsePublishedEpoch,       \* BOOLEAN
+  RetireStampUsesPublishedEpoch,  \* BOOLEAN
+  AllowUseAfterExit               \* BOOLEAN
+
+ASSUME MaxEntries \in Nat
+ASSUME MaxEpoch \in Nat
+ASSUME ReadersUsePublishedEpoch \in BOOLEAN
+ASSUME RetireStampUsesPublishedEpoch \in BOOLEAN
+ASSUME AllowUseAfterExit \in BOOLEAN
+
+ObjStates == {"Unused", "Live", "Retired", "Freed"}
+
+(*****************************************************************
+Helpers
+*****************************************************************)
+
+Max2(a, b) == IF a >= b THEN a ELSE b
+
+MinSet(S) == CHOOSE m \in S : \A x \in S : m <= x
+
+StampEpoch(published_epoch) ==
+  IF RetireStampUsesPublishedEpoch
+  THEN published_epoch
+  ELSE IF published_epoch = 0 THEN 0 ELSE published_epoch - 1
+
+EnterEpochValue(published_epoch) ==
+  IF ReadersUsePublishedEpoch
+  THEN published_epoch
+  ELSE IF published_epoch = 0 THEN 0 ELSE published_epoch - 1
+
+ActiveEpochs(cpu_epoch) ==
+  {e \in 0..MaxEpoch : (e # 0) /\ (\E c \in CPUs : cpu_epoch[c] = e)}
+
+\* Map a key to a bucket index.
+\* Configs typically use a single bucket, making this deterministic.
+BucketOfKey(k) == CHOOSE b \in BucketIds : TRUE
+
+BucketKeyCount(bucketPtr, bucketContents) ==
+  Cardinality({k \in Keys : LET b == BucketOfKey(k) IN
+      /\ bucketPtr[b] # 0
+      /\ bucketContents[bucketPtr[b]][k] # 0})
+
+(*****************************************************************
+State
+*****************************************************************)
+
+VARIABLES
+  \* Epoch state.
+  published_epoch,
+  released_epoch,
+  cpu_epoch,
+
+  \* Heap objects.
+  obj_state,
+  obj_key,
+  obj_val,
+  obj_freed_epoch,
+
+  bucket_state,
+  bucket_contents,
+  bucket_freed_epoch,
+  bucket_ptr,
+
+  \* Reader local state.
+  reader_key,
+  snapshot_bucket,
+  held_bucket,
+  held_obj,
+
+  \* Error latch.
+  bad
+
+TypeOK ==
+  /\ published_epoch \in Nat
+  /\ released_epoch \in Nat
+  /\ cpu_epoch \in [CPUs -> Nat]
+
+  /\ obj_state \in [ObjIds -> ObjStates]
+  /\ obj_key \in [ObjIds -> Keys]
+  /\ obj_val \in [ObjIds -> Values]
+  /\ obj_freed_epoch \in [ObjIds -> Nat]
+
+  /\ bucket_state \in [BucketObjs -> ObjStates]
+  /\ bucket_contents \in [BucketObjs -> [Keys -> ObjIds \cup {0}]]
+  /\ bucket_freed_epoch \in [BucketObjs -> Nat]
+  /\ bucket_ptr \in [BucketIds -> BucketObjs \cup {0}]
+
+  /\ reader_key \in [CPUs -> Keys]
+  /\ snapshot_bucket \in [CPUs -> BucketObjs \cup {0}]
+  /\ held_bucket \in [CPUs -> BucketObjs \cup {0}]
+  /\ held_obj \in [CPUs -> ObjIds \cup {0}]
+
+  /\ bad \in BOOLEAN
+
+BucketContentsWellFormed ==
+  \A bo \in BucketObjs :
+    \A k \in Keys :
+      LET o == bucket_contents[bo][k] IN
+        o = 0 \/ (o \in ObjIds /\ obj_key[o] = k)
+
+BucketPtrPointsToLiveOrEmpty ==
+  \A b \in BucketIds : bucket_ptr[b] = 0 \/ bucket_state[bucket_ptr[b]] = "Live"
+
+NoFreedBeforeRetired ==
+  \A o \in ObjIds : (obj_state[o] = "Freed") => (obj_freed_epoch[o] <= released_epoch)
+
+
+(*****************************************************************
+Initialization
+*****************************************************************)
+
+Init ==
+  /\ published_epoch = 1
+  /\ released_epoch = 0
+  /\ cpu_epoch = [c \in CPUs |-> 0]
+
+  /\ obj_state = [o \in ObjIds |-> "Unused"]
+  /\ obj_key = [o \in ObjIds |-> CHOOSE k \in Keys : TRUE]
+  /\ obj_val = [o \in ObjIds |-> CHOOSE v \in Values : TRUE]
+  /\ obj_freed_epoch = [o \in ObjIds |-> 0]
+
+  /\ bucket_state = [bo \in BucketObjs |-> "Unused"]
+  /\ bucket_contents = [bo \in BucketObjs |-> [k \in Keys |-> 0]]
+  /\ bucket_freed_epoch = [bo \in BucketObjs |-> 0]
+  /\ bucket_ptr = [b \in BucketIds |-> 0]
+
+  /\ reader_key = [c \in CPUs |-> CHOOSE k \in Keys : TRUE]
+  /\ snapshot_bucket = [c \in CPUs |-> 0]
+  /\ held_bucket = [c \in CPUs |-> 0]
+  /\ held_obj = [c \in CPUs |-> 0]
+
+  /\ bad = FALSE
+
+(*****************************************************************
+Reader steps (modeling ebpf_hash_table_find snapshot + dereference)
+*****************************************************************)
+
+ReaderEnter(c) ==
+  /\ cpu_epoch[c] = 0
+  /\ cpu_epoch' = [cpu_epoch EXCEPT ![c] = EnterEpochValue(published_epoch)]
+  /\ UNCHANGED <<published_epoch, released_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                reader_key, snapshot_bucket, held_bucket, held_obj,
+                bad>>
+
+ReaderExit(c) ==
+  /\ cpu_epoch[c] # 0
+  /\ cpu_epoch' = [cpu_epoch EXCEPT ![c] = 0]
+  /\ IF AllowUseAfterExit
+     THEN UNCHANGED <<snapshot_bucket, held_bucket, held_obj>>
+     ELSE /\ snapshot_bucket' = [snapshot_bucket EXCEPT ![c] = 0]
+          /\ held_bucket' = [held_bucket EXCEPT ![c] = 0]
+          /\ held_obj' = [held_obj EXCEPT ![c] = 0]
+  /\ UNCHANGED <<published_epoch, released_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                reader_key,
+                bad>>
+
+ReaderBeginFind(c, k) ==
+  /\ cpu_epoch[c] # 0
+  /\ reader_key' = [reader_key EXCEPT ![c] = k]
+  /\ LET b == BucketOfKey(k) IN
+       snapshot_bucket' = [snapshot_bucket EXCEPT ![c] = bucket_ptr[b]]
+  /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                held_bucket, held_obj,
+                bad>>
+
+ReaderFinishFind(c) ==
+  /\ cpu_epoch[c] # 0
+  /\ LET bo == snapshot_bucket[c]
+         k  == reader_key[c]
+         o  == IF bo = 0 THEN 0 ELSE bucket_contents[bo][k]
+     IN
+     /\ held_bucket' = [held_bucket EXCEPT ![c] = bo]
+     /\ held_obj' = [held_obj EXCEPT ![c] = o]
+     /\ bad' = bad \/
+         ((bo # 0) /\ bucket_state[bo] = "Freed") \/
+         ((o  # 0) /\ obj_state[o] = "Freed")
+  /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                reader_key, snapshot_bucket>>
+
+ReaderUseHeld(c) ==
+  /\ held_obj[c] # 0
+  /\ bad' = bad \/
+      (held_bucket[c] # 0 /\ bucket_state[held_bucket[c]] = "Freed") \/
+      (obj_state[held_obj[c]] = "Freed")
+  /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                reader_key, snapshot_bucket, held_bucket, held_obj>>
+
+(*****************************************************************
+Writer step (modeling immutable bucket replacement + retiring old)
+*****************************************************************)
+
+AllocateUnusedObj(o) == obj_state[o] = "Unused"
+AllocateUnusedBucket(bo) == bucket_state[bo] = "Unused"
+
+HasUnusedObj == \E o \in ObjIds : AllocateUnusedObj(o)
+HasUnusedBucket == \E bo \in BucketObjs : AllocateUnusedBucket(bo)
+
+ChooseUnusedObj == CHOOSE o \in ObjIds : AllocateUnusedObj(o)
+ChooseUnusedBucket == CHOOSE bo \in BucketObjs : AllocateUnusedBucket(bo)
+
+RetiredObjs == {o \in ObjIds : obj_state[o] = "Retired" /\ obj_freed_epoch[o] <= released_epoch}
+RetiredBuckets == {bo \in BucketObjs : bucket_state[bo] = "Retired" /\ bucket_freed_epoch[bo] <= released_epoch}
+
+WriterUpsert(k, v) ==
+  /\ HasUnusedObj
+  /\ HasUnusedBucket
+  /\ LET new_obj == ChooseUnusedObj
+         new_bo  == ChooseUnusedBucket
+         b == BucketOfKey(k)
+         old_bo == bucket_ptr[b]
+         old_obj == IF old_bo = 0 THEN 0 ELSE bucket_contents[old_bo][k]
+         key_is_new == (old_obj = 0)
+         can_insert == (BucketKeyCount(bucket_ptr, bucket_contents) < MaxEntries)
+     IN
+     /\ (\lnot key_is_new) \/ can_insert
+
+     /\ LET
+           base_obj_state == [obj_state EXCEPT ![new_obj] = "Live"]
+           base_obj_freed == [obj_freed_epoch EXCEPT ![new_obj] = 0]
+           final_obj_state ==
+             IF old_obj = 0 THEN base_obj_state ELSE [base_obj_state EXCEPT ![old_obj] = "Retired"]
+           final_obj_freed ==
+             IF old_obj = 0
+             THEN base_obj_freed
+             ELSE [base_obj_freed EXCEPT ![old_obj] = StampEpoch(published_epoch)]
+
+           base_bucket_state == [bucket_state EXCEPT ![new_bo] = "Live"]
+           base_bucket_freed == [bucket_freed_epoch EXCEPT ![new_bo] = 0]
+           final_bucket_state ==
+             IF old_bo = 0 THEN base_bucket_state ELSE [base_bucket_state EXCEPT ![old_bo] = "Retired"]
+           final_bucket_freed ==
+             IF old_bo = 0
+             THEN base_bucket_freed
+             ELSE [base_bucket_freed EXCEPT ![old_bo] = StampEpoch(published_epoch)]
+         IN
+         /\ obj_state' = final_obj_state
+         /\ obj_key' = [obj_key EXCEPT ![new_obj] = k]
+         /\ obj_val' = [obj_val EXCEPT ![new_obj] = v]
+         /\ obj_freed_epoch' = final_obj_freed
+
+         /\ bucket_state' = final_bucket_state
+         /\ bucket_freed_epoch' = final_bucket_freed
+         /\ bucket_contents' =
+              [bucket_contents EXCEPT ![new_bo] =
+                IF old_bo = 0
+                THEN [x \in Keys |-> IF x = k THEN new_obj ELSE 0]
+                ELSE [x \in Keys |-> IF x = k THEN new_obj ELSE bucket_contents[old_bo][x]]]
+
+         /\ bucket_ptr' = [bucket_ptr EXCEPT ![b] = new_bo]
+
+         /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+                       reader_key, snapshot_bucket, held_bucket, held_obj,
+                       bad>>
+
+WriterDelete(k) ==
+  /\ HasUnusedBucket
+  /\ LET new_bo == ChooseUnusedBucket
+         b == BucketOfKey(k)
+         old_bo == bucket_ptr[b]
+     IN
+     /\ old_bo # 0
+     /\ LET old_obj == bucket_contents[old_bo][k] IN
+        /\ old_obj # 0
+
+          \* New bucket is copy of old, with key removed.
+          /\ bucket_state' = [bucket_state EXCEPT ![new_bo] = "Live"]
+          /\ bucket_freed_epoch' = [bucket_freed_epoch EXCEPT ![new_bo] = 0]
+          /\ bucket_contents' =
+               [bucket_contents EXCEPT ![new_bo] =
+                 [x \in Keys |-> IF x = k THEN 0 ELSE bucket_contents[old_bo][x]]]
+          /\ bucket_ptr' = [bucket_ptr EXCEPT ![b] = new_bo]
+
+          \* Retire old bucket and old value.
+          /\ bucket_state' = [bucket_state' EXCEPT ![old_bo] = "Retired"]
+          /\ bucket_freed_epoch' = [bucket_freed_epoch' EXCEPT ![old_bo] = StampEpoch(published_epoch)]
+
+          /\ obj_state' = [obj_state EXCEPT ![old_obj] = "Retired"]
+          /\ obj_freed_epoch' = [obj_freed_epoch EXCEPT ![old_obj] = StampEpoch(published_epoch)]
+
+          /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+                        obj_key, obj_val,
+                        reader_key, snapshot_bucket, held_bucket, held_obj,
+                        bad>>
+
+(*****************************************************************
+Epoch progression + reclamation
+*****************************************************************)
+
+AdvancePublishedEpoch ==
+  /\ published_epoch < MaxEpoch
+  /\ published_epoch' = published_epoch + 1
+  /\ UNCHANGED <<released_epoch, cpu_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                reader_key, snapshot_bucket, held_bucket, held_obj,
+                bad>>
+
+ComputeReleasedEpoch ==
+  /\ LET active == ActiveEpochs(cpu_epoch)
+         candidate ==
+           IF active = {}
+           THEN IF published_epoch = 0 THEN 0 ELSE published_epoch - 1
+           ELSE LET m == MinSet(active) IN IF m = 0 THEN 0 ELSE m - 1
+     IN
+     released_epoch' = Max2(released_epoch, candidate)
+  /\ UNCHANGED <<published_epoch, cpu_epoch,
+                obj_state, obj_key, obj_val, obj_freed_epoch,
+                bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                reader_key, snapshot_bucket, held_bucket, held_obj,
+                bad>>
+
+ReclaimOne ==
+  \/ /\ RetiredObjs # {}
+    /\ LET o == CHOOSE x \in RetiredObjs : TRUE IN
+      /\ obj_state' = [obj_state EXCEPT ![o] = "Freed"]
+      /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+               obj_key, obj_val, obj_freed_epoch,
+               bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+               reader_key, snapshot_bucket, held_bucket, held_obj,
+               bad>>
+  \/ /\ RetiredBuckets # {}
+    /\ LET bo == CHOOSE x \in RetiredBuckets : TRUE IN
+      /\ bucket_state' = [bucket_state EXCEPT ![bo] = "Freed"]
+      /\ UNCHANGED <<published_epoch, released_epoch, cpu_epoch,
+               obj_state, obj_key, obj_val, obj_freed_epoch,
+               bucket_contents, bucket_freed_epoch, bucket_ptr,
+               reader_key, snapshot_bucket, held_bucket, held_obj,
+               bad>>
+
+(*****************************************************************
+Next-state relation
+*****************************************************************)
+
+Next ==
+  \/ \E c \in CPUs : ReaderEnter(c)
+  \/ \E c \in CPUs : ReaderExit(c)
+  \/ \E c \in CPUs : \E k \in Keys : ReaderBeginFind(c, k)
+  \/ \E c \in CPUs : ReaderFinishFind(c)
+  \/ \E c \in CPUs : ReaderUseHeld(c)
+
+  \/ \E k \in Keys : \E v \in Values : WriterUpsert(k, v)
+  \/ \E k \in Keys : WriterDelete(k)
+
+  \/ AdvancePublishedEpoch
+  \/ ComputeReleasedEpoch
+  \/ ReclaimOne
+
+(*****************************************************************
+Invariants
+*****************************************************************)
+
+Safety ==
+  /\ ~bad
+  /\ released_epoch <= published_epoch
+
+  \* While in an epoch, held objects/buckets must not be reclaimed.
+  /\ \A c \in CPUs :
+       (cpu_epoch[c] # 0 /\ held_obj[c] # 0) => obj_state[held_obj[c]] # "Freed"
+  /\ \A c \in CPUs :
+       (cpu_epoch[c] # 0 /\ held_bucket[c] # 0) => bucket_state[held_bucket[c]] # "Freed"
+
+Spec == Init /\ [][Next]_<<published_epoch, released_epoch, cpu_epoch,
+                   obj_state, obj_key, obj_val, obj_freed_epoch,
+                   bucket_state, bucket_contents, bucket_freed_epoch, bucket_ptr,
+                   reader_key, snapshot_bucket, held_bucket, held_obj,
+                   bad>>
+
+====

--- a/models/hash_table/HashTableModel_buggy_use_after_exit.cfg
+++ b/models/hash_table/HashTableModel_buggy_use_after_exit.cfg
@@ -1,0 +1,23 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  CPUs = {0, 1}
+  Keys = {1, 2}
+  Values = {0, 1}
+  BucketIds = {0}
+
+  ObjIds = {1, 2, 3}
+  BucketObjs = {1, 2, 3}
+
+  MaxEntries = 2
+  MaxEpoch = 3
+
+  ReadersUsePublishedEpoch = TRUE
+  RetireStampUsesPublishedEpoch = TRUE
+  AllowUseAfterExit = TRUE
+
+INVARIANT TypeOK
+INVARIANT Safety

--- a/models/hash_table/README.md
+++ b/models/hash_table/README.md
@@ -1,0 +1,32 @@
+# HashTableModel (TLA+)
+
+This folder contains a small, bounded TLA+ model that captures the key concurrency pattern in `libs/runtime/ebpf_hash_table.c`:
+
+- buckets are immutable snapshots
+- writers replace a bucket via an atomic pointer swap
+- old buckets/values are retired and later reclaimed (freed) via epoch-based reclamation
+
+The model focuses on a safety property: while a reader is inside an epoch, it must never dereference a reclaimed bucket/value.
+
+## Files
+
+- `HashTableModel.tla`: the spec
+- `HashTableModel.cfg`: “safe usage” config (readers enter/exit epoch; no use-after-exit)
+- `HashTableModel_buggy_use_after_exit.cfg`: config that allows use-after-exit (expected to find a counterexample)
+- `CONFORMANCE.md`: mapping from model concepts to the C implementation
+
+## Running TLC
+
+From the repo root:
+
+```powershell
+# Safe config: should pass.
+java -cp models\tla2tools.jar tlc2.TLC -workers auto -config models\hash_table\HashTableModel.cfg models\hash_table\HashTableModel.tla
+
+# Buggy config: should fail (Safety invariant violation).
+java -cp models\tla2tools.jar tlc2.TLC -workers auto -config models\hash_table\HashTableModel_buggy_use_after_exit.cfg models\hash_table\HashTableModel.tla
+```
+
+Notes:
+- TLC creates `states/` folders next to the model by default.
+- If you don’t have Java installed, you can use `winget install Microsoft.OpenJDK.21`.

--- a/models/hash_table/tlatex/HashTableModel.tex
+++ b/models/hash_table/tlatex/HashTableModel.tex
@@ -1,0 +1,1656 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{\,\backslash\,}}* Copyright (\ensuremath{c}) \ensuremath{eBPF}
+ for Windows contributors
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{\,\backslash\,}}* SPDX-License-Identifier: \ensuremath{MIT
+}%
+\end{cpar}%
+\end{lcom}%
+\@x{}\moduleLeftDash\@xx{ {\MODULE} HashTableModel}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals ,\, FiniteSets ,\, TLC}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+This is a bounded, executable TLA+ model of the key concurrency and
+ lifetime aspects of libs/runtime/\ensuremath{ebpf\_hash\_table.c}.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+High-level intent\ensuremath{\.{:}
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{-}} Writers replace an immutable bucket by swapping a pointer.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+- Readers take a snapshot of the bucket pointer and then read entries.
+\end{cpar}%
+\begin{cpar}{0}{T}{T}{0}{2.5}{%
+-}%
+Old buckets and old values are ``retired'' and later ``reclaimed'' via a
+ simplified epoch-based reclamation scheme.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+The model checks a core safety property\ensuremath{\.{:}
+ \.{-}} While a reader is in an epoch, it must never observe a reclaimed
+\end{cpar}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+(Freed) bucket/value it is using.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+ This is NOT a full linearizability model of all \ensuremath{APIs}
+ (iterate/\ensuremath{next\_key},
+ notifications, allocator failures, etc.). See \ensuremath{CONFORMANCE.md}.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ {\CONSTANTS}}%
+\@x{\@s{8.2} CPUs ,\,\@s{53.65}}%
+\@y{\@s{0}%
+ Finite set of reader \ensuremath{CPUs}/threads.
+}%
+\@xx{}%
+\@x{\@s{8.2} Keys ,\,\@s{57.88}}%
+\@y{\@s{0}%
+ Finite set of keys.
+}%
+\@xx{}%
+\@x{\@s{8.2} Values ,\,\@s{50.72}}%
+\@y{\@s{0}%
+ Finite set of values.
+}%
+\@xx{}%
+\@x{\@s{8.2} BucketIds ,\,\@s{36.53}}%
+\@y{\@s{0}%
+ Finite set of bucket indices.
+}%
+\@xx{}%
+\@x{\@s{8.2} ObjIds ,\,\@s{50.72}}%
+\@y{\@s{0}%
+ Finite set of value-object identifiers.
+}%
+\@xx{}%
+\@x{\@s{8.2} BucketObjs ,\,\@s{30.16}}%
+\@y{\@s{0}%
+ Finite set of bucket-object identifiers.
+}%
+\@xx{}%
+\@x{\@s{8.2} MaxEntries ,\,\@s{28.7}}%
+\@y{\@s{0}%
+ \ensuremath{Nat}, \ensuremath{max \.{\neq}}keys allowed in table.
+}%
+\@xx{}%
+\@x{\@s{8.2} MaxEpoch ,\,\@s{34.75}}%
+\@y{\@s{0}%
+ \ensuremath{Nat}, upper bound to keep \ensuremath{TLC} finite.
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2} ReadersUsePublishedEpoch ,\,\@s{27.61}}%
+\@y{\@s{0}%
+ \ensuremath{{\BOOLEAN}
+}}%
+\@xx{}%
+\@x{\@s{8.2} RetireStampUsesPublishedEpoch ,\,\@s{4.10}}%
+\@y{\@s{0}%
+ \ensuremath{{\BOOLEAN}
+}}%
+\@xx{}%
+\@x{\@s{8.2} AllowUseAfterExit\@s{69.00}}%
+\@y{\@s{0}%
+ \ensuremath{{\BOOLEAN}
+}}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ {\ASSUME} MaxEntries \.{\in} Nat}%
+\@x{ {\ASSUME} MaxEpoch \.{\in} Nat}%
+\@x{ {\ASSUME} ReadersUsePublishedEpoch \.{\in} {\BOOLEAN}}%
+\@x{ {\ASSUME} RetireStampUsesPublishedEpoch \.{\in} {\BOOLEAN}}%
+\@x{ {\ASSUME} AllowUseAfterExit \.{\in} {\BOOLEAN}}%
+\@pvspace{8.0pt}%
+ \@x{ ObjStates \.{\defeq} \{\@w{Unused} ,\,\@w{Live} ,\,\@w{Retired}
+ ,\,\@w{Freed} \}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Helpers
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ Max2 ( a ,\, b ) \.{\defeq} {\IF} a \.{\geq} b \.{\THEN} a \.{\ELSE} b}%
+\@pvspace{8.0pt}%
+ \@x{ MinSet ( S ) \.{\defeq} {\CHOOSE} m \.{\in} S \.{:} \A\, x \.{\in} S
+ \.{:} m \.{\leq} x}%
+\@pvspace{8.0pt}%
+\@x{ StampEpoch ( published\_epoch ) \.{\defeq}}%
+\@x{\@s{8.2} {\IF} RetireStampUsesPublishedEpoch}%
+\@x{\@s{8.2} \.{\THEN} published\_epoch}%
+ \@x{\@s{8.2} \.{\ELSE} {\IF} published\_epoch \.{=} 0 \.{\THEN} 0 \.{\ELSE}
+ published\_epoch \.{-} 1}%
+\@pvspace{8.0pt}%
+\@x{ EnterEpochValue ( published\_epoch ) \.{\defeq}}%
+\@x{\@s{8.2} {\IF} ReadersUsePublishedEpoch}%
+\@x{\@s{8.2} \.{\THEN} published\_epoch}%
+ \@x{\@s{8.2} \.{\ELSE} {\IF} published\_epoch \.{=} 0 \.{\THEN} 0 \.{\ELSE}
+ published\_epoch \.{-} 1}%
+\@pvspace{8.0pt}%
+\@x{ ActiveEpochs ( cpu\_epoch ) \.{\defeq}}%
+ \@x{\@s{8.2} \{ e \.{\in} 0 \.{\dotdot} MaxEpoch \.{:} ( e \.{\neq} 0 )
+ \.{\land} ( \E\, c \.{\in} CPUs \.{:} cpu\_epoch [ c ] \.{=} e ) \}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Map a key to a bucket index.
+}%
+\@xx{}%
+\@x{}%
+\@y{\@s{0}%
+ Configs typically use a single bucket, making this deterministic.
+}%
+\@xx{}%
+ \@x{ BucketOfKey ( k ) \.{\defeq} {\CHOOSE} b \.{\in} BucketIds \.{:}
+ {\TRUE}}%
+\@pvspace{8.0pt}%
+\@x{ BucketKeyCount ( bucketPtr ,\, bucketContents ) \.{\defeq}}%
+ \@x{\@s{8.2} Cardinality ( \{ k \.{\in} Keys \.{:} \.{\LET} b \.{\defeq}
+ BucketOfKey ( k ) \.{\IN}}%
+\@x{\@s{24.59} \.{\land} bucketPtr [ b ] \.{\neq} 0}%
+ \@x{\@s{24.59} \.{\land} bucketContents [ bucketPtr [ b ] ] [ k ] \.{\neq} 0
+ \} )}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+State
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ {\VARIABLES}}%
+\@x{\@s{8.2}}%
+\@y{\@s{0}%
+ Epoch state.
+}%
+\@xx{}%
+\@x{\@s{8.2} published\_epoch ,\,}%
+\@x{\@s{8.2} released\_epoch ,\,}%
+\@x{\@s{8.2} cpu\_epoch ,\,}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2}}%
+\@y{\@s{0}%
+ Heap objects.
+}%
+\@xx{}%
+\@x{\@s{8.2} obj\_state ,\,}%
+\@x{\@s{8.2} obj\_key ,\,}%
+\@x{\@s{8.2} obj\_val ,\,}%
+\@x{\@s{8.2} obj\_freed\_epoch ,\,}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2} bucket\_state ,\,}%
+\@x{\@s{8.2} bucket\_contents ,\,}%
+\@x{\@s{8.2} bucket\_freed\_epoch ,\,}%
+\@x{\@s{8.2} bucket\_ptr ,\,}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2}}%
+\@y{\@s{0}%
+ Reader local state.
+}%
+\@xx{}%
+\@x{\@s{8.2} reader\_key ,\,}%
+\@x{\@s{8.2} snapshot\_bucket ,\,}%
+\@x{\@s{8.2} held\_bucket ,\,}%
+\@x{\@s{8.2} held\_obj ,\,}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2}}%
+\@y{\@s{0}%
+ Error latch.
+}%
+\@xx{}%
+\@x{\@s{8.2} bad}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} published\_epoch \.{\in} Nat}%
+\@x{\@s{8.2} \.{\land} released\_epoch \.{\in} Nat}%
+\@x{\@s{8.2} \.{\land} cpu\_epoch \.{\in} [ CPUs \.{\rightarrow} Nat ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{8.2} \.{\land} obj\_state\@s{4.70} \.{\in} [ ObjIds \.{\rightarrow}
+ ObjStates ]}%
+\@x{\@s{8.2} \.{\land} obj\_key \.{\in} [ ObjIds \.{\rightarrow} Keys ]}%
+ \@x{\@s{8.2} \.{\land} obj\_val\@s{1.64} \.{\in} [ ObjIds \.{\rightarrow}
+ Values ]}%
+ \@x{\@s{8.2} \.{\land} obj\_freed\_epoch \.{\in} [ ObjIds \.{\rightarrow} Nat
+ ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{8.2} \.{\land} bucket\_state \.{\in} [ BucketObjs \.{\rightarrow}
+ ObjStates ]}%
+ \@x{\@s{8.2} \.{\land} bucket\_contents \.{\in} [ BucketObjs \.{\rightarrow}
+ [ Keys \.{\rightarrow} ObjIds \.{\cup} \{ 0 \} ] ]}%
+ \@x{\@s{8.2} \.{\land} bucket\_freed\_epoch \.{\in} [ BucketObjs
+ \.{\rightarrow} Nat ]}%
+ \@x{\@s{8.2} \.{\land} bucket\_ptr\@s{1.08} \.{\in} [ BucketIds
+ \.{\rightarrow} BucketObjs \.{\cup} \{ 0 \} ]}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2} \.{\land} reader\_key \.{\in} [ CPUs \.{\rightarrow} Keys ]}%
+ \@x{\@s{8.2} \.{\land} snapshot\_bucket \.{\in} [ CPUs \.{\rightarrow}
+ BucketObjs \.{\cup} \{ 0 \} ]}%
+ \@x{\@s{8.2} \.{\land} held\_bucket \.{\in} [ CPUs \.{\rightarrow} BucketObjs
+ \.{\cup} \{ 0 \} ]}%
+ \@x{\@s{8.2} \.{\land} held\_obj \.{\in} [ CPUs \.{\rightarrow} ObjIds
+ \.{\cup} \{ 0 \} ]}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2} \.{\land} bad \.{\in} {\BOOLEAN}}%
+\@pvspace{8.0pt}%
+\@x{ BucketContentsWellFormed \.{\defeq}}%
+\@x{\@s{8.2} \A\, bo \.{\in} BucketObjs \.{:}}%
+\@x{\@s{16.4} \A\, k \.{\in} Keys \.{:}}%
+\@x{\@s{24.59} \.{\LET} o \.{\defeq} bucket\_contents [ bo ] [ k ] \.{\IN}}%
+ \@x{\@s{32.8} o \.{=} 0 \.{\lor} ( o \.{\in} ObjIds \.{\land} obj\_key [ o ]
+ \.{=} k )}%
+\@pvspace{8.0pt}%
+\@x{ BucketPtrPointsToLiveOrEmpty \.{\defeq}}%
+ \@x{\@s{8.2} \A\, b \.{\in} BucketIds \.{:} bucket\_ptr [ b ] \.{=} 0
+ \.{\lor} bucket\_state [ bucket\_ptr [ b ] ] \.{=}\@w{Live}}%
+\@pvspace{8.0pt}%
+\@x{ NoFreedBeforeRetired \.{\defeq}}%
+ \@x{\@s{8.2} \A\, o \.{\in} ObjIds \.{:} ( obj\_state [ o ] \.{=}\@w{Freed} )
+ \.{\implies} ( obj\_freed\_epoch [ o ] \.{\leq} released\_epoch )}%
+\@pvspace{16.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Initialization
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ Init \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} published\_epoch \.{=} 1}%
+\@x{\@s{8.2} \.{\land} released\_epoch\@s{3.31} \.{=} 0}%
+ \@x{\@s{8.2} \.{\land} cpu\_epoch \.{=} [ c\@s{0.57} \.{\in} CPUs \.{\mapsto}
+ 0 ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{8.2} \.{\land} obj\_state\@s{4.70} \.{=} [ o \.{\in} ObjIds
+ \.{\mapsto}\@w{Unused} ]}%
+ \@x{\@s{8.2} \.{\land} obj\_key \.{=} [ o \.{\in} ObjIds \.{\mapsto}
+ {\CHOOSE} k \.{\in} Keys \.{:} {\TRUE} ]}%
+ \@x{\@s{8.2} \.{\land} obj\_val\@s{1.64} \.{=} [ o \.{\in} ObjIds \.{\mapsto}
+ {\CHOOSE} v \.{\in} Values \.{:} {\TRUE} ]}%
+ \@x{\@s{8.2} \.{\land} obj\_freed\_epoch \.{=} [ o \.{\in} ObjIds \.{\mapsto}
+ 0 ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{8.2} \.{\land} bucket\_state \.{=} [ bo \.{\in} BucketObjs
+ \.{\mapsto}\@w{Unused} ]}%
+ \@x{\@s{8.2} \.{\land} bucket\_contents \.{=} [ bo \.{\in} BucketObjs
+ \.{\mapsto} [ k \.{\in} Keys \.{\mapsto} 0 ] ]}%
+ \@x{\@s{8.2} \.{\land} bucket\_freed\_epoch \.{=} [ bo \.{\in} BucketObjs
+ \.{\mapsto} 0 ]}%
+ \@x{\@s{8.2} \.{\land} bucket\_ptr\@s{1.08} \.{=} [ b\@s{2.36} \.{\in}
+ BucketIds \.{\mapsto} 0 ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{8.2} \.{\land} reader\_key \.{=} [ c\@s{2.42} \.{\in} CPUs
+ \.{\mapsto} {\CHOOSE} k \.{\in} Keys \.{:} {\TRUE} ]}%
+ \@x{\@s{8.2} \.{\land} snapshot\_bucket \.{=} [ c \.{\in} CPUs \.{\mapsto} 0
+ ]}%
+\@x{\@s{8.2} \.{\land} held\_bucket \.{=} [ c \.{\in} CPUs \.{\mapsto} 0 ]}%
+\@x{\@s{8.2} \.{\land} held\_obj \.{=} [ c \.{\in} CPUs \.{\mapsto} 0 ]}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2} \.{\land} bad \.{=} {\FALSE}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+ Reader steps (modeling \ensuremath{ebpf\_hash\_table\_find} snapshot +
+ dereference)
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ ReaderEnter ( c ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} cpu\_epoch [ c ] \.{=} 0}%
+ \@x{\@s{8.2} \.{\land} cpu\_epoch \.{'} \.{=} [ cpu\_epoch {\EXCEPT} {\bang}
+ [ c ] \.{=} EnterEpochValue ( published\_epoch ) ]}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+ \@x{\@s{81.99} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{81.99} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderExit ( c ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} cpu\_epoch [ c ] \.{\neq} 0}%
+ \@x{\@s{8.2} \.{\land} cpu\_epoch \.{'} \.{=} [ cpu\_epoch {\EXCEPT} {\bang}
+ [ c ] \.{=} 0 ]}%
+\@x{\@s{8.2} \.{\land} {\IF} AllowUseAfterExit}%
+ \@x{\@s{19.31} \.{\THEN} {\UNCHANGED} {\langle} snapshot\_bucket ,\,
+ held\_bucket ,\, held\_obj {\rangle}}%
+ \@x{\@s{19.31} \.{\ELSE} \.{\land} snapshot\_bucket \.{'} \.{=} [
+ snapshot\_bucket {\EXCEPT} {\bang} [ c ] \.{=} 0 ]}%
+ \@x{\@s{50.62} \.{\land} held\_bucket \.{'} \.{=} [ held\_bucket {\EXCEPT}
+ {\bang} [ c ] \.{=} 0 ]}%
+ \@x{\@s{50.62} \.{\land} held\_obj \.{'} \.{=} [ held\_obj {\EXCEPT} {\bang}
+ [ c ] \.{=} 0 ]}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+\@x{\@s{81.99} reader\_key ,\,}%
+\@x{\@s{81.99} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderBeginFind ( c ,\, k ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} cpu\_epoch [ c ] \.{\neq} 0}%
+ \@x{\@s{8.2} \.{\land} reader\_key \.{'} \.{=} [ reader\_key {\EXCEPT}
+ {\bang} [ c ] \.{=} k ]}%
+\@x{\@s{8.2} \.{\land} \.{\LET} b \.{\defeq} BucketOfKey ( k ) \.{\IN}}%
+ \@x{\@s{27.51} snapshot\_bucket \.{'} \.{=} [ snapshot\_bucket {\EXCEPT}
+ {\bang} [ c ] \.{=} bucket\_ptr [ b ] ]}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+\@x{\@s{81.99} held\_bucket ,\, held\_obj ,\,}%
+\@x{\@s{81.99} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderFinishFind ( c ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} cpu\_epoch [ c ] \.{\neq} 0}%
+\@x{\@s{8.2} \.{\land} \.{\LET} bo \.{\defeq} snapshot\_bucket [ c ]}%
+\@x{\@s{39.71} k\@s{4.16} \.{\defeq} reader\_key [ c ]}%
+ \@x{\@s{39.71} o\@s{4.08} \.{\defeq} {\IF} bo \.{=} 0 \.{\THEN} 0 \.{\ELSE}
+ bucket\_contents [ bo ] [ k ]}%
+\@x{\@s{19.31} \.{\IN}}%
+ \@x{\@s{19.31} \.{\land} held\_bucket \.{'} \.{=} [ held\_bucket {\EXCEPT}
+ {\bang} [ c ] \.{=} bo ]}%
+ \@x{\@s{19.31} \.{\land} held\_obj \.{'} \.{=} [ held\_obj {\EXCEPT} {\bang}
+ [ c ] \.{=} o ]}%
+\@x{\@s{19.31} \.{\land} bad \.{'} \.{=} bad \.{\lor}}%
+ \@x{\@s{34.52} ( ( bo \.{\neq} 0 ) \.{\land} bucket\_state [ bo ]
+ \.{=}\@w{Freed} ) \.{\lor}}%
+ \@x{\@s{34.52} ( ( o\@s{4.08} \.{\neq} 0 ) \.{\land} obj\_state [ o ]
+ \.{=}\@w{Freed} )}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+\@x{\@s{81.99} reader\_key ,\, snapshot\_bucket {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderUseHeld ( c ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} held\_obj [ c ] \.{\neq} 0}%
+\@x{\@s{8.2} \.{\land} bad \.{'} \.{=} bad \.{\lor}}%
+ \@x{\@s{23.41} ( held\_bucket [ c ] \.{\neq} 0 \.{\land} bucket\_state [
+ held\_bucket [ c ] ] \.{=}\@w{Freed} ) \.{\lor}}%
+\@x{\@s{23.41} ( obj\_state [ held\_obj [ c ] ] \.{=}\@w{Freed} )}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+ \@x{\@s{81.99} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj {\rangle}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Writer step (modeling immutable bucket replacement + retiring old)
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ AllocateUnusedObj ( o ) \.{\defeq} obj\_state [ o ] \.{=}\@w{Unused}}%
+ \@x{ AllocateUnusedBucket ( bo ) \.{\defeq} bucket\_state [ bo ]
+ \.{=}\@w{Unused}}%
+\@pvspace{8.0pt}%
+ \@x{ HasUnusedObj \.{\defeq} \E\, o \.{\in} ObjIds \.{:} AllocateUnusedObj (
+ o )}%
+ \@x{ HasUnusedBucket\@s{0.33} \.{\defeq} \E\, bo \.{\in} BucketObjs \.{:}
+ AllocateUnusedBucket ( bo )}%
+\@pvspace{8.0pt}%
+ \@x{ ChooseUnusedObj \.{\defeq} {\CHOOSE} o \.{\in} ObjIds \.{:}
+ AllocateUnusedObj ( o )}%
+ \@x{ ChooseUnusedBucket \.{\defeq} {\CHOOSE} bo \.{\in} BucketObjs \.{:}
+ AllocateUnusedBucket ( bo )}%
+\@pvspace{8.0pt}%
+ \@x{ RetiredObjs \.{\defeq} \{ o \.{\in} ObjIds \.{:} obj\_state [ o ]
+ \.{=}\@w{Retired} \.{\land} obj\_freed\_epoch [ o ] \.{\leq} released\_epoch
+ \}}%
+ \@x{ RetiredBuckets \.{\defeq} \{ bo \.{\in} BucketObjs \.{:} bucket\_state [
+ bo ] \.{=}\@w{Retired} \.{\land} bucket\_freed\_epoch [ bo ] \.{\leq}
+ released\_epoch \}}%
+\@pvspace{8.0pt}%
+\@x{ WriterUpsert ( k ,\, v ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} HasUnusedObj}%
+\@x{\@s{8.2} \.{\land} HasUnusedBucket}%
+\@x{\@s{8.2} \.{\land} \.{\LET} new\_obj \.{\defeq} ChooseUnusedObj}%
+\@x{\@s{39.71} new\_bo\@s{4.39} \.{\defeq} ChooseUnusedBucket}%
+\@x{\@s{39.71} b \.{\defeq} BucketOfKey ( k )}%
+\@x{\@s{39.71} old\_bo \.{\defeq} bucket\_ptr [ b ]}%
+ \@x{\@s{39.71} old\_obj \.{\defeq} {\IF} old\_bo \.{=} 0 \.{\THEN} 0
+ \.{\ELSE} bucket\_contents [ old\_bo ] [ k ]}%
+\@x{\@s{39.71} key\_is\_new \.{\defeq} ( old\_obj \.{=} 0 )}%
+ \@x{\@s{39.71} can\_insert\@s{3.90} \.{\defeq} ( BucketKeyCount ( bucket\_ptr
+ ,\, bucket\_contents ) \.{<} MaxEntries )}%
+\@x{\@s{19.31} \.{\IN}}%
+\@x{\@s{19.31} \.{\land} ( {\lnot} key\_is\_new ) \.{\lor} can\_insert}%
+\@pvspace{8.0pt}%
+\@x{\@s{19.31} \.{\land} \.{\LET}}%
+ \@x{\@s{42.72} base\_obj\_state \.{\defeq} [ obj\_state {\EXCEPT} {\bang} [
+ new\_obj ] \.{=}\@w{Live} ]}%
+ \@x{\@s{42.72} base\_obj\_freed\@s{0.10} \.{\defeq} [ obj\_freed\_epoch
+ {\EXCEPT} {\bang} [ new\_obj ] \.{=} 0 ]}%
+\@x{\@s{42.72} final\_obj\_state \.{\defeq}}%
+ \@x{\@s{50.92} {\IF} old\_obj \.{=} 0 \.{\THEN} base\_obj\_state \.{\ELSE} [
+ base\_obj\_state {\EXCEPT} {\bang} [ old\_obj ] \.{=}\@w{Retired} ]}%
+\@x{\@s{42.72} final\_obj\_freed \.{\defeq}}%
+\@x{\@s{50.92} {\IF} old\_obj \.{=} 0}%
+\@x{\@s{50.92} \.{\THEN} base\_obj\_freed}%
+ \@x{\@s{50.92} \.{\ELSE} [ base\_obj\_freed {\EXCEPT} {\bang} [ old\_obj ]
+ \.{=} StampEpoch ( published\_epoch ) ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{42.72} base\_bucket\_state \.{\defeq} [ bucket\_state {\EXCEPT}
+ {\bang} [ new\_bo ] \.{=}\@w{Live} ]}%
+ \@x{\@s{42.72} base\_bucket\_freed\@s{0.10} \.{\defeq} [ bucket\_freed\_epoch
+ {\EXCEPT} {\bang} [ new\_bo ] \.{=} 0 ]}%
+\@x{\@s{42.72} final\_bucket\_state \.{\defeq}}%
+ \@x{\@s{50.92} {\IF} old\_bo \.{=} 0 \.{\THEN} base\_bucket\_state \.{\ELSE}
+ [ base\_bucket\_state {\EXCEPT} {\bang} [ old\_bo ] \.{=}\@w{Retired} ]}%
+\@x{\@s{42.72} final\_bucket\_freed \.{\defeq}}%
+\@x{\@s{50.92} {\IF} old\_bo \.{=} 0}%
+\@x{\@s{50.92} \.{\THEN} base\_bucket\_freed}%
+ \@x{\@s{50.92} \.{\ELSE} [ base\_bucket\_freed {\EXCEPT} {\bang} [ old\_bo ]
+ \.{=} StampEpoch ( published\_epoch ) ]}%
+\@x{\@s{34.52} \.{\IN}}%
+\@x{\@s{34.52} \.{\land} obj\_state \.{'} \.{=} final\_obj\_state}%
+ \@x{\@s{34.52} \.{\land} obj\_key \.{'} \.{=} [ obj\_key {\EXCEPT} {\bang} [
+ new\_obj ] \.{=} k ]}%
+ \@x{\@s{34.52} \.{\land} obj\_val \.{'}\@s{1.64} \.{=} [ obj\_val {\EXCEPT}
+ {\bang} [ new\_obj ]\@s{1.64} \.{=} v ]}%
+\@x{\@s{34.52} \.{\land} obj\_freed\_epoch \.{'} \.{=} final\_obj\_freed}%
+\@pvspace{8.0pt}%
+\@x{\@s{34.52} \.{\land} bucket\_state \.{'} \.{=} final\_bucket\_state}%
+ \@x{\@s{34.52} \.{\land} bucket\_freed\_epoch \.{'} \.{=}
+ final\_bucket\_freed}%
+\@x{\@s{34.52} \.{\land} bucket\_contents \.{'} \.{=}}%
+\@x{\@s{53.83} [ bucket\_contents {\EXCEPT} {\bang} [ new\_bo ] \.{=}}%
+\@x{\@s{60.71} {\IF} old\_bo \.{=} 0}%
+ \@x{\@s{60.71} \.{\THEN} [ x \.{\in} Keys \.{\mapsto} {\IF} x \.{=} k
+ \.{\THEN} new\_obj \.{\ELSE} 0 ]}%
+ \@x{\@s{60.71} \.{\ELSE} [ x \.{\in} Keys \.{\mapsto} {\IF} x \.{=} k
+ \.{\THEN} new\_obj \.{\ELSE} bucket\_contents [ old\_bo ] [ x ] ] ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{34.52} \.{\land} bucket\_ptr \.{'}\@s{5.94} \.{=} [ bucket\_ptr
+ {\EXCEPT} {\bang} [ b ] \.{=} new\_bo ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{34.52} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+ \@x{\@s{108.32} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{108.32} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ WriterDelete ( k ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} HasUnusedBucket}%
+\@x{\@s{8.2} \.{\land} \.{\LET} new\_bo \.{\defeq} ChooseUnusedBucket}%
+\@x{\@s{39.71} b \.{\defeq} BucketOfKey ( k )}%
+\@x{\@s{39.71} old\_bo \.{\defeq} bucket\_ptr [ b ]}%
+\@x{\@s{19.31} \.{\IN}}%
+\@x{\@s{19.31} \.{\land} old\_bo \.{\neq} 0}%
+ \@x{\@s{19.31} \.{\land} \.{\LET} old\_obj \.{\defeq} bucket\_contents [
+ old\_bo ] [ k ] \.{\IN}}%
+\@x{\@s{30.42} \.{\land} old\_obj \.{\neq} 0}%
+\@pvspace{8.0pt}%
+\@x{\@s{38.62}}%
+\@y{\@s{0}%
+ New bucket is copy of old, with key removed.
+}%
+\@xx{}%
+ \@x{\@s{38.62} \.{\land} bucket\_state \.{'} \.{=} [ bucket\_state {\EXCEPT}
+ {\bang} [ new\_bo ] \.{=}\@w{Live} ]}%
+ \@x{\@s{38.62} \.{\land} bucket\_freed\_epoch \.{'} \.{=} [
+ bucket\_freed\_epoch {\EXCEPT} {\bang} [ new\_bo ] \.{=} 0 ]}%
+\@x{\@s{38.62} \.{\land} bucket\_contents \.{'} \.{=}}%
+\@x{\@s{57.93} [ bucket\_contents {\EXCEPT} {\bang} [ new\_bo ] \.{=}}%
+ \@x{\@s{64.81} [ x \.{\in} Keys \.{\mapsto} {\IF} x \.{=} k \.{\THEN} 0
+ \.{\ELSE} bucket\_contents [ old\_bo ] [ x ] ] ]}%
+ \@x{\@s{38.62} \.{\land} bucket\_ptr \.{'} \.{=} [ bucket\_ptr {\EXCEPT}
+ {\bang} [ b ] \.{=} new\_bo ]}%
+\@pvspace{8.0pt}%
+\@x{\@s{38.62}}%
+\@y{\@s{0}%
+ Retire old bucket and old value.
+}%
+\@xx{}%
+ \@x{\@s{38.62} \.{\land} bucket\_state \.{'} \.{=} [ bucket\_state \.{'}
+ {\EXCEPT} {\bang} [ old\_bo ] \.{=}\@w{Retired} ]}%
+ \@x{\@s{38.62} \.{\land} bucket\_freed\_epoch \.{'} \.{=} [
+ bucket\_freed\_epoch \.{'} {\EXCEPT} {\bang} [ old\_bo ] \.{=} StampEpoch (
+ published\_epoch ) ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{38.62} \.{\land} obj\_state \.{'} \.{=} [ obj\_state {\EXCEPT}
+ {\bang} [ old\_obj ] \.{=}\@w{Retired} ]}%
+ \@x{\@s{38.62} \.{\land} obj\_freed\_epoch \.{'} \.{=} [ obj\_freed\_epoch
+ {\EXCEPT} {\bang} [ old\_obj ] \.{=} StampEpoch ( published\_epoch ) ]}%
+\@pvspace{8.0pt}%
+ \@x{\@s{38.62} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+\@x{\@s{112.42} obj\_key ,\, obj\_val ,\,}%
+ \@x{\@s{112.42} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{112.42} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Epoch progression + reclamation
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ AdvancePublishedEpoch \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} published\_epoch \.{<} MaxEpoch}%
+\@x{\@s{8.2} \.{\land} published\_epoch \.{'} \.{=} published\_epoch \.{+} 1}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} released\_epoch ,\, cpu\_epoch
+ ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+ \@x{\@s{81.99} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{81.99} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ComputeReleasedEpoch \.{\defeq}}%
+ \@x{\@s{8.2} \.{\land} \.{\LET} active \.{\defeq} ActiveEpochs ( cpu\_epoch
+ )}%
+\@x{\@s{39.71} candidate \.{\defeq}}%
+\@x{\@s{47.91} {\IF} active \.{=} \{ \}}%
+ \@x{\@s{47.91} \.{\THEN} {\IF} published\_epoch \.{=} 0 \.{\THEN} 0 \.{\ELSE}
+ published\_epoch \.{-} 1}%
+ \@x{\@s{47.91} \.{\ELSE} \.{\LET} m \.{\defeq} MinSet ( active ) \.{\IN}
+ {\IF} m \.{=} 0 \.{\THEN} 0 \.{\ELSE} m \.{-} 1}%
+\@x{\@s{19.31} \.{\IN}}%
+ \@x{\@s{19.31} released\_epoch \.{'} \.{=} Max2 ( released\_epoch ,\,
+ candidate )}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\, cpu\_epoch
+ ,\,}%
+ \@x{\@s{81.99} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{81.99} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+ \@x{\@s{81.99} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{81.99} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReclaimOne \.{\defeq}}%
+\@x{\@s{8.2} \.{\lor} \.{\land} RetiredObjs \.{\neq} \{ \}}%
+ \@x{\@s{16.4} \.{\land} \.{\LET} o \.{\defeq} {\CHOOSE} x \.{\in} RetiredObjs
+ \.{:} {\TRUE} \.{\IN}}%
+ \@x{\@s{24.59} \.{\land} obj\_state \.{'} \.{=} [ obj\_state {\EXCEPT}
+ {\bang} [ o ] \.{=}\@w{Freed} ]}%
+ \@x{\@s{24.59} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+\@x{\@s{60.31} obj\_key ,\, obj\_val ,\, obj\_freed\_epoch ,\,}%
+ \@x{\@s{60.31} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+ \@x{\@s{60.31} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{60.31} bad {\rangle}}%
+\@x{\@s{8.2} \.{\lor} \.{\land} RetiredBuckets \.{\neq} \{ \}}%
+ \@x{\@s{16.4} \.{\land} \.{\LET} bo \.{\defeq} {\CHOOSE} x \.{\in}
+ RetiredBuckets \.{:} {\TRUE} \.{\IN}}%
+ \@x{\@s{24.59} \.{\land} bucket\_state \.{'} \.{=} [ bucket\_state {\EXCEPT}
+ {\bang} [ bo ] \.{=}\@w{Freed} ]}%
+ \@x{\@s{24.59} \.{\land} {\UNCHANGED} {\langle} published\_epoch ,\,
+ released\_epoch ,\, cpu\_epoch ,\,}%
+ \@x{\@s{60.31} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+\@x{\@s{60.31} bucket\_contents ,\, bucket\_freed\_epoch ,\, bucket\_ptr ,\,}%
+ \@x{\@s{60.31} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{60.31} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Next-state relation
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ Next \.{\defeq}}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, c\@s{0.51} \.{\in} CPUs \.{:} ReaderEnter
+ ( c )}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, c\@s{0.51} \.{\in} CPUs \.{:} ReaderExit
+ ( c )}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, c\@s{0.51} \.{\in} CPUs \.{:} \E\, k
+ \.{\in} Keys \.{:} ReaderBeginFind ( c ,\, k )}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, c\@s{0.51} \.{\in} CPUs \.{:}
+ ReaderFinishFind ( c )}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, c\@s{0.51} \.{\in} CPUs \.{:}
+ ReaderUseHeld ( c )}%
+\@pvspace{8.0pt}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, k \.{\in} Keys\@s{4.22} \.{:} \E\, v
+ \.{\in} Values \.{:} WriterUpsert ( k ,\, v )}%
+ \@x{\@s{8.2} \.{\lor}\@s{1.63} \E\, k \.{\in} Keys\@s{4.22} \.{:}
+ WriterDelete ( k )}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2} \.{\lor}\@s{1.63} AdvancePublishedEpoch}%
+\@x{\@s{8.2} \.{\lor}\@s{1.63} ComputeReleasedEpoch}%
+\@x{\@s{8.2} \.{\lor}\@s{1.63} ReclaimOne}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Invariants
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ Safety \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} {\lnot} bad}%
+\@x{\@s{8.2} \.{\land} released\_epoch \.{\leq} published\_epoch}%
+\@pvspace{8.0pt}%
+\@x{\@s{8.2}}%
+\@y{\@s{0}%
+ While in an epoch, held objects/buckets must not be reclaimed.
+}%
+\@xx{}%
+\@x{\@s{8.2} \.{\land} \A\, c \.{\in} CPUs \.{:}}%
+ \@x{\@s{27.51} ( cpu\_epoch [ c ] \.{\neq} 0 \.{\land} held\_obj [ c ]
+ \.{\neq} 0 ) \.{\implies} obj\_state [ held\_obj [ c ] ] \.{\neq}\@w{Freed}}%
+\@x{\@s{8.2} \.{\land} \A\, c \.{\in} CPUs \.{:}}%
+ \@x{\@s{27.51} ( cpu\_epoch [ c ] \.{\neq} 0 \.{\land} held\_bucket [ c ]
+ \.{\neq} 0 ) \.{\implies} bucket\_state [ held\_bucket [ c ] ]
+ \.{\neq}\@w{Freed}}%
+\@pvspace{8.0pt}%
+ \@x{ Spec \.{\defeq} Init \.{\land} {\Box} [ Next ] {\langle}
+ published\_epoch ,\, released\_epoch ,\, cpu\_epoch ,\,}%
+ \@x{\@s{76.54} obj\_state ,\, obj\_key ,\, obj\_val ,\, obj\_freed\_epoch
+ ,\,}%
+ \@x{\@s{76.54} bucket\_state ,\, bucket\_contents ,\, bucket\_freed\_epoch
+ ,\, bucket\_ptr ,\,}%
+ \@x{\@s{76.54} reader\_key ,\, snapshot\_bucket ,\, held\_bucket ,\,
+ held\_obj ,\,}%
+\@x{\@s{76.54} bad {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/models/object_array_map/CONFORMANCE.md
+++ b/models/object_array_map/CONFORMANCE.md
@@ -1,0 +1,46 @@
+# Conformance Notes: Object Array Map lock-free read model
+
+This document maps `models/object_array_map/ObjectArrayMapModel.tla` to the relevant implementation patterns.
+
+## Relevant implementation sites
+
+Lock-free read of an object pointer from an array-map slot:
+- `libs/execution_context/ebpf_maps.c`
+  - `_find_object_array_map_entry()` uses `ReadULong64NoFence` to atomically load the object pointer without taking the map lock.
+  - `_get_object_from_array_map_entry()` uses `ReadULong64NoFence` similarly.
+
+Writer update under a lock:
+- `libs/execution_context/ebpf_maps.c`
+  - `_update_array_map_entry_with_handle()` runs under `object_map->lock`, releases the old object reference via `EBPF_OBJECT_RELEASE_REFERENCE(old_object)`, then writes the new pointer with `WriteULong64NoFence`.
+
+Deferred destruction via epoch:
+- `libs/runtime/ebpf_object.c`
+  - `ebpf_object_release_reference()` schedules destruction using `ebpf_epoch_schedule_work_item(...)` when the reference count reaches zero.
+
+## Model-to-code mapping
+
+### Slot pointer
+
+- Model variable `slot` represents the pointer-sized slot stored in `map->data[index * actual_value_size]`.
+- Model action `ReaderLoad` represents the lock-free load via `ReadULong64NoFence`.
+
+### Update and retirement
+
+- Model action `WriterUpdate` represents the update under `object_map->lock`:
+  - retiring the old object (conceptually after `EBPF_OBJECT_RELEASE_REFERENCE(old_object)`), and
+  - writing the new pointer to the slot.
+
+The model abstracts away reference counts and focuses on the lifetime effect:
+- Objects are not actually freed immediately; they become `Retired` and are later `Freed` by `ReclaimOne`.
+
+### Epoch rule / contract
+
+- Model variables `publishedEpoch` and `readerEpoch` approximate the epoch guard described in the codebase.
+- `AllowReadOutsideEpoch = FALSE` encodes the intended safe contract for readers.
+- Under this contract, the reader must enter an epoch before it loads the slot and must drop/stop using the pointer before it exits the epoch.
+- The buggy config sets `AllowReadOutsideEpoch = TRUE`, which allows a reader to hold an object while appearing "not in epoch" to the reclamation rule, permitting premature freeing.
+
+## What this model is (and isn’t)
+
+- It is a safety model of the lifetime contract around lock-free reads.
+- It is not a linearizability model of map update semantics, and it does not model multiple writers/readers.

--- a/models/object_array_map/ObjectArrayMapModel.cfg
+++ b/models/object_array_map/ObjectArrayMapModel.cfg
@@ -1,0 +1,12 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  ObjIds = {1, 2, 3}
+  MaxEpoch = 3
+  AllowReadOutsideEpoch = FALSE
+
+INVARIANT TypeOK
+INVARIANT Safety

--- a/models/object_array_map/ObjectArrayMapModel.tla
+++ b/models/object_array_map/ObjectArrayMapModel.tla
@@ -1,0 +1,148 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+---- MODULE ObjectArrayMapModel ----
+EXTENDS Naturals, FiniteSets, TLC
+
+(*****************************************************************
+Bounded, executable TLA+ model of the lock-free (no-lock) read of an
+object pointer stored in an array map slot, as used by prog-array and
+(map-in-map) array variants.
+
+Key implementation pattern (libs/execution_context/ebpf_maps.c):
+- Reader: atomically reads a pointer from a map slot with NoFence and
+  then uses it without taking the map lock and without taking an extra
+  object reference.
+- Writer: updates the slot under a lock, releases the old object
+  reference, and writes the new pointer.
+
+Correctness relies on a lifetime rule:
+- The reader must be executing inside an epoch (or equivalent guard)
+  such that objects whose refcount reaches zero are not actually freed
+  until after the epoch ends.
+
+This model checks a core safety property:
+- A reader must never hold/use an object that has been Freed.
+
+It provides a buggy configuration that permits reads outside an epoch.
+*****************************************************************)
+
+CONSTANTS
+  ObjIds,                \* Finite set of object identities.
+  MaxEpoch,              \* Nat: upper bound for published epoch.
+  AllowReadOutsideEpoch  \* BOOLEAN: if TRUE, allow reader to load without entering epoch.
+
+ASSUME ObjIds \subseteq Nat
+ASSUME MaxEpoch \in Nat
+ASSUME Cardinality(ObjIds) >= 2
+
+Epochs == 0..MaxEpoch
+NoEpoch == MaxEpoch + 1
+AllEpochVals == Epochs \cup {NoEpoch}
+
+ObjStates == {"Live", "Retired", "Freed"}
+
+VARIABLES
+  publishedEpoch,   \* global/published epoch (monotonic).
+  readerEpoch,      \* reader's current epoch, or NoEpoch if not in epoch.
+  slot,             \* array slot pointer: 0 (NULL) or an ObjId.
+  objState,         \* [ObjIds -> ObjStates]
+  retireEpoch,      \* [ObjIds -> AllEpochVals]
+  held              \* 0 (none) or ObjId the reader is currently using.
+
+TypeOK ==
+  /\ publishedEpoch \in Epochs
+  /\ readerEpoch \in AllEpochVals
+  /\ slot \in (ObjIds \cup {0})
+  /\ held \in (ObjIds \cup {0})
+  /\ objState \in [ObjIds -> ObjStates]
+  /\ retireEpoch \in [ObjIds -> AllEpochVals]
+
+Safety ==
+  /\ held = 0 \/ objState[held] # "Freed"
+
+Init ==
+  LET o1 == CHOOSE o \in ObjIds: TRUE
+      o2 == CHOOSE o \in (ObjIds \ {o1}): TRUE
+  IN
+  /\ publishedEpoch = 0
+  /\ readerEpoch = NoEpoch
+  /\ slot = o1
+  /\ held = 0
+  /\ objState = [o \in ObjIds |-> IF o = o1 THEN "Live" ELSE "Freed"]
+  /\ retireEpoch = [o \in ObjIds |-> NoEpoch]
+
+\* Reader operations
+ReaderEnter ==
+  /\ readerEpoch = NoEpoch
+  /\ readerEpoch' = publishedEpoch
+  /\ UNCHANGED <<publishedEpoch, slot, objState, retireEpoch, held>>
+
+ReaderExit ==
+  /\ readerEpoch # NoEpoch
+  /\ held = 0
+  /\ readerEpoch' = NoEpoch
+  /\ UNCHANGED <<publishedEpoch, slot, objState, retireEpoch, held>>
+
+ReaderLoad ==
+  /\ held = 0
+  /\ slot # 0
+  /\ (AllowReadOutsideEpoch \/ readerEpoch # NoEpoch)
+  /\ held' = slot
+  /\ UNCHANGED <<publishedEpoch, readerEpoch, slot, objState, retireEpoch>>
+
+ReaderDrop ==
+  /\ held # 0
+  /\ held' = 0
+  /\ UNCHANGED <<publishedEpoch, readerEpoch, slot, objState, retireEpoch>>
+
+\* Writer operations
+AllocateNewLiveObject ==
+  CHOOSE o \in ObjIds: objState[o] = "Freed"
+
+WriterUpdate ==
+  /\ slot # 0
+  /\ \E new \in ObjIds:
+       /\ objState[new] = "Freed"
+       /\ slot' = new
+       /\ objState' = [objState EXCEPT
+                       ![slot] = "Retired",
+                       ![new] = "Live"]
+       /\ retireEpoch' = [retireEpoch EXCEPT ![slot] = publishedEpoch]
+       /\ UNCHANGED <<publishedEpoch, readerEpoch, held>>
+
+\* Epoch progression + reclamation
+AdvanceEpoch ==
+  /\ publishedEpoch < MaxEpoch
+  /\ publishedEpoch' = publishedEpoch + 1
+  /\ UNCHANGED <<readerEpoch, slot, objState, retireEpoch, held>>
+
+MinActiveEpoch == IF readerEpoch = NoEpoch THEN NoEpoch ELSE readerEpoch
+
+CanReclaim(o) ==
+  /\ objState[o] = "Retired"
+  /\ retireEpoch[o] \in Epochs
+  /\ retireEpoch[o] < MinActiveEpoch
+
+ReclaimOne ==
+  /\ \E o \in ObjIds: CanReclaim(o)
+  /\ LET o == CHOOSE x \in ObjIds: CanReclaim(x)
+     IN
+     /\ objState' = [objState EXCEPT ![o] = "Freed"]
+     /\ retireEpoch' = [retireEpoch EXCEPT ![o] = NoEpoch]
+     /\ UNCHANGED <<publishedEpoch, readerEpoch, slot, held>>
+
+vars == <<publishedEpoch, readerEpoch, slot, objState, retireEpoch, held>>
+
+Next ==
+  ReaderEnter
+  \/ ReaderExit
+  \/ ReaderLoad
+  \/ ReaderDrop
+  \/ WriterUpdate
+  \/ AdvanceEpoch
+  \/ ReclaimOne
+
+Spec == Init /\ [][Next]_vars
+
+====

--- a/models/object_array_map/ObjectArrayMapModel_buggy_read_outside_epoch.cfg
+++ b/models/object_array_map/ObjectArrayMapModel_buggy_read_outside_epoch.cfg
@@ -1,0 +1,12 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  ObjIds = {1, 2, 3}
+  MaxEpoch = 3
+  AllowReadOutsideEpoch = TRUE
+
+INVARIANT TypeOK
+INVARIANT Safety

--- a/models/object_array_map/README.md
+++ b/models/object_array_map/README.md
@@ -1,0 +1,40 @@
+# Object Array Map (lock-free read) TLA+ Model
+
+This folder contains a bounded TLA+ model of the lock-free read of an object pointer stored in an array map slot.
+
+This corresponds to the pattern used by:
+- program arrays (`BPF_MAP_TYPE_PROG_ARRAY`)
+- array-of-maps (`BPF_MAP_TYPE_ARRAY_OF_MAPS`)
+
+## What the model checks
+
+Safety invariant (`Safety`):
+- A reader must never hold/use an object that has been freed.
+
+The model captures the key intended contract:
+- Readers that load a pointer from the slot must be inside an epoch (or equivalent guard), because object destruction is deferred via an epoch work item when the reference count reaches zero.
+- Readers must also stop using any pointers read from the slot before exiting the epoch.
+
+## Files
+
+- `ObjectArrayMapModel.tla`: the model.
+- `ObjectArrayMapModel.cfg`: safe configuration (expected to pass).
+- `ObjectArrayMapModel_buggy_read_outside_epoch.cfg`: deliberately unsafe configuration (expected to fail `Safety`).
+
+## Running TLC locally
+
+From the repo root:
+
+- Safe model (expected PASS):
+  - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -cp models\tla2tools.jar tlc2.TLC -workers auto models\object_array_map\ObjectArrayMapModel.tla -config models\object_array_map\ObjectArrayMapModel.cfg`
+
+- Buggy model (expected FAIL):
+  - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -cp models\tla2tools.jar tlc2.TLC -workers auto models\object_array_map\ObjectArrayMapModel.tla -config models\object_array_map\ObjectArrayMapModel_buggy_read_outside_epoch.cfg`
+
+## Notes / limitations
+
+- Single reader, single writer, single array slot.
+- No attempt to model map locks explicitly; the writer update is modeled as atomic.
+- Object reference counts are abstracted: the writer update retires the old object; reclamation happens later when the epoch condition permits.
+- The buggy configuration models a contract violation: reading the slot without being in an epoch.
+- The safe configuration assumes the reader drops the pointer before exiting the epoch.

--- a/models/object_array_map/tlatex/ObjectArrayMapModel.tex
+++ b/models/object_array_map/tlatex/ObjectArrayMapModel.tex
@@ -1,0 +1,1187 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{\,\backslash\,}}* Copyright (c) \ensuremath{eBPF} for Windows
+ contributors
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{\,\backslash\,}}* SPDX-License-Identifier: \ensuremath{MIT
+}%
+\end{cpar}%
+\end{lcom}%
+ \@x{}\moduleLeftDash\@xx{ {\MODULE}
+ ObjectArrayMapModel}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals ,\, FiniteSets ,\, TLC}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Bounded, executable TLA+ model of the lock-free (no-lock) read of an
+ object pointer stored in an array map slot, as used by prog-array and
+ (map-in-map) array variants.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ Key implementation pattern
+ (libs/\ensuremath{execution\_context}/\ensuremath{ebpf\_maps.c}):
+ - Reader: atomically reads a pointer from a map slot with
+ \ensuremath{NoFence} and
+\end{cpar}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+then uses it without taking the map lock and without taking an extra
+ object reference.
+\end{cpar}%
+\begin{cpar}{1}{T}{T}{0}{2.5}{%
+-}%
+Writer: updates the slot under a lock, releases the old object
+ reference, and writes the new pointer.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Correctness relies on a lifetime rule:
+ - The reader must be executing inside an epoch (or equivalent guard)
+\end{cpar}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+such that objects whose refcount reaches zero are not actually freed
+ until after the epoch ends.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+This model checks a core safety property:
+ - A reader must never hold/use an object that has been \ensuremath{Freed}.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+It provides a buggy configuration that permits reads outside an epoch.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ {\CONSTANTS}}%
+\@x{\@s{8.2} ObjIds ,\,\@s{74.11}}%
+\@y{\@s{0}%
+ Finite set of object identities.
+}%
+\@xx{}%
+\@x{\@s{8.2} MaxEpoch ,\,\@s{58.14}}%
+\@y{\@s{0}%
+ \ensuremath{Nat}: upper bound for published epoch.
+}%
+\@xx{}%
+\@x{\@s{8.2} AllowReadOutsideEpoch\@s{4.09}}%
+\@y{\@s{0}%
+ \ensuremath{{\BOOLEAN}}: if \ensuremath{{\TRUE}}, allow reader to load
+ without entering epoch.
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ {\ASSUME} ObjIds \.{\subseteq} Nat}%
+\@x{ {\ASSUME} MaxEpoch \.{\in} Nat}%
+\@x{ {\ASSUME} Cardinality ( ObjIds ) \.{\geq} 2}%
+\@pvspace{8.0pt}%
+\@x{ Epochs \.{\defeq} 0 \.{\dotdot} MaxEpoch}%
+\@x{ NoEpoch \.{\defeq} MaxEpoch \.{+} 1}%
+\@x{ AllEpochVals \.{\defeq} Epochs \.{\cup} \{ NoEpoch \}}%
+\@pvspace{8.0pt}%
+\@x{ ObjStates \.{\defeq} \{\@w{Live} ,\,\@w{Retired} ,\,\@w{Freed} \}}%
+\@pvspace{8.0pt}%
+\@x{ {\VARIABLES}}%
+\@x{\@s{8.2} publishedEpoch ,\,\@s{8.2}}%
+\@y{\@s{0}%
+ global/published epoch (monotonic).
+}%
+\@xx{}%
+\@x{\@s{8.2} readerEpoch ,\,\@s{20.5}}%
+\@y{\@s{0}%
+ reader\mbox{'}s current epoch, or \ensuremath{NoEpoch} if not in epoch.
+}%
+\@xx{}%
+\@x{\@s{8.2} slot ,\,\@s{57.73}}%
+\@y{\@s{0}%
+ array slot pointer: 0 (NULL) or an \ensuremath{ObjId}.
+}%
+\@xx{}%
+\@x{\@s{8.2} objState ,\,\@s{38.25}}%
+\@y{\@s{0}%
+ [\ensuremath{ObjIds \.{\rightarrow} ObjStates}]
+}%
+\@xx{}%
+\@x{\@s{8.2} retireEpoch ,\,\@s{24.29}}%
+\@y{\@s{0}%
+ [\ensuremath{ObjIds \.{\rightarrow} AllEpochVals}]
+}%
+\@xx{}%
+\@x{\@s{8.2} held\@s{61.46}}%
+\@y{\@s{0}%
+ 0 (none) or \ensuremath{ObjId} the reader is currently using.
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} publishedEpoch \.{\in} Epochs}%
+\@x{\@s{8.2} \.{\land} readerEpoch \.{\in} AllEpochVals}%
+\@x{\@s{8.2} \.{\land} slot\@s{2.38} \.{\in} ( ObjIds \.{\cup} \{ 0 \} )}%
+\@x{\@s{8.2} \.{\land} held \.{\in} ( ObjIds \.{\cup} \{ 0 \} )}%
+\@x{\@s{8.2} \.{\land} objState \.{\in} [ ObjIds \.{\rightarrow} ObjStates ]}%
+ \@x{\@s{8.2} \.{\land} retireEpoch \.{\in} [ ObjIds \.{\rightarrow}
+ AllEpochVals ]}%
+\@pvspace{8.0pt}%
+\@x{ Safety \.{\defeq}}%
+ \@x{\@s{8.2} \.{\land} held \.{=} 0 \.{\lor} objState [ held ]
+ \.{\neq}\@w{Freed}}%
+\@pvspace{8.0pt}%
+\@x{ Init \.{\defeq}}%
+\@x{\@s{8.2} \.{\LET} o1 \.{\defeq} {\CHOOSE} o \.{\in} ObjIds \.{:} {\TRUE}}%
+ \@x{\@s{28.59} o2 \.{\defeq} {\CHOOSE} o \.{\in} ( ObjIds \.{\,\backslash\,}
+ \{ o1 \} ) \.{:} {\TRUE}}%
+\@x{\@s{8.2} \.{\IN}}%
+\@x{\@s{8.2} \.{\land} publishedEpoch \.{=} 0}%
+\@x{\@s{8.2} \.{\land} readerEpoch \.{=} NoEpoch}%
+\@x{\@s{8.2} \.{\land} slot\@s{2.38} \.{=} o1}%
+\@x{\@s{8.2} \.{\land} held \.{=} 0}%
+ \@x{\@s{8.2} \.{\land} objState \.{=} [ o \.{\in} ObjIds \.{\mapsto} {\IF} o
+ \.{=} o1 \.{\THEN}\@w{Live} \.{\ELSE}\@w{Freed} ]}%
+ \@x{\@s{8.2} \.{\land} retireEpoch \.{=} [ o \.{\in} ObjIds \.{\mapsto}
+ NoEpoch ]}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Reader operations
+}%
+\@xx{}%
+\@x{ ReaderEnter \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} readerEpoch \.{=} NoEpoch}%
+\@x{\@s{8.2} \.{\land} readerEpoch \.{'} \.{=} publishedEpoch}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} publishedEpoch ,\, slot ,\,
+ objState ,\, retireEpoch ,\, held {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderExit \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} readerEpoch \.{\neq} NoEpoch}%
+\@x{\@s{8.2} \.{\land} held \.{=} 0}%
+\@x{\@s{8.2} \.{\land} readerEpoch \.{'} \.{=} NoEpoch}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} publishedEpoch ,\, slot ,\,
+ objState ,\, retireEpoch ,\, held {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderLoad \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} held \.{=} 0}%
+\@x{\@s{8.2} \.{\land} slot\@s{2.38} \.{\neq} 0}%
+ \@x{\@s{8.2} \.{\land} ( AllowReadOutsideEpoch \.{\lor} readerEpoch \.{\neq}
+ NoEpoch )}%
+\@x{\@s{8.2} \.{\land} held \.{'} \.{=} slot}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} publishedEpoch ,\, readerEpoch
+ ,\, slot ,\, objState ,\, retireEpoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ReaderDrop \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} held \.{\neq} 0}%
+\@x{\@s{8.2} \.{\land} held \.{'} \.{=} 0}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} publishedEpoch ,\, readerEpoch
+ ,\, slot ,\, objState ,\, retireEpoch {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Writer operations
+}%
+\@xx{}%
+\@x{ AllocateNewLiveObject \.{\defeq}}%
+\@x{\@s{8.2} {\CHOOSE} o \.{\in} ObjIds \.{:} objState [ o ] \.{=}\@w{Freed}}%
+\@pvspace{8.0pt}%
+\@x{ WriterUpdate \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} slot \.{\neq} 0}%
+\@x{\@s{8.2} \.{\land} \E\, new \.{\in} ObjIds \.{:}}%
+\@x{\@s{27.51} \.{\land} objState [ new ] \.{=}\@w{Freed}}%
+\@x{\@s{27.51} \.{\land} slot \.{'} \.{=} new}%
+\@x{\@s{27.51} \.{\land} objState \.{'} \.{=} [ objState {\EXCEPT}}%
+\@x{\@s{93.04} {\bang} [ slot ] \.{=}\@w{Retired} ,\,}%
+\@x{\@s{93.04} {\bang} [ new ] \.{=}\@w{Live} ]}%
+ \@x{\@s{27.51} \.{\land} retireEpoch \.{'} \.{=} [ retireEpoch {\EXCEPT}
+ {\bang} [ slot ] \.{=} publishedEpoch ]}%
+ \@x{\@s{27.51} \.{\land} {\UNCHANGED} {\langle} publishedEpoch ,\,
+ readerEpoch ,\, held {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Epoch progression + reclamation
+}%
+\@xx{}%
+\@x{ AdvanceEpoch \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} publishedEpoch \.{<} MaxEpoch}%
+\@x{\@s{8.2} \.{\land} publishedEpoch \.{'} \.{=} publishedEpoch \.{+} 1}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} readerEpoch ,\, slot ,\,
+ objState ,\, retireEpoch ,\, held {\rangle}}%
+\@pvspace{8.0pt}%
+ \@x{ MinActiveEpoch \.{\defeq} {\IF} readerEpoch \.{=} NoEpoch \.{\THEN}
+ NoEpoch \.{\ELSE} readerEpoch}%
+\@pvspace{8.0pt}%
+\@x{ CanReclaim ( o ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} objState [ o ] \.{=}\@w{Retired}}%
+\@x{\@s{8.2} \.{\land} retireEpoch [ o ] \.{\in} Epochs}%
+\@x{\@s{8.2} \.{\land} retireEpoch [ o ] \.{<} MinActiveEpoch}%
+\@pvspace{8.0pt}%
+\@x{ ReclaimOne \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} \E\, o \.{\in} ObjIds \.{:} CanReclaim ( o )}%
+ \@x{\@s{8.2} \.{\land} \.{\LET} o \.{\defeq} {\CHOOSE} x \.{\in} ObjIds \.{:}
+ CanReclaim ( x )}%
+\@x{\@s{19.31} \.{\IN}}%
+ \@x{\@s{19.31} \.{\land} objState \.{'} \.{=} [ objState {\EXCEPT} {\bang} [
+ o ] \.{=}\@w{Freed} ]}%
+ \@x{\@s{19.31} \.{\land} retireEpoch \.{'} \.{=} [ retireEpoch {\EXCEPT}
+ {\bang} [ o ] \.{=} NoEpoch ]}%
+ \@x{\@s{19.31} \.{\land} {\UNCHANGED} {\langle} publishedEpoch ,\,
+ readerEpoch ,\, slot ,\, held {\rangle}}%
+\@pvspace{8.0pt}%
+ \@x{ vars\@s{2.10} \.{\defeq} {\langle} publishedEpoch ,\, readerEpoch ,\,
+ slot ,\, objState ,\, retireEpoch ,\, held {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ Next \.{\defeq}}%
+\@x{\@s{8.2} ReaderEnter}%
+\@x{\@s{8.2} \.{\lor} ReaderExit}%
+\@x{\@s{8.2} \.{\lor} ReaderLoad}%
+\@x{\@s{8.2} \.{\lor} ReaderDrop}%
+\@x{\@s{8.2} \.{\lor} WriterUpdate}%
+\@x{\@s{8.2} \.{\lor} AdvanceEpoch}%
+\@x{\@s{8.2} \.{\lor} ReclaimOne}%
+\@pvspace{8.0pt}%
+\@x{ Spec \.{\defeq} Init \.{\land} {\Box} [ Next ]_{ vars}}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/models/ring_buffer/CONFORMANCE.md
+++ b/models/ring_buffer/CONFORMANCE.md
@@ -1,0 +1,85 @@
+# Conformance Notes: Ring Buffer Model
+
+This document maps the TLA+ model in `models/ring_buffer/RingBufferModel.tla` to the implementation.
+
+## Source locations
+
+Ring buffer map plumbing:
+- `libs/execution_context/ebpf_maps.c`
+  - `ebpf_ring_buffer_map_output()` (signals async query completion after output)
+  - `_async_query_ring_buffer_map()` / `_map_async_query()`
+  - `_map_async_query_complete()`
+  - `_query_ring_buffer_map()`
+  - `_query_buffer_ring_buffer_map()` / `_return_buffer_ring_buffer_map()`
+  - `_map_user_ring_buffer_map()` / `_unmap_user_ring_buffer_map()`
+
+Ring buffer core implementation:
+- `libs/runtime/ebpf_ring_buffer.c`
+  - `ebpf_ring_buffer_reserve()` / `ebpf_ring_buffer_reserve_exclusive()`
+  - `ebpf_ring_buffer_submit()` / `ebpf_ring_buffer_discard()`
+  - `_ring_next_consumer_record()` and `ebpf_ring_buffer_next_consumer_record()`
+  - `ebpf_ring_buffer_return_buffer()`
+  - `ebpf_ring_buffer_query()`
+
+Record format / lock+discard bits:
+- `libs/shared/ebpf_ring_buffer_record.h`
+
+## Model-to-code mapping
+
+### Offsets
+
+Model variables:
+- `consumer`: corresponds to the consumer offset (`consumer_page->consumer_offset`).
+- `producer`: corresponds to the published producer offset (`producer_page->producer_offset`).
+- `reserve`: corresponds to the producer reserve offset (`kernel_page->producer_reserve_offset`).
+
+In the C code, the key safety ordering is:
+- reserve initializes a record header with the lock bit set
+- then write-releases the `producer_offset` so the consumer cannot observe an uninitialized/unlocked record header
+
+The model captures this ordering via `ProducerReserve` vs `ProducerReserveBuggyPublish`.
+
+### Record state machine
+
+Model record `state`:
+- `Locked`: reserved and not yet submitted/discarded (lock bit set)
+- `Submitted`: submitted (lock bit cleared, discard bit clear)
+- `Discarded`: discarded (lock bit cleared, discard bit set)
+- `Uninit`: represents a not-yet-locked/initialized header (this should not become visible to the consumer in the safe model)
+
+This corresponds to `header.length` (plus lock/discard bits) in `ebpf_ring_buffer_record_t`.
+
+### Consumer behavior
+
+Model actions:
+- `ConsumerNext`: approximates `_ring_next_consumer_record()`:
+  - returns NULL if the next record is locked
+  - skips discarded records by advancing the consumer offset
+  - otherwise "holds" the record for return
+- `ConsumerReturn`: approximates `ebpf_ring_buffer_return_buffer()` for the normal, valid return case
+
+The model intentionally does not explore invalid return offsets; it focuses on the producer/consumer ordering guarantees.
+
+### Async query
+
+Model actions:
+- `AsyncQuery`: approximates `_map_async_query()` for ring-buffer maps
+- `AsyncComplete`: approximates `_map_async_query_complete()`
+
+The model reflects the key constraint in `ebpf_maps.c` that only one async query may be pending at a time.
+
+## Configurations
+
+- `RingBufferModel.cfg`:
+  - `BuggyPublishBeforeLock = FALSE`
+  - Expected: invariants hold.
+
+- `RingBufferModel_buggy_publish_before_lock.cfg`:
+  - `BuggyPublishBeforeLock = TRUE`
+  - Expected: `Safety` is violated (consumer can "hold" an `Uninit` record).
+
+## Known gaps
+
+- No attempt to model the full multi-producer reserve loop / compare-exchange serialization.
+- No modeling of wait handle signaling semantics (only the notion of async completion).
+- No modeling of record size alignment/padding beyond abstract unit sizes.

--- a/models/ring_buffer/README.md
+++ b/models/ring_buffer/README.md
@@ -1,0 +1,43 @@
+# Ring Buffer TLA+ Model
+
+This folder contains a bounded TLA+ model of the ring buffer behaviors as they are exposed through the map plumbing in `libs/execution_context/ebpf_maps.c`.
+
+## What this model covers
+
+- Producer reserving space and publishing the producer offset.
+- Producer submitting or discarding a record (unlocking it).
+- Consumer reading the next record in-order, skipping discarded records.
+- Consumer returning space by advancing the consumer offset.
+- Map async query: a single pending query that completes when `producer > consumer`.
+
+## Files
+
+- `RingBufferModel.tla`: the model.
+- `RingBufferModel.cfg`: "safe" configuration (expected to pass invariants).
+- `RingBufferModel_buggy_publish_before_lock.cfg`: intentionally buggy configuration (expected to fail `Safety`).
+
+## Safety property checked
+
+The core invariant is `Safety`:
+
+- The consumer must never "hold" (consume) a record unless it is in the `Submitted` state.
+
+This is meant to capture the essential guarantee provided by the acquire/release ordering in the C implementation: the consumer should not observe an uninitialized record as consumable.
+
+## Running TLC locally
+
+From the repo root:
+
+- Safe model (expected PASS):
+  - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -cp models\tla2tools.jar tlc2.TLC -workers auto models\ring_buffer\RingBufferModel.tla -config models\ring_buffer\RingBufferModel.cfg`
+
+- Buggy model (expected FAIL):
+  - `"C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\bin\java.exe" -cp models\tla2tools.jar tlc2.TLC -workers auto models\ring_buffer\RingBufferModel.tla -config models\ring_buffer\RingBufferModel_buggy_publish_before_lock.cfg`
+
+If Java is already on your `PATH`, you can replace the quoted `java.exe` path with `java`.
+
+## Notes / limitations
+
+- The model uses an abstract unit size and does not represent actual bytes, alignment, `page_offset`, or the mmap header pages.
+- It models a single consumer and does not model the full multi-producer reserve loop.
+- It is a bounded model: `Capacity`, `MaxOffset`, and `MaxLiveRecords` limit the state space for TLC.

--- a/models/ring_buffer/RingBufferModel.cfg
+++ b/models/ring_buffer/RingBufferModel.cfg
@@ -1,0 +1,15 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  Capacity = 4
+  Sizes = {1, 2}
+  MaxOffset = 8
+  MaxLiveRecords = 3
+  BuggyPublishBeforeLock = FALSE
+
+INVARIANT TypeOK
+INVARIANT OffsetsConsistent
+INVARIANT Safety

--- a/models/ring_buffer/RingBufferModel.tla
+++ b/models/ring_buffer/RingBufferModel.tla
@@ -1,0 +1,201 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+---- MODULE RingBufferModel ----
+EXTENDS Naturals, Sequences, TLC
+
+(*****************************************************************
+Bounded, executable TLA+ model of the core ring-buffer behaviors
+that are exposed via libs/execution_context/ebpf_maps.c.
+
+Focus:
+- Producer reserves space (publishes producer offset).
+- Producer submits or discards a record (clears lock bit).
+- Consumer reads the next record in order, skipping discarded records.
+- Consumer returns buffers by advancing consumer offset.
+- Async query is completed when producer has advanced beyond consumer.
+
+This model is intentionally small and does not model:
+- actual byte contents, alignment details, page_offset, or mmap pages
+- kernel wait handle semantics
+- multiple producers / full reserve loop serialization
+
+See CONFORMANCE.md for mapping to C sources.
+*****************************************************************)
+
+CONSTANTS
+  Capacity,               \* Nat: ring capacity in abstract "units".
+  Sizes,                  \* Finite set of Nat record sizes (in units).
+  MaxOffset,              \* Nat: max reserve/producer offset to keep TLC finite.
+  MaxLiveRecords,         \* Nat: bound on number of live (unreturned) records.
+  BuggyPublishBeforeLock  \* BOOLEAN: if TRUE, allow producer to publish offset before locking record.
+
+ASSUME Capacity \in Nat
+ASSUME MaxOffset \in Nat
+ASSUME MaxLiveRecords \in Nat
+ASSUME Sizes \subseteq Nat
+ASSUME \A s \in Sizes: s > 0
+
+States == {"Uninit", "Locked", "Submitted", "Discarded"}
+
+Record == [size: Sizes, state: States]
+
+VARIABLES
+  consumer,        \* Consumer offset (monotonic).
+  producer,        \* Published producer offset.
+  reserve,         \* Producer reserve offset (end of last reserved record).
+  liveSize,        \* reserve - consumer
+  records,         \* Sequence of live records in order.
+  held,            \* [active, size, state] representing a currently "read" record.
+  asyncPending,    \* Whether an async query is queued.
+  asyncCompleted,  \* Sticky flag: an async query completed at least once.
+  asyncResult,     \* [consumer, producer] captured on completion.
+  tripWire         \* Sticky: TRUE after first async query is queued.
+
+Held == [active: BOOLEAN, size: 0..MaxOffset, state: States]
+
+TypeOK ==
+  /\ consumer \in 0..MaxOffset
+  /\ producer \in 0..MaxOffset
+  /\ reserve \in 0..MaxOffset
+  /\ liveSize \in 0..Capacity
+  /\ records \in Seq(Record)
+  /\ Len(records) \leq MaxLiveRecords
+  /\ held \in Held
+  /\ asyncPending \in BOOLEAN
+  /\ asyncCompleted \in BOOLEAN
+  /\ asyncResult \in [consumer: 0..MaxOffset, producer: 0..MaxOffset]
+  /\ tripWire \in BOOLEAN
+
+OffsetsConsistent ==
+  /\ consumer \leq producer
+  /\ producer \leq reserve
+  /\ reserve = consumer + liveSize
+  /\ liveSize \leq Capacity
+
+Safety ==
+  \* Consumer must never "hold" an unsubmitted record.
+  held.active => held.state = "Submitted"
+
+Init ==
+  /\ consumer = 0
+  /\ producer = 0
+  /\ reserve = 0
+  /\ liveSize = 0
+  /\ records = <<>>
+  /\ held = [active |-> FALSE, size |-> 0, state |-> "Locked"]
+  /\ asyncPending = FALSE
+  /\ asyncCompleted = FALSE
+  /\ asyncResult = [consumer |-> 0, producer |-> 0]
+  /\ tripWire = FALSE
+
+CanReserve(sz) ==
+  /\ sz \in Sizes
+  /\ liveSize + sz \leq Capacity
+  /\ reserve + sz \leq MaxOffset
+  /\ Len(records) < MaxLiveRecords
+
+ProducerReserve ==
+  \E sz \in Sizes:
+    /\ CanReserve(sz)
+    /\ ~BuggyPublishBeforeLock
+    /\ records' = Append(records, [size |-> sz, state |-> "Locked"])
+    /\ reserve' = reserve + sz
+    /\ producer' = reserve'
+    /\ liveSize' = liveSize + sz
+    /\ UNCHANGED <<consumer, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+ProducerReserveBuggyPublish ==
+  \E sz \in Sizes:
+    /\ CanReserve(sz)
+    /\ BuggyPublishBeforeLock
+    \* Publish the offsets before the record is locked/initialized.
+    /\ records' = Append(records, [size |-> sz, state |-> "Uninit"])
+    /\ reserve' = reserve + sz
+    /\ producer' = reserve'
+    /\ liveSize' = liveSize + sz
+    /\ UNCHANGED <<consumer, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+ProducerFinalizeLock ==
+  /\ BuggyPublishBeforeLock
+  /\ Len(records) > 0
+  /\ Head(records).state = "Uninit"
+  /\ records' = << [size |-> Head(records).size, state |-> "Locked"] >> \o Tail(records)
+  /\ UNCHANGED <<consumer, producer, reserve, liveSize, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+ProducerSubmit ==
+  /\ Len(records) > 0
+  /\ Head(records).state = "Locked"
+  /\ records' = << [size |-> Head(records).size, state |-> "Submitted"] >> \o Tail(records)
+  /\ UNCHANGED <<consumer, producer, reserve, liveSize, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+ProducerDiscard ==
+  /\ Len(records) > 0
+  /\ Head(records).state = "Locked"
+  /\ records' = << [size |-> Head(records).size, state |-> "Discarded"] >> \o Tail(records)
+  /\ UNCHANGED <<consumer, producer, reserve, liveSize, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+ConsumerNext ==
+  /\ held.active = FALSE
+  /\ Len(records) > 0
+  /\ IF Head(records).state = "Locked" THEN
+       \* Cannot pass a locked record.
+       UNCHANGED <<consumer, producer, reserve, liveSize, records, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+     ELSE IF Head(records).state = "Discarded" THEN
+       \* Skip discarded records and immediately return their space.
+       /\ consumer' = consumer + Head(records).size
+       /\ liveSize' = liveSize - Head(records).size
+       /\ records' = Tail(records)
+       /\ UNCHANGED <<producer, reserve, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+     ELSE
+       \* Any unlocked record is treated as consumable.
+       /\ held' = [active |-> TRUE, size |-> Head(records).size, state |-> Head(records).state]
+       /\ UNCHANGED <<consumer, producer, reserve, liveSize, records, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+ConsumerReturn ==
+  /\ held.active = TRUE
+  /\ Len(records) > 0
+  /\ Head(records).size = held.size
+  /\ Head(records).state = held.state
+  /\ consumer' = consumer + held.size
+  /\ liveSize' = liveSize - held.size
+  /\ records' = Tail(records)
+  /\ held' = [active |-> FALSE, size |-> 0, state |-> "Locked"]
+  /\ UNCHANGED <<producer, reserve, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+AsyncQuery ==
+  /\ asyncPending = FALSE
+  /\ asyncPending' = TRUE
+  /\ tripWire' = TRUE
+  /\ UNCHANGED <<consumer, producer, reserve, liveSize, records, held, asyncCompleted, asyncResult>>
+
+AsyncCancel ==
+  /\ asyncPending = TRUE
+  /\ asyncPending' = FALSE
+  /\ UNCHANGED <<consumer, producer, reserve, liveSize, records, held, asyncCompleted, asyncResult, tripWire>>
+
+AsyncComplete ==
+  /\ asyncPending = TRUE
+  /\ producer > consumer
+  /\ asyncPending' = FALSE
+  /\ asyncCompleted' = TRUE
+  /\ asyncResult' = [consumer |-> consumer, producer |-> producer]
+  /\ UNCHANGED <<consumer, producer, reserve, liveSize, records, held, tripWire>>
+
+vars == <<consumer, producer, reserve, liveSize, records, held, asyncPending, asyncCompleted, asyncResult, tripWire>>
+
+Next ==
+  ProducerReserve
+  \/ ProducerReserveBuggyPublish
+  \/ ProducerFinalizeLock
+  \/ ProducerSubmit
+  \/ ProducerDiscard
+  \/ ConsumerNext
+  \/ ConsumerReturn
+  \/ AsyncQuery
+  \/ AsyncCancel
+  \/ AsyncComplete
+
+Spec == Init /\ [][Next]_vars
+
+====

--- a/models/ring_buffer/RingBufferModel_buggy_publish_before_lock.cfg
+++ b/models/ring_buffer/RingBufferModel_buggy_publish_before_lock.cfg
@@ -1,0 +1,15 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  Capacity = 4
+  Sizes = {1, 2}
+  MaxOffset = 8
+  MaxLiveRecords = 3
+  BuggyPublishBeforeLock = TRUE
+
+INVARIANT TypeOK
+INVARIANT OffsetsConsistent
+INVARIANT Safety

--- a/models/ring_buffer/tlatex/RingBufferModel.tex
+++ b/models/ring_buffer/tlatex/RingBufferModel.tex
@@ -1,0 +1,1314 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{\,\backslash\,}}* Copyright (c) \ensuremath{eBPF} for Windows
+ contributors
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{\,\backslash\,}}* SPDX-License-Identifier: \ensuremath{MIT
+}%
+\end{cpar}%
+\end{lcom}%
+\@x{}\moduleLeftDash\@xx{ {\MODULE} RingBufferModel}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals ,\, Sequences ,\, TLC}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{T}{F}{5.0}{0}{}%
+****************************************************************
+\end{cpar}%
+\begin{cpar}{1}{F}{F}{0}{0}{}%
+Bounded, executable TLA+ model of the core ring-buffer behaviors
+ that are exposed via
+ libs/\ensuremath{execution\_context}/\ensuremath{ebpf\_maps.c}.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+Focus\ensuremath{\.{:}
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-}} Producer reserves space (publishes producer
+ offset)\ensuremath{.
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-}} Producer submits or discards a record (clears lock
+ bit)\ensuremath{.
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-}} Consumer reads the next record in order, skipping
+ discarded records\ensuremath{.
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-}} Consumer returns buffers by advancing consumer
+ offset\ensuremath{.
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-} Async} query is completed when producer has advanced beyond
+ consumer.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+This model is intentionally small and does not model\ensuremath{\.{:}
+}%
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{-}} actual byte contents, alignment details,
+ \ensuremath{page\_offset}, or mmap pages
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+- kernel wait handle semantics
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+- multiple producers / full reserve loop serialization
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+See \ensuremath{CONFORMANCE.md} for mapping to \ensuremath{C} sources.
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+****************************************************************
+\end{cpar}%
+\end{lcom}%
+\@x{ {\CONSTANTS}}%
+\@x{\@s{8.2} Capacity ,\,\@s{66.07}}%
+\@y{\@s{0}%
+ \ensuremath{Nat}: ring capacity in abstract ``units''.
+}%
+\@xx{}%
+\@x{\@s{8.2} Sizes ,\,\@s{82.49}}%
+\@y{\@s{0}%
+ Finite set of \ensuremath{Nat} record sizes (in units).
+}%
+\@xx{}%
+\@x{\@s{8.2} MaxOffset ,\,\@s{59.30}}%
+\@y{\@s{0}%
+ \ensuremath{Nat}: max reserve/producer offset to keep \ensuremath{TLC}
+ finite.
+}%
+\@xx{}%
+\@x{\@s{8.2} MaxLiveRecords ,\,\@s{33.72}}%
+\@y{\@s{0}%
+ \ensuremath{Nat}: bound on number of live (unreturned) records.
+}%
+\@xx{}%
+\@x{\@s{8.2} BuggyPublishBeforeLock\@s{4.09}}%
+\@y{\@s{0}%
+ \ensuremath{{\BOOLEAN}}: if \ensuremath{{\TRUE}}, allow producer to publish
+ offset before locking record.
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+\@x{ {\ASSUME} Capacity \.{\in} Nat}%
+\@x{ {\ASSUME} MaxOffset \.{\in} Nat}%
+\@x{ {\ASSUME} MaxLiveRecords \.{\in} Nat}%
+\@x{ {\ASSUME} Sizes \.{\subseteq} Nat}%
+\@x{ {\ASSUME} \A\, s \.{\in} Sizes \.{:} s \.{>} 0}%
+\@pvspace{8.0pt}%
+ \@x{ States\@s{3.03} \.{\defeq} \{\@w{Uninit} ,\,\@w{Locked}
+ ,\,\@w{Submitted} ,\,\@w{Discarded} \}}%
+\@pvspace{8.0pt}%
+\@x{ Record \.{\defeq} [ size \.{:} Sizes ,\, state \.{:} States ]}%
+\@pvspace{8.0pt}%
+\@x{ {\VARIABLES}}%
+\@x{\@s{8.2} consumer ,\,\@s{32.29}}%
+\@y{\@s{0}%
+ Consumer offset (monotonic).
+}%
+\@xx{}%
+\@x{\@s{8.2} producer ,\,\@s{36.76}}%
+\@y{\@s{0}%
+ Published producer offset.
+}%
+\@xx{}%
+\@x{\@s{8.2} reserve ,\,\@s{43.48}}%
+\@y{\@s{0}%
+ Producer reserve offset (end of last reserved record).
+}%
+\@xx{}%
+\@x{\@s{8.2} liveSize ,\,\@s{41.69}}%
+\@y{\@s{0}%
+ \ensuremath{reserve \.{-} consumer
+}}%
+\@xx{}%
+\@x{\@s{8.2} records ,\,\@s{43.92}}%
+\@y{\@s{0}%
+ Sequence of live records in order.
+}%
+\@xx{}%
+\@x{\@s{8.2} held ,\,\@s{56.23}}%
+\@y{\@s{0}%
+ [active, size, state] representing a currently ``read'' record.
+}%
+\@xx{}%
+\@x{\@s{8.2} asyncPending ,\,\@s{14.07}}%
+\@y{\@s{0}%
+ Whether an async query is queued.
+}%
+\@xx{}%
+\@x{\@s{8.2} asyncCompleted ,\,\@s{4.1}}%
+\@y{\@s{0}%
+ Sticky flag: an async query completed at least once.
+}%
+\@xx{}%
+\@x{\@s{8.2} asyncResult ,\,\@s{22.70}}%
+\@y{\@s{0}%
+ [consumer, producer] captured on completion.
+}%
+\@xx{}%
+\@x{\@s{8.2} tripWire\@s{42.92}}%
+\@y{\@s{0}%
+ Sticky: \ensuremath{{\TRUE}} after first async query is queued.
+}%
+\@xx{}%
+\@pvspace{8.0pt}%
+ \@x{ Held \.{\defeq} [ active \.{:} {\BOOLEAN} ,\, size \.{:} 0 \.{\dotdot}
+ MaxOffset ,\, state \.{:} States ]}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} consumer \.{\in} 0 \.{\dotdot} MaxOffset}%
+\@x{\@s{8.2} \.{\land} producer\@s{4.47} \.{\in} 0 \.{\dotdot} MaxOffset}%
+\@x{\@s{8.2} \.{\land} reserve \.{\in} 0 \.{\dotdot} MaxOffset}%
+\@x{\@s{8.2} \.{\land} liveSize \.{\in} 0 \.{\dotdot} Capacity}%
+\@x{\@s{8.2} \.{\land} records \.{\in} Seq ( Record )}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{\leq} MaxLiveRecords}%
+\@x{\@s{8.2} \.{\land} held \.{\in} Held}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{\in} {\BOOLEAN}}%
+\@x{\@s{8.2} \.{\land} asyncCompleted \.{\in} {\BOOLEAN}}%
+ \@x{\@s{8.2} \.{\land} asyncResult \.{\in} [ consumer \.{:} 0 \.{\dotdot}
+ MaxOffset ,\, producer \.{:} 0 \.{\dotdot} MaxOffset ]}%
+\@x{\@s{8.2} \.{\land} tripWire \.{\in} {\BOOLEAN}}%
+\@pvspace{8.0pt}%
+\@x{ OffsetsConsistent \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} consumer \.{\leq} producer}%
+\@x{\@s{8.2} \.{\land} producer \.{\leq} reserve}%
+\@x{\@s{8.2} \.{\land} reserve \.{=} consumer \.{+} liveSize}%
+\@x{\@s{8.2} \.{\land} liveSize \.{\leq} Capacity}%
+\@pvspace{8.0pt}%
+\@x{ Safety \.{\defeq}}%
+\@x{\@s{8.2}}%
+\@y{\@s{0}%
+ Consumer must never ``hold'' an unsubmitted record.
+}%
+\@xx{}%
+\@x{\@s{8.2} held . active \.{\implies} held . state \.{=}\@w{Submitted}}%
+\@pvspace{8.0pt}%
+\@x{ Init \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} consumer \.{=} 0}%
+\@x{\@s{8.2} \.{\land} producer\@s{4.47} \.{=} 0}%
+\@x{\@s{8.2} \.{\land} reserve \.{=} 0}%
+\@x{\@s{8.2} \.{\land} liveSize \.{=} 0}%
+\@x{\@s{8.2} \.{\land} records \.{=} {\langle} {\rangle}}%
+ \@x{\@s{8.2} \.{\land} held \.{=} [ active \.{\mapsto} {\FALSE} ,\, size
+ \.{\mapsto} 0 ,\, state \.{\mapsto}\@w{Locked} ]}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} asyncCompleted \.{=} {\FALSE}}%
+ \@x{\@s{8.2} \.{\land} asyncResult \.{=} [ consumer \.{\mapsto} 0 ,\,
+ producer \.{\mapsto} 0 ]}%
+\@x{\@s{8.2} \.{\land} tripWire \.{=} {\FALSE}}%
+\@pvspace{8.0pt}%
+\@x{ CanReserve ( sz ) \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} sz \.{\in} Sizes}%
+\@x{\@s{8.2} \.{\land} liveSize \.{+} sz \.{\leq} Capacity}%
+\@x{\@s{8.2} \.{\land} reserve \.{+} sz \.{\leq} MaxOffset}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{<} MaxLiveRecords}%
+\@pvspace{8.0pt}%
+\@x{ ProducerReserve \.{\defeq}}%
+\@x{\@s{8.2} \E\, sz \.{\in} Sizes \.{:}}%
+\@x{\@s{16.4} \.{\land} CanReserve ( sz )}%
+\@x{\@s{16.4} \.{\land} {\lnot} BuggyPublishBeforeLock}%
+ \@x{\@s{16.4} \.{\land} records \.{'}\@s{0.44} \.{=} Append ( records ,\, [
+ size \.{\mapsto} sz ,\, state \.{\mapsto}\@w{Locked} ] )}%
+\@x{\@s{16.4} \.{\land} reserve \.{'} \.{=} reserve \.{+} sz}%
+\@x{\@s{16.4} \.{\land} producer \.{'} \.{=} reserve \.{'}}%
+\@x{\@s{16.4} \.{\land} liveSize \.{'}\@s{4.92} \.{=} liveSize \.{+} sz}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} consumer ,\, held ,\,
+ asyncPending ,\, asyncCompleted ,\, asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ProducerReserveBuggyPublish \.{\defeq}}%
+\@x{\@s{8.2} \E\, sz \.{\in} Sizes \.{:}}%
+\@x{\@s{16.4} \.{\land} CanReserve ( sz )}%
+\@x{\@s{16.4} \.{\land} BuggyPublishBeforeLock}%
+\@x{\@s{16.4}}%
+\@y{\@s{0}%
+ Publish the offsets before the record is locked/initialized.
+}%
+\@xx{}%
+ \@x{\@s{16.4} \.{\land} records \.{'}\@s{0.44} \.{=} Append ( records ,\, [
+ size \.{\mapsto} sz ,\, state \.{\mapsto}\@w{Uninit} ] )}%
+\@x{\@s{16.4} \.{\land} reserve \.{'} \.{=} reserve \.{+} sz}%
+\@x{\@s{16.4} \.{\land} producer \.{'} \.{=} reserve \.{'}}%
+\@x{\@s{16.4} \.{\land} liveSize \.{'}\@s{4.92} \.{=} liveSize \.{+} sz}%
+ \@x{\@s{16.4} \.{\land} {\UNCHANGED} {\langle} consumer ,\, held ,\,
+ asyncPending ,\, asyncCompleted ,\, asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ProducerFinalizeLock \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} BuggyPublishBeforeLock}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{>} 0}%
+\@x{\@s{8.2} \.{\land} Head ( records ) . state \.{=}\@w{Uninit}}%
+ \@x{\@s{8.2} \.{\land} records \.{'} \.{=} {\langle} [ size \.{\mapsto} Head
+ ( records ) . size ,\, state \.{\mapsto}\@w{Locked} ] {\rangle} \.{\circ}
+ Tail ( records )}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, held ,\, asyncPending ,\, asyncCompleted ,\,
+ asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ProducerSubmit \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{>} 0}%
+\@x{\@s{8.2} \.{\land} Head ( records ) . state \.{=}\@w{Locked}}%
+ \@x{\@s{8.2} \.{\land} records \.{'} \.{=} {\langle} [ size \.{\mapsto} Head
+ ( records ) . size ,\, state \.{\mapsto}\@w{Submitted} ] {\rangle} \.{\circ}
+ Tail ( records )}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, held ,\, asyncPending ,\, asyncCompleted ,\,
+ asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ProducerDiscard \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{>} 0}%
+\@x{\@s{8.2} \.{\land} Head ( records ) . state \.{=}\@w{Locked}}%
+ \@x{\@s{8.2} \.{\land} records \.{'} \.{=} {\langle} [ size \.{\mapsto} Head
+ ( records ) . size ,\, state \.{\mapsto}\@w{Discarded} ] {\rangle} \.{\circ}
+ Tail ( records )}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, held ,\, asyncPending ,\, asyncCompleted ,\,
+ asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ConsumerNext \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} held . active \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{>} 0}%
+ \@x{\@s{8.2} \.{\land} {\IF} Head ( records ) . state \.{=}\@w{Locked}
+ \.{\THEN}}%
+\@x{\@s{27.51}}%
+\@y{\@s{0}%
+ Cannot pass a locked record.
+}%
+\@xx{}%
+ \@x{\@s{27.51} {\UNCHANGED} {\langle} consumer ,\, producer ,\, reserve ,\,
+ liveSize ,\, records ,\, held ,\, asyncPending ,\, asyncCompleted ,\,
+ asyncResult ,\, tripWire {\rangle}}%
+ \@x{\@s{19.31} \.{\ELSE} {\IF} Head ( records ) . state \.{=}\@w{Discarded}
+ \.{\THEN}}%
+\@x{\@s{27.51}}%
+\@y{\@s{0}%
+ Skip discarded records and immediately return their space.
+}%
+\@xx{}%
+ \@x{\@s{27.51} \.{\land} consumer \.{'} \.{=} consumer \.{+} Head ( records )
+ . size}%
+ \@x{\@s{27.51} \.{\land} liveSize \.{'}\@s{9.39} \.{=} liveSize\@s{9.39}
+ \.{-} Head ( records ) . size}%
+\@x{\@s{27.51} \.{\land} records \.{'} \.{=} Tail ( records )}%
+ \@x{\@s{27.51} \.{\land} {\UNCHANGED} {\langle} producer ,\, reserve ,\, held
+ ,\, asyncPending ,\, asyncCompleted ,\, asyncResult ,\, tripWire {\rangle}}%
+\@x{\@s{19.31} \.{\ELSE}}%
+\@x{\@s{27.51}}%
+\@y{\@s{0}%
+ Any unlocked record is treated as consumable.
+}%
+\@xx{}%
+ \@x{\@s{27.51} \.{\land} held \.{'} \.{=} [ active \.{\mapsto} {\TRUE} ,\,
+ size \.{\mapsto} Head ( records ) . size ,\, state \.{\mapsto} Head (
+ records ) . state ]}%
+ \@x{\@s{27.51} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, records ,\, asyncPending ,\, asyncCompleted ,\,
+ asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ ConsumerReturn \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} held . active \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} Len ( records ) \.{>} 0}%
+\@x{\@s{8.2} \.{\land} Head ( records ) . size \.{=} held . size}%
+\@x{\@s{8.2} \.{\land} Head ( records ) . state \.{=} held . state}%
+\@x{\@s{8.2} \.{\land} consumer \.{'} \.{=} consumer \.{+} held . size}%
+ \@x{\@s{8.2} \.{\land} liveSize \.{'}\@s{9.39} \.{=} liveSize\@s{9.39} \.{-}
+ held . size}%
+\@x{\@s{8.2} \.{\land} records \.{'} \.{=} Tail ( records )}%
+ \@x{\@s{8.2} \.{\land} held \.{'} \.{=} [ active \.{\mapsto} {\FALSE} ,\,
+ size \.{\mapsto} 0 ,\, state \.{\mapsto}\@w{Locked} ]}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} producer ,\, reserve ,\,
+ asyncPending ,\, asyncCompleted ,\, asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ AsyncQuery \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{'} \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} tripWire \.{'} \.{=} {\TRUE}}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, records ,\, held ,\, asyncCompleted ,\, asyncResult
+ {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ AsyncCancel \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{'} \.{=} {\FALSE}}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, records ,\, held ,\, asyncCompleted ,\, asyncResult
+ ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ AsyncComplete \.{\defeq}}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{=} {\TRUE}}%
+\@x{\@s{8.2} \.{\land} producer \.{>} consumer}%
+\@x{\@s{8.2} \.{\land} asyncPending \.{'} \.{=} {\FALSE}}%
+\@x{\@s{8.2} \.{\land} asyncCompleted \.{'} \.{=} {\TRUE}}%
+ \@x{\@s{8.2} \.{\land} asyncResult \.{'} \.{=} [ consumer \.{\mapsto}
+ consumer ,\, producer \.{\mapsto} producer ]}%
+ \@x{\@s{8.2} \.{\land} {\UNCHANGED} {\langle} consumer ,\, producer ,\,
+ reserve ,\, liveSize ,\, records ,\, held ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+ \@x{ vars\@s{2.10} \.{\defeq} {\langle} consumer ,\, producer ,\, reserve ,\,
+ liveSize ,\, records ,\, held ,\, asyncPending ,\, asyncCompleted ,\,
+ asyncResult ,\, tripWire {\rangle}}%
+\@pvspace{8.0pt}%
+\@x{ Next \.{\defeq}}%
+\@x{\@s{8.2} ProducerReserve}%
+\@x{\@s{8.2} \.{\lor} ProducerReserveBuggyPublish}%
+\@x{\@s{8.2} \.{\lor} ProducerFinalizeLock}%
+\@x{\@s{8.2} \.{\lor} ProducerSubmit}%
+\@x{\@s{8.2} \.{\lor} ProducerDiscard}%
+\@x{\@s{8.2} \.{\lor} ConsumerNext}%
+\@x{\@s{8.2} \.{\lor} ConsumerReturn}%
+\@x{\@s{8.2} \.{\lor} AsyncQuery}%
+\@x{\@s{8.2} \.{\lor} AsyncCancel}%
+\@x{\@s{8.2} \.{\lor} AsyncComplete}%
+\@pvspace{8.0pt}%
+\@x{ Spec \.{\defeq} Init \.{\land} {\Box} [ Next ]_{ vars}}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/models/simple/Counter.cfg
+++ b/models/simple/Counter.cfg
@@ -1,0 +1,11 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+\* Try small bounds so TLC runs quickly.
+CONSTANTS
+  Min = 0
+  Max = 3
+
+INVARIANT Invariant

--- a/models/simple/Counter.tla
+++ b/models/simple/Counter.tla
@@ -1,0 +1,34 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+---- MODULE Counter ----
+EXTENDS Naturals
+
+(***************************************************************************)
+(* A very small TLA+ model intended for beginners.                         *)
+(*                                                                         *)
+(* State: a single integer variable x.                                     *)
+(* Behavior: on each step, x either increments or decrements, but never    *)
+(* leaves the range [Min, Max].                                            *)
+(***************************************************************************)
+
+CONSTANTS Min, Max
+VARIABLE x
+
+TypeOK == x \in Min..Max
+
+Init == x = Min
+
+Inc == /\ x < Max
+       /\ x' = x + 1
+
+Dec == /\ x > Min
+       /\ x' = x - 1
+
+Next == Inc \/ Dec
+
+Spec == Init /\ [][Next]_<<x>>
+
+Invariant == TypeOK
+
+====

--- a/models/simple/Failure.tla
+++ b/models/simple/Failure.tla
@@ -1,0 +1,31 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+---- MODULE Failure ----
+EXTENDS Naturals
+
+(***************************************************************************)
+(* A deliberately broken version of the simple counter model.              *)
+(*                                                                         *)
+(* It violates the invariant by allowing x to increment past Max.          *)
+(* TLC should find an invariant violation and produce a counterexample.    *)
+(***************************************************************************)
+
+CONSTANTS Min, Max
+VARIABLE x
+
+TypeOK == x \in Min..Max
+
+Init == x = Min
+
+\* BUG: no guard to stop x from exceeding Max.
+Inc == x' = x + 1
+
+\* Keep it minimal: only increments.
+Next == Inc
+
+Spec == Init /\ [][Next]_<<x>>
+
+Invariant == TypeOK
+
+====

--- a/models/simple/Failure_buggy.cfg
+++ b/models/simple/Failure_buggy.cfg
@@ -1,0 +1,10 @@
+\* Copyright (c) eBPF for Windows contributors
+\* SPDX-License-Identifier: MIT
+
+SPECIFICATION Spec
+
+CONSTANTS
+  Min = 0
+  Max = 3
+
+INVARIANT Invariant

--- a/models/simple/README.md
+++ b/models/simple/README.md
@@ -1,0 +1,41 @@
+# Simple TLA+ model (beginner friendly)
+
+This folder contains a tiny TLA+ spec you can run with TLC.
+
+## What it models
+
+- One variable: `x`
+- Two actions:
+  - `Inc`: increment `x` if `x < Max`
+  - `Dec`: decrement `x` if `x > Min`
+- An invariant: `x` always stays within `Min..Max`
+
+## Files
+
+- `Counter.tla`: the TLA+ module
+- `Counter.cfg`: TLC configuration (sets constants and checks invariant)
+- `Failure.tla`: intentionally buggy model that violates the invariant
+- `Failure_buggy.cfg`: TLC config for `Failure.tla` (expected to FAIL)
+
+## How to run (VS Code)
+
+1. Install the **TLA+** extension if you don’t have it.
+2. Open `Counter.tla`.
+3. Use the extension’s TLC/Model Checker command to run TLC using `Counter.cfg`.
+
+## How to run (command line, Windows)
+
+From the repo root:
+
+`java -cp models\tla2tools.jar tlc2.TLC -workers auto -config models\simple\Counter.cfg models\simple\Counter.tla`
+
+To see a real counterexample (expected to FAIL with an invariant violation):
+
+`java -cp models\tla2tools.jar tlc2.TLC -workers auto -config models\simple\Failure_buggy.cfg models\simple\Failure.tla`
+
+Note: TLC treats the filename you pass as the module name. If you run `... counter.tla`, TLC expects the top-level module to be `counter`, which will fail for this spec (module name is `Counter`).
+
+## What to try next
+
+- Change `Max` in `Counter.cfg` to a larger number.
+- Break the model (for learning): edit `Inc` to allow `x' = x + 2` and see TLC find a counterexample to the invariant.

--- a/models/simple/tlatex/Counter.tex
+++ b/models/simple/tlatex/Counter.tex
@@ -1,0 +1,986 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{\,\backslash\,}}* Copyright (c) \ensuremath{eBPF} for Windows
+ contributors
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{\,\backslash\,}}* SPDX-License-Identifier: \ensuremath{MIT
+}%
+\end{cpar}%
+\end{lcom}%
+\@x{}\moduleLeftDash\@xx{ {\MODULE} Counter}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+A very small TLA+ model intended for beginners.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+State: a single integer variable \ensuremath{x}.
+ Behavior: on each step, \ensuremath{x} either increments or decrements, but
+ never
+ leaves the range [\ensuremath{Min}, \ensuremath{Max}].
+\end{cpar}%
+\end{lcom}%
+\@pvspace{8.0pt}%
+\@x{ {\CONSTANTS} Min ,\, Max}%
+\@x{ {\VARIABLE} x}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq} x \.{\in} Min \.{\dotdot} Max}%
+\@pvspace{8.0pt}%
+\@x{ Init \.{\defeq} x \.{=} Min}%
+\@pvspace{8.0pt}%
+\@x{ Inc\@s{2.16} \.{\defeq} \.{\land} x \.{<} Max}%
+\@x{\@s{35.69} \.{\land} x \.{'} \.{=} x \.{+} 1}%
+\@pvspace{8.0pt}%
+\@x{ Dec \.{\defeq} \.{\land} x \.{>} Min}%
+\@x{\@s{35.69} \.{\land} x \.{'} \.{=} x \.{-} 1}%
+\@pvspace{8.0pt}%
+\@x{ Next \.{\defeq} Inc \.{\lor} Dec}%
+\@pvspace{8.0pt}%
+ \@x{ Spec\@s{1.46} \.{\defeq} Init \.{\land} {\Box} [ Next ]_{ {\langle} x
+ {\rangle}}}%
+\@pvspace{8.0pt}%
+\@x{ Invariant \.{\defeq} TypeOK}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/models/simple/tlatex/Failure.tex
+++ b/models/simple/tlatex/Failure.tex
@@ -1,0 +1,992 @@
+\batchmode %% Suppresses most terminal output.
+\documentclass{article}
+\setlength{\textwidth}{360pt}
+\setlength{\textheight}{541pt}
+\usepackage{latexsym}
+\usepackage{ifthen}
+% \usepackage{color}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SWITCHES                                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newboolean{shading}
+\setboolean{shading}{false}
+\makeatletter
+ %% this is needed only when inserted into the file, not when
+ %% used as a package file.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                           %
+% DEFINITIONS OF SYMBOL-PRODUCING COMMANDS                                  %
+%                                                                           %
+%    TLA+      LaTeX                                                        %
+%    symbol    command                                                      %
+%    ------    -------                                                      %
+%    =>        \implies                                                     %
+%    <:        \ltcolon                                                     %
+%    :>        \colongt                                                     %
+%    ==        \defeq                                                       %
+%    ..        \dotdot                                                      %
+%    ::        \coloncolon                                                  %
+%    =|        \eqdash                                                      %
+%    ++        \pp                                                          %
+%    --        \mm                                                          %
+%    **        \stst                                                        %
+%    //        \slsl                                                        %
+%    ^         \ct                                                          %
+%    \A        \A                                                           %
+%    \E        \E                                                           %
+%    \AA       \AA                                                          %
+%    \EE       \EE                                                          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\symlength}
+\newcommand{\implies}{\Rightarrow}
+\newcommand{\ltcolon}{\mathrel{<\!\!\mbox{:}}}
+\newcommand{\colongt}{\mathrel{\!\mbox{:}\!\!>}}
+\newcommand{\defeq}{\;\mathrel{\smash   %% keep this symbol from being too tall
+    {{\stackrel{\scriptscriptstyle\Delta}{=}}}}\;}
+\newcommand{\dotdot}{\mathrel{\ldotp\ldotp}}
+\newcommand{\coloncolon}{\mathrel{::\;}}
+\newcommand{\eqdash}{\mathrel = \joinrel \hspace{-.28em}|}
+\newcommand{\pp}{\mathbin{++}}
+\newcommand{\mm}{\mathbin{--}}
+\newcommand{\stst}{*\!*}
+\newcommand{\slsl}{/\!/}
+\newcommand{\ct}{\hat{\hspace{.4em}}}
+\newcommand{\A}{\forall}
+\newcommand{\E}{\exists}
+\renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
+   \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}
+\newcommand{\EE}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
+   $\exists\hspace{-.517em}\exists\hspace{-.517em}\exists$}}%
+   \exists\hspace{-.517em}\exists\hspace{-.517em}\exists\,$}}
+\newcommand{\whileop}{\.{\stackrel
+  {\mbox{\raisebox{-.3em}[0pt][0pt]{$\scriptscriptstyle+\;\,$}}}%
+  {-\hspace{-.16em}\triangleright}}}
+
+% Commands are defined to produce the upper-case keywords.
+% Note that some have space after them.
+\newcommand{\ASSUME}{\textsc{assume }}
+\newcommand{\ASSUMPTION}{\textsc{assumption }}
+\newcommand{\AXIOM}{\textsc{axiom }}
+\newcommand{\BOOLEAN}{\textsc{boolean }}
+\newcommand{\CASE}{\textsc{case }}
+\newcommand{\CONSTANT}{\textsc{constant }}
+\newcommand{\CONSTANTS}{\textsc{constants }}
+\newcommand{\ELSE}{\settowidth{\symlength}{\THEN}%
+   \makebox[\symlength][l]{\textsc{ else}}}
+\newcommand{\EXCEPT}{\textsc{ except }}
+\newcommand{\EXTENDS}{\textsc{extends }}
+\newcommand{\FALSE}{\textsc{false}}
+\newcommand{\IF}{\textsc{if }}
+\newcommand{\IN}{\settowidth{\symlength}{\LET}%
+   \makebox[\symlength][l]{\textsc{in}}}
+\newcommand{\INSTANCE}{\textsc{instance }}
+\newcommand{\LET}{\textsc{let }}
+\newcommand{\LOCAL}{\textsc{local }}
+\newcommand{\MODULE}{\textsc{module }}
+\newcommand{\OTHER}{\textsc{other }}
+\newcommand{\STRING}{\textsc{string}}
+\newcommand{\THEN}{\textsc{ then }}
+\newcommand{\THEOREM}{\textsc{theorem }}
+\newcommand{\LEMMA}{\textsc{lemma }}
+\newcommand{\PROPOSITION}{\textsc{proposition }}
+\newcommand{\COROLLARY}{\textsc{corollary }}
+\newcommand{\TRUE}{\textsc{true}}
+\newcommand{\VARIABLE}{\textsc{variable }}
+\newcommand{\VARIABLES}{\textsc{variables }}
+\newcommand{\WITH}{\textsc{ with }}
+\newcommand{\WF}{\textrm{WF}}
+\newcommand{\SF}{\textrm{SF}}
+\newcommand{\CHOOSE}{\textsc{choose }}
+\newcommand{\ENABLED}{\textsc{enabled }}
+\newcommand{\UNCHANGED}{\textsc{unchanged }}
+\newcommand{\SUBSET}{\textsc{subset }}
+\newcommand{\UNION}{\textsc{union }}
+\newcommand{\DOMAIN}{\textsc{domain }}
+% Added for tla2tex
+\newcommand{\BY}{\textsc{by }}
+\newcommand{\OBVIOUS}{\textsc{obvious }}
+\newcommand{\HAVE}{\textsc{have }}
+\newcommand{\QED}{\textsc{qed }}
+\newcommand{\TAKE}{\textsc{take }}
+\newcommand{\DEF}{\textsc{ def }}
+\newcommand{\HIDE}{\textsc{hide }}
+\newcommand{\RECURSIVE}{\textsc{recursive }}
+\newcommand{\USE}{\textsc{use }}
+\newcommand{\DEFINE}{\textsc{define }}
+\newcommand{\PROOF}{\textsc{proof }}
+\newcommand{\WITNESS}{\textsc{witness }}
+\newcommand{\PICK}{\textsc{pick }}
+\newcommand{\DEFS}{\textsc{defs }}
+\newcommand{\PROVE}{\settowidth{\symlength}{\ASSUME}%
+   \makebox[\symlength][l]{\textsc{prove}}\@s{-4.1}}%
+  %% The \@s{-4.1) is a kludge added on 24 Oct 2009 [happy birthday, Ellen]
+  %% so the correct alignment occurs if the user types
+  %%   ASSUME X
+  %%   PROVE  Y
+  %% because it cancels the extra 4.1 pts added because of the
+  %% extra space after the PROVE.  This seems to works OK.
+  %% However, the 4.1 equals Parameters.LaTeXLeftSpace(1) and
+  %% should be changed if that method ever changes.
+\newcommand{\SUFFICES}{\textsc{suffices }}
+\newcommand{\NEW}{\textsc{new }}
+\newcommand{\LAMBDA}{\textsc{lambda }}
+\newcommand{\STATE}{\textsc{state }}
+\newcommand{\ACTION}{\textsc{action }}
+\newcommand{\TEMPORAL}{\textsc{temporal }}
+\newcommand{\ONLY}{\textsc{only }}              %% added by LL on 2 Oct 2009
+\newcommand{\OMITTED}{\textsc{omitted }}        %% added by LL on 31 Oct 2009
+\newcommand{\@pfstepnum}[2]{\ensuremath{\langle#1\rangle}\textrm{#2}}
+\newcommand{\bang}{\@s{1}\mbox{\small !}\@s{1}}
+%% We should format || differently in PlusCal code than in TLA+ formulas.
+\newcommand{\p@barbar}{\ifpcalsymbols
+   \,\,\rule[-.25em]{.075em}{1em}\hspace*{.2em}\rule[-.25em]{.075em}{1em}\,\,%
+   \else \,||\,\fi}
+%% PlusCal keywords
+\newcommand{\p@fair}{\textbf{fair }}
+\newcommand{\p@semicolon}{\textbf{\,; }}
+\newcommand{\p@algorithm}{\textbf{algorithm }}
+\newcommand{\p@mmfair}{\textbf{-{}-fair }}
+\newcommand{\p@mmalgorithm}{\textbf{-{}-algorithm }}
+\newcommand{\p@assert}{\textbf{assert }}
+\newcommand{\p@await}{\textbf{await }}
+\newcommand{\p@begin}{\textbf{begin }}
+\newcommand{\p@end}{\textbf{end }}
+\newcommand{\p@call}{\textbf{call }}
+\newcommand{\p@define}{\textbf{define }}
+\newcommand{\p@do}{\textbf{ do }}
+\newcommand{\p@either}{\textbf{either }}
+\newcommand{\p@or}{\textbf{or }}
+\newcommand{\p@goto}{\textbf{goto }}
+\newcommand{\p@if}{\textbf{if }}
+\newcommand{\p@then}{\,\,\textbf{then }}
+\newcommand{\p@else}{\ifcsyntax \textbf{else } \else \,\,\textbf{else }\fi}
+\newcommand{\p@elsif}{\,\,\textbf{elsif }}
+\newcommand{\p@macro}{\textbf{macro }}
+\newcommand{\p@print}{\textbf{print }}
+\newcommand{\p@procedure}{\textbf{procedure }}
+\newcommand{\p@process}{\textbf{process }}
+\newcommand{\p@return}{\textbf{return}}
+\newcommand{\p@skip}{\textbf{skip}}
+\newcommand{\p@variable}{\textbf{variable }}
+\newcommand{\p@variables}{\textbf{variables }}
+\newcommand{\p@while}{\textbf{while }}
+\newcommand{\p@when}{\textbf{when }}
+\newcommand{\p@with}{\textbf{with }}
+\newcommand{\p@lparen}{\textbf{(\,\,}}
+\newcommand{\p@rparen}{\textbf{\,\,) }}
+\newcommand{\p@lbrace}{\textbf{\{\,\,}}
+\newcommand{\p@rbrace}{\textbf{\,\,\} }}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% REDEFINE STANDARD COMMANDS TO MAKE THEM FORMAT BETTER %
+%                                                       %
+% We redefine \in and \notin                            %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewcommand{\_}{\rule{.4em}{.06em}\hspace{.05em}}
+\newlength{\equalswidth}
+\let\oldin=\in
+\let\oldnotin=\notin
+\renewcommand{\in}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth][c]{$\oldin$}}}
+\renewcommand{\notin}{%
+   {\settowidth{\equalswidth}{$\.{=}$}\makebox[\equalswidth]{$\oldnotin$}}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                  %
+% HORIZONTAL BARS:                                 %
+%                                                  %
+%   \moduleLeftDash    |~~~~~~~~~~                 %
+%   \moduleRightDash    ~~~~~~~~~~|                %
+%   \midbar            |----------|                %
+%   \bottombar         |__________|                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\charwidth}\settowidth{\charwidth}{{\small\tt M}}
+\newlength{\boxrulewd}\setlength{\boxrulewd}{.4pt}
+\newlength{\boxlineht}\setlength{\boxlineht}{.5\baselineskip}
+\newcommand{\boxsep}{\charwidth}
+\newlength{\boxruleht}\setlength{\boxruleht}{.5ex}
+\newlength{\boxruledp}\setlength{\boxruledp}{-\boxruleht}
+\addtolength{\boxruledp}{\boxrulewd}
+\newcommand{\boxrule}{\leaders\hrule height \boxruleht depth \boxruledp
+                      \hfill\mbox{}}
+\newcommand{\@computerule}{%
+  \setlength{\boxruleht}{.5ex}%
+  \setlength{\boxruledp}{-\boxruleht}%
+  \addtolength{\boxruledp}{\boxrulewd}}
+
+\newcommand{\bottombar}{\hspace{-\boxsep}%
+  \raisebox{-\boxrulewd}[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}%
+  \boxrule
+  \raisebox{-\boxrulewd}[0pt][0pt]{%
+      \rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}\vspace{0pt}}
+
+\newcommand{\moduleLeftDash}%
+   {\hspace*{-\boxsep}%
+     \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}%
+    \boxrule\hspace*{.4em }}
+
+\newcommand{\moduleRightDash}%
+    {\hspace*{.4em}\boxrule
+    \raisebox{-\boxlineht}[0pt][0pt]{\rule[.5ex]{\boxrulewd
+               }{\boxlineht}}\hspace{-\boxsep}}%\vspace{.2em}
+
+\newcommand{\midbar}{\hspace{-\boxsep}\raisebox{-.5\boxlineht}[0pt][0pt]{%
+   \rule[.5ex]{\boxrulewd}{\boxlineht}}\boxrule\raisebox{-.5\boxlineht%
+   }[0pt][0pt]{\rule[.5ex]{\boxrulewd}{\boxlineht}}\hspace{-\boxsep}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% FORMATING COMMANDS                                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% PLUSCAL SHADING                                                           %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% The TeX pcalshading switch is set on to cause PlusCal shading to be
+% performed.  This changes the behavior of the following commands and
+% environments to cause full-width shading to be performed on all lines.
+%
+%   \tstrut \@x cpar mcom \@pvspace
+%
+% The TeX pcalsymbols switch is turned on when typesetting a PlusCal algorithm,
+% whether or not shading is being performed.  It causes symbols (other than
+% parentheses and braces and PlusCal-only keywords) that should be typeset
+% differently depending on whether they are in an algorithm to be typeset
+% appropriately.  Currently, the only such symbol is "||".
+%
+% The TeX csyntax switch is turned on when typesetting a PlusCal algorithm in
+% c-syntax.  This allows symbols to be format differently in the two syntaxes.
+% The "else" keyword is the only one that is.
+
+\newif\ifpcalshading \pcalshadingfalse
+\newif\ifpcalsymbols \pcalsymbolsfalse
+\newif\ifcsyntax     \csyntaxtrue
+
+% The \@pvspace command makes a vertical space.  It uses \vspace
+% except with \ifpcalshading, in which case it sets \pvcalvspace
+% and the space is added by a following \@x command.
+%
+\newlength{\pcalvspace}\setlength{\pcalvspace}{0pt}%
+\newcommand{\@pvspace}[1]{%
+  \ifpcalshading
+     \par\global\setlength{\pcalvspace}{#1}%
+  \else
+     \par\vspace{#1}%
+  \fi
+}
+
+% The lcom environment was changed to set \lcomindent equal to
+% the indentation it produces.  This length is used by the
+% cpar environment to make shading extend for the full width
+% of the line.  This assumes that lcom environments are not
+% nested.  I hope TLATeX does not nest them.
+%
+\newlength{\lcomindent}%
+\setlength{\lcomindent}{0pt}%
+
+%\tstrut: A strut to produce inter-paragraph space in a comment.
+%\rstrut: A strut to extend the bottom of a one-line comment so
+%         there's no break in the shading between comments on
+%         successive lines.
+\newcommand\tstrut%
+  {\raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{1.15em}}}%
+   \global\setlength{\vshadelen}{0pt}}
+\newcommand\rstrut{\raisebox{-.25em}{\rule{0pt}{1.15em}}%
+ \global\setlength{\vshadelen}{0pt}}
+
+
+% \.{op} formats operator op in math mode with empty boxes on either side.
+% Used because TeX otherwise vary the amount of space it leaves around op.
+\renewcommand{\.}[1]{\ensuremath{\mbox{}#1\mbox{}}}
+
+% \@s{n} produces an n-point space
+\newcommand{\@s}[1]{\hspace{#1pt}}
+
+% \@x{txt} starts a specification line in the beginning with txt
+% in the final LaTeX source.
+\newlength{\@xlen}
+\newcommand\xtstrut%
+  {\setlength{\@xlen}{1.05em}%
+   \addtolength{\@xlen}{\pcalvspace}%
+    \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\@xlen}}}%
+   \global\setlength{\vshadelen}{0pt}%
+   \global\setlength{\pcalvspace}{0pt}}
+
+\newcommand{\@x}[1]{\par
+  \ifpcalshading
+  \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+  \fi
+  \mbox{$\mbox{}#1\mbox{}$}}
+
+% \@xx{txt} continues a specification line with the text txt.
+\newcommand{\@xx}[1]{\mbox{$\mbox{}#1\mbox{}$}}
+
+% \@y{cmt} produces a one-line comment.
+\newcommand{\@y}[1]{\mbox{\footnotesize\hspace{.65em}%
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+% \@z{cmt} produces a zero-width one-line comment.
+\newcommand{\@z}[1]{\makebox[0pt][l]{\footnotesize
+  \ifthenelse{\boolean{shading}}{%
+      \shadebox{#1\hspace{-\the\lastskip}\rstrut}}%
+               {#1\hspace{-\the\lastskip}\rstrut}}}
+
+
+% \@w{str} produces the TLA+ string "str".
+\newcommand{\@w}[1]{\textsf{``{#1}''}}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SHADING                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\graymargin{1}
+  % The number of points of margin in the shaded box.
+
+% \definecolor{boxshade}{gray}{.85}
+% Defines the darkness of the shading: 1 = white, 0 = black
+% Added by TLATeX only if needed.
+
+% \shadebox{txt} puts txt in a shaded box.
+\newlength{\templena}
+\newlength{\templenb}
+\newsavebox{\tempboxa}
+\newcommand{\shadebox}[1]{{\setlength{\fboxsep}{\graymargin pt}%
+     \savebox{\tempboxa}{#1}%
+     \settoheight{\templena}{\usebox{\tempboxa}}%
+     \settodepth{\templenb}{\usebox{\tempboxa}}%
+     \hspace*{-\fboxsep}\raisebox{0pt}[\templena][\templenb]%
+        {\colorbox{boxshade}{\usebox{\tempboxa}}}\hspace*{-\fboxsep}}}
+
+% \vshade{n} makes an n-point inter-paragraph space, with
+%  shading if the `shading' flag is true.
+\newlength{\vshadelen}
+\setlength{\vshadelen}{0pt}
+\newcommand{\vshade}[1]{\ifthenelse{\boolean{shading}}%
+   {\global\setlength{\vshadelen}{#1pt}}%
+   {\vspace{#1pt}}}
+
+\newlength{\boxwidth}
+\newlength{\multicommentdepth}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE cpar ENVIRONMENT                                                      %
+% ^^^^^^^^^^^^^^^^^^^^                                                      %
+% The LaTeX input                                                           %
+%                                                                           %
+%   \begin{cpar}{pop}{nest}{isLabel}{d}{e}{arg6}                            %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%     XXXXXXXXXXXXXXX                                                       %
+%   \end{cpar}                                                              %
+%                                                                           %
+% produces one of two possible results.  If isLabel is the letter "T",      %
+% it produces the following, where [label] is the result of typesetting     %
+% arg6 in an LR box, and d is is a number representing a distance in        %
+% points.                                                                   %
+%                                                                           %
+%   prevailing |<-- d -->[label]<- e ->XXXXXXXXXXXXXXX                      %
+%         left |                       XXXXXXXXXXXXXXX                      %
+%       margin |                       XXXXXXXXXXXXXXX                      %
+%                                                                           %
+% If isLabel is the letter "F", then it produces                            %
+%                                                                           %
+%   prevailing |<-- d -->XXXXXXXXXXXXXXXXXXXXXXX                            %
+%         left |         <- e ->XXXXXXXXXXXXXXXX                            %
+%       margin |                XXXXXXXXXXXXXXXX                            %
+%                                                                           %
+% where d and e are numbers representing distances in points.               %
+%                                                                           %
+% The prevailing left margin is the one in effect before the most recent    %
+% pop (argument 1) cpar environments with "T" as the nest argument, where   %
+% pop is a number \geq 0.                                                   %
+%                                                                           %
+% If the nest argument is the letter "T", then the prevailing left          %
+% margin is moved to the left of the second (and following) lines of        %
+% X's.  Otherwise, the prevailing left margin is left unchanged.            %
+%                                                                           %
+% An \unnest{n} command moves the prevailing left margin to where it was    %
+% before the most recent n cpar environments with "T" as the nesting        %
+% argument.                                                                 %
+%                                                                           %
+% The environment leaves no vertical space above or below it, or between    %
+% its paragraphs.  (TLATeX inserts the proper amount of vertical space.)    %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\newcounter{pardepth}
+\setcounter{pardepth}{0}
+
+% \setgmargin{txt} defines \gmarginN to be txt, where N is \roman{pardepth}.
+% \thegmargin equals \gmarginN, where N is \roman{pardepth}.
+\newcommand{\setgmargin}[1]{%
+  \expandafter\xdef\csname gmargin\roman{pardepth}\endcsname{#1}}
+\newcommand{\thegmargin}{\csname gmargin\roman{pardepth}\endcsname}
+\newcommand{\gmargin}{0pt}
+
+\newsavebox{\tempsbox}
+
+\newlength{\@cparht}
+\newlength{\@cpardp}
+\newenvironment{cpar}[6]{%
+  \addtocounter{pardepth}{-#1}%
+  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+                                 \begin{minipage}[t]{\linewidth}}{}%
+  \begin{list}{}{%
+     \edef\temp{\thegmargin}
+     \ifthenelse{\equal{#3}{T}}%
+       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+        \addtolength{\leftmargin}{#4pt}}%
+       {\setlength{\leftmargin}{#4pt}%
+        \addtolength{\leftmargin}{#5pt}%
+        \addtolength{\leftmargin}{\temp}%
+        \setlength{\itemindent}{-#5pt}}%
+      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+                                 \setgmargin{\the\leftmargin}}{}%
+      \setlength{\labelwidth}{0pt}%
+      \setlength{\labelsep}{0pt}%
+      \setlength{\itemindent}{-\leftmargin}%
+      \setlength{\topsep}{0pt}%
+      \setlength{\parsep}{0pt}%
+      \setlength{\partopsep}{0pt}%
+      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{0pt}
+      \setlength{\itemindent}{#4pt}%
+      \addtolength{\itemindent}{-\leftmargin}}%
+   \ifthenelse{\equal{#3}{T}}%
+      {\item[\tstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]
+        }%
+      {\item[\tstrut\hspace{\temp}]%
+         }%
+   \footnotesize}
+ {\hspace{-\the\lastskip}\tstrut
+ \end{list}%
+  \ifthenelse{\boolean{shading}}%
+          {\end{minipage}%
+           \end{lrbox}%
+           \ifpcalshading
+             \setlength{\@cparht}{\ht\tempsbox}%
+             \setlength{\@cpardp}{\dp\tempsbox}%
+             \addtolength{\@cparht}{.15em}%
+             \addtolength{\@cpardp}{.2em}%
+             \addtolength{\@cparht}{\@cpardp}%
+            % I don't know what's going on here.  I want to add a
+            % \pcalvspace high shaded line, but I don't know how to
+            % do it.  A little trial and error shows that the following
+            % does a reasonable job approximating that, eliminating
+            % the line if \pcalvspace is small.
+            \addtolength{\@cparht}{\pcalvspace}%
+             \ifdim \pcalvspace > .8em
+               \addtolength{\pcalvspace}{-.2em}%
+               \hspace*{-\lcomindent}%
+               \shadebox{\rule{0pt}{\pcalvspace}\hspace*{\textwidth}}\par
+               \global\setlength{\pcalvspace}{0pt}%
+               \fi
+             \hspace*{-\lcomindent}%
+             \makebox[0pt][l]{\raisebox{-\@cpardp}[0pt][0pt]{%
+                 \shadebox{\rule{0pt}{\@cparht}\hspace*{\textwidth}}}}%
+             \hspace*{\lcomindent}\usebox{\tempsbox}%
+             \par
+           \else
+             \shadebox{\usebox{\tempsbox}}\par
+           \fi}%
+           {}%
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE ppar ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% The environment                                                            %
+%                                                                            %
+%   \begin{ppar} ... \end{ppar}                                              %
+%                                                                            %
+% is equivalent to                                                           %
+%                                                                            %
+%   \begin{cpar}{0}{F}{F}{0}{0}{} ... \end{cpar}                             %
+%                                                                            %
+% The environment is put around each line of the output for a PlusCal        %
+% algorithm.                                                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\newenvironment{ppar}{%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}
+%        \setlength{\leftmargin}{0pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{0pt}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}
+%      \setlength{\itemindent}{0pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%      \item[\tstrut\hspace{\temp}]}%
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \shadebox{\usebox{\tempsbox}}\par}{}%
+%  }
+
+ %%% TESTING
+ \newcommand{\xtest}[1]{\par
+ \makebox[0pt][l]{\shadebox{\xtstrut\hspace*{\textwidth}}}%
+ \mbox{$\mbox{}#1\mbox{}$}}
+
+% \newcommand{\xxtest}[1]{\par
+% \makebox[0pt][l]{\shadebox{\xtstrut{#1}\hspace*{\textwidth}}}%
+% \mbox{$\mbox{}#1\mbox{}$}}
+
+%\newlength{\pcalvspace}
+%\setlength{\pcalvspace}{0pt}
+% \newlength{\xxtestlen}
+% \setlength{\xxtestlen}{0pt}
+% \newcommand\xtstrut%
+%   {\setlength{\xxtestlen}{1.15em}%
+%    \addtolength{\xxtestlen}{\pcalvspace}%
+%     \raisebox{\vshadelen}{\raisebox{-.25em}{\rule{0pt}{\xxtestlen}}}%
+%    \global\setlength{\vshadelen}{0pt}%
+%    \global\setlength{\pcalvspace}{0pt}}
+
+   %%%% TESTING
+
+   %% The xcpar environment
+   %%  Note: overloaded use of \pcalvspace for testing.
+   %%
+%   \newlength{\xcparht}%
+%   \newlength{\xcpardp}%
+
+%   \newenvironment{xcpar}[6]{%
+%  \addtocounter{pardepth}{-#1}%
+%  \ifthenelse{\boolean{shading}}{\par\begin{lrbox}{\tempsbox}%
+%                                 \begin{minipage}[t]{\linewidth}}{}%
+%  \begin{list}{}{%
+%     \edef\temp{\thegmargin}%
+%     \ifthenelse{\equal{#3}{T}}%
+%       {\settowidth{\leftmargin}{\hspace{\temp}\footnotesize #6\hspace{#5pt}}%
+%        \addtolength{\leftmargin}{#4pt}}%
+%       {\setlength{\leftmargin}{#4pt}%
+%        \addtolength{\leftmargin}{#5pt}%
+%        \addtolength{\leftmargin}{\temp}%
+%        \setlength{\itemindent}{-#5pt}}%
+%      \ifthenelse{\equal{#2}{T}}{\addtocounter{pardepth}{1}%
+%                                 \setgmargin{\the\leftmargin}}{}%
+%      \setlength{\labelwidth}{0pt}%
+%      \setlength{\labelsep}{0pt}%
+%      \setlength{\itemindent}{-\leftmargin}%
+%      \setlength{\topsep}{0pt}%
+%      \setlength{\parsep}{0pt}%
+%      \setlength{\partopsep}{0pt}%
+%      \setlength{\parskip}{0pt}%
+%      \setlength{\itemsep}{0pt}%
+%      \setlength{\itemindent}{#4pt}%
+%      \addtolength{\itemindent}{-\leftmargin}}%
+%   \ifthenelse{\equal{#3}{T}}%
+%      {\item[\xtstrut\footnotesize \hspace{\temp}{#6}\hspace{#5pt}]%
+%        }%
+%      {\item[\xtstrut\hspace{\temp}]%
+%         }%
+%   \footnotesize}
+% {\hspace{-\the\lastskip}\tstrut
+% \end{list}%
+%  \ifthenelse{\boolean{shading}}{\end{minipage}
+%                                 \end{lrbox}%
+%                                 \setlength{\xcparht}{\ht\tempsbox}%
+%                                 \setlength{\xcpardp}{\dp\tempsbox}%
+%                                 \addtolength{\xcparht}{.15em}%
+%                                 \addtolength{\xcpardp}{.2em}%
+%                                 \addtolength{\xcparht}{\xcpardp}%
+%                                 \hspace*{-\lcomindent}%
+%                                 \makebox[0pt][l]{\raisebox{-\xcpardp}[0pt][0pt]{%
+%                                      \shadebox{\rule{0pt}{\xcparht}\hspace*{\textwidth}}}}%
+%                                 \hspace*{\lcomindent}\usebox{\tempsbox}%
+%                                 \par}{}%
+%  }
+%
+% \newlength{\xmcomlen}
+%\newenvironment{xmcom}[1]{%
+%  \setcounter{pardepth}{0}%
+%  \hspace{.65em}%
+%  \begin{lrbox}{\alignbox}\sloppypar%
+%      \setboolean{shading}{false}%
+%      \setlength{\boxwidth}{#1pt}%
+%      \addtolength{\boxwidth}{-.65em}%
+%      \begin{minipage}[t]{\boxwidth}\footnotesize
+%      \parskip=0pt\relax}%
+%       {\end{minipage}\end{lrbox}%
+%       \setlength{\xmcomlen}{\textwidth}%
+%       \addtolength{\xmcomlen}{-\wd\alignbox}%
+%       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+%       \global\setlength{\multicommentdepth}{\alignwidth}%
+%       \setlength{\boxwidth}{\alignwidth}%
+%       \global\addtolength{\alignwidth}{-\maxdepth}%
+%       \addtolength{\boxwidth}{.1em}%
+%       \raisebox{0pt}[0pt][0pt]{%
+%        \ifthenelse{\boolean{shading}}%
+%          {\hspace*{-\xmcomlen}\shadebox{\rule[-\boxwidth]{0pt}{0pt}%
+%                                 \hspace*{\xmcomlen}\usebox{\alignbox}}}%
+%          {\usebox{\alignbox}}}%
+%       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+% % a multi-line comment, whose first argument is its width in points.
+%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE lcom ENVIRONMENT                                                       %
+% ^^^^^^^^^^^^^^^^^^^^                                                       %
+% A multi-line comment with no text to its left is typeset in an lcom        %
+% environment, whose argument is a number representing the indentation       %
+% of the left margin, in points.  All the text of the comment should be      %
+% inside cpar environments.                                                  %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newenvironment{lcom}[1]{%
+  \setlength{\lcomindent}{#1pt} % Added for PlusCal handling.
+  \par\vspace{.2em}%
+  \sloppypar
+  \setcounter{pardepth}{0}%
+  \footnotesize
+  \begin{list}{}{%
+    \setlength{\leftmargin}{#1pt}
+    \setlength{\labelwidth}{0pt}%
+    \setlength{\labelsep}{0pt}%
+    \setlength{\itemindent}{0pt}%
+    \setlength{\topsep}{0pt}%
+    \setlength{\parsep}{0pt}%
+    \setlength{\partopsep}{0pt}%
+    \setlength{\parskip}{0pt}}
+    \item[]}%
+  {\end{list}\vspace{.3em}\setlength{\lcomindent}{0pt}%
+ }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% THE mcom ENVIRONMENT AND \mutivspace COMMAND                              %
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              %
+%                                                                           %
+% A part of the spec containing a right-comment of the form                 %
+%                                                                           %
+%      xxxx (*************)                                                 %
+%      yyyy (* ccccccccc *)                                                 %
+%      ...  (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (* ccccccccc *)                                                 %
+%           (*************)                                                 %
+%                                                                           %
+% is typeset by                                                             %
+%                                                                           %
+%     XXXX \begin{mcom}{d}                                                  %
+%            CCCC ... CCC                                                   %
+%          \end{mcom}                                                       %
+%     YYYY ...                                                              %
+%     \multivspace{n}                                                       %
+%                                                                           %
+% where the number d is the width in points of the comment, n is the        %
+% number of xxxx, yyyy, ...  lines to the left of the comment.              %
+% All the text of the comment should be typeset in cpar environments.       %
+%                                                                           %
+% This puts the comment into a single box (so no page breaks can occur      %
+% within it).  The entire box is shaded iff the shading flag is true.       %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newlength{\xmcomlen}%
+\newenvironment{mcom}[1]{%
+  \setcounter{pardepth}{0}%
+  \hspace{.65em}%
+  \begin{lrbox}{\alignbox}\sloppypar%
+      \setboolean{shading}{false}%
+      \setlength{\boxwidth}{#1pt}%
+      \addtolength{\boxwidth}{-.65em}%
+      \begin{minipage}[t]{\boxwidth}\footnotesize
+      \parskip=0pt\relax}%
+       {\end{minipage}\end{lrbox}%
+       \setlength{\xmcomlen}{\textwidth}%       % For PlusCal shading
+       \addtolength{\xmcomlen}{-\wd\alignbox}%  % For PlusCal shading
+       \settodepth{\alignwidth}{\usebox{\alignbox}}%
+       \global\setlength{\multicommentdepth}{\alignwidth}%
+       \setlength{\boxwidth}{\alignwidth}%      % For PlusCal shading
+       \global\addtolength{\alignwidth}{-\maxdepth}%
+       \addtolength{\boxwidth}{.1em}%           % For PlusCal shading
+      \raisebox{0pt}[0pt][0pt]{%
+        \ifthenelse{\boolean{shading}}%
+          {\ifpcalshading
+             \hspace*{-\xmcomlen}%
+             \shadebox{\rule[-\boxwidth]{0pt}{0pt}\hspace*{\xmcomlen}%
+                          \usebox{\alignbox}}%
+           \else
+             \shadebox{\usebox{\alignbox}}
+           \fi
+          }%
+          {\usebox{\alignbox}}}%
+       \vspace*{\alignwidth}\pagebreak[0]\vspace{-\alignwidth}\par}
+ % a multi-line comment, whose first argument is its width in points.
+
+
+% \multispace{n} produces the vertical space indicated by "|"s in
+% this situation
+%
+%     xxxx (*************)
+%     xxxx (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (* ccccccccc *)
+%      |   (*************)
+%
+% where n is the number of "xxxx" lines.
+\newcommand{\multivspace}[1]{\addtolength{\multicommentdepth}{-#1\baselineskip}%
+ \addtolength{\multicommentdepth}{1.2em}%
+ \ifthenelse{\lengthtest{\multicommentdepth > 0pt}}%
+    {\par\vspace{\multicommentdepth}\par}{}}
+
+%\newenvironment{hpar}[2]{%
+%  \begin{list}{}{\setlength{\leftmargin}{#1pt}%
+%                 \addtolength{\leftmargin}{#2pt}%
+%                 \setlength{\itemindent}{-#2pt}%
+%                 \setlength{\topsep}{0pt}%
+%                 \setlength{\parsep}{0pt}%
+%                 \setlength{\partopsep}{0pt}%
+%                 \setlength{\parskip}{0pt}%
+%                 \addtolength{\labelsep}{0pt}}%
+%  \item[]\footnotesize}{\end{list}}
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%    % Typesets a sequence of paragraphs like this:                         %
+%    %                                                                      %
+%    %      left |<-- d1 --> XXXXXXXXXXXXXXXXXXXXXXXX                       %
+%    %    margin |           <- d2 -> XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                                                          %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %           |                    XXXXXXXXXXXXXXX                       %
+%    %                                                                      %
+%    % where d1 = #1pt and d2 = #2pt, but with no vspace between            %
+%    % paragraphs.                                                          %
+%    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Commands for repeated characters that produce dashes.              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \raisedDash{wd}{ht}{thk} makes a horizontal line wd characters wide,
+% raised a distance ht ex's above the baseline, with a thickness of
+% thk em's.
+\newcommand{\raisedDash}[3]{\raisebox{#2ex}{\setlength{\alignwidth}{.5em}%
+  \rule{#1\alignwidth}{#3em}}}
+
+% The following commands take a single argument n and produce the
+% output for n repeated characters, as follows
+%   \cdash:    -
+%   \tdash:    ~
+%   \ceqdash:  =
+%   \usdash:   _
+\newcommand{\cdash}[1]{\raisedDash{#1}{.5}{.04}}
+\newcommand{\usdash}[1]{\raisedDash{#1}{0}{.04}}
+\newcommand{\ceqdash}[1]{\raisedDash{#1}{.5}{.08}}
+\newcommand{\tdash}[1]{\raisedDash{#1}{1}{.08}}
+
+\newlength{\spacewidth}
+\setlength{\spacewidth}{.2em}
+\newcommand{\e}[1]{\hspace{#1\spacewidth}}
+%% \e{i} produces space corresponding to i input spaces.
+
+
+%% Alignment-file Commands
+
+\newlength{\alignboxwidth}
+\newlength{\alignwidth}
+\newsavebox{\alignbox}
+
+% \al{i}{j}{txt} is used in the alignment file to put "%{i}{j}{wd}"
+% in the log file, where wd is the width of the line up to that point,
+% and txt is the following text.
+\newcommand{\al}[3]{%
+  \typeout{\%{#1}{#2}{\the\alignwidth}}%
+  \cl{#3}}
+
+%% \cl{txt} continues a specification line in the alignment file
+%% with text txt.
+\newcommand{\cl}[1]{%
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignboxwidth}{\usebox{\alignbox}}%
+  \addtolength{\alignwidth}{\alignboxwidth}%
+  \usebox{\alignbox}}
+
+% \fl{txt} in the alignment file begins a specification line that
+% starts with the text txt.
+\newcommand{\fl}[1]{%
+  \par
+  \savebox{\alignbox}{\mbox{$\mbox{}#1\mbox{}$}}%
+  \settowidth{\alignwidth}{\usebox{\alignbox}}%
+  \usebox{\alignbox}}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ordinarily, TeX typesets letters in math mode in a special math italic    %
+% font.  This makes it typeset "it" to look like the product of the         %
+% variables i and t, rather than like the word "it".  The following         %
+% commands tell TeX to use an ordinary italic font instead.                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifx\documentclass\undefined
+\else
+  \DeclareSymbolFont{tlaitalics}{\encodingdefault}{cmr}{m}{it}
+  \let\itfam\symtlaitalics
+\fi
+
+\makeatletter
+\newcommand{\tlx@c}{\c@tlx@ctr\advance\c@tlx@ctr\@ne}
+\newcounter{tlx@ctr}
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7061\relax
+\mathcode`a=\tlx@c \mathcode`b=\tlx@c \mathcode`c=\tlx@c \mathcode`d=\tlx@c
+\mathcode`e=\tlx@c \mathcode`f=\tlx@c \mathcode`g=\tlx@c \mathcode`h=\tlx@c
+\mathcode`i=\tlx@c \mathcode`j=\tlx@c \mathcode`k=\tlx@c \mathcode`l=\tlx@c
+\mathcode`m=\tlx@c \mathcode`n=\tlx@c \mathcode`o=\tlx@c \mathcode`p=\tlx@c
+\mathcode`q=\tlx@c \mathcode`r=\tlx@c \mathcode`s=\tlx@c \mathcode`t=\tlx@c
+\mathcode`u=\tlx@c \mathcode`v=\tlx@c \mathcode`w=\tlx@c \mathcode`x=\tlx@c
+\mathcode`y=\tlx@c \mathcode`z=\tlx@c
+\c@tlx@ctr=\itfam \multiply\c@tlx@ctr"100\relax \advance\c@tlx@ctr "7041\relax
+\mathcode`A=\tlx@c \mathcode`B=\tlx@c \mathcode`C=\tlx@c \mathcode`D=\tlx@c
+\mathcode`E=\tlx@c \mathcode`F=\tlx@c \mathcode`G=\tlx@c \mathcode`H=\tlx@c
+\mathcode`I=\tlx@c \mathcode`J=\tlx@c \mathcode`K=\tlx@c \mathcode`L=\tlx@c
+\mathcode`M=\tlx@c \mathcode`N=\tlx@c \mathcode`O=\tlx@c \mathcode`P=\tlx@c
+\mathcode`Q=\tlx@c \mathcode`R=\tlx@c \mathcode`S=\tlx@c \mathcode`T=\tlx@c
+\mathcode`U=\tlx@c \mathcode`V=\tlx@c \mathcode`W=\tlx@c \mathcode`X=\tlx@c
+\mathcode`Y=\tlx@c \mathcode`Z=\tlx@c
+\makeatother
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                THE describe ENVIRONMENT                %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% It is like the description environment except it takes an argument
+% ARG that should be the text of the widest label.  It adjusts the
+% indentation so each item with label LABEL produces
+%%      LABEL             blah blah blah
+%%      <- width of ARG ->blah blah blah
+%%                        blah blah blah
+\newenvironment{describe}[1]%
+   {\begin{list}{}{\settowidth{\labelwidth}{#1}%
+            \setlength{\labelsep}{.5em}%
+            \setlength{\leftmargin}{\labelwidth}%
+            \addtolength{\leftmargin}{\labelsep}%
+            \addtolength{\leftmargin}{\parindent}%
+            \def\makelabel##1{\rm ##1\hfill}}%
+            \setlength{\topsep}{0pt}}%%
+                % Sets \topsep to 0 to reduce vertical space above
+                % and below embedded displayed equations
+   {\end{list}}
+
+%   For tlatex.TeX
+\usepackage{verbatim}
+\makeatletter
+\def\tla{\let\%\relax%
+         \@bsphack
+         \typeout{\%{\the\linewidth}}%
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endtla=\@esphack
+
+\let\pcal=\tla
+\let\endpcal=\endtla
+\let\ppcal=\tla
+\let\endppcal=\endtla
+
+% The tlatex environment is used by TLATeX.TeX to typeset TLA+.
+% TLATeX.TLA starts its files by writing a \tlatex command.  This
+% command/environment sets \parindent to 0 and defines \% to its
+% standard definition because the writing of the log files is messed up
+% if \% is defined to be something else.  It also executes
+% \@computerule to determine the dimensions for the TLA horizonatl
+% bars.
+\newenvironment{tlatex}{\@computerule%
+                        \setlength{\parindent}{0pt}%
+                       \makeatletter\chardef\%=`\%}{}
+
+
+% The notla environment produces no output.  You can turn a
+% tla environment to a notla environment to prevent tlatex.TeX from
+% re-formatting the environment.
+
+\def\notla{\let\%\relax%
+         \@bsphack
+             \let\do\@makeother\dospecials\catcode`\^^M\active
+             \let\verbatim@startline\relax
+             \let\verbatim@addtoline\@gobble
+             \let\verbatim@processline\relax
+             \let\verbatim@finish\relax
+             \verbatim@}
+\let\endnotla=\@esphack
+
+\let\nopcal=\notla
+\let\endnopcal=\endnotla
+\let\noppcal=\notla
+\let\endnoppcal=\endnotla
+
+%%%%%%%%%%%%%%%%%%%%%%%% end of tlatex.sty file %%%%%%%%%%%%%%%%%%%%%%%
+% last modified on Fri  3 August 2012 at 14:23:49 PST by lamport
+
+\begin{document}
+\tlatex
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ \ensuremath{\.{\,\backslash\,}}* Copyright (c) \ensuremath{eBPF} for Windows
+ contributors
+\end{cpar}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+\ensuremath{\.{\,\backslash\,}}* SPDX-License-Identifier: \ensuremath{MIT
+}%
+\end{cpar}%
+\end{lcom}%
+\@x{}\moduleLeftDash\@xx{ {\MODULE} Failure}\moduleRightDash\@xx{}%
+\@x{ {\EXTENDS} Naturals}%
+\@pvspace{8.0pt}%
+\begin{lcom}{0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+A deliberately broken version of the simple counter model.
+\end{cpar}%
+\vshade{5.0}%
+\begin{cpar}{0}{F}{F}{0}{0}{}%
+ It violates the invariant by allowing \ensuremath{x} to increment past
+ \ensuremath{Max}.
+ \ensuremath{TLC} should find an invariant violation and produce a
+ counterexample.
+\end{cpar}%
+\end{lcom}%
+\@pvspace{8.0pt}%
+\@x{ {\CONSTANTS} Min ,\, Max}%
+\@x{ {\VARIABLE} x}%
+\@pvspace{8.0pt}%
+\@x{ TypeOK \.{\defeq} x \.{\in} Min \.{\dotdot} Max}%
+\@pvspace{8.0pt}%
+\@x{ Init \.{\defeq} x \.{=} Min}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ BUG: no guard to stop \ensuremath{x} from exceeding \ensuremath{Max}.
+}%
+\@xx{}%
+\@x{ Inc \.{\defeq} x \.{'} \.{=} x \.{+} 1}%
+\@pvspace{8.0pt}%
+\@x{}%
+\@y{\@s{0}%
+ Keep it minimal: only increments.
+}%
+\@xx{}%
+\@x{ Next \.{\defeq} Inc}%
+\@pvspace{8.0pt}%
+ \@x{ Spec\@s{1.46} \.{\defeq} Init \.{\land} {\Box} [ Next ]_{ {\langle} x
+ {\rangle}}}%
+\@pvspace{8.0pt}%
+\@x{ Invariant \.{\defeq} TypeOK}%
+\@pvspace{8.0pt}%
+\@x{}\bottombar\@xx{}%
+\end{document}

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -10,6 +10,7 @@
 .*\.rc$
 .*\.sln$
 .*\.vsdx$
+.*models/.*/tlatex/.*\.tex$
 
 # Directories with files that don't support embedding license info
 .*corpus

--- a/scripts/generate_tlatex.ps1
+++ b/scripts/generate_tlatex.ps1
@@ -1,0 +1,91 @@
+# Copyright (c) eBPF for Windows contributors
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Tla2ToolsJar = "tla2tools.jar"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-TlaTex {
+    param(
+        [Parameter(Mandatory = $true)][string]$JarPath,
+        [Parameter(Mandatory = $true)][string]$SpecPath,
+        [Parameter(Mandatory = $true)][string]$OutDir
+    )
+
+    $specRoot = [System.IO.Path]::GetFileNameWithoutExtension($SpecPath)
+    $logPath = Join-Path $OutDir ($specRoot + '.tlatex.log')
+
+    $javaArgs = @(
+        '-cp', $JarPath,
+        'tla2tex.TLA',
+        '-metadir', $OutDir,
+        $SpecPath
+    )
+
+    try {
+        & java @javaArgs *> $logPath
+        $exitCode = $LASTEXITCODE
+    } catch {
+        $exitCode = 1
+    }
+
+    $texPath = Join-Path $OutDir ($specRoot + '.tex')
+    if (-not (Test-Path $texPath)) {
+        Write-Error "TLATeX did not produce $texPath"
+    }
+
+    # TLATeX may emit trailing whitespace which trips pre-commit hooks.
+    # Strip it deterministically.
+    $rawText = [System.IO.File]::ReadAllText($texPath)
+    $endsWithNewline = $rawText.EndsWith("`n")
+    $lines = [System.IO.File]::ReadAllLines($texPath)
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        $lines[$i] = $lines[$i] -replace "[ \t]+$", ""
+    }
+
+    $normalizedText = $lines -join "`n"
+    if ($endsWithNewline) {
+        $normalizedText += "`n"
+    }
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($texPath, $normalizedText, $utf8NoBom)
+
+    if ($exitCode -ne 0) {
+        $log = Get-Content -Raw -ErrorAction SilentlyContinue $logPath
+        Write-Error "TLATeX failed for $SpecPath`n$log"
+    }
+
+    Remove-Item -Force (Join-Path $OutDir ($specRoot + '.aux')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $OutDir ($specRoot + '.log')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $OutDir ($specRoot + '.dvi')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $OutDir ($specRoot + '.ps')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $OutDir ($specRoot + '.pdf')) -ErrorAction SilentlyContinue
+    Remove-Item -Force $logPath -ErrorAction SilentlyContinue
+
+    # TLATeX may also copy LaTeX build artifacts next to the input module.
+    $specDir = Split-Path -Parent $SpecPath
+    Remove-Item -Force (Join-Path $specDir ($specRoot + '.aux')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $specDir ($specRoot + '.log')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $specDir ($specRoot + '.dvi')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $specDir ($specRoot + '.ps')) -ErrorAction SilentlyContinue
+    Remove-Item -Force (Join-Path $specDir ($specRoot + '.pdf')) -ErrorAction SilentlyContinue
+}
+
+if (-not (Test-Path $Tla2ToolsJar)) {
+    throw "tla2tools.jar not found at: $Tla2ToolsJar`nDownload it (CI does) or pass -Tla2ToolsJar <path>."
+}
+
+$tlaFiles = Get-ChildItem -Path (Join-Path $PSScriptRoot '..\models') -Filter *.tla -Recurse |
+    Where-Object { $_.FullName -notmatch '\\tlatex\\' }
+
+foreach ($tla in $tlaFiles) {
+    $modelDir = Split-Path -Parent $tla.FullName
+    $outDir = Join-Path $modelDir 'tlatex'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    Write-Host "Generating TLATeX for $($tla.FullName) -> $outDir"
+    Invoke-TlaTex -JarPath $Tla2ToolsJar -SpecPath $tla.FullName -OutDir $outDir
+}

--- a/scripts/generate_tlatex.sh
+++ b/scripts/generate_tlatex.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright (c) eBPF for Windows contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+# Generate TLATeX (.tex) outputs for all models under models/*.
+#
+# By default this script uses ./tla2tools.jar (as downloaded by CI).
+# You can override with TLA2TOOLS_JAR=/path/to/tla2tools.jar
+#
+# Note: TLATeX runs LaTeX to compute alignment. If LaTeX is not installed,
+# the tool still usually writes the .tex file but exits non-zero.
+# We tolerate only the specific "latex not found" failure; everything else fails.
+
+TLA2TOOLS_JAR="${TLA2TOOLS_JAR:-tla2tools.jar}"
+
+if [[ ! -f "${TLA2TOOLS_JAR}" ]]; then
+  echo "tla2tools.jar not found at: ${TLA2TOOLS_JAR}" >&2
+  echo "Set TLA2TOOLS_JAR or download it (CI downloads it automatically)." >&2
+  exit 1
+fi
+
+shopt -s nullglob
+
+for model_dir in models/*/ ; do
+  tla_files=("${model_dir}"*.tla)
+  if [[ ${#tla_files[@]} -eq 0 ]]; then
+    continue
+  fi
+  model_dir_root="${model_dir%/}"
+  out_dir="${model_dir_root}/tlatex"
+  mkdir -p "${out_dir}"
+
+  for tla in "${tla_files[@]}"; do
+    spec_root="$(basename "${tla}" .tla)"
+
+    echo "Generating TLATeX for ${tla} -> ${out_dir}/${spec_root}.tex"
+
+    log_file="${out_dir}/${spec_root}.tlatex.log"
+
+    set +e
+    java -cp "${TLA2TOOLS_JAR}" tla2tex.TLA -metadir "${out_dir}" "${tla}" >"${log_file}" 2>&1
+    status=$?
+    set -e
+
+    if [[ ! -f "${out_dir}/${spec_root}.tex" ]]; then
+      echo "TLATeX did not produce ${out_dir}/${spec_root}.tex" >&2
+      cat "${log_file}" >&2
+      exit 1
+    fi
+
+    # TLATeX may emit trailing whitespace which trips pre-commit hooks.
+    # Strip it deterministically.
+    sed -i -e 's/[[:space:]]\+$//' "${out_dir}/${spec_root}.tex"
+
+    if [[ ${status} -ne 0 ]]; then
+      echo "TLATeX failed for ${tla}" >&2
+      cat "${log_file}" >&2
+      exit 1
+    fi
+
+    # Keep the committed output clean: remove transient build artifacts if they exist.
+    rm -f "${out_dir}/${spec_root}.aux" "${out_dir}/${spec_root}.log" "${out_dir}/${spec_root}.dvi" "${out_dir}/${spec_root}.ps" "${out_dir}/${spec_root}.pdf"
+    rm -f "${log_file}"
+
+    # TLATeX may also copy LaTeX build artifacts next to the input module.
+    rm -f "${model_dir_root}/${spec_root}.aux" "${model_dir_root}/${spec_root}.log" "${model_dir_root}/${spec_root}.dvi" "${model_dir_root}/${spec_root}.ps" "${model_dir_root}/${spec_root}.pdf"
+  done
+done


### PR DESCRIPTION
Resolves: #4921

## Description

This PR adds/expands bounded TLA+ (TLC) models for critical concurrency/lifetime patterns and adds CI plumbing to run the passing configs.

## Testing

- CI runs TLC for the passing model configurations.

## Documentation

- Adds/updates `models/README.md` and model-specific README/CONFORMANCE docs.

## Installation

- No installer impact.
