### PR TITLE
Fix exception-unsafe socket ownership in connect_redirect tests

### DIFF
--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -21,6 +21,7 @@
 #include "socket_tests_common.h"
 #include "watchdog.h"
 
+#include <memory>
 #include <mstcpip.h>
 #include <ntsecapi.h>
 
@@ -495,11 +496,11 @@ get_client_socket(
 void
 authorize_test_wrapper(bool dual_stack, _Inout_ sockaddr_storage& destination)
 {
-    client_socket_t* sender_socket = nullptr;
+    client_socket_t* raw_socket = nullptr;
+    get_client_socket(dual_stack, &raw_socket);
+    std::unique_ptr<client_socket_t> sender_socket(raw_socket);
 
-    get_client_socket(dual_stack, &sender_socket);
-    authorize_test(sender_socket, destination, dual_stack);
-    delete sender_socket;
+    authorize_test(sender_socket.get(), destination, dual_stack);
 }
 
 void
@@ -510,7 +511,6 @@ connect_redirect_test_wrapper(
     bool dual_stack,
     bool implicit_bind)
 {
-    client_socket_t* sender_socket = nullptr;
     // Determine address family for lookups
     socket_family_t address_family = (_globals.family == AF_INET6)
                                          ? socket_family_t::IPv6
@@ -548,15 +548,17 @@ connect_redirect_test_wrapper(
         return;
     }
 
+    client_socket_t* raw_socket = nullptr;
     if (implicit_bind) {
         // Use implicit bind (no source_address specified).
-        get_client_socket(dual_stack, &sender_socket);
+        get_client_socket(dual_stack, &raw_socket);
     } else {
-        get_client_socket(dual_stack, &sender_socket, source_address);
+        get_client_socket(dual_stack, &raw_socket, source_address);
     }
+    std::unique_ptr<client_socket_t> sender_socket(raw_socket);
+
     update_policy_map_and_test_connection(
-        sender_socket, destination, proxy, _globals.destination_port, _globals.proxy_port, dual_stack);
-    delete sender_socket;
+        sender_socket.get(), destination, proxy, _globals.destination_port, _globals.proxy_port, dual_stack);
 }
 
 #define DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(destination)                                                  \

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -187,6 +187,19 @@ _client_socket::_client_socket(
 {
 }
 
+_client_socket::~_client_socket()
+{
+    // Cancel any pending overlapped receive and close the event handle.
+    if (receive_posted) {
+        CancelIoEx(reinterpret_cast<HANDLE>(socket), &overlapped);
+        receive_posted = false;
+    }
+    if (overlapped.hEvent != nullptr && overlapped.hEvent != INVALID_HANDLE_VALUE) {
+        WSACloseEvent(overlapped.hEvent);
+        overlapped.hEvent = INVALID_HANDLE_VALUE;
+    }
+}
+
 void
 _client_socket::close()
 {

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -151,6 +151,7 @@ typedef class _client_socket : public _base_socket
         socket_family_t family,
         _In_ const sockaddr_storage& source_address = {},
         int expected_bind_error = 0);
+    virtual ~_client_socket();
     virtual void
     send_message_to_remote_host(
         _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port) = 0;


### PR DESCRIPTION
## Description

Fixes #5105

### Problem

`authorize_test_wrapper()` and `connect_redirect_test_wrapper()` use
raw `new`/`delete` for `client_socket_t*`. When test assertions throw
(via `FAIL()` or `SAFE_REQUIRE()`), the socket leaks — including its
Winsock handle and any pending overlapped I/O. Also, `_client_socket`
lacks a destructor, so `overlapped.hEvent` is never cleaned up.

### Changes

- **`socket_helper.h/.cpp`**: Add `~_client_socket()` that cancels
  pending I/O and closes the event handle.
- **`connect_redirect_tests.cpp`**: Replace raw `new`/`delete` with
  `std::unique_ptr<client_socket_t>` in both wrapper functions,
  following the pattern already used in `socket_tests.cpp`.

## Testing

Test code changes only.

## Documentation

N/A

## Installation

N/A
