### PR TITLE
fix section link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the `bpf2c` tool converts every instruction in the bytecode to equivalent `C` st
 module (stored in a `.sys` file) using the standard visual studio toolchain. The generated driver is also known as the native eBPF program.
 
    **Note:** This is the *preferred* way of deploying eBPF programs.
-   See the [FAQ on HVCI](readme.md#3-will-ebpf-work-with-hypervisor-enforced-code-integrity-hvci) for details as to why this mode is
+   See the [FAQ on HVCI](#3-will-ebpf-work-with-hypervisor-enforced-code-integrity-hvci) for details as to why this mode is
    also the most secure.
 
 1. **JIT Compiler**


### PR DESCRIPTION
## Description

There is a section link in `README.md` that uses `readme.md#...`. The name is case-sensitive on linux (where CI runs), so fails the new markdown checker.

This change removes the file name altogether since it is a link within the same file.

**This fix doesn't work -- there is a bug in the markdown link checker**

```
Here's the bug in check-links.sh line ~102:

   if ! grep -q "^#\+ ${fragment}\s*$\|..." "$target_path"

  The checker doesn't slugify headings — it does a raw grep for the fragment text 
  3-will-ebpf-work-with-hypervisor-enforced-code-integrity-hvci directly in heading lines. But the actual heading is:

   ### 3. Will eBPF work with HyperVisor-enforced Code Integrity (HVCI)?

  The fragment is the GitHub-slugified form of that heading, not the raw text, so the grep never matches. This is a bug in
  the harryvasanth/markdown-link-checker action.
```

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
