### PR TITLE
Add missing header field to program_runtime_context_t in docs

### DIFF
--- a/docs/BtfResolvedFunctions.md
+++ b/docs/BtfResolvedFunctions.md
@@ -270,9 +270,9 @@ typedef struct _btf_resolved_function_data
 } btf_resolved_function_data_t;
 
 // Proposed extension to include/bpf2c.h program_runtime_context_t.
-// The existing header field is omitted here for brevity.
 typedef struct _program_runtime_context
 {
+    ebpf_native_module_header_t header;
     helper_function_data_t* helper_data;
     map_data_t* map_data;
     global_variable_section_data_t* global_variable_section_data;

--- a/docs/MultipleLoadNativeModule.md
+++ b/docs/MultipleLoadNativeModule.md
@@ -143,6 +143,7 @@ The `program_runtime_context_t` must include BTF-resolved function addresses:
 ```c
 typedef struct _program_runtime_context
 {
+    ebpf_native_module_header_t header;
     helper_function_data_t* helper_data;
     map_data_t* map_data;
     global_variable_section_data_t* global_variable_section_data;

--- a/docs/NativeCodeGeneration.md
+++ b/docs/NativeCodeGeneration.md
@@ -178,6 +178,7 @@ typedef struct _global_variable_section_data
 
 typedef struct _program_runtime_context
 {
+    ebpf_native_module_header_t header;
     helper_function_data_t* helper_data;
     map_data_t* map_data;
     global_variable_section_data_t* global_variable_section_data;
@@ -258,6 +259,7 @@ typedef struct _btf_resolved_function_data
 
 typedef struct _program_runtime_context
 {
+    ebpf_native_module_header_t header;
     helper_function_data_t* helper_data;
     map_data_t* map_data;
     global_variable_section_data_t* global_variable_section_data;


### PR DESCRIPTION
## Description

All documentation snippets showing `program_runtime_context_t` were missing the `ebpf_native_module_header_t header` field that exists in the actual definition in `include/bpf2c.h`. This causes confusion when reading the docs vs the code.

### Changes:
- `docs/NativeCodeGeneration.md`: Added `header` field to both the base struct and BTF extension snippets
- `docs/BtfResolvedFunctions.md`: Added `header` field and removed "omitted for brevity" comment
- `docs/MultipleLoadNativeModule.md`: Added `header` field to the BTF extension snippet

Fixes #5093

## Testing

Documentation-only change. No code changes.