### PR TITLE
epoch: use ReadAcquire64 instead of InterlockedCompareExchange64 for published epoch reads

### DIFF
--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -17,9 +17,12 @@ static volatile int64_t _ebpf_epoch_published_current_epoch = 1;
 static __forceinline uint64_t
 _ebpf_epoch_get_published_epoch()
 {
-    // ebpf_interlocked_compare_exchange_int64() (implemented using InterlockedCompareExchange64) provides a
-    // sequentially consistent atomic read.
-    return (uint64_t)ebpf_interlocked_compare_exchange_int64(&_ebpf_epoch_published_current_epoch, 0, 0);
+    // ReadAcquire64 provides an acquire-fence load which is sufficient here:
+    // the writer side uses InterlockedIncrement (release semantics) so an
+    // acquire load on the reader side forms a correct release/acquire pair.
+    // This avoids the LOCK-prefixed bus transaction that
+    // InterlockedCompareExchange64 would emit on every epoch_enter/retire.
+    return (uint64_t)ReadAcquire64(&_ebpf_epoch_published_current_epoch);
 }
 
 /**


### PR DESCRIPTION
## Description

Replace the LOCK-prefixed `InterlockedCompareExchange64` in `_ebpf_epoch_get_published_epoch()` with `ReadAcquire64`, which provides acquire semantics without the full bus-lock overhead.

### Background

Commit dca94d4a ("epoch: fix per-CPU epoch skew") introduced a globally published epoch (`_ebpf_epoch_published_current_epoch`) to prevent an epoch-skew hazard where a reader could observe a newer epoch on one CPU while another CPU stamped a retirement with an older epoch. The fix was correct, but the implementation used `InterlockedCompareExchange64(&var, 0, 0)` as an atomic read — this emits a `LOCK CMPXCHG8B` instruction on every call to `ebpf_epoch_enter()` and every retirement insert, both of which are extremely hot paths.

This caused a measurable performance regression visible in the [Grafana performance dashboard](https://bpfperformancegrafana.azurewebsites.net/public-dashboards/3826972d0ff245158b6df21d5e6868a9?orgId=1&from=now-60d&to=now&timezone=utc) around 01/28/2026, affecting both baseline and hash-map benchmarks.

### Why `ReadAcquire64` is sufficient

The safety invariant (verified by the [TLA+ epoch model](https://github.com/microsoft/ebpf-for-windows/blob/main/models/epoch/EpochModel.tla)) requires that readers see a `published_epoch` value that is >= any epoch the writer had committed at the time of the read. This is a classic release/acquire pairing:

- **Writer (CPU 0):** `InterlockedIncrement64` provides release (and full) semantics — the incremented value is globally visible before the function returns.
- **Reader (any CPU):** Only needs **acquire** semantics — it must see the writer's store and not reorder subsequent reads before it.

`ReadAcquire64` provides exactly this:
- **x64 (TSO):** Compiles to a plain `MOV` — x64's Total Store Order gives acquire semantics for free on every load.
- **ARM64:** Compiles to `LDAR` (Load-Acquire Register) — the minimum instruction that provides acquire ordering.

Neither requires a `LOCK` prefix or full memory barrier, eliminating the cache-line contention that was causing the regression.

### Benchmark results (lab hardware, 4 CPUs)

| Test | main (ns) | This PR (ns) | Change |
|------|-----------|--------------|--------|
| Baseline | 10 | 9 | **-10%** |
| Hash map update | 819 | 714 | **-12.8%** |
| Hash map replace | 913 | 799 | **-12.5%** |
| Percpu hash replace | 6905 | 6587 | **-4.6%** |
| LPM trie 1K update | 1014 | 931 | **-8.2%** |
| LPM trie 1K replace | 1431 | 1288 | **-10%** |
| LPM trie 16K update | 1018 | 963 | **-5.4%** |
| LPM trie 16K replace | 1488 | 1404 | **-5.6%** |
| LPM trie 256K update | 1188 | 1089 | **-8.3%** |
| LPM trie 256K replace | 1721 | 1595 | **-7.3%** |
| LPM trie 1M update | 1296 | 1236 | **-4.6%** |
| LPM trie 1M replace | 1821 | 1753 | **-3.7%** |
| Array-of-maps update | 886 | 812 | **-8.4%** |
| Hash-of-maps read | 171 | 159 | **-7%** |
| Hash-of-maps update | 955 | 908 | **-4.9%** |
| Ringbuf 300K x 400B | 238 | 136 | **-42.9%** |
| Ringbuf 100K x 1420B | 355 | 272 | **-23.4%** |

No regressions observed — read-heavy benchmarks and throughput tests (CtsTraffic) are within noise.

## Testing

Existing unit tests, fault injection tests, and the netperf performance test suite cover this change. No new tests are needed — the one-line change only affects the read barrier used; the epoch protocol logic is unchanged and remains validated by the TLA+ model.

## Documentation

No documentation impact. The inline code comment has been updated to explain why `ReadAcquire64` is used.

## Installation

No installer impact.