### PR TITLE
bpf2c/nuget: Track script dependencies as CustomBuild inputs

### DIFF
--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -172,15 +172,15 @@
       <Command Condition="'$(Configuration)'=='FuzzerDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
-      <AdditionalInputs Condition="'$(Configuration)'=='Debug'">
+      <AdditionalInputs Condition="'$(Configuration)'=='Debug'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyDebug'">
+      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='FuzzerDebug'">
+      <AdditionalInputs Condition="'$(Configuration)'=='FuzzerDebug'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='Release'">
+      <AdditionalInputs Condition="'$(Configuration)'=='Release'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyRelease'">
+      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyRelease'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(OutputPath)%(Filename).template</Outputs>
@@ -193,6 +193,7 @@
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='FuzzerDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
+      <AdditionalInputs>$(SolutionDir)scripts\escape_text.ps1</AdditionalInputs>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='FuzzerDebug'">$(OutputPath)%(Filename).template</Outputs>
@@ -203,6 +204,7 @@
     </CustomBuild>
     <CustomBuild Include="bpf2c.exe.manifest.in">
       <FileType>Document</FileType>
+      <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h</AdditionalInputs>
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile bpf2c.exe.manifest.in -OutputFile $(OutputPath)bpf2c.exe.manifest</Command>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)bpf2c.exe.manifest</Outputs>
       <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile bpf2c.exe.manifest.in -OutputFile $(OutputPath)bpf2c.exe.manifest</Command>

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -84,11 +84,6 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyDebug'">
     <ClCompile>
@@ -109,11 +104,6 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -138,11 +128,6 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyRelease'">
     <ClCompile>
@@ -167,16 +152,12 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="ebpf-for-windows.nuspec.in">
       <FileType>Document</FileType>
-      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(EbpfVersion).nupkg</Outputs>
+      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(Configuration).$(EbpfVersion).nupkg</Outputs>
+      <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h;$(SolutionDir)tools\nuget\ebpf-for-windows.props.in</AdditionalInputs>
       <Command>
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -Configuration $(Configuration)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.props.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).props -Architecture $(Platform)


### PR DESCRIPTION
## Description

Refactors bpf2c build steps to improve incremental build time for bpf2c and bpf programs.


Add AdditionalInputs to CustomBuild items in bpf2c.vcxproj and nuget.vcxproj so that changes to helper scripts and data files correctly trigger rebuilds:

 - bpf2c_dll.c / bpf2c_driver.c: track escape_text.ps1
 - bpf2c.exe.manifest.in: track Set-Version.ps1, Directory.Build.props, git_commit_id.h
 - ebpf-for-windows.nuspec.in: track Set-Version.ps1, Directory.Build.props, git_commit_id.h, ebpf-for-windows.props.in

Also fix two nuget incremental-build bugs:

 - Outputs mismatch: add missing $(Configuration) to match actual nupkg filename (fixes MSB8065 warning)
 - PreBuildEvent defeating incremental builds: remove del ebpf-for-windows.*.nupkg that unconditionally deleted the CustomBuild output every build

Closes #5024 

## Testing

Build only changes - locally validated that rebuilds happen (or don't) when files are touched.

## Documentation

N/A

## Installation

N/A