### PR TITLE
Changes to the check-PR workflow.

### DIFF
--- a/.github/workflows/check-pr-fork.yml
+++ b/.github/workflows/check-pr-fork.yml
@@ -5,18 +5,25 @@
 ---
 name: Fork PR Checks
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to validate'
+        required: true
+        type: string
   pull_request_target:
 
 permissions:
   contents: read  # Required by actions/checkout to fetch code.
-  issues: write  # Required to comment on PRs.
+  pull-requests: write  # Required to comment on PRs.
 
 jobs:
   call-common:
     uses: ./.github/workflows/check-pr.yml
     with:
       run_on_fork: true
+      pr_number: ${{ inputs.pr_number || '' }}
     secrets: inherit
     permissions:
       contents: read
-      issues: write
+      pull-requests: write

--- a/.github/workflows/check-pr-local.yml
+++ b/.github/workflows/check-pr-local.yml
@@ -5,18 +5,25 @@
 ---
 name: Local PR Checks
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to validate'
+        required: true
+        type: string
   pull_request:
 
 permissions:
   contents: read  # Required by actions/checkout to fetch code.
-  issues: write  # Required to comment on PRs.
+  pull-requests: write  # Required to comment on PRs.
 
 jobs:
   call-common:
     uses: ./.github/workflows/check-pr.yml
     with:
       run_on_fork: false
+      pr_number: ${{ inputs.pr_number || '' }}
     secrets: inherit
     permissions:
       contents: read
-      issues: write
+      pull-requests: write

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -14,6 +14,10 @@ on:
       run_on_fork:
         required: true
         type: boolean
+      pr_number:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   conditional-check:
@@ -23,11 +27,23 @@ jobs:
     steps:
       - name: Detect if PR is from a fork
         id: check-fork
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Base repo: ${{ github.repository }}"
-          echo "Head repo: ${{ github.event.pull_request.head.repo.full_name }}"
 
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+                              -H "Accept: application/vnd.github+json" \
+                              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}")
+            HEAD_REPO=$(echo "$PR_DATA" | jq -r .head.repo.full_name)
+          else
+            HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          fi
+
+          echo "Head repo: $HEAD_REPO"
+
+          if [ "$HEAD_REPO" != "${{ github.repository }}" ]; then
             echo "is_fork=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_fork=false" >> "$GITHUB_OUTPUT"
@@ -68,7 +84,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPO="${{ github.repository }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
           echo "Checking PR #$PR_NUMBER in $REPO..."
 
           PR_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \


### PR DESCRIPTION
## Description

This PR attempts to fix the check-pr-fork and check-pr-local workflows that were broken for a long time due to permission issues. This PR grants write permission on pull-requests, which was causing the failure when the WF were trying to write a comment on PRs missing an issue #.

Additionally, for ease of testing, I changed both the WFs to be triggered manually. The manual trigger asks for a PR # as input.

## Testing

I pushed the changes to my fork and created a dummy PR to test. The result looks encouraging.
https://github.com/shankarseal/ebpf-for-windows/pull/441#issuecomment-4020626662

At least the WF for local PR now is able to add a comment. Fork PR can only be tested once this PR is merged to the base repo.

## Documentation
_Is there any documentation impact for this change?_
No changes are needed.

## Installation

_Is there any installer impact for this change?_
No.