### PR TITLE
Fix memory leak

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -4555,6 +4555,7 @@ _custom_hash_map_notification(
         break;
     default:
         ebpf_assert(!"Invalid notification type");
+        break;
     }
 
     return result;

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -819,7 +819,15 @@ ebpf_hash_table_create(_Out_ ebpf_hash_table_t** hash_table, _In_ const ebpf_has
     table->supplemental_value_size = options->supplemental_value_size;
     table->notification_context = options->notification_context;
     table->notification_callback = options->notification_callback;
-    table->notification_flags = options->notification_flags;
+
+    // Sanitize notification flags: mask out unsupported bits and disable
+    // notifications if callback is not provided.
+    ebpf_hash_table_notification_type_t notification_flags =
+        options->notification_flags & EBPF_HASH_TABLE_NOTIFICATION_TYPE_ALL;
+    if (table->notification_callback == NULL) {
+        notification_flags = EBPF_HASH_TABLE_NOTIFICATION_TYPE_NONE;
+    }
+    table->notification_flags = notification_flags;
 
     *hash_table = table;
     retval = EBPF_SUCCESS;

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -73,8 +73,7 @@ extern "C"
         void* notification_context;     //< Context to pass to notification functions.
         ebpf_hash_table_notification_function
             notification_callback; //< Function to call when value storage is allocated or freed.
-        ebpf_hash_table_notification_type_t
-            notification_flags; //< Bitmask of notification types to enable - defaults to 0 (no notifications).
+        ebpf_hash_table_notification_type_t notification_flags; //< Bitmask of notification types to enable.
     } ebpf_hash_table_creation_options_t;
 
     /**


### PR DESCRIPTION
Fixes #5054

## Description

**Issue**
Following is the sequence of steps when an update elem is called for a custom map that stores modified values in the map.
1. ebpfcore calls `provider->process_map_add_element` to get actual value to store in the map.
2. ebpfcore calls `_update_hash_map_entry_operation_context` to store the actual value in the map.
3. If memory allocation inside `_update_hash_map_entry_operation_context` fails, ebpfcore should ideally call `provider->process_map_delete_element` to let provider clean up any context / memory.

The issue is that ebpfcore fails to call `provider->process_map_delete_element`.
There is another issue in the code that invocation of `process_map_add_element` and `process_map_delete_element` is somewhat asymmetric and hard to debug.

**Fix:**
Update hash table `notification_callback` logic to also take `notification_flags` as input. This tells hash table what all notification types are enabled for a particular hash table.

Custom maps now only enable DELETE notification, and all other notifications are handled outside the hash table implementation. This fixes the original issue, and also makes invoking provider dispatch functions symmetric.

## Testing

Existing tests cover this.

## Documentation

No.

## Installation

No.
