### PR TITLE
Find msbuild path using vswhere

### DIFF
--- a/scripts/initialize_ebpf_repo.ps1
+++ b/scripts/initialize_ebpf_repo.ps1
@@ -18,6 +18,41 @@ $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 # Change the parent directory for the script directory
 Set-Location $scriptPath\..
 
+# Find msbuild.exe using vswhere
+$vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (Test-Path $vswherePath) {
+    $msbuildPath = & $vswherePath -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\amd64\MSBuild.exe" | Select-Object -First 1
+}
+if (-not $msbuildPath -or -not (Test-Path $msbuildPath)) {
+    # Fall back to assuming msbuild is on PATH.
+    $msbuildPath = "msbuild"
+}
+Write-Host "Using MSBuild: $msbuildPath"
+
+# Helper to run a command, check exit code, and abort on failure.
+function Invoke-NativeCommand {
+    param([string]$Command)
+    Write-Host ">> Running command: $Command"
+    Invoke-Expression -Command $Command
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Command failed. Exit code: $LASTEXITCODE"
+        Exit $LASTEXITCODE
+    }
+}
+
+# Helper to run msbuild with the correct path (cannot use Invoke-Expression
+# because PowerShell interprets '/' in msbuild arguments as a division operator).
+function Invoke-MSBuild {
+    param([string[]]$Arguments)
+    $cmd = "& `"$msbuildPath`" $($Arguments -join ' ')"
+    Write-Host ">> Running command: $msbuildPath $($Arguments -join ' ')"
+    & $msbuildPath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Command failed. Exit code: $LASTEXITCODE"
+        Exit $LASTEXITCODE
+    }
+}
+
 # Define the commands to run
 $cmakeCommonArgs = "-G `"Visual Studio 17 2022`" -A $Architecture"
 $commands = @(
@@ -26,21 +61,16 @@ $commands = @(
     "cmake $cmakeCommonArgs -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>",
     "cmake $cmakeCommonArgs -S external\ubpf -B external\ubpf\build -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>",
     "cmake $cmakeCommonArgs -S external\ubpf -B external\ubpf\build_fuzzer -DUBPF_ENABLE_LIBFUZZER=on",
-    "nuget restore ebpf-for-windows.sln",
-    "msbuild /t:restore external\usersim\src\usersim.vcxproj /p:Platform=$Architecture",
-    "msbuild /t:restore external\usersim\usersim_dll_skeleton\usersim_dll_skeleton.vcxproj /p:Platform=$Architecture"
+    "nuget restore ebpf-for-windows.sln"
 )
 
-# Loop through each command and run them sequentially without opening a new window
+# Run non-msbuild commands via Invoke-Expression.
 foreach ($command in $commands) {
-    Write-Host ">> Running command: $command"
-    Invoke-Expression -Command $command
-
-    # Check the exit code
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Command failed. Exit code: $LASTEXITCODE"
-        Exit  $LASTEXITCODE
-    }
+    Invoke-NativeCommand -Command $command
 }
+
+# Run msbuild restore commands using the call operator to avoid '/' parsing issues.
+Invoke-MSBuild -Arguments "/t:restore", "external\usersim\src\usersim.vcxproj", "/p:Platform=$Architecture"
+Invoke-MSBuild -Arguments "/t:restore", "external\usersim\usersim_dll_skeleton\usersim_dll_skeleton.vcxproj", "/p:Platform=$Architecture"
 
 Write-Host "All commands succeeded."


### PR DESCRIPTION
## Description
Find msbuild path using vswhere.exe instead of assuming it to be on PATH.
_Describe the purpose of and changes within this Pull Request._
_Please reference an issue with a keyword such as Fixes #abc, Closes #xyz, etc., so the work can be tracked._

## Testing
Ran the initialize_ebpf_repo.ps1 and it works fine
_Do any existing tests cover this change? Are new tests needed?_

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.

## Documentation

_Is there any documentation impact for this change?_
No
## Installation

_Is there any installer impact for this change?_
No