### PR TITLE
Fix fault injection crash in NmrRegisterClient

### DIFF
--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -410,8 +410,10 @@ _preprocess_load_native_module(_Inout_ service_context_t* context)
     assert(context->table != nullptr);
 
     NTSTATUS status = NmrRegisterClient(&context->nmr_client_characteristics, context, &context->nmr_client_handle);
-    assert(NT_SUCCESS(status));
-    UNREFERENCED_PARAMETER(status);
+    if (!NT_SUCCESS(status)) {
+        assert(get_native_module_failures());
+        return;
+    }
 
     context->loaded = true;
 }

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -403,6 +403,8 @@ _preprocess_load_native_module(_Inout_ service_context_t* context)
         reinterpret_cast<decltype(&get_metadata_table)>(GetProcAddress(context->dll, "get_metadata_table"));
     if (get_function == nullptr) {
         assert(get_native_module_failures());
+        FreeLibrary(context->dll);
+        context->dll = nullptr;
         return;
     }
 
@@ -412,6 +414,8 @@ _preprocess_load_native_module(_Inout_ service_context_t* context)
     NTSTATUS status = NmrRegisterClient(&context->nmr_client_characteristics, context, &context->nmr_client_handle);
     if (!NT_SUCCESS(status)) {
         assert(get_native_module_failures());
+        FreeLibrary(context->dll);
+        context->dll = nullptr;
         return;
     }
 

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -416,6 +416,7 @@ _preprocess_load_native_module(_Inout_ service_context_t* context)
         assert(get_native_module_failures());
         FreeLibrary(context->dll);
         context->dll = nullptr;
+        context->table = nullptr;
         return;
     }
 


### PR DESCRIPTION
## Description

Fixes #5174 

 When fault injection causes an allocation failure inside ``NmrRegisterClient``, the function returns a failing ``NTSTATUS``. The code used ``assert(NT_SUCCESS(status))`` which calls ``abort()`` and produces a crash dump instead of allowing the test to fail gracefully.

 ### Root Cause
When ``REQUIRE()`` was replaced with ``assert()`` in ``_preprocess_load_native_module()`` for thread-safety, that introduced a bug. Previously, the ``REQUIRE()`` throw was silently caught by the ``catch(...)`` block in ``_preprocess_ioctl()``, masking the missing error handling. The switch to ``assert()`` exposed the latent bug since ``abort()`` cannot be caught.

## Fix
Follow the same pattern used elsewhere in the function for handling fault injection failures: check the return status, assert fault injection is enabled via ``get_native_module_failures()``, and return early without setting ``context->loaded``.                   

## Testing

No

## Documentation

No

## Installation

No
