### PR TITLE
Fix km_ebpfcore_restart_test to run inside VM

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -669,7 +669,7 @@ jobs:
     with:
       name: km_ebpfcore_restart_test
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\ebpf_restart_test_controller.exe
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartEbpfCore")
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: '["self-hosted", "1ES.Pool=ebpf-cicd-runner-pool-server-2019", "1ES.ImageOverride=server2022"]'

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -450,10 +450,23 @@ function Invoke-CICDStressTests
           [parameter(Mandatory = $false)][int] $TestHangTimeout = (120*60),
           [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
           [parameter(Mandatory = $false)][bool] $NeedKernelDump = $true,
-          [parameter(Mandatory = $false)][bool] $RestartExtension = $false)
+          [parameter(Mandatory = $false)][bool] $RestartExtension = $false,
+          [parameter(Mandatory = $false)][bool] $RestartEbpfCore = $false)
 
     Push-Location $WorkingDirectory
     $env:EBPF_ENABLE_WER_REPORT = "yes"
+
+    if ($RestartEbpfCore) {
+        Write-Log "Executing eBPF core restart stress test."
+
+        $LASTEXITCODE = 0
+
+        $TestCommand = ".\ebpf_restart_test_controller.exe"
+        Invoke-Test -TestName $TestCommand -VerboseLogs $VerboseLogs -TestHangTimeout $TestHangTimeout -TracingProfileName "EbpfForWindowsProvider"
+
+        Pop-Location
+        return
+    }
 
     Write-Log "Executing eBPF kernel mode multi-threaded stress tests (restart extension:$RestartExtension)."
 

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -336,9 +336,12 @@ function Run-KernelTests {
             "stress" {
                 # Set RestartExtension to true if options contains that string.
                 $RestartExtension = $Options -contains "RestartExtension"
+                # Set RestartEbpfCore to true if options contains that string.
+                $RestartEbpfCore = $Options -contains "RestartEbpfCore"
                 Invoke-CICDStressTests `
                     -VerboseLogs $VerboseLogs `
                     -RestartExtension $RestartExtension `
+                    -RestartEbpfCore $RestartEbpfCore `
                     2>&1 | Write-Log
             }
             "performance" {


### PR DESCRIPTION
## Problem

The `km_ebpfcore_restart_test` has been failing every scheduled run since it was introduced (issue #4950). The previous RCA (Chocolatey missing) was fixed by PR #4968, but the test continues to fail with a new error:

`
Failed to create map, error: -1
Failed to open ebpfcore service, error: 1060
FAIL: ebpfcore service does not exist - environment issue!
`

## Root Cause

The test command `.\ebpf_restart_test_controller.exe` was invoked directly on the **1ES runner host**, but the eBPF components (`ebpfcore` service) are installed inside the **Hyper-V VM** (`runner_vm`) by `setup_ebpf_cicd_tests.ps1`. Error 1060 is `ERROR_SERVICE_DOES_NOT_EXIST`.

Other KM tests (e.g., `km_mt_stress_tests_restart_extension`) correctly route execution through `execute_ebpf_cicd_tests.ps1`, which uses `Invoke-OnHostOrVM` to run inside the VM.

## Fix

Route the restart test through the existing VM execution infrastructure:
1. **cicd.yml** - Changed test_command to use `execute_ebpf_cicd_tests.ps1` with `RestartEbpfCore` option
2. **run_driver_tests.psm1** - Added `RestartEbpfCore` parameter to `Invoke-CICDStressTests`
3. **vm_run_tests.psm1** - Passes the new option through

Fixes #4950
