### PR TITLE
Install procdump using curl instead of chocolately

### DIFF
--- a/.azure/reusable-test.yml
+++ b/.azure/reusable-test.yml
@@ -100,8 +100,12 @@ jobs:
         displayName: 'Shallow Checkout Repo'
 
       - powershell: |
-          curl -L -o $(Build.SourcesDirectory)\Procdump.zip https://download.sysinternals.com/files/Procdump.zip
+          $expectedHash = '863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4'
+          curl.exe -L -o $(Build.SourcesDirectory)\Procdump.zip https://download.sysinternals.com/files/Procdump.zip
+          $actualHash = (Get-FileHash -Path $(Build.SourcesDirectory)\Procdump.zip -Algorithm SHA256).Hash
+          if ($actualHash -ne $expectedHash) { throw "Checksum mismatch: expected $expectedHash, got $actualHash" }
           Expand-Archive -Path $(Build.SourcesDirectory)\Procdump.zip -DestinationPath $(Build.SourcesDirectory)\procdump -Force
+          Remove-Item -Path $(Build.SourcesDirectory)\Procdump.zip -Force
           echo "##vso[task.prependpath]$(Build.SourcesDirectory)\procdump"
           if (-not (Test-Path "$(Build.SourcesDirectory)\procdump\procdump.exe")) { throw "ProcDump download failed" }
           # Accept Sysinternals EULA via registry (avoids exit code 1 from -accepteula)

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -159,9 +159,14 @@ jobs:
       - name: Install ProcDump
         id: install_procdump
         if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
+        env:
+          PROCDUMP_EXPECTED_HASH: '863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4'
         run: |
-          curl -L -o ${{github.workspace}}\Procdump.zip https://download.sysinternals.com/files/Procdump.zip
+          curl.exe -L -o ${{github.workspace}}\Procdump.zip https://download.sysinternals.com/files/Procdump.zip
+          $actualHash = (Get-FileHash -Path ${{github.workspace}}\Procdump.zip -Algorithm SHA256).Hash
+          if ($actualHash -ne $env:PROCDUMP_EXPECTED_HASH) { throw "Checksum mismatch: expected $env:PROCDUMP_EXPECTED_HASH, got $actualHash" }
           Expand-Archive -Path ${{github.workspace}}\Procdump.zip -DestinationPath ${{github.workspace}}\procdump -Force
+          Remove-Item -Path ${{github.workspace}}\Procdump.zip -Force
           echo "${{github.workspace}}\procdump" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           if (-not (Test-Path "${{github.workspace}}\procdump\procdump.exe")) { throw "ProcDump download failed" }
           # Accept Sysinternals EULA via registry (avoids exit code 1 from -accepteula)


### PR DESCRIPTION
## Description

Install procdump using curl instead of chocolatey to reduce test flakiness. 

Resolves #5037 

## Testing

No

## Documentation

No

## Installation

No
