### PR TITLE
Add GitHub workflow to check Markdown links

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -18,6 +18,9 @@ on:
     paths:
       - '**.md'
 
+  # Permit manual runs of the workflow.
+  workflow_dispatch:
+
   schedule:
     # Run weekly on Sundays at midnight UTC.
     - cron: "0 0 * * 0"


### PR DESCRIPTION
## Summary
Add a CI workflow using \harryvasanth/markdown-link-checker\ to catch broken links in Markdown documentation.

## Details
- **Action chosen**: \harryvasanth/markdown-link-checker@v1\ — simplest of the three options listed in the issue (zero required inputs, checks internal/external/fragment links)
- **Triggers**: PRs modifying \.md\ files, pushes to \main\, and a weekly schedule (Sundays at midnight UTC)
- **Security**: Uses pinned SHAs and \step-security/harden-runner\ to match repo conventions

### Why this action?
| Action | Status |
|--------|--------|
| \gaurav-nelson/github-action-markdown-link-check\ | Deprecated (April 2025) |
| \dutchakdev/markdown-links-action\ | Many required inputs |
| \harryvasanth/markdown-link-checker\ | **Simplest** — zero config, validates anchors |

Fixes #5090