### PR TITLE
Fix intermittent recv_accept hard permit test timeout (#4978)

### DIFF
--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -435,7 +435,7 @@ execute_connection_test(_In_ const connection_test_case& test_case)
         // Reset sockets after each sub-test. For TCP, a cancelled ConnectEx leaves the socket
         // in an indeterminate state (e.g., SYN_SENT if the SYN was transmitted before the WFP
         // block). CancelIoEx does not wait for completion, so reusing the socket/OVERLAPPED for
-        // a subsequent ConnectEx is unreliable. See GitHub issue #4978.
+        // a subsequent ConnectEx is unreliable.
         client.reset();
         server.reset();
 

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -432,7 +432,7 @@ execute_connection_test(_In_ const connection_test_case& test_case)
         // Connection test (sock_addr).
         execute_connection_attempt(client, server, test_case.address_family, test.expected_result, SOCKET_TEST_PORT);
 
-        // Reset sockets after each sub-test. For TCP, a cancelled ConnectEx leaves the socket
+        // Reset sockets after each sub-test. For TCP, a canceled ConnectEx leaves the socket
         // in an indeterminate state (e.g., SYN_SENT if the SYN was transmitted before the WFP
         // block). CancelIoEx does not wait for completion, so reusing the socket/OVERLAPPED for
         // a subsequent ConnectEx is unreliable.

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -432,11 +432,12 @@ execute_connection_test(_In_ const connection_test_case& test_case)
         // Connection test (sock_addr).
         execute_connection_attempt(client, server, test_case.address_family, test.expected_result, SOCKET_TEST_PORT);
 
-        if (test.expected_result == connection_test_result::allow) {
-            // Reset sockets for next test after allow.
-            client.reset();
-            server.reset();
-        }
+        // Reset sockets after each sub-test. For TCP, a cancelled ConnectEx leaves the socket
+        // in an indeterminate state (e.g., SYN_SENT if the SYN was transmitted before the WFP
+        // block). CancelIoEx does not wait for completion, so reusing the socket/OVERLAPPED for
+        // a subsequent ConnectEx is unreliable. See GitHub issue #4978.
+        client.reset();
+        server.reset();
 
         ++test_index;
     }


### PR DESCRIPTION
## Description

Fixes: #4978

Reset client/server sockets after each sub-test in execute_connection_test instead of only after allow results.

Root cause: connection_test_recv_accept_hard_permit runs two sub-tests on the same TCP socket pair -- sub-test 0 (soft permit, blocked by WFP) then sub-test 1 (hard permit, should override WFP). After sub-test 0, the client TCP socket is in SYN_SENT state because:
- The WFP block filter is on AUTH_RECV_ACCEPT (server-side)
- The client SYN is transmitted before WFP drops it
- cancel_send_message() calls CancelIoEx without waiting for completion

When sub-test 1 reuses this socket, ConnectEx operates on a socket with residual transport state and a prematurely-reused OVERLAPPED, causing an intermittent timeout. This does not affect connect_hard_permit because its WFP block is on AUTH_CONNECT (client-side), preventing SYN transmission.

The fix creates fresh sockets for every sub-test, eliminating the socket reuse hazard. No test depends on socket state persisting across sub-tests -- verdict policy is conveyed through eBPF map updates, not socket state.

## Testing

This only updates test helpers.

## Documentation

N/A

## Installation

N/A
