### PR TITLE
Add .github/copilot-instructions.md for Copilot sessions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,52 +2,19 @@
 
 This project brings eBPF (extended Berkeley Packet Filter) to Windows, enabling programmable OS kernel extensions for use cases like network filtering and observability.
 
-## Build Commands
+## Quick Reference
 
-**Prerequisites**: Visual Studio 2022 (v17.4.2+), Clang 18.1.8, Git. Run `scripts\initialize_ebpf_repo.ps1` once after cloning.
+| Task | Command |
+|------|---------|
+| Build | `msbuild /m /p:Configuration=Debug /p:Platform=x64 ebpf-for-windows.sln` |
+| Build (native only) | `msbuild /m /p:Configuration=NativeOnlyDebug /p:Platform=x64 ebpf-for-windows.sln` |
+| Format code | `./scripts/format-code --staged` |
+| Run unit tests | `unit_tests.exe` (from `x64\Debug`) |
+| Run single test | `unit_tests.exe "test name"` |
+| List tests | `unit_tests.exe -l` |
 
-```cmd
-# Build (from Developer Command Prompt for VS 2022)
-msbuild /m /p:Configuration=Debug /p:Platform=x64 ebpf-for-windows.sln
-
-# Build without JIT/Interpreter (native mode only)
-msbuild /m /p:Configuration=NativeOnlyDebug /p:Platform=x64 ebpf-for-windows.sln
-```
-
-**Format code** (run before committing):
-```bash
-./scripts/format-code           # Format all C/C++ files
-./scripts/format-code --staged  # Format only staged files
-```
-
-**Check license headers**:
-```bash
-./scripts/check-license.sh
-```
-
-## Test Commands
-
-Tests use the [Catch2](https://github.com/catchorg/Catch2) framework. Run from the build output directory (`x64\Debug` or `x64\Release`).
-
-```cmd
-# User-mode unit tests (no drivers required)
-unit_tests.exe
-bpf2c_tests.exe
-netebpfext_unit.exe
-
-# Run a single test by name
-unit_tests.exe "test name here"
-
-# List all tests
-unit_tests.exe -l
-
-# Kernel tests (require drivers loaded and eBPFSvc running)
-api_test.exe
-socket_tests.exe
-connect_redirect_tests.exe
-```
-
-Useful Catch2 flags: `-s` (show passing tests), `-b` (break on failure), `~[tag]` (exclude tagged tests).
+See [docs/GettingStarted.md](../docs/GettingStarted.md) for prerequisites, build options, and detailed setup.
+See [docs/AutomatedTests.md](../docs/AutomatedTests.md) for test categories and descriptions.
 
 ## Architecture Overview
 
@@ -108,64 +75,26 @@ Useful Catch2 flags: `-s` (show passing tests), `-b` (break on failure), `~[tag]
 
 ## Code Conventions
 
-### Naming
-- `lower_snake_case` for variables, functions, fields
-- `UPPER_SNAKE_CASE` for macros and constants
-- Prefix with `ebpf_` for eBPF-specific names in global namespace
-- Prefix with `_` for file-local static functions/variables
-- Structs: `typedef struct _ebpf_widget { ... } ebpf_widget_t;`
+See [docs/DevelopmentGuide.md](../docs/DevelopmentGuide.md) for full details. Key points:
 
-### Types
-- Use `stdint.h` fixed-width types (`uint32_t`, `int64_t`) instead of `int`, `long`
-- Use `const` and `static` to limit scope
-
-### Headers
-- Use `#pragma once` (not include guards)
-- Include local headers (`""`) before system headers (`<>`)
-- Alphabetize includes within groups
-
-### Formatting
-- **clang-format 18.1.8** with `.clang-format` config (LLVM-based)
-- 120-character line limit
-- Single-line if/else/loop blocks must use braces
-- Run `./scripts/format-code --staged` before committing
-
-### License Header (required on all new source files)
-```c
-// Copyright (c) eBPF for Windows contributors
-// SPDX-License-Identifier: MIT
-```
-
-### Doxygen
-Use doxygen comments with `\[in,out\]` direction annotations for public API headers.
+- **Naming**: `lower_snake_case` for functions/variables, `UPPER_SNAKE_CASE` for macros, `ebpf_` prefix for global names
+- **Structs**: `typedef struct _ebpf_widget { ... } ebpf_widget_t;`
+- **Types**: Use `stdint.h` fixed-width types (`uint32_t`, not `int`)
+- **Headers**: `#pragma once`, local includes before system includes, alphabetized
+- **Formatting**: clang-format 18.1.8, 120-char limit, braces required on single-line blocks
+- **License header** (required):
+  ```c
+  // Copyright (c) eBPF for Windows contributors
+  // SPDX-License-Identifier: MIT
+  ```
 
 ## Extension Development
 
-eBPF extensions are Windows kernel drivers that provide hooks or helper functions via NMR (Network Module Registrar):
-
-1. **Program Information NPI Provider**: Defines program type ABI (context structure, available helpers)
-2. **Hook NPI Provider**: Invokes eBPF programs when OS events occur
-
-See `docs/eBpfExtensions.md` for detailed extension authoring guide.
-
-## Testing Guidelines
-
-- Unit tests link against static libraries with mocked kernel APIs (run entirely in user mode)
-- Kernel tests require actual driver installation and eBPFSvc running
-- Address sanitization is enabled for unit tests
-- Fault injection tests verify behavior under failure conditions
+eBPF extensions are kernel drivers providing hooks/helpers via NMR. See [docs/eBpfExtensions.md](../docs/eBpfExtensions.md).
 
 ## Tracing
 
-eBPF for Windows uses ETW. Capture traces with:
-```cmd
-wpr.exe -start "%ProgramFiles%\ebpf-for-windows\ebpfforwindows.wprp" -filemode
-# ... run scenario ...
-wpr.exe -stop ebpfforwindows.etl
-netsh trace convert ebpfforwindows.etl
-```
-
-View `bpf_printk()` output in real-time:
+See "Using tracing" section in [docs/GettingStarted.md](../docs/GettingStarted.md). Quick reference:
 ```cmd
 tracelog -start MyTrace -guid ebpf-printk.guid -rt
 tracefmt -rt MyTrace -displayonly -jsonMeta 0


### PR DESCRIPTION
## Summary

Add comprehensive instructions to help GitHub Copilot work effectively in this repository.

## Contents

- **Build commands**: MSBuild with Debug/Release and NativeOnly configurations
- **Test commands**: Unit tests, kernel tests, and how to run single tests with Catch2
- **Architecture diagram**: Layered architecture showing user space → ebpfapi.dll → ebpfcore.sys → extension drivers
- **Key components table**: Maps components to locations and purposes
- **Code conventions**: Naming, types, headers, formatting (clang-format 18.1.8), license headers
- **Extension development**: NMR-based hook/helper provider guidance
- **Tracing**: ETW capture and bpf_printk viewing

## Notes

This file is automatically read by GitHub Copilot to provide context about the codebase structure and conventions.