### PR TITLE
Set-Version.ps1 does not handle a NULL EbpfVersion_Modifier

### DIFF
--- a/scripts/Set-Version.ps1
+++ b/scripts/Set-Version.ps1
@@ -20,7 +20,7 @@ $version = ""
 $version += $VersionPropertyGroup.EbpfVersion_Major + "."
 $version += $VersionPropertyGroup.EbpfVersion_Minor + "."
 $version += $VersionPropertyGroup.EbpfVersion_Revision
-if ($VersionPropertyGroup.EbpfVersion_Modifier -ne "") {
+if (-not [string]::IsNullOrEmpty($VersionPropertyGroup.EbpfVersion_Modifier)) {
     $version += "-" + $VersionPropertyGroup.EbpfVersion_Modifier
 }
 


### PR DESCRIPTION
## Description

This pull request contains a minor update to the version modifier check in the `scripts/Set-Version.ps1` script. The change improves reliability by using a more robust method to determine if the version modifier is empty.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
