### PR TITLE
Fix nuget.vcxproj Outputs mismatch for Release configurations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,14 @@
     <EbpfVersion Condition="'$(EbpfVersion_Modifier)' == ''">$(EbpfVersion_Major).$(EbpfVersion_Minor).$(EbpfVersion_Revision)</EbpfVersion>
     <EbpfVersion Condition="'$(EbpfVersion_Modifier)' != ''">$(EbpfVersion_Major).$(EbpfVersion_Minor).$(EbpfVersion_Revision)-$(EbpfVersion_Modifier)</EbpfVersion>
   </PropertyGroup>
+  <!-- NuGet package name suffix: Release configs omit configuration, Debug configs include it.
+       Used by Set-Version.ps1 (via -ConfigSuffix parameter) and nuget/redist Outputs. -->
+  <PropertyGroup Condition="$(Configuration.Contains('Release'))">
+    <NugetConfigSuffix></NugetConfigSuffix>
+  </PropertyGroup>
+  <PropertyGroup Condition="!$(Configuration.Contains('Release'))">
+    <NugetConfigSuffix>.$(Configuration)</NugetConfigSuffix>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>

--- a/scripts/Set-Version.ps1
+++ b/scripts/Set-Version.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) eBPF for Windows contributors
 # SPDX-License-Identifier: MIT
 
-param ($InputFile, $OutputFile, [parameter(Mandatory=$false)]$VCToolsRedistDir, [parameter(Mandatory=$false)]$architecture, [parameter(Mandatory=$false)]$configuration)
+param ($InputFile, $OutputFile, [parameter(Mandatory=$false)]$VCToolsRedistDir, [parameter(Mandatory=$false)]$architecture, [parameter(Mandatory=$false)]$configuration, [parameter(Mandatory=$false)]$ConfigSuffix)
 
 # The git commit ID is in the include directory and is in the format:
 # #define GIT_COMMIT_ID "some commit id"
@@ -35,7 +35,9 @@ $content = $content.Replace("{version_no_modifier}", $version_no_modifier)
 $content = $content.Replace("{VCToolsRedistDir}", $VCToolsRedistDir)
 $content = $content.Replace("{git_commit_id}", $git_commit_id)
 $content = $content.Replace("{architecture}", $architecture)
-if ($configuration -match "Release") {
+if ($PSBoundParameters.ContainsKey('ConfigSuffix')) {
+    $content = $content.Replace("{configuration}", $ConfigSuffix)
+} elseif ($configuration -match "Release") {
     $content = $content.Replace("{configuration}", "")
 } else {
     $content = $content.Replace("{configuration}", ".$configuration")

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -163,15 +163,15 @@
       <Command Condition="'$(Configuration)'=='FuzzerDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
-      <AdditionalInputs Condition="'$(Configuration)'=='Debug'">
+      <AdditionalInputs Condition="'$(Configuration)'=='Debug'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyDebug'">
+      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='FuzzerDebug'">
+      <AdditionalInputs Condition="'$(Configuration)'=='FuzzerDebug'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='Release'">
+      <AdditionalInputs Condition="'$(Configuration)'=='Release'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyRelease'">
+      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyRelease'">$(SolutionDir)scripts\escape_text.ps1
       </AdditionalInputs>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(OutputPath)%(Filename).template</Outputs>
@@ -184,6 +184,7 @@
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='FuzzerDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
+      <AdditionalInputs>$(SolutionDir)scripts\escape_text.ps1</AdditionalInputs>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='FuzzerDebug'">$(OutputPath)%(Filename).template</Outputs>
@@ -194,6 +195,7 @@
     </CustomBuild>
     <CustomBuild Include="bpf2c.exe.manifest.in">
       <FileType>Document</FileType>
+      <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h</AdditionalInputs>
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile bpf2c.exe.manifest.in -OutputFile $(OutputPath)bpf2c.exe.manifest</Command>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)bpf2c.exe.manifest</Outputs>
       <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile bpf2c.exe.manifest.in -OutputFile $(OutputPath)bpf2c.exe.manifest</Command>

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -84,11 +84,6 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyDebug'">
     <ClCompile>
@@ -109,11 +104,6 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -138,11 +128,6 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyRelease'">
     <ClCompile>
@@ -167,16 +152,12 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-del ebpf-for-windows.*.nupkg
-popd $(OutDir)</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="ebpf-for-windows.nuspec.in">
       <FileType>Document</FileType>
-      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(EbpfVersion).nupkg</Outputs>
+      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(Configuration).$(EbpfVersion).nupkg</Outputs>
+      <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h;$(SolutionDir)tools\nuget\ebpf-for-windows.props.in</AdditionalInputs>
       <Command>
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -Configuration $(Configuration)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.props.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).props -Architecture $(Platform)

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -159,7 +159,7 @@ popd $(OutDir)</Command>
       <Outputs>$(OutDir)eBPF-for-Windows.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg</Outputs>
       <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h;$(SolutionDir)tools\nuget\ebpf-for-windows.props.in</AdditionalInputs>
       <Command>
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -ConfigSuffix $(NugetConfigSuffix)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -ConfigSuffix '$(NugetConfigSuffix)'
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.props.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).props -Architecture $(Platform)
         NuGet.exe pack $(OutDir)ebpf-for-windows.$(Platform).nuspec -OutputDirectory $(OutDir)</Command>
     </CustomBuild>

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -156,10 +156,10 @@ popd $(OutDir)</Command>
   <ItemGroup>
     <CustomBuild Include="ebpf-for-windows.nuspec.in">
       <FileType>Document</FileType>
-      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(Configuration).$(EbpfVersion).nupkg</Outputs>
+      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg</Outputs>
       <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h;$(SolutionDir)tools\nuget\ebpf-for-windows.props.in</AdditionalInputs>
       <Command>
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -Configuration $(Configuration)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -ConfigSuffix $(NugetConfigSuffix)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.props.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).props -Architecture $(Platform)
         NuGet.exe pack $(OutDir)ebpf-for-windows.$(Platform).nuspec -OutputDirectory $(OutDir)</Command>
     </CustomBuild>

--- a/tools/redist-package/redist-package.vcxproj
+++ b/tools/redist-package/redist-package.vcxproj
@@ -125,17 +125,14 @@
   <ItemGroup Condition="'$(Analysis)'==''">
     <CustomBuild Include="ebpf-for-windows-redist.nuspec.in">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
+      <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -ConfigSuffix '$(NugetConfigSuffix)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
-      <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
+      <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -ConfigSuffix '$(NugetConfigSuffix)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
-      <Outputs Condition="'$(Configuration)'=='Debug'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
-      <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
-      <Outputs Condition="'$(Configuration)'=='Release'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
-      <Outputs Condition="'$(Configuration)'=='NativeOnlyRelease'">eBPF-for-Windows-Redist.2023.5.22.nupkg</Outputs>
-      <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
+      <Outputs>$(OutDir)eBPF-for-Windows-Redist.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg</Outputs>
+      <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -ConfigSuffix '$(NugetConfigSuffix)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
-      <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -Configuration '$(Configuration)'
+      <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -ConfigSuffix '$(NugetConfigSuffix)'
 NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir)</Command>
     </CustomBuild>
   </ItemGroup>


### PR DESCRIPTION
## Description

Closes #5024 

PR #5003 added Configuration to the CustomBuild Outputs for the nuget package, but Set-Version.ps1 strips configuration from the package name for Release configs. This caused Outputs to never match the actual nupkg filename for Release/NativeOnlyRelease builds, defeating incremental builds and potentially causing MSB8065 warnings.

Add NugetConfigSuffix property that mirrors Set-Version.ps1 logic:
- Release configs: empty suffix (package name has no configuration)
- Debug configs: .Configuration suffix

## Testing

Manual testing, CI runs on github and internal mirror.

## Documentation

N/A

## Installation

N/A
