### PR TITLE
[custom maps] Update dispatch function names #2

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -616,23 +616,23 @@ The Map Type for the custom maps also comes from the same map type numbering spa
 typedef struct _ebpf_map_provider_dispatch_table
 {
     ebpf_extension_header_t header;
-    _Notnull_ ebpf_process_map_create_t process_map_create;
-    _Notnull_ ebpf_process_map_delete_t process_map_delete;
-    _Notnull_ ebpf_map_associate_program_type_t associate_program_function;
+    _Notnull_ ebpf_preprocess_map_create_t preprocess_map_create;
+    _Notnull_ ebpf_postprocess_map_delete_t postprocess_map_delete;
+    _Notnull_ ebpf_preprocess_map_associate_program_type_t preprocess_associate_program_type;
     ebpf_postprocess_map_find_element_t postprocess_map_find_element;
     ebpf_preprocess_map_update_element_t preprocess_map_update_element;
     ebpf_preprocess_map_delete_element_t preprocess_map_delete_element;
 } ebpf_base_map_provider_dispatch_table_t;
 ```
 This is the dispatch table that the extension needs to implement and provide to eBPF runtime. It contains the following fields:
-1. `process_map_create` - Called by eBPF runtime to process map creation.
-2. `process_map_delete` - Called by eBPF runtime to process map deletion.
-3. `associate_program_function` - Called by eBPF runtime to validate if a specific map can be associated with the supplied program type. eBPFCore invokes this function before an custom map is associated with a program.
+1. `preprocess_map_create` - Called by eBPF runtime to process map creation.
+2. `postprocess_map_delete` - Called by eBPF runtime to process map deletion.
+3. `preprocess_associate_program_type` - Called by eBPF runtime to validate if a specific map can be associated with the supplied program type. eBPFCore invokes this function before an custom map is associated with a program.
 4. `postprocess_map_find_element` - Function to post-process a map entry after lookup.
 5. `preprocess_map_update_element` - Function to pre-process a map entry before an add/update operation.
 5. `preprocess_map_delete_element` - Function to pre-process a map entry before a delete operation.
 
-When `process_map_create` is invoked, the extension will allocate a map context, and return a pointer to it (called `map_context`) back to the eBPF runtime. When any of the other APIs are invoked for this map, the extension will get this `map_context` back as an input parameter.
+When `preprocess_map_create` is invoked, the extension will allocate a map context, and return a pointer to it (called `map_context`) back to the eBPF runtime. When any of the other APIs are invoked for this map, the extension will get this `map_context` back as an input parameter.
 
 The `postprocess_map_find_element`, `preprocess_map_update_element`, and `preprocess_map_delete_element` functions each receive a `flags` parameter. When `EBPF_MAP_OPERATION_HELPER` is set in `flags`, the operation is being invoked from a BPF program. When `EBPF_MAP_OPERATION_HELPER` is **not** set, the function is called in the context of the original user mode process. In that case, the provider may implicitly use the current process's handle table (e.g., to resolve file descriptors passed as map values).
 

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -151,7 +151,7 @@ typedef struct _ebpf_execution_context_state
  * @param[in] max_entries The maximum number of entries in the map.
  * @param[out] actual_value_size The value size in bytes that will actually be stored in the map.
  * @param[out] map_context Provider-defined per-map context. The eBPF core will pass this back to subsequent map
- *             operations and will eventually pass it to ebpf_process_map_delete_t.
+ *             operations and will eventually pass it to ebpf_postprocess_map_delete_t.
  *
  * Note: When a map lookup happens from user mode, the value is copied into the buffer provided by the user,
  * whereas when a map lookup happens from a BPF program, a pointer to the value is provided to the program,
@@ -164,7 +164,7 @@ typedef struct _ebpf_execution_context_state
  * @retval EBPF_NO_MEMORY Unable to allocate memory.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
  */
-typedef ebpf_result_t (*ebpf_process_map_create_t)(
+typedef ebpf_result_t (*ebpf_preprocess_map_create_t)(
     _In_ void* binding_context,
     uint32_t map_type,
     uint32_t key_size,
@@ -179,7 +179,7 @@ typedef ebpf_result_t (*ebpf_process_map_create_t)(
  * @param[in] binding_context The binding context provided when the map provider was bound.
  * @param[in] map_context The map context to delete.
  */
-typedef void (*ebpf_process_map_delete_t)(_In_ void* binding_context, _In_ _Post_invalid_ void* map_context);
+typedef void (*ebpf_postprocess_map_delete_t)(_In_ void* binding_context, _In_ _Post_invalid_ void* map_context);
 
 /**
  * @brief Post-process a found element in a provider-backed map (called after the core lookup).
@@ -306,7 +306,7 @@ typedef ebpf_result_t (*ebpf_preprocess_map_delete_element_t)(
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_OPERATION_NOT_SUPPORTED The operation is not supported.
  */
-typedef ebpf_result_t (*ebpf_map_associate_program_type_t)(
+typedef ebpf_result_t (*ebpf_preprocess_map_associate_program_type_t)(
     _In_ void* binding_context, _In_ void* map_context, _In_ const ebpf_program_type_t* program_type);
 
 typedef struct _ebpf_base_map_provider_properties
@@ -323,9 +323,9 @@ typedef struct _ebpf_base_map_provider_properties
 typedef struct _ebpf_map_provider_dispatch_table
 {
     ebpf_extension_header_t header;
-    _Notnull_ ebpf_process_map_create_t process_map_create;
-    _Notnull_ ebpf_process_map_delete_t process_map_delete;
-    _Notnull_ ebpf_map_associate_program_type_t associate_program_function;
+    _Notnull_ ebpf_preprocess_map_create_t preprocess_map_create;
+    _Notnull_ ebpf_postprocess_map_delete_t postprocess_map_delete;
+    _Notnull_ ebpf_preprocess_map_associate_program_type_t preprocess_associate_program_type;
     ebpf_postprocess_map_find_element_t postprocess_map_find_element;
     ebpf_preprocess_map_update_element_t preprocess_map_update_element;
     ebpf_preprocess_map_delete_element_t preprocess_map_delete_element;

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -4640,7 +4640,7 @@ ebpf_custom_map_create(
     rundown_acquired = true;
 
     // Invoke extension to validate map parameters and get actual value size.
-    result = custom_map->provider_dispatch->process_map_create(
+    result = custom_map->provider_dispatch->preprocess_map_create(
         custom_map->provider_context,
         map_definition->type,
         map_definition->key_size,
@@ -4653,7 +4653,7 @@ ebpf_custom_map_create(
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_MAP,
-            "process_map_create failed for custom map type",
+            "preprocess_map_create failed for custom map type",
             custom_map->core_map.ebpf_map_definition.type);
 
         result = EBPF_EXTENSION_FAILED_TO_LOAD;
@@ -4721,7 +4721,7 @@ Done:
     if (custom_map) {
         if (custom_map_context && custom_map->provider_dispatch) {
             // Clean up custom map data if map creation failed.
-            custom_map->provider_dispatch->process_map_delete(custom_map->provider_context, custom_map_context);
+            custom_map->provider_dispatch->postprocess_map_delete(custom_map->provider_context, custom_map_context);
         }
         if (rundown_acquired) {
             ExReleaseRundownProtection(&custom_map->provider_rundown_reference);
@@ -4741,7 +4741,7 @@ ebpf_custom_map_delete(_In_ _Post_ptr_invalid_ ebpf_core_map_t* map)
     }
 
     // Call provider to notify map deletion.
-    custom_map->provider_dispatch->process_map_delete(
+    custom_map->provider_dispatch->postprocess_map_delete(
         custom_map->provider_context, custom_map->core_map.custom_map_context);
 
     // Now that the map is deleted, release the rundown reference acquired during map creation.
@@ -5098,11 +5098,11 @@ ebpf_custom_map_associate_program(_Inout_ ebpf_map_t* map, _In_ const struct _eb
 
     // Get provider dispatch.
     ebpf_base_map_provider_dispatch_table_t* provider_dispatch = custom_map->provider_dispatch;
-    ebpf_assert(provider_dispatch != NULL && provider_dispatch->associate_program_function != NULL);
+    ebpf_assert(provider_dispatch != NULL && provider_dispatch->preprocess_associate_program_type != NULL);
     // Call the provider's associate program function.
     __analysis_assume(provider_dispatch != NULL);
-    __analysis_assume(provider_dispatch->associate_program_function != NULL);
-    result = provider_dispatch->associate_program_function(
+    __analysis_assume(provider_dispatch->preprocess_associate_program_type != NULL);
+    result = provider_dispatch->preprocess_associate_program_type(
         custom_map->provider_context, custom_map->core_map.custom_map_context, &program_type);
 
     return result;

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -828,8 +828,8 @@ _ebpf_validate_map_provider_dispatch_table(_In_ const ebpf_base_map_provider_dis
 
     if (local_dispatch_table.header.version == EBPF_BASE_MAP_PROVIDER_DISPATCH_TABLE_CURRENT_VERSION) {
         if (local_dispatch_table.header.size == EBPF_BASE_MAP_PROVIDER_DISPATCH_TABLE_CURRENT_VERSION_SIZE) {
-            if (local_dispatch_table.process_map_create == NULL || local_dispatch_table.process_map_delete == NULL ||
-                local_dispatch_table.associate_program_function == NULL) {
+            if (local_dispatch_table.preprocess_map_create == NULL || local_dispatch_table.postprocess_map_delete == NULL ||
+                local_dispatch_table.preprocess_associate_program_type == NULL) {
                 return false;
             }
         } else {

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -195,9 +195,9 @@ _Success_(return == EBPF_SUCCESS) static ebpf_result_t _test_sample_hash_map_upd
 
 static ebpf_base_map_provider_dispatch_table_t _test_sample_hash_map_dispatch_table = {
     .header = EBPF_BASE_MAP_PROVIDER_DISPATCH_TABLE_HEADER,
-    .process_map_create = _test_sample_hash_map_create,
-    .process_map_delete = _test_sample_hash_map_delete,
-    .associate_program_function = _test_sample_map_associate_program,
+    .preprocess_map_create = _test_sample_hash_map_create,
+    .postprocess_map_delete = _test_sample_hash_map_delete,
+    .preprocess_associate_program_type = _test_sample_map_associate_program,
     .postprocess_map_find_element = _test_sample_hash_map_find_entry,
     .preprocess_map_update_element = _test_sample_hash_map_update_entry,
     .preprocess_map_delete_element = _test_sample_hash_map_delete_entry};

--- a/undocked/tests/sample/ext/drv/sample_ext.c
+++ b/undocked/tests/sample/ext/drv/sample_ext.c
@@ -162,9 +162,9 @@ _sample_map_associate_program(
 // Sample map extension data.
 static ebpf_base_map_provider_dispatch_table_t _sample_map_dispatch_table = {
     EBPF_BASE_MAP_PROVIDER_DISPATCH_TABLE_HEADER,
-    .process_map_create = _sample_map_create,
-    .process_map_delete = _sample_map_delete,
-    .associate_program_function = _sample_map_associate_program,
+    .preprocess_map_create = _sample_map_create,
+    .postprocess_map_delete = _sample_map_delete,
+    .preprocess_associate_program_type = _sample_map_associate_program,
     .postprocess_map_find_element = _sample_map_find_entry,
     .preprocess_map_update_element = _sample_map_update_entry,
     .preprocess_map_delete_element = _sample_map_delete_entry};


### PR DESCRIPTION
Fixes #5147 

## Description

This PR updates the remaining custom map provider dispatch function names to correctly mention pre and post prefixes.

## Testing

Existing CICD

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.

## Documentation

Updated doc.

## Installation

No
