### PR TITLE
Revert "bpf2c/nuget: Track script dependencies as CustomBuild inputs …

### DIFF
--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -163,15 +163,15 @@
       <Command Condition="'$(Configuration)'=='FuzzerDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='NativeOnlyRelease'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
-      <AdditionalInputs Condition="'$(Configuration)'=='Debug'">$(SolutionDir)scripts\escape_text.ps1
+      <AdditionalInputs Condition="'$(Configuration)'=='Debug'">
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(SolutionDir)scripts\escape_text.ps1
+      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyDebug'">
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='FuzzerDebug'">$(SolutionDir)scripts\escape_text.ps1
+      <AdditionalInputs Condition="'$(Configuration)'=='FuzzerDebug'">
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='Release'">$(SolutionDir)scripts\escape_text.ps1
+      <AdditionalInputs Condition="'$(Configuration)'=='Release'">
       </AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyRelease'">$(SolutionDir)scripts\escape_text.ps1
+      <AdditionalInputs Condition="'$(Configuration)'=='NativeOnlyRelease'">
       </AdditionalInputs>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(OutputPath)%(Filename).template</Outputs>
@@ -184,7 +184,6 @@
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='NativeOnlyDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
       <Command Condition="'$(Configuration)'=='FuzzerDebug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\escape_text.ps1 %(Filename).c $(OutputPath)%(Filename).template</Command>
-      <AdditionalInputs>$(SolutionDir)scripts\escape_text.ps1</AdditionalInputs>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='NativeOnlyDebug'">$(OutputPath)%(Filename).template</Outputs>
       <Outputs Condition="'$(Configuration)'=='FuzzerDebug'">$(OutputPath)%(Filename).template</Outputs>
@@ -195,7 +194,6 @@
     </CustomBuild>
     <CustomBuild Include="bpf2c.exe.manifest.in">
       <FileType>Document</FileType>
-      <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h</AdditionalInputs>
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile bpf2c.exe.manifest.in -OutputFile $(OutputPath)bpf2c.exe.manifest</Command>
       <Outputs Condition="'$(Configuration)'=='Debug'">$(OutputPath)bpf2c.exe.manifest</Outputs>
       <Command Condition="'$(Configuration)'=='Release'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile bpf2c.exe.manifest.in -OutputFile $(OutputPath)bpf2c.exe.manifest</Command>

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -84,6 +84,11 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyDebug'">
     <ClCompile>
@@ -104,6 +109,11 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -128,6 +138,11 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyRelease'">
     <ClCompile>
@@ -152,12 +167,16 @@ xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="ebpf-for-windows.nuspec.in">
       <FileType>Document</FileType>
-      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(Configuration).$(EbpfVersion).nupkg</Outputs>
-      <AdditionalInputs>$(SolutionDir)scripts\Set-Version.ps1;$(SolutionDir)Directory.Build.props;$(SolutionDir)include\git_commit_id.h;$(SolutionDir)tools\nuget\ebpf-for-windows.props.in</AdditionalInputs>
+      <Outputs>$(OutDir)eBPF-for-Windows.$(Platform).$(EbpfVersion).nupkg</Outputs>
       <Command>
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.nuspec.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).nuspec -Architecture $(Platform) -Configuration $(Configuration)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\nuget\ebpf-for-windows.props.in -OutputFile $(OutDir)ebpf-for-windows.$(Platform).props -Architecture $(Platform)


### PR DESCRIPTION
## Description

#5003 improves incremental build behavior but has a bug in the package naming, so reverting to unblock CI.

This reverts commit a9587ffa6538502349d5f5be7ba5506384146443.

## Testing

Local build, CI tests in github and internal mirror

## Documentation

N/A

## Installation

N/A
