### PR TITLE
Align Debug/Release with native-only defaults (phase 1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,7 +63,7 @@
   <PropertyGroup Condition="'$(AddressSanitizer)'=='True'">
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='NativeOnlyDebug' Or '$(Configuration)'=='NativeOnlyRelease'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release' Or '$(Configuration)'=='NativeOnlyDebug' Or '$(Configuration)'=='NativeOnlyRelease'">
     <DisableJIT>true</DisableJIT>
     <DisableInterpreter>true</DisableInterpreter>
   </PropertyGroup>

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -96,22 +96,24 @@ The following steps need to be executed *once* before the first build on a new c
 
 ##### Setting compile time options when building from Developer Command Prompt
 
-To build with the specific compile time options for disabling JIT compiler and/or the Interpreter, append "`/p:<option>=True`". Available options are:
+`Debug` and `Release` configurations now compile with both JIT compiler and interpreter disabled by default
+(the same behavior as `NativeOnlyDebug` and `NativeOnlyRelease`).
+The following properties are still available for explicit configuration:
 
 1. `DisableJIT` - Compile eBPF's *execution context* without support for eBPF JIT compiler.
 1. `DisableInterpreter` - Compile eBPF's *execution context* without support for eBPF interpreter.
 
-Both options are set when compiling with the "NativeOnlyDebug" or "NativeOnlyRelease" configurations.
+Both options are enabled by default in `Debug`, `Release`, `NativeOnlyDebug`, and `NativeOnlyRelease`.
 
 #### Building using Visual Studio IDE
 
 1. Open the `ebpf-for-windows.sln` solution.
-1. Switch the configuration to "`Debug`|`x64`".  To build with the JIT and Interpreter disabled, switch the configuration to "`NativeOnlyDebug`|`x64`" instead.
+1. Switch the configuration to "`Debug`|`x64`" (or "`Release`|`x64`"). JIT and interpreter are disabled by default.
 1. Rebuild the solution.
 
 ##### Setting compile time options when building from Visual Studio IDE
 
-To build with the specific compile time options for disabling JIT compiler and/or the interpreter:
+By default, these options are already enabled for `Debug` and `Release`. To set them manually for a project:
 
 1. Select the project to modify from the Solution Explorer.
 1. Navigate to "`C/C++`" -> "`Preprocessor`" -> "`Preprocessor Definitions`"


### PR DESCRIPTION
## Description

Align Debug/Release behavior with current NativeOnly defaults for phase 1 of JIT/interpreter removal.

Changes in this PR:
- `Directory.Build.props`: apply `DisableJIT=true` and `DisableInterpreter=true` to `Debug` and `Release` (while keeping existing `NativeOnly*` behavior unchanged).
- `docs/GettingStarted.md`: update build guidance to state that `Debug` and `Release` now disable JIT/interpreter by default.

Part of #4997.

## Testing

- Built `libs\kernel\execution_context_kernel` for `Debug|x64` and `Release|x64` successfully.
- Attempted a broader `tests\unit_tests` target build; it currently fails with an existing unrelated linker error in `ebpfapi` (`prevail::make_kfunc_call` unresolved).

## Documentation

Yes. Updated `docs/GettingStarted.md` to reflect Debug/Release default behavior.

## Installation

No installer impact from this change.
