### PR TITLE
ci: Set gather_dumps to false for km_ebpfcore_restart_test

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -674,7 +674,8 @@ jobs:
       build_artifact: Build-x64
       environment: '["self-hosted", "1ES.Pool=ebpf-cicd-runner-pool-server-2019", "1ES.ImageOverride=server2022"]'
       code_coverage: false
-      gather_dumps: true
+      # Dumps are gathered inside the VM, not on the runner.
+      gather_dumps: false
 
   performance:
     needs: regular


### PR DESCRIPTION
Fixes #4967

The km_ebpfcore_restart_test job runs on a 1ES runner which doesn't have Chocolatey installed. Setting \gather_dumps: true\ triggers the choco step to install procdump, which fails.

Dumps are gathered inside the VM by the test controller, not on the runner, so \gather_dumps\ should be \alse\ like other driver tests.