### PR TITLE
Replace PrefetchForWrite with PreFetchCacheLine

### DIFF
--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -894,7 +894,7 @@ ebpf_hash_table_find(_In_ const ebpf_hash_table_t* hash_table, _In_ const uint8_
         goto Done;
     }
 
-    PrefetchForWrite(data);
+    PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, data);
 
     *value = data;
     if (hash_table->notification_callback && (hash_table->notification_flags & EBPF_HASH_TABLE_NOTIFICATION_TYPE_USE)) {


### PR DESCRIPTION
## Description

Currently `ebpf_hash_table_find` calls `PrefetchForWrite` for the data. PrefetchForWrite attempts to load data in cache line in exclusive state. This can cause contention with other CPUs if they are trying to read the same map value.

Fix is to replace it with PreFetchCacheLine which attempts to load data in cache in shared state.

## Testing

Existing performance tests.

## Performance Comparison (HASH, LPM TRIE, LRU HASH)

| Test | Baseline (ns) | Prefetch (ns) | % Change |
|------|---------------|---------------|----------|
| BPF_MAP_TYPE_HASH read | 83 | 83 | 0.0% |
| BPF_MAP_TYPE_HASH update | 720 | 723 | +0.4% |
| BPF_MAP_TYPE_HASH update and read | 146 | 145 | **-0.7%** |
| BPF_MAP_TYPE_HASH replace | 803 | 807 | +0.5% |
| BPF_MAP_TYPE_PERCPU_HASH read | 85 | 84 | **-1.2%** |
| BPF_MAP_TYPE_PERCPU_HASH update | 100 | 100 | 0.0% |
| BPF_MAP_TYPE_PERCPU_HASH update and read | 88 | 86 | **-2.3%** |
| BPF_MAP_TYPE_PERCPU_HASH replace | 6106 | 5766 | **-5.6%** |
| BPF_MAP_TYPE_LRU_HASH read | 190 | 183 | **-3.7%** |
| BPF_MAP_TYPE_LRU_HASH update | 1776 | 1769 | **-0.4%** |
| BPF_MAP_TYPE_LRU_HASH update and read | 378 | 372 | **-1.6%** |
| BPF_MAP_TYPE_LRU_HASH replace | 1936 | 1982 | +2.4% |
| BPF_MAP_TYPE_LRU_PERCPU_HASH read | 194 | 185 | **-4.6%** |
| BPF_MAP_TYPE_LRU_PERCPU_HASH update | 112 | 112 | 0.0% |
| BPF_MAP_TYPE_LRU_PERCPU_HASH update and read | 158 | 162 | +2.5% |
| BPF_MAP_TYPE_LRU_PERCPU_HASH replace | 7922 | 8127 | +2.6% |
| BPF_MAP_TYPE_LRU_HASH rolling update | 214 | 213 | **-0.5%** |
| BPF_MAP_TYPE_HASH_OF_MAPS read | 160 | 166 | +3.8% |
| BPF_MAP_TYPE_HASH_OF_MAPS update | 907 | 913 | +0.7% |
| BPF_MAP_TYPE_LPM_TRIE_1K read | 437 | 437 | 0.0% |
| BPF_MAP_TYPE_LPM_TRIE_1K update | 936 | 902 | **-3.6%** |
| BPF_MAP_TYPE_LPM_TRIE_1K replace | 1296 | 1330 | +2.6% |
| BPF_MAP_TYPE_LPM_TRIE_16K read | 455 | 457 | +0.4% |
| BPF_MAP_TYPE_LPM_TRIE_16K update | 937 | 977 | +4.3% |
| BPF_MAP_TYPE_LPM_TRIE_16K replace | 1407 | 1414 | +0.5% |
| BPF_MAP_TYPE_LPM_TRIE_256K read | 629 | 655 | +4.1% |
| BPF_MAP_TYPE_LPM_TRIE_256K update | 1123 | 1101 | **-2.0%** |
| BPF_MAP_TYPE_LPM_TRIE_256K replace | 1653 | 1603 | **-3.0%** |
| BPF_MAP_TYPE_LPM_TRIE_1M read | 1365 | 1226 | **-10.2%** |
| BPF_MAP_TYPE_LPM_TRIE_1M update | 1321 | 1243 | **-5.9%** |
| BPF_MAP_TYPE_LPM_TRIE_1M replace | 1806 | 1750 | **-3.1%** |

### Summary

| Category | Verdict |
|----------|---------|
| **HASH** | Mostly neutral (±1%), PERCPU_HASH replace improved **-5.6%** |
| **LRU_HASH** | Read operations improved (-3.7% to -4.6%), replace regressed slightly (+2.4% to +2.6%) |
| **LPM_TRIE** | Scales with size — larger tries (1M) show best improvement (**-10.2%** read, **-5.9%** update, **-3.1%** replace); smaller tries (16K) show slight regression |

> **Key insight:** Prefetch benefits increase with data structure size. Best gains on LPM_TRIE_1M and LRU reads.


_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.

## Documentation

No

## Installation

No
