### PR TITLE
Wrap remaining ebpf async completion code paths in epoch logic.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -627,6 +627,22 @@ jobs:
       gather_dumps: true
       capture_etw: true
 
+  # Run api_test ioctl stress tests.
+  km_ioctl_stress_tests:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: '["self-hosted", "1ES.Pool=ebpf-cicd-runner-pool-server-2019", "1ES.ImageOverride=server2022"]'
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
+
   # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
   # against the kernel mode eBPF sub-system.
   km_mt_stress_tests:
@@ -636,7 +652,7 @@ jobs:
     with:
       name: km_mt_stress_tests
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("MultiThread")
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: '["self-hosted", "1ES.Pool=ebpf-cicd-runner-pool-server-2019", "1ES.ImageOverride=server2022"]'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -633,7 +633,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_mt_stress_tests
+      name: km_ioctl_stress_tests
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1098,7 +1098,7 @@ _ebpf_core_protocol_program_test_run_complete(
         reply->duration = options->duration;
     }
 
-    ebpf_async_complete(async_context, reply->header.length, result);
+    ebpf_async_complete_with_epoch(async_context, reply->header.length, result);
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)program);
     ebpf_free((void*)options);
 }
@@ -2173,7 +2173,7 @@ _ebpf_core_epoch_synchronize_work_item(_In_ cxplat_preemptible_work_item_t* work
     UNREFERENCED_PARAMETER(work_item);
     ebpf_epoch_synchronize();
     if (work_item_context != NULL) {
-        ebpf_async_complete(work_item_context, 0, EBPF_SUCCESS);
+        ebpf_async_complete_with_epoch(work_item_context, 0, EBPF_SUCCESS);
     }
 
     cxplat_free_preemptible_work_item(work_item);

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2480,7 +2480,7 @@ _map_async_query_complete(_In_ const ebpf_core_map_t* map, _Inout_ ebpf_core_map
         ebpf_list_remove_entry(&context->entry);
         ebpf_operation_map_async_query_reply_t* reply =
             EBPF_FROM_FIELD(ebpf_operation_map_async_query_reply_t, async_query_result, async_query_result);
-        ebpf_async_complete(context->async_context, sizeof(*reply), EBPF_SUCCESS);
+        ebpf_async_complete_with_epoch(context->async_context, sizeof(*reply), EBPF_SUCCESS);
         ebpf_free(context);
         context = NULL;
     }
@@ -2520,7 +2520,7 @@ _map_async_query_cancel(
 
     ebpf_list_remove_entry(&found_context->entry);
     ebpf_lock_unlock(&async_contexts->lock, state);
-    ebpf_async_complete(found_context->async_context, 0, EBPF_CANCELED);
+    ebpf_async_complete_with_epoch(found_context->async_context, 0, EBPF_CANCELED);
     ebpf_free(found_context);
 }
 

--- a/libs/runtime/ebpf_async.c
+++ b/libs/runtime/ebpf_async.c
@@ -125,6 +125,17 @@ ebpf_async_complete(_Inout_ void* context, size_t output_buffer_length, ebpf_res
     EBPF_RETURN_VOID();
 }
 
+void
+ebpf_async_complete_with_epoch(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result)
+{
+    EBPF_LOG_ENTRY();
+    ebpf_epoch_state_t epoch_state = {0};
+    ebpf_epoch_enter(&epoch_state);
+    ebpf_async_complete(context, output_buffer_length, result);
+    ebpf_epoch_exit(&epoch_state);
+    EBPF_RETURN_VOID();
+}
+
 _Must_inspect_result_ ebpf_result_t
 ebpf_async_reset_completion_callback(_In_ const void* context)
 {

--- a/libs/runtime/ebpf_async.h
+++ b/libs/runtime/ebpf_async.h
@@ -102,7 +102,7 @@ extern "C"
     ebpf_async_cancel(_Inout_ void* context);
 
     /**
-     * @brief Complete the action associated with this context.
+     * @brief Complete the action associated with this context. This function assumes the caller has entered an epoch.
      *
      * @param[in, out] context Context associated with the action.
      * @param[in] output_buffer_length Length (in bytes) of the buffer containing the result of the async operation.
@@ -110,6 +110,16 @@ extern "C"
      */
     void
     ebpf_async_complete(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result);
+
+    /**
+     * @brief Complete the action associated with this context, using epoch protection.
+     *
+     * @param[in, out] context Context associated with the action.
+     * @param[in] output_buffer_length Length (in bytes) of the buffer containing the result of the async operation.
+     * @param[in] result The outcome of the action.
+     */
+    void
+    ebpf_async_complete_with_epoch(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result);
 
 #ifdef __cplusplus
 }

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -466,6 +466,7 @@ function Invoke-CICDStressTests
         $TestCommand = "api_test.exe"
         $TestArguments = "--stress-test-duration $api_stress_duration ioctl_stress"
         Invoke-Test -TestName $TestCommand -TestArgs $TestArguments -VerboseLogs $VerboseLogs -TestHangTimeout $TestHangTimeout -TracingProfileName "EbpfForWindowsProvider"
+        Pop-Location
         return
     }
 

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -449,6 +449,7 @@ function Invoke-CICDStressTests
     param([parameter(Mandatory = $true)][bool] $VerboseLogs,
           [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
           [parameter(Mandatory = $false)][bool] $NeedKernelDump = $true,
+          [parameter(Mandatory = $false)][bool] $MultiThread = $false,
           [parameter(Mandatory = $false)][bool] $RestartExtension = $false,
           [parameter(Mandatory = $false)][bool] $RestartEbpfCore = $false)
 
@@ -456,13 +457,17 @@ function Invoke-CICDStressTests
     Push-Location $WorkingDirectory
     $env:EBPF_ENABLE_WER_REPORT = "yes"
 
-    # run api test's ioctl_stress test.
-    $LASTEXITCODE = 0
-    $TestHangTimeout = 60*60 # 60 minutes hang timeout.
-    $api_stress_duration = 30*60 # 30 minutes test duration.
-    $TestCommand = "api_test.exe"
-    $TestArguments = "--stress-test-duration $api_stress_duration [stress]"
-    Invoke-Test -TestName $TestCommand -TestArgs $TestArguments -VerboseLogs $VerboseLogs -TestHangTimeout $TestHangTimeout -TracingProfileName "EbpfForWindowsProvider"
+    if (-not $MultiThread) {
+        Write-Log "Executing eBPF API IOCTL stress tests."
+        # run api test's ioctl_stress test.
+        $LASTEXITCODE = 0
+        $TestHangTimeout = 60*60 # 60 minutes hang timeout.
+        $api_stress_duration = 30*60 # 30 minutes test duration.
+        $TestCommand = "api_test.exe"
+        $TestArguments = "--stress-test-duration $api_stress_duration ioctl_stress"
+        Invoke-Test -TestName $TestCommand -TestArgs $TestArguments -VerboseLogs $VerboseLogs -TestHangTimeout $TestHangTimeout -TracingProfileName "EbpfForWindowsProvider"
+        return
+    }
 
     if ($RestartEbpfCore) {
         Write-Log "Executing eBPF core restart stress test."

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -334,7 +334,7 @@ function Run-KernelTests {
                     2>&1 | Write-Log
             }
             "stress" {
-                # Set MultiThred to true if options contains that string.
+                # Set MultiThread to true if options contains that string.
                 $MultiThread = $Options -contains "MultiThread"
                 # Set RestartExtension to true if options contains that string.
                 $RestartExtension = $Options -contains "RestartExtension"

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -334,12 +334,15 @@ function Run-KernelTests {
                     2>&1 | Write-Log
             }
             "stress" {
+                # Set MultiThred to true if options contains that string.
+                $MultiThread = $Options -contains "MultiThread"
                 # Set RestartExtension to true if options contains that string.
                 $RestartExtension = $Options -contains "RestartExtension"
                 # Set RestartEbpfCore to true if options contains that string.
                 $RestartEbpfCore = $Options -contains "RestartEbpfCore"
                 Invoke-CICDStressTests `
                     -VerboseLogs $VerboseLogs `
+                    -MultiThread $MultiThread `
                     -RestartExtension $RestartExtension `
                     -RestartEbpfCore $RestartEbpfCore `
                     2>&1 | Write-Log

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -37,7 +37,31 @@
 #include <vector>
 using namespace std::chrono_literals;
 
-CATCH_REGISTER_LISTENER(_watchdog)
+static int _stress_test_duration = 60; // Default to 60 seconds.
+
+/**
+ * @brief A catch2 listener that uses the stress test duration as the watchdog timeout for ioctl_stress tests.
+ */
+class _api_test_watchdog : public _watchdog
+{
+  public:
+    using _watchdog::_watchdog;
+
+    void
+    testCaseStarting(Catch::TestCaseInfo const& test_case_info) override
+    {
+        if (test_case_info.name == "ioctl_stress") {
+            // Use stress test duration plus a margin for the watchdog timeout.
+            int64_t timeout = (static_cast<uint64_t>(_stress_test_duration) + EBPF_WATCHDOG_TIMER_DUE_TIME_IN_SECONDS) *
+                              FILETIME_TICKS_PER_SECOND;
+            _watchdog_timer = std::make_unique<_ebpf_watchdog_timer<true>>(timeout);
+        } else {
+            _watchdog::testCaseStarting(test_case_info);
+        }
+    }
+};
+
+CATCH_REGISTER_LISTENER(_api_test_watchdog)
 
 #define SAMPLE_PATH ""
 
@@ -1360,8 +1384,6 @@ TEST_CASE("close_unload_test", "[native_tests][native_close_cleanup_tests]")
     bpf_object__close(object);
     */
 }
-
-static int _stress_test_duration = 60; // Default to 60 seconds.
 
 TEST_CASE("ioctl_stress", "[stress]")
 {
@@ -3652,8 +3674,8 @@ _test_custom_maps_program_load_common(ebpf_map_type_t type, ebpf_execution_type_
     result = bpf_prog_test_run_opts(program_fd, &opts);
     REQUIRE(result == 0);
 
-    // Since it is an object map, an update from a BPF program is not allowed. Look up the sample map value and validate the
-    // result.
+    // Since it is an object map, an update from a BPF program is not allowed. Look up the sample map value and validate
+    // the result.
     validate_sample_map_value(1234);
     validate_result_map(OPERATION_FAILURE);
 

--- a/tests/libs/common/watchdog.h
+++ b/tests/libs/common/watchdog.h
@@ -30,6 +30,6 @@ class _watchdog : public Catch::EventListenerBase
         _watchdog_timer.reset();
     }
 
-  private:
+  protected:
     std::unique_ptr<_ebpf_watchdog_timer<true>> _watchdog_timer;
 };


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

This is an additional fix needed for #4904.
There were missing cases of the eBPF code invoke `ebpf_async_complete` without being in epoch. A new function `    ebpf_async_complete_with_epoch` is introduced that wraps the function inside epoch. And the new function is being called from the vulnerable code paths.

Additionally, this fixes #5053, where the ioctl_stress variation of api_test was hitting the default watchdog of 15 minutes when tried to run for 30 minutes.

## Testing

api_test ioctl_stress variation for 30 minutes.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.