### PR TITLE
Fix LRU user mode access test

### DIFF
--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -2368,7 +2368,7 @@ TEST_CASE("lru_map_user_vs_kernel_access", "[lru]")
         REQUIRE(value == (100 + i));
     }
 
-    // update key 0 to update its LRU status (it should not be evicted next).
+    // Update key 0 to update its LRU status (it should not be evicted next).
     uint32_t key_zero = 0;
     uint32_t updated_value = 200;
     REQUIRE(bpf_map_update_elem(map_fd, &key_zero, &updated_value, BPF_ANY) == 0);
@@ -2394,7 +2394,7 @@ TEST_CASE("lru_map_user_vs_kernel_access", "[lru]")
     }
     REQUIRE(key_count == 2);
 
-    // Verify key 4 is present
+    // Verify key 4 is present.
     uint32_t lookup_key = 4;
     uint32_t value = 0;
     REQUIRE(bpf_map_lookup_elem(map_fd, &lookup_key, &value) == 0); // Should succeed.


### PR DESCRIPTION
## Description

Closes #4962 

There was a bug in the `lru_map_user_vs_kernel_access` test in `api_test.cpp` introduced in #4893 where it assumes exact LRU behavior (rather than hot/cold lists).

This updates the test to use updates from user-mode to affect LRU state, and assumes 1 of the cold entries will be evicted instead of exact LRU ordering.

## Testing

Updates tests.

## Documentation

N/A

## Installation

N/A
