### PR TITLE
Use cxplat safe integer helpers

### DIFF
--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -115,7 +115,27 @@ _ebpf_driver_build_privileged_security_descriptor()
     }
 
     // Allocate and initialize a DACL with one ACE.
-    ULONG aclSize = sizeof(ACL) + sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(sid) - sizeof(ULONG);
+    size_t acl_size = 0;
+    size_t sid_length = RtlLengthSid(sid);
+    size_t ace_size = 0;
+    ebpf_result_t safe_result = EBPF_SUCCESS;
+    ULONG aclSize = 0;
+    safe_result = ebpf_safe_size_t_add(sizeof(ACL), sizeof(ACCESS_ALLOWED_ACE), &ace_size);
+    if (safe_result != EBPF_SUCCESS) {
+        status = STATUS_INTEGER_OVERFLOW;
+        goto Exit;
+    }
+    safe_result = ebpf_safe_size_t_add(ace_size, sid_length, &acl_size);
+    if (safe_result != EBPF_SUCCESS) {
+        status = STATUS_INTEGER_OVERFLOW;
+        goto Exit;
+    }
+    safe_result = ebpf_safe_size_t_subtract(acl_size, sizeof(ULONG), &acl_size);
+    if (safe_result != EBPF_SUCCESS || acl_size > MAXULONG) {
+        status = STATUS_INTEGER_OVERFLOW;
+        goto Exit;
+    }
+    aclSize = (ULONG)acl_size;
     dacl = (PACL)ebpf_allocate_with_tag(aclSize, 'fpBE'); // Use a tag to help with debugging memory leaks.
     if (dacl == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -526,6 +526,15 @@ _ebpf_driver_io_device_control(
                     }
                 }
 
+                if ((actual_input_length > UINT16_MAX) || (actual_output_length > UINT16_MAX)) {
+                    status = STATUS_INVALID_PARAMETER;
+                    EBPF_LOG_MESSAGE(
+                        EBPF_TRACELOG_LEVEL_ERROR,
+                        EBPF_TRACELOG_KEYWORD_ERROR,
+                        "Input or output buffer length exceeds protocol limit");
+                    goto Done;
+                }
+
                 if (async) {
                     WdfObjectReference(request);
                     async_context = request;

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -713,7 +713,11 @@ ebpf_api_elf_enumerate_programs(
             }
 
             info->offset_in_section = raw_program.insn_off;
-            std::vector<uint8_t> raw_data = convert_ebpf_program_to_bytes(raw_program.prog);
+            std::vector<uint8_t> raw_data;
+            result = convert_ebpf_program_to_bytes(raw_program.prog, raw_data);
+            if (result != EBPF_SUCCESS) {
+                throw std::runtime_error("instruction byte count overflow");
+            }
             info->raw_data_size = raw_data.size();
             info->raw_data = (char*)ebpf_allocate_with_tag(info->raw_data_size, EBPF_POOL_TAG_DEFAULT);
             if (info->raw_data == nullptr) {

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -591,8 +591,15 @@ load_byte_code(
         }
     } catch (std::runtime_error& err) {
         auto message = err.what();
-        auto message_length = strlen(message) + 1;
-        char* error = reinterpret_cast<char*>(ebpf_allocate_with_tag(message_length + 1, EBPF_POOL_TAG_DEFAULT));
+        size_t message_length = 0;
+        size_t error_length = 0;
+        if ((ebpf_safe_size_t_add(strlen(message), 1, &message_length) != EBPF_SUCCESS) ||
+            (ebpf_safe_size_t_add(message_length, 1, &error_length) != EBPF_SUCCESS)) {
+            *error_message = nullptr;
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Exit;
+        }
+        char* error = reinterpret_cast<char*>(ebpf_allocate_with_tag(error_length, EBPF_POOL_TAG_DEFAULT));
         if (error) {
             strcpy_s(error, message_length, message);
         }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -619,6 +619,10 @@ _ebpf_map_lookup_element_batch_helper(
     // Compute the maximum number of entries that can be updated in a single batch.
     max_entries_per_batch = UINT16_MAX - EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_reply, data);
     max_entries_per_batch /= entry_size;
+    if (max_entries_per_batch == 0) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
 
     while (count_returned < input_count) {
         // Fetch the next batch of entries.
@@ -904,6 +908,10 @@ _update_map_element_batch(
     // Compute the maximum number of entries that can be updated in a single batch.
     max_entries_per_batch = UINT16_MAX - EBPF_OFFSET_OF(ebpf_operation_map_update_element_batch_request_t, data);
     max_entries_per_batch /= entry_size;
+    if (max_entries_per_batch == 0) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
 
     try {
         for (size_t key_index = 0; key_index < input_count;) {

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -531,8 +531,8 @@ _ebpf_map_lookup_element_helper(fd_t map_fd, bool find_and_delete, _In_opt_ cons
     }
     assert(value_size != 0);
     if (BPF_MAP_TYPE_PER_CPU(type)) {
-        if (cxplat_safe_uint32_t_multiply(EBPF_PAD_8(value_size), libbpf_num_possible_cpus(), &value_size) !=
-            CXPLAT_STATUS_SUCCESS) {
+        if (ebpf_safe_uint32_t_multiply(EBPF_PAD_8(value_size), libbpf_num_possible_cpus(), &value_size) !=
+            EBPF_SUCCESS) {
             result = EBPF_ARITHMETIC_OVERFLOW;
             goto Exit;
         }
@@ -1481,6 +1481,11 @@ _create_program(
     result = ebpf_safe_size_t_add(section_name_offset, section_name.size(), &program_name_offset);
     if (result != EBPF_SUCCESS) {
         EBPF_RETURN_RESULT(result);
+    }
+
+    if ((request_buffer_size > UINT16_MAX) || (section_name_offset > UINT16_MAX) ||
+        (program_name_offset > UINT16_MAX)) {
+        EBPF_RETURN_RESULT(EBPF_ARITHMETIC_OVERFLOW);
     }
 
     request_buffer.resize(request_buffer_size);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -315,7 +315,10 @@ _create_map(
 
     request = reinterpret_cast<ebpf_operation_create_map_request_t*>(request_buffer.data());
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_CREATE_MAP;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
     request->ebpf_map_definition = *map_definition;
     request->inner_map_handle = (uint64_t)inner_map_handle;
     std::copy(
@@ -428,7 +431,10 @@ _map_lookup_element(
         auto request = reinterpret_cast<ebpf_operation_map_find_element_request_t*>(request_buffer.data());
         auto reply = reinterpret_cast<ebpf_operation_map_find_element_reply_t*>(reply_buffer.data());
 
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_FIND_ELEMENT;
         request->find_and_delete = find_and_delete;
         request->handle = handle;
@@ -658,7 +664,10 @@ _ebpf_map_lookup_element_batch_helper(
         ebpf_protocol_buffer_t reply_buffer(reply_buffer_size);
         auto reply = reinterpret_cast<_ebpf_operation_map_get_next_key_value_batch_reply*>(reply_buffer.data());
 
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_GET_NEXT_KEY_VALUE_BATCH;
         request->handle = map_handle;
         request->find_and_delete = find_and_delete;
@@ -850,7 +859,10 @@ _update_map_element(
         request_buffer.resize(request_buffer_size);
         request = reinterpret_cast<_ebpf_operation_map_update_element_request*>(request_buffer.data());
 
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_UPDATE_ELEMENT;
         request->handle = (uint64_t)map_handle;
         request->option = static_cast<ebpf_map_option_t>(flags);
@@ -931,7 +943,10 @@ _update_map_element_batch(
             request_buffer.resize(request_buffer_size);
             request = reinterpret_cast<ebpf_operation_map_update_element_batch_request_t*>(request_buffer.data());
 
-            request->header.length = static_cast<uint16_t>(request_buffer.size());
+            result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
             request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_UPDATE_ELEMENT_BATCH;
             request->handle = (uint64_t)map_handle;
             request->option = static_cast<ebpf_map_option_t>(flags);
@@ -1011,11 +1026,15 @@ _update_map_element_with_handle(
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(key);
+    ebpf_result_t result = EBPF_SUCCESS;
     ebpf_protocol_buffer_t request_buffer(
         EBPF_OFFSET_OF(ebpf_operation_map_update_element_with_handle_request_t, key) + key_size);
     auto request = reinterpret_cast<ebpf_operation_map_update_element_with_handle_request_t*>(request_buffer.data());
 
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_UPDATE_ELEMENT_WITH_HANDLE;
     request->map_handle = (uintptr_t)map_handle;
     request->value_handle = (uintptr_t)value_handle;
@@ -1212,7 +1231,10 @@ ebpf_map_delete_element(fd_t map_fd, _In_ const void* key) NO_EXCEPT_TRY
         request_buffer.resize(request_buffer_size);
         request = reinterpret_cast<ebpf_operation_map_delete_element_request_t*>(request_buffer.data());
 
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_DELETE_ELEMENT;
         request->handle = (uint64_t)map_handle;
         std::copy((uint8_t*)key, (uint8_t*)key + key_size, request->key);
@@ -1309,7 +1331,10 @@ ebpf_map_delete_element_batch(fd_t map_fd, _In_ const void* keys, _Inout_ uint32
             request_buffer.resize(request_buffer_size);
             request = reinterpret_cast<ebpf_operation_map_delete_element_batch_request_t*>(request_buffer.data());
 
-            request->header.length = static_cast<uint16_t>(request_buffer.size());
+            result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
             request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_DELETE_ELEMENT_BATCH;
             request->handle = (uint64_t)map_handle;
 
@@ -1409,7 +1434,10 @@ ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_opt_ 
         request = reinterpret_cast<ebpf_operation_map_get_next_key_request_t*>(request_buffer.data());
         reply = reinterpret_cast<ebpf_operation_map_get_next_key_reply_t*>(reply_buffer.data());
 
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_GET_NEXT_KEY;
         request->handle = map_handle;
         if (previous_key) {
@@ -1483,19 +1511,23 @@ _create_program(
         EBPF_RETURN_RESULT(result);
     }
 
-    if ((request_buffer_size > UINT16_MAX) || (section_name_offset > UINT16_MAX) ||
-        (program_name_offset > UINT16_MAX)) {
-        EBPF_RETURN_RESULT(EBPF_ARITHMETIC_OVERFLOW);
-    }
-
     request_buffer.resize(request_buffer_size);
 
     request = reinterpret_cast<ebpf_operation_create_program_request_t*>(request_buffer.data());
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_CREATE_PROGRAM;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     request->program_type = program_type;
-    request->section_name_offset = static_cast<uint16_t>(section_name_offset);
-    request->program_name_offset = static_cast<uint16_t>(program_name_offset);
+    result = ebpf_safe_size_t_to_uint16(section_name_offset, &request->section_name_offset);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    result = ebpf_safe_size_t_to_uint16(program_name_offset, &request->program_name_offset);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     std::copy(
         file_name.begin(),
         file_name.end(),
@@ -1559,7 +1591,10 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) NO_EXCEPT_TRY
     auto request = reinterpret_cast<ebpf_operation_update_pinning_request_t*>(request_buffer.data());
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_UPDATE_PINNING;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     request->handle = handle;
     std::copy(canonical_path, canonical_path + path_length, request->path);
     result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer));
@@ -1592,7 +1627,10 @@ ebpf_object_unpin(_In_z_ const char* path) NO_EXCEPT_TRY
     auto request = reinterpret_cast<ebpf_operation_update_pinning_request_t*>(request_buffer.data());
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_UPDATE_PINNING;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     request->handle = UINT64_MAX;
     std::copy(canonical_path, canonical_path + path_length, request->path);
     EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer)));
@@ -1710,7 +1748,11 @@ ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) NO_EXCEPT_TRY
     ebpf_operation_get_pinned_object_reply_t reply;
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_PINNED_OBJECT;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        *fd = (fd_t)ebpf_fd_invalid;
+        EBPF_RETURN_RESULT(result);
+    }
     std::copy(canonical_path, canonical_path + path_length, request->path);
     uint32_t win32_result = invoke_ioctl(request_buffer, reply);
     if (win32_result != ERROR_SUCCESS) {
@@ -1836,7 +1878,10 @@ _link_ebpf_program(
         request_buffer.resize(buffer_size);
         request = reinterpret_cast<ebpf_operation_link_program_request_t*>(request_buffer.data());
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_LINK_PROGRAM;
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            EBPF_RETURN_RESULT(result);
+        }
         request->program_handle = program_handle;
         request->attach_type = *attach_type;
 
@@ -2120,7 +2165,10 @@ ebpf_program_detach(
     }
     request = reinterpret_cast<ebpf_operation_unlink_program_request_t*>(request_buffer.data());
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_UNLINK_PROGRAM;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
     request->link_handle = ebpf_handle_invalid;
     request->program_handle =
         (program_fd != ebpf_fd_invalid) ? _get_handle_from_file_descriptor(program_fd) : ebpf_handle_invalid;
@@ -3966,7 +4014,10 @@ _load_native_module(
 
     request = reinterpret_cast<ebpf_operation_load_native_module_request_t*>(request_buffer.data());
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_LOAD_NATIVE_MODULE;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
     request->module_id = *module_id;
     memcpy(
         request_buffer.data() + offsetof(ebpf_operation_load_native_module_request_t, data),
@@ -4677,8 +4728,14 @@ ebpf_get_next_pinned_object_path(
         reinterpret_cast<ebpf_operation_get_next_pinned_object_path_reply_t*>(reply_buffer.data());
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
-    reply->header.length = static_cast<uint16_t>(reply_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    result = ebpf_safe_size_t_to_uint16(reply_buffer.size(), &reply->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
 
     request->type = *type;
     memcpy(request->start_path, canonical_start_path, canonical_start_path_length);
@@ -5318,7 +5375,10 @@ _map_write(ebpf_handle_t map_handle, _In_reads_bytes_(data_length) const void* d
 
         request_buffer.resize(request_buffer_size);
         request = reinterpret_cast<ebpf_operation_map_write_data_request_t*>(request_buffer.data());
-        request->header.length = static_cast<uint16_t>(request_buffer.size());
+        result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+        if (result != EBPF_SUCCESS) {
+            EBPF_RETURN_RESULT(result);
+        }
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_WRITE_DATA;
         request->map_handle = (uint64_t)map_handle;
         std::copy((uint8_t*)data, (uint8_t*)data + data_length, request->data);
@@ -5544,7 +5604,10 @@ ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options)
         reinterpret_cast<ebpf_operation_program_test_run_reply_t*>(reply_buffer.data());
 
     request->header.id = EBPF_OPERATION_PROGRAM_TEST_RUN;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     request->program_handle = _get_handle_from_file_descriptor(program_fd);
     request->repeat_count = options->repeat_count;
     request->flags = options->flags;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4678,7 +4678,9 @@ ebpf_get_next_pinned_object_path(
     ebpf_assert(reply->header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH);
     size_t reply_next_path_len = 0;
     result = ebpf_safe_size_t_subtract(
-        reply->header.length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path), &reply_next_path_len);
+        reply->header.length,
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path),
+        &reply_next_path_len);
     if (result != EBPF_SUCCESS) {
         EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
     }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -92,6 +92,28 @@ _Guarded_by_(_ebpf_state_mutex) static std::vector<ebpf_object_t*> _ebpf_objects
 #define CATCH_NO_MEMORY_INT(X) \
     catch (const std::bad_alloc&) { EBPF_RETURN_ERROR(X); }
 
+static _Must_inspect_result_ ebpf_result_t
+_ebpf_safe_size_t_add3(size_t augend, size_t addend_1, size_t addend_2, _Out_ size_t* result) noexcept
+{
+    ebpf_result_t status = ebpf_safe_size_t_add(augend, addend_1, result);
+    if (status != EBPF_SUCCESS) {
+        return status;
+    }
+
+    return ebpf_safe_size_t_add(*result, addend_2, result);
+}
+
+static _Must_inspect_result_ ebpf_result_t
+_ebpf_safe_size_t_multiply_add(size_t multiplicand, size_t multiplier, size_t addend, _Out_ size_t* result) noexcept
+{
+    ebpf_result_t status = ebpf_safe_size_t_multiply(multiplicand, multiplier, result);
+    if (status != EBPF_SUCCESS) {
+        return status;
+    }
+
+    return ebpf_safe_size_t_add(*result, addend, result);
+}
+
 typedef class _ebpf_signal
 {
   public:
@@ -283,7 +305,12 @@ _create_map(
     *map_handle = ebpf_handle_invalid;
     map_name_size = map_name.size();
 
-    size_t buffer_size = offsetof(ebpf_operation_create_map_request_t, data) + map_name_size;
+    size_t buffer_size = 0;
+    result = ebpf_safe_size_t_add(offsetof(ebpf_operation_create_map_request_t, data), map_name_size, &buffer_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
     request_buffer.resize(buffer_size);
 
     request = reinterpret_cast<ebpf_operation_create_map_request_t*>(request_buffer.data());
@@ -382,10 +409,22 @@ _map_lookup_element(
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_assert(value);
     try {
-        ebpf_protocol_buffer_t request_buffer(
-            EBPF_OFFSET_OF(ebpf_operation_map_find_element_request_t, key) + key_size);
-        ebpf_protocol_buffer_t reply_buffer(
-            EBPF_OFFSET_OF(ebpf_operation_map_find_element_reply_t, value) + value_size);
+        size_t request_buffer_size = 0;
+        size_t reply_buffer_size = 0;
+        result = ebpf_safe_size_t_add(
+            EBPF_OFFSET_OF(ebpf_operation_map_find_element_request_t, key), key_size, &request_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        result = ebpf_safe_size_t_add(
+            EBPF_OFFSET_OF(ebpf_operation_map_find_element_reply_t, value), value_size, &reply_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        ebpf_protocol_buffer_t request_buffer(request_buffer_size);
+        ebpf_protocol_buffer_t reply_buffer(reply_buffer_size);
         auto request = reinterpret_cast<ebpf_operation_map_find_element_request_t*>(request_buffer.data());
         auto reply = reinterpret_cast<ebpf_operation_map_find_element_reply_t*>(reply_buffer.data());
 
@@ -492,7 +531,11 @@ _ebpf_map_lookup_element_helper(fd_t map_fd, bool find_and_delete, _In_opt_ cons
     }
     assert(value_size != 0);
     if (BPF_MAP_TYPE_PER_CPU(type)) {
-        value_size = EBPF_PAD_8(value_size) * libbpf_num_possible_cpus();
+        if (cxplat_safe_uint32_t_multiply(EBPF_PAD_8(value_size), libbpf_num_possible_cpus(), &value_size) !=
+            CXPLAT_STATUS_SUCCESS) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Exit;
+        }
     }
 
     result = _map_lookup_element(map_handle, find_and_delete, key_size, (uint8_t*)key, value_size, (uint8_t*)value);
@@ -528,6 +571,7 @@ _ebpf_map_lookup_element_batch_helper(
     size_t max_entries_per_batch = 0;
     size_t key_size = 0;
     size_t value_size = 0;
+    size_t entry_size = 0;
 
     const uint8_t* previous_key = reinterpret_cast<const uint8_t*>(in_batch);
 
@@ -561,24 +605,53 @@ _ebpf_map_lookup_element_batch_helper(
     }
 
     if (BPF_MAP_TYPE_PER_CPU(type)) {
-        value_size = EBPF_PAD_8(value_size) * libbpf_num_possible_cpus();
+        result = ebpf_safe_size_t_multiply(EBPF_PAD_8(value_size), libbpf_num_possible_cpus(), &value_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+    }
+
+    result = ebpf_safe_size_t_add(key_size, value_size, &entry_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
     }
 
     // Compute the maximum number of entries that can be updated in a single batch.
     max_entries_per_batch = UINT16_MAX - EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_reply, data);
-    max_entries_per_batch /= (key_size + value_size);
+    max_entries_per_batch /= entry_size;
 
     while (count_returned < input_count) {
         // Fetch the next batch of entries.
         size_t entries_to_fetch = std::min(input_count - count_returned, max_entries_per_batch);
+        size_t request_buffer_size = 0;
+        size_t reply_data_length = 0;
+        size_t reply_buffer_size = 0;
+        size_t entries_byte_count = 0;
 
-        ebpf_protocol_buffer_t request_buffer(
-            EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_request, previous_key) +
-            (previous_key ? key_size : 0));
+        result = ebpf_safe_size_t_add(
+            EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_request, previous_key),
+            previous_key ? key_size : 0,
+            &request_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        result = ebpf_safe_size_t_multiply(entries_to_fetch, entry_size, &entries_byte_count);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        result = ebpf_safe_size_t_add(
+            EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_reply, data),
+            entries_byte_count,
+            &reply_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        ebpf_protocol_buffer_t request_buffer(request_buffer_size);
         auto request = reinterpret_cast<_ebpf_operation_map_get_next_key_value_batch_request*>(request_buffer.data());
-        ebpf_protocol_buffer_t reply_buffer(
-            EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_reply, data) +
-            entries_to_fetch * (key_size + value_size));
+        ebpf_protocol_buffer_t reply_buffer(reply_buffer_size);
         auto reply = reinterpret_cast<_ebpf_operation_map_get_next_key_value_batch_reply*>(reply_buffer.data());
 
         request->header.length = static_cast<uint16_t>(request_buffer.size());
@@ -594,9 +667,15 @@ _ebpf_map_lookup_element_batch_helper(
             goto Exit;
         }
 
-        size_t entries_returned =
-            reply->header.length - EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_reply, data);
-        entries_returned /= (key_size + value_size);
+        result = ebpf_safe_size_t_subtract(
+            reply->header.length,
+            EBPF_OFFSET_OF(_ebpf_operation_map_get_next_key_value_batch_reply, data),
+            &reply_data_length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        size_t entries_returned = reply_data_length / entry_size;
 
         // Add this check to make the static analyzer happy.
         if (entries_returned == 0) {
@@ -604,11 +683,42 @@ _ebpf_map_lookup_element_batch_helper(
             goto Exit;
         }
 
-        for (uint32_t index = 0; index < entries_returned; index++) {
-            uint8_t* key_data = reply->data + index * (key_size + value_size);
-            uint8_t* value_data = reply->data + index * (key_size + value_size) + key_size;
-            std::copy(key_data, key_data + key_size, (uint8_t*)keys + (count_returned + index) * key_size);
-            std::copy(value_data, value_data + value_size, (uint8_t*)values + (count_returned + index) * value_size);
+        for (size_t index = 0; index < entries_returned; index++) {
+            size_t entry_offset = 0;
+            size_t value_offset = 0;
+            size_t output_index = 0;
+            size_t key_output_offset = 0;
+            size_t value_output_offset = 0;
+
+            result = ebpf_safe_size_t_multiply(index, entry_size, &entry_offset);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            result = ebpf_safe_size_t_add(entry_offset, key_size, &value_offset);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            result = ebpf_safe_size_t_add(count_returned, index, &output_index);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            result = ebpf_safe_size_t_multiply(output_index, key_size, &key_output_offset);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            result = ebpf_safe_size_t_multiply(output_index, value_size, &value_output_offset);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            uint8_t* key_data = reply->data + entry_offset;
+            uint8_t* value_data = reply->data + value_offset;
+            std::copy(key_data, key_data + key_size, (uint8_t*)keys + key_output_offset);
+            std::copy(value_data, value_data + value_size, (uint8_t*)values + value_output_offset);
         }
         count_returned += entries_returned;
 
@@ -620,7 +730,12 @@ _ebpf_map_lookup_element_batch_helper(
             previous_key = nullptr;
         } else {
             // Point previous_key to the last key in the batch.
-            previous_key = (uint8_t*)keys + (count_returned - 1) * key_size;
+            size_t previous_key_offset = 0;
+            result = ebpf_safe_size_t_multiply(count_returned - 1, key_size, &previous_key_offset);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+            previous_key = (uint8_t*)keys + previous_key_offset;
         }
 
         // Partial return signals last no more entries.
@@ -718,8 +833,17 @@ _update_map_element(
     ebpf_assert(key || !key_size);
 
     try {
-        request_buffer.resize(
-            EBPF_OFFSET_OF(ebpf_operation_map_update_element_request_t, data) + key_size + value_size);
+        size_t request_buffer_size = 0;
+        result = _ebpf_safe_size_t_add3(
+            EBPF_OFFSET_OF(ebpf_operation_map_update_element_request_t, data),
+            key_size,
+            value_size,
+            &request_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        request_buffer.resize(request_buffer_size);
         request = reinterpret_cast<_ebpf_operation_map_update_element_request*>(request_buffer.data());
 
         request->header.length = static_cast<uint16_t>(request_buffer.size());
@@ -762,6 +886,7 @@ _update_map_element_batch(
     ebpf_operation_map_update_element_batch_reply_t reply;
     size_t input_count = *count;
     size_t max_entries_per_batch = 0;
+    size_t entry_size = 0;
 
     ebpf_assert(value);
     ebpf_assert(key || !key_size);
@@ -771,18 +896,31 @@ _update_map_element_batch(
         goto Exit;
     }
 
+    result = ebpf_safe_size_t_add(key_size, value_size, &entry_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
     // Compute the maximum number of entries that can be updated in a single batch.
     max_entries_per_batch = UINT16_MAX - EBPF_OFFSET_OF(ebpf_operation_map_update_element_batch_request_t, data);
-    max_entries_per_batch /= (key_size + value_size);
+    max_entries_per_batch /= entry_size;
 
     try {
         for (size_t key_index = 0; key_index < input_count;) {
             // Compute the number of entries to update in this batch.
             size_t entries_to_update = std::min(input_count - key_index, max_entries_per_batch);
+            size_t request_buffer_size = 0;
 
-            request_buffer.resize(
-                EBPF_OFFSET_OF(ebpf_operation_map_update_element_batch_request_t, data) +
-                entries_to_update * (key_size + value_size));
+            result = _ebpf_safe_size_t_multiply_add(
+                entries_to_update,
+                entry_size,
+                EBPF_OFFSET_OF(ebpf_operation_map_update_element_batch_request_t, data),
+                &request_buffer_size);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            request_buffer.resize(request_buffer_size);
             request = reinterpret_cast<ebpf_operation_map_update_element_batch_request_t*>(request_buffer.data());
 
             request->header.length = static_cast<uint16_t>(request_buffer.size());
@@ -791,10 +929,41 @@ _update_map_element_batch(
             request->option = static_cast<ebpf_map_option_t>(flags);
 
             for (size_t index = 0; index < entries_to_update; index++) {
-                uint8_t* source_key = (uint8_t*)key + (key_index + index) * key_size;
-                uint8_t* source_value = (uint8_t*)value + (key_index + index) * value_size;
-                uint8_t* destination_key = request->data + index * (key_size + value_size);
-                uint8_t* destination_value = request->data + index * (key_size + value_size) + key_size;
+                size_t source_index = 0;
+                size_t source_key_offset = 0;
+                size_t source_value_offset = 0;
+                size_t destination_key_offset = 0;
+                size_t destination_value_offset = 0;
+
+                result = ebpf_safe_size_t_add(key_index, index, &source_index);
+                if (result != EBPF_SUCCESS) {
+                    goto Exit;
+                }
+
+                result = ebpf_safe_size_t_multiply(source_index, key_size, &source_key_offset);
+                if (result != EBPF_SUCCESS) {
+                    goto Exit;
+                }
+
+                result = ebpf_safe_size_t_multiply(source_index, value_size, &source_value_offset);
+                if (result != EBPF_SUCCESS) {
+                    goto Exit;
+                }
+
+                result = ebpf_safe_size_t_multiply(index, entry_size, &destination_key_offset);
+                if (result != EBPF_SUCCESS) {
+                    goto Exit;
+                }
+
+                result = ebpf_safe_size_t_add(destination_key_offset, key_size, &destination_value_offset);
+                if (result != EBPF_SUCCESS) {
+                    goto Exit;
+                }
+
+                uint8_t* source_key = (uint8_t*)key + source_key_offset;
+                uint8_t* source_value = (uint8_t*)value + source_value_offset;
+                uint8_t* destination_key = request->data + destination_key_offset;
+                uint8_t* destination_value = request->data + destination_value_offset;
 
                 std::copy(source_key, source_key + key_size, destination_key);
                 std::copy(source_value, source_value + value_size, destination_value);
@@ -1025,7 +1194,14 @@ ebpf_map_delete_element(fd_t map_fd, _In_ const void* key) NO_EXCEPT_TRY
     assert(value_size != 0);
 
     try {
-        request_buffer.resize(EBPF_OFFSET_OF(ebpf_operation_map_delete_element_request_t, key) + key_size);
+        size_t request_buffer_size = 0;
+        result = ebpf_safe_size_t_add(
+            EBPF_OFFSET_OF(ebpf_operation_map_delete_element_request_t, key), key_size, &request_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        request_buffer.resize(request_buffer_size);
         request = reinterpret_cast<ebpf_operation_map_delete_element_request_t*>(request_buffer.data());
 
         request->header.length = static_cast<uint16_t>(request_buffer.size());
@@ -1109,9 +1285,20 @@ ebpf_map_delete_element_batch(fd_t map_fd, _In_ const void* keys, _Inout_ uint32
         for (size_t key_index = 0; key_index < input_count;) {
             // Compute the number of entries to update in this batch.
             size_t entries_to_delete = std::min(input_count - key_index, max_entries_per_batch);
+            size_t request_buffer_size = 0;
+            size_t copy_length = 0;
+            size_t key_offset = 0;
 
-            request_buffer.resize(
-                EBPF_OFFSET_OF(ebpf_operation_map_delete_element_batch_request_t, keys) + key_size * entries_to_delete);
+            result = _ebpf_safe_size_t_multiply_add(
+                key_size,
+                entries_to_delete,
+                EBPF_OFFSET_OF(ebpf_operation_map_delete_element_batch_request_t, keys),
+                &request_buffer_size);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            request_buffer.resize(request_buffer_size);
             request = reinterpret_cast<ebpf_operation_map_delete_element_batch_request_t*>(request_buffer.data());
 
             request->header.length = static_cast<uint16_t>(request_buffer.size());
@@ -1119,7 +1306,17 @@ ebpf_map_delete_element_batch(fd_t map_fd, _In_ const void* keys, _Inout_ uint32
             request->handle = (uint64_t)map_handle;
 
             // Copy keys into request buffer.
-            memcpy(request->keys, (uint8_t*)keys + key_size * key_index, key_size * entries_to_delete);
+            result = ebpf_safe_size_t_multiply(key_size, key_index, &key_offset);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            result = ebpf_safe_size_t_multiply(key_size, entries_to_delete, &copy_length);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+
+            memcpy(request->keys, (uint8_t*)keys + key_offset, copy_length);
 
             result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer, reply));
             if (result == EBPF_INVALID_OBJECT) {
@@ -1185,8 +1382,22 @@ ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_opt_ 
     assert(value_size != 0);
 
     try {
-        request_buffer.resize((offsetof(ebpf_operation_map_get_next_key_request_t, previous_key) + key_size));
-        reply_buffer.resize((offsetof(ebpf_operation_map_get_next_key_reply_t, next_key) + key_size));
+        size_t request_buffer_size = 0;
+        size_t reply_buffer_size = 0;
+        result = ebpf_safe_size_t_add(
+            offsetof(ebpf_operation_map_get_next_key_request_t, previous_key), key_size, &request_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        result = ebpf_safe_size_t_add(
+            offsetof(ebpf_operation_map_get_next_key_reply_t, next_key), key_size, &reply_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+
+        request_buffer.resize(request_buffer_size);
+        reply_buffer.resize(reply_buffer_size);
         request = reinterpret_cast<ebpf_operation_map_get_next_key_request_t*>(request_buffer.data());
         reply = reinterpret_cast<ebpf_operation_map_get_next_key_reply_t*>(reply_buffer.data());
 
@@ -1232,20 +1443,46 @@ _create_program(
     ebpf_protocol_buffer_t request_buffer;
     ebpf_operation_create_program_request_t* request;
     ebpf_operation_create_program_reply_t reply;
+    ebpf_result_t result = EBPF_SUCCESS;
+    size_t request_buffer_size = 0;
+    size_t section_name_offset = 0;
+    size_t program_name_offset = 0;
     ebpf_assert(program_handle);
     *program_handle = ebpf_handle_invalid;
 
-    request_buffer.resize(
-        offsetof(ebpf_operation_create_program_request_t, data) + file_name.size() + section_name.size() +
-        program_name.size());
+    result = _ebpf_safe_size_t_add3(
+        offsetof(ebpf_operation_create_program_request_t, data),
+        file_name.size(),
+        section_name.size(),
+        &request_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    result = ebpf_safe_size_t_add(request_buffer_size, program_name.size(), &request_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    result = ebpf_safe_size_t_add(
+        offsetof(ebpf_operation_create_program_request_t, data), file_name.size(), &section_name_offset);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    result = ebpf_safe_size_t_add(section_name_offset, section_name.size(), &program_name_offset);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    request_buffer.resize(request_buffer_size);
 
     request = reinterpret_cast<ebpf_operation_create_program_request_t*>(request_buffer.data());
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_CREATE_PROGRAM;
     request->header.length = static_cast<uint16_t>(request_buffer.size());
     request->program_type = program_type;
-    request->section_name_offset =
-        static_cast<uint16_t>(offsetof(ebpf_operation_create_program_request_t, data) + file_name.size());
-    request->program_name_offset = static_cast<uint16_t>(request->section_name_offset + section_name.size());
+    request->section_name_offset = static_cast<uint16_t>(section_name_offset);
+    request->program_name_offset = static_cast<uint16_t>(program_name_offset);
     std::copy(
         file_name.begin(),
         file_name.end(),
@@ -1298,7 +1535,14 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) NO_EXCEPT_TRY
     }
 
     auto path_length = strlen(canonical_path);
-    ebpf_protocol_buffer_t request_buffer(offsetof(ebpf_operation_update_pinning_request_t, path) + path_length);
+    size_t request_buffer_size = 0;
+    result = ebpf_safe_size_t_add(
+        offsetof(ebpf_operation_update_pinning_request_t, path), path_length, &request_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    ebpf_protocol_buffer_t request_buffer(request_buffer_size);
     auto request = reinterpret_cast<ebpf_operation_update_pinning_request_t*>(request_buffer.data());
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_UPDATE_PINNING;
@@ -1324,7 +1568,14 @@ ebpf_object_unpin(_In_z_ const char* path) NO_EXCEPT_TRY
     }
 
     auto path_length = strlen(canonical_path);
-    ebpf_protocol_buffer_t request_buffer(offsetof(ebpf_operation_update_pinning_request_t, path) + path_length);
+    size_t request_buffer_size = 0;
+    ebpf_result_t result = ebpf_safe_size_t_add(
+        offsetof(ebpf_operation_update_pinning_request_t, path), path_length, &request_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    ebpf_protocol_buffer_t request_buffer(request_buffer_size);
     auto request = reinterpret_cast<ebpf_operation_update_pinning_request_t*>(request_buffer.data());
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_UPDATE_PINNING;
@@ -1424,6 +1675,7 @@ ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) NO_EXCEPT_TRY
     EBPF_LOG_ENTRY();
     ebpf_assert(fd);
     ebpf_assert(path);
+    ebpf_result_t result = EBPF_SUCCESS;
 
     char canonical_path[MAX_PATH];
     uint32_t return_value = ebpf_canonicalize_path(canonical_path, sizeof(canonical_path), path);
@@ -1432,17 +1684,25 @@ ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) NO_EXCEPT_TRY
     }
 
     size_t path_length = strlen(canonical_path);
-    ebpf_protocol_buffer_t request_buffer(offsetof(ebpf_operation_get_pinned_object_request_t, path) + path_length);
+    size_t request_buffer_size = 0;
+    result = ebpf_safe_size_t_add(
+        offsetof(ebpf_operation_get_pinned_object_request_t, path), path_length, &request_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        *fd = (fd_t)ebpf_fd_invalid;
+        EBPF_RETURN_RESULT(result);
+    }
+
+    ebpf_protocol_buffer_t request_buffer(request_buffer_size);
     auto request = reinterpret_cast<ebpf_operation_get_pinned_object_request_t*>(request_buffer.data());
     ebpf_operation_get_pinned_object_reply_t reply;
 
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_PINNED_OBJECT;
     request->header.length = static_cast<uint16_t>(request_buffer.size());
     std::copy(canonical_path, canonical_path + path_length, request->path);
-    auto result = invoke_ioctl(request_buffer, reply);
-    if (result != ERROR_SUCCESS) {
+    uint32_t win32_result = invoke_ioctl(request_buffer, reply);
+    if (win32_result != ERROR_SUCCESS) {
         *fd = (fd_t)ebpf_fd_invalid;
-        EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(result));
+        EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(win32_result));
     }
 
     ebpf_assert(reply.header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_PINNED_OBJECT);
@@ -1454,7 +1714,7 @@ ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) NO_EXCEPT_TRY
         result = EBPF_NO_MEMORY;
     }
 
-    EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(result));
+    EBPF_RETURN_RESULT(result);
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
@@ -1535,7 +1795,13 @@ _link_ebpf_program(
     ebpf_assert(attach_parameter || !attach_parameter_size);
 
     try {
-        size_t buffer_size = offsetof(ebpf_operation_link_program_request_t, data) + attach_parameter_size;
+        size_t buffer_size = 0;
+        result = ebpf_safe_size_t_add(
+            offsetof(ebpf_operation_link_program_request_t, data), attach_parameter_size, &buffer_size);
+        if (result != EBPF_SUCCESS) {
+            EBPF_RETURN_RESULT(result);
+        }
+
         request_buffer.resize(buffer_size);
         request = reinterpret_cast<ebpf_operation_link_program_request_t*>(request_buffer.data());
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_LINK_PROGRAM;
@@ -1805,9 +2071,15 @@ ebpf_program_detach(
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_protocol_buffer_t request_buffer;
     ebpf_operation_unlink_program_request_t* request;
-    size_t buffer_size = offsetof(ebpf_operation_unlink_program_request_t, data) + attach_parameter_size;
+    size_t buffer_size = 0;
 
     EBPF_LOG_ENTRY();
+
+    result = ebpf_safe_size_t_add(
+        offsetof(ebpf_operation_unlink_program_request_t, data), attach_parameter_size, &buffer_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
 
     try {
         request_buffer.resize(buffer_size);
@@ -3641,13 +3913,24 @@ _load_native_module(
     ebpf_protocol_buffer_t request_buffer;
     ebpf_operation_load_native_module_request_t* request;
     ebpf_operation_load_native_module_reply_t reply;
-    size_t service_path_size = service_path.size() * 2;
+    size_t service_path_size = 0;
+    size_t buffer_size = 0;
 
     *count_of_maps = 0;
     *count_of_programs = 0;
     *module_handle = ebpf_handle_invalid;
 
-    size_t buffer_size = offsetof(ebpf_operation_load_native_module_request_t, data) + service_path_size;
+    result = ebpf_safe_size_t_multiply(service_path.size(), sizeof(wchar_t), &service_path_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    result = ebpf_safe_size_t_add(
+        offsetof(ebpf_operation_load_native_module_request_t, data), service_path_size, &buffer_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
     request_buffer.resize(buffer_size);
 
     request = reinterpret_cast<ebpf_operation_load_native_module_request_t*>(request_buffer.data());
@@ -3711,10 +3994,31 @@ _load_native_programs(
     ebpf_protocol_buffer_t reply_buffer;
     ebpf_operation_load_native_programs_request_t request;
     ebpf_operation_load_native_programs_reply_t* reply;
-    size_t map_handles_size = count_of_maps * sizeof(ebpf_handle_t);
-    size_t program_handles_size = count_of_programs * sizeof(ebpf_handle_t);
-    size_t handles_size = map_handles_size + program_handles_size;
-    size_t buffer_size = offsetof(ebpf_operation_load_native_programs_reply_t, data) + handles_size;
+    size_t map_handles_size = 0;
+    size_t program_handles_size = 0;
+    size_t handles_size = 0;
+    size_t buffer_size = 0;
+
+    result = ebpf_safe_size_t_multiply(count_of_maps, sizeof(ebpf_handle_t), &map_handles_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    result = ebpf_safe_size_t_multiply(count_of_programs, sizeof(ebpf_handle_t), &program_handles_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    result = ebpf_safe_size_t_add(map_handles_size, program_handles_size, &handles_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    result =
+        ebpf_safe_size_t_add(offsetof(ebpf_operation_load_native_programs_reply_t, data), handles_size, &buffer_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     if (count_of_maps > 0) {
         *map_handles = (ebpf_handle_t*)ebpf_allocate_with_tag(map_handles_size, EBPF_POOL_TAG_DEFAULT);
@@ -4310,12 +4614,32 @@ ebpf_get_next_pinned_object_path(
         EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
     }
 
-    size_t canonical_start_path_length = strlen(canonical_start_path);
+    if (next_path_len == 0) {
+        EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
+    }
 
-    ebpf_protocol_buffer_t request_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_request_t, start_path) + canonical_start_path_length);
-    ebpf_protocol_buffer_t reply_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path) + (next_path_len - 1));
+    size_t canonical_start_path_length = strlen(canonical_start_path);
+    size_t request_buffer_size = 0;
+    size_t reply_buffer_size = 0;
+
+    result = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_request_t, start_path),
+        canonical_start_path_length,
+        &request_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    result = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path),
+        next_path_len - 1,
+        &reply_buffer_size);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    ebpf_protocol_buffer_t request_buffer(request_buffer_size);
+    ebpf_protocol_buffer_t reply_buffer(reply_buffer_size);
     ebpf_operation_get_next_pinned_object_path_request_t* request =
         reinterpret_cast<ebpf_operation_get_next_pinned_object_path_request_t*>(request_buffer.data());
     ebpf_operation_get_next_pinned_object_path_reply_t* reply =
@@ -4948,7 +5272,14 @@ _map_write(ebpf_handle_t map_handle, _In_reads_bytes_(data_length) const void* d
     ebpf_assert(data_length != 0);
 
     try {
-        request_buffer.resize(EBPF_OFFSET_OF(ebpf_operation_map_write_data_request_t, data) + data_length);
+        size_t request_buffer_size = 0;
+        result = ebpf_safe_size_t_add(
+            EBPF_OFFSET_OF(ebpf_operation_map_write_data_request_t, data), data_length, &request_buffer_size);
+        if (result != EBPF_SUCCESS) {
+            EBPF_RETURN_RESULT(result);
+        }
+
+        request_buffer.resize(request_buffer_size);
         request = reinterpret_cast<ebpf_operation_map_write_data_request_t*>(request_buffer.data());
         request->header.length = static_cast<uint16_t>(request_buffer.size());
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_WRITE_DATA;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1750,12 +1750,30 @@ ebpf_program_query_info(
     }
     ebpf_assert(reply->header.id == ebpf_operation_id_t::EBPF_OPERATION_QUERY_PROGRAM_INFO);
 
-    size_t file_name_length = reply->section_name_offset - reply->file_name_offset;
-    size_t section_name_length = reply->header.length - reply->section_name_offset;
+    size_t file_name_length = 0;
+    size_t section_name_length = 0;
+    size_t file_name_allocation_length = 0;
+    size_t section_name_allocation_length = 0;
+    result = ebpf_safe_size_t_subtract(reply->section_name_offset, reply->file_name_offset, &file_name_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
+    }
+    result = ebpf_safe_size_t_subtract(reply->header.length, reply->section_name_offset, &section_name_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
+    }
+    result = ebpf_safe_size_t_add(file_name_length, 1, &file_name_allocation_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    result = ebpf_safe_size_t_add(section_name_length, 1, &section_name_allocation_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     char* local_file_name =
-        reinterpret_cast<char*>(ebpf_allocate_with_tag(file_name_length + 1, EBPF_POOL_TAG_DEFAULT));
+        reinterpret_cast<char*>(ebpf_allocate_with_tag(file_name_allocation_length, EBPF_POOL_TAG_DEFAULT));
     char* local_section_name =
-        reinterpret_cast<char*>(ebpf_allocate_with_tag(section_name_length + 1, EBPF_POOL_TAG_DEFAULT));
+        reinterpret_cast<char*>(ebpf_allocate_with_tag(section_name_allocation_length, EBPF_POOL_TAG_DEFAULT));
 
     if (!local_file_name || !local_section_name) {
         ebpf_free(local_file_name);
@@ -4658,8 +4676,12 @@ ebpf_get_next_pinned_object_path(
         EBPF_RETURN_RESULT(result);
     }
     ebpf_assert(reply->header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PINNED_OBJECT_PATH);
-    size_t reply_next_path_len =
-        reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path);
+    size_t reply_next_path_len = 0;
+    result = ebpf_safe_size_t_subtract(
+        reply->header.length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path), &reply_next_path_len);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
+    }
     strncpy_s(next_path, next_path_len, (char*)reply->next_path, reply_next_path_len);
     *type = reply->type;
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
@@ -5543,9 +5565,16 @@ ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options)
             }
         }
         if (options->context_out) {
-            size_t context_size_out = reply->header.length -
-                                      EBPF_OFFSET_OF(ebpf_operation_program_test_run_reply_t, data) -
-                                      reply->context_offset;
+            size_t context_size_out = 0;
+            result = ebpf_safe_size_t_subtract(
+                reply->header.length, EBPF_OFFSET_OF(ebpf_operation_program_test_run_reply_t, data), &context_size_out);
+            if (result != EBPF_SUCCESS) {
+                return EBPF_INVALID_ARGUMENT;
+            }
+            result = ebpf_safe_size_t_subtract(context_size_out, reply->context_offset, &context_size_out);
+            if (result != EBPF_SUCCESS) {
+                return EBPF_INVALID_ARGUMENT;
+            }
             if (context_size_out > options->context_size_out) {
                 options->context_size_out = context_size_out;
                 return EBPF_INSUFFICIENT_BUFFER;

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -4,9 +4,9 @@
 #include "api_common.hpp"
 #include "api_internal.h"
 #include "ebpf_api.h"
+#include "ebpf_shared_framework.h"
 #include "ebpf_verifier_wrapper.hpp"
 #include "map_descriptors.hpp"
-#include "ebpf_shared_framework.h"
 #include "windows_platform.hpp"
 #include "windows_platform_common.hpp"
 

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -6,6 +6,7 @@
 #include "ebpf_api.h"
 #include "ebpf_verifier_wrapper.hpp"
 #include "map_descriptors.hpp"
+#include "ebpf_shared_framework.h"
 #include "windows_platform.hpp"
 #include "windows_platform_common.hpp"
 
@@ -33,8 +34,12 @@ _parse_maps_section_windows(
     // Add map definitions into the map cache.
     uint32_t previous_map_count = (uint32_t)get_map_descriptor_size();
     for (int i = 0; i < map_count; i++) {
-        size_t section_offset = (i * map_record_size);
-        uint32_t idx = previous_map_count + i;
+        size_t section_offset = 0;
+        uint32_t idx = 0;
+        if ((ebpf_safe_size_t_multiply((size_t)i, map_record_size, &section_offset) != EBPF_SUCCESS) ||
+            (ebpf_safe_uint32_t_add(previous_map_count, (uint32_t)i, &idx) != EBPF_SUCCESS)) {
+            throw std::runtime_error("map section offset overflow");
+        }
 
         // Copy the data from the record into an ebpf_map_definition_in_file_t structure,
         // zero-padding any extra, and being careful not to overflow the buffer.

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -11,6 +11,7 @@
 #include "windows_platform_common.hpp"
 
 #include <stdint.h>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -38,9 +39,14 @@ allocate_string(const std::string& string, uint32_t* length) noexcept
 std::vector<uint8_t>
 convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions)
 {
+    size_t byte_count = 0;
+    if (ebpf_safe_size_t_multiply(instructions.size(), sizeof(ebpf_inst), &byte_count) != EBPF_SUCCESS) {
+        throw std::overflow_error("instruction byte count overflow");
+    }
+
     return {
         reinterpret_cast<const uint8_t*>(instructions.data()),
-        reinterpret_cast<const uint8_t*>(instructions.data()) + instructions.size() * sizeof(ebpf_inst)};
+        reinterpret_cast<const uint8_t*>(instructions.data()) + byte_count};
 }
 
 int

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -10,8 +10,8 @@
 #include "map_descriptors.hpp"
 #include "windows_platform_common.hpp"
 
-#include <stdint.h>
 #include <stdexcept>
+#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -112,7 +112,10 @@ ebpf_object_get_info(
     auto request = reinterpret_cast<ebpf_operation_get_object_info_request_t*>(request_buffer.data());
     auto reply = reinterpret_cast<ebpf_operation_get_object_info_reply_t*>(reply_buffer.data());
 
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    result = ebpf_safe_size_t_to_uint16(request_buffer.size(), &request->header.length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_OBJECT_INFO;
     request->handle = handle;
     if (info != nullptr) {

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -26,6 +26,9 @@ allocate_string(const std::string& string, uint32_t* length) noexcept
     if (ebpf_safe_size_t_add(string.size(), 1, &string_length) != EBPF_SUCCESS) {
         return nullptr;
     }
+    if ((length != nullptr) && (string_length > UINT32_MAX)) {
+        return nullptr;
+    }
     new_string = (char*)ebpf_allocate_with_tag(string_length, EBPF_POOL_TAG_DEFAULT);
     if (new_string != nullptr) {
         strcpy_s(new_string, string_length, string.c_str());

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -63,6 +63,10 @@ ebpf_object_get_info(
     _Out_opt_ ebpf_object_type_t* type) noexcept
 {
     EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+    size_t request_buffer_length = 0;
+    size_t reply_buffer_length = 0;
+    size_t returned_info_size = 0;
 
     if (info != nullptr && (info_size == nullptr || *info_size == 0)) {
         return EBPF_INVALID_ARGUMENT;
@@ -77,10 +81,20 @@ ebpf_object_get_info(
         request_info_size = *info_size;
     }
 
-    ebpf_protocol_buffer_t request_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_object_info_request_t, info) + request_info_size);
-    ebpf_protocol_buffer_t reply_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info) + request_info_size);
+    result = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_operation_get_object_info_request_t, info), request_info_size, &request_buffer_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    result = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info), request_info_size, &reply_buffer_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+
+    ebpf_protocol_buffer_t request_buffer(request_buffer_length);
+    ebpf_protocol_buffer_t reply_buffer(reply_buffer_length);
     auto request = reinterpret_cast<ebpf_operation_get_object_info_request_t*>(request_buffer.data());
     auto reply = reinterpret_cast<ebpf_operation_get_object_info_reply_t*>(reply_buffer.data());
 
@@ -91,13 +105,20 @@ ebpf_object_get_info(
         memcpy(request->info, info, *info_size);
     }
 
-    ebpf_result_t result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer, reply_buffer));
+    result = win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer, reply_buffer));
     if (result == EBPF_SUCCESS) {
         if (type != nullptr) {
             *type = reply->type;
         }
         if (info != nullptr) {
-            *info_size = reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info);
+            result = ebpf_safe_size_t_subtract(
+                static_cast<size_t>(reply->header.length),
+                EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info),
+                &returned_info_size);
+            if (result != EBPF_SUCCESS) {
+                EBPF_RETURN_RESULT(result);
+            }
+            *info_size = static_cast<uint32_t>(returned_info_size);
             memcpy(info, reply->info, *info_size);
         }
     }

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -21,7 +21,10 @@ const char*
 allocate_string(const std::string& string, uint32_t* length) noexcept
 {
     char* new_string;
-    size_t string_length = string.size() + 1;
+    size_t string_length = 0;
+    if (ebpf_safe_size_t_add(string.size(), 1, &string_length) != EBPF_SUCCESS) {
+        return nullptr;
+    }
     new_string = (char*)ebpf_allocate_with_tag(string_length, EBPF_POOL_TAG_DEFAULT);
     if (new_string != nullptr) {
         strcpy_s(new_string, string_length, string.c_str());

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -36,17 +36,19 @@ allocate_string(const std::string& string, uint32_t* length) noexcept
     return new_string;
 }
 
-std::vector<uint8_t>
-convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions)
+ebpf_result_t
+convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions, std::vector<uint8_t>& byte_code)
 {
     size_t byte_count = 0;
-    if (ebpf_safe_size_t_multiply(instructions.size(), sizeof(ebpf_inst), &byte_count) != EBPF_SUCCESS) {
-        throw std::overflow_error("instruction byte count overflow");
+    ebpf_result_t result = ebpf_safe_size_t_multiply(instructions.size(), sizeof(ebpf_inst), &byte_count);
+    if (result != EBPF_SUCCESS) {
+        return result;
     }
 
-    return {
+    byte_code = {
         reinterpret_cast<const uint8_t*>(instructions.data()),
         reinterpret_cast<const uint8_t*>(instructions.data()) + byte_count};
+    return EBPF_SUCCESS;
 }
 
 int

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -37,6 +37,17 @@ typedef prevail::EbpfInst ebpf_inst;
 // in the order the maps appear in the maps sections.
 const int ORIGINAL_FD_OFFSET = 1;
 
+_Must_inspect_result_ inline ebpf_result_t
+ebpf_safe_size_t_to_uint16(size_t value, _Out_ uint16_t* result) noexcept
+{
+    if (value > static_cast<size_t>(UINT16_MAX)) {
+        return EBPF_ARITHMETIC_OVERFLOW;
+    }
+
+    *result = static_cast<uint16_t>(value);
+    return EBPF_SUCCESS;
+}
+
 inline fd_t
 map_idx_to_original_fd(uint32_t idx)
 {

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -99,8 +99,8 @@ typedef struct _map_cache
 const char*
 allocate_string(const std::string& string, uint32_t* length = nullptr) noexcept;
 
-std::vector<uint8_t>
-convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions);
+ebpf_result_t
+convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions, std::vector<uint8_t>& byte_code);
 
 int
 get_file_size(const char* filename, size_t* byte_code_size) noexcept;

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -354,8 +354,15 @@ _ebpf_store_load_program_information(
             goto Exit;
         }
 
-        ebpf_helper_function_prototype_t* helper_prototype = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(
-            helper_count * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_DEFAULT);
+        size_t helper_prototype_length = 0;
+        ebpf_helper_function_prototype_t* helper_prototype = nullptr;
+        if (ebpf_safe_size_t_multiply(
+                helper_count, sizeof(ebpf_helper_function_prototype_t), &helper_prototype_length) != EBPF_SUCCESS) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Exit;
+        }
+        helper_prototype =
+            (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_prototype_length, EBPF_POOL_TAG_DEFAULT);
         if (helper_prototype == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -363,16 +370,25 @@ _ebpf_store_load_program_information(
         program_information->program_type_specific_helper_prototype = helper_prototype;
 
         // Add space for null terminator.
-        max_helper_name_size += 1;
+        if (cxplat_safe_uint32_t_add(max_helper_name_size, 1, &max_helper_name_size) != CXPLAT_STATUS_SUCCESS) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Exit;
+        }
 
-        helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
+        size_t helper_name_length = 0;
+        if (ebpf_safe_size_t_multiply(max_helper_name_size, sizeof(wchar_t), &helper_name_length) != EBPF_SUCCESS) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Exit;
+        }
+
+        helper_name = (wchar_t*)ebpf_allocate_with_tag(helper_name_length, EBPF_POOL_TAG_DEFAULT);
         if (helper_name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
 
         for (uint32_t index = 0; index < max_helpers_count; index++) {
-            memset(helper_name, 0, (max_helper_name_size) * sizeof(wchar_t));
+            memset(helper_name, 0, helper_name_length);
             key_size = (max_helper_name_size - 1) * sizeof(wchar_t);
             status = RegEnumKeyEx(
                 helper_key, index, helper_name, (unsigned long*)&key_size, nullptr, nullptr, nullptr, nullptr);
@@ -487,7 +503,12 @@ ebpf_store_load_program_data(
 
         if (program_info_array.size() > 0) {
             // Copy the vector data to a new array.
-            auto size = program_info_array.size() * sizeof(ebpf_program_info_t*);
+            size_t size = 0;
+            if (ebpf_safe_size_t_multiply(program_info_array.size(), sizeof(ebpf_program_info_t*), &size) !=
+                EBPF_SUCCESS) {
+                result = EBPF_ARITHMETIC_OVERFLOW;
+                goto Exit;
+            }
             *program_info = (ebpf_program_info_t**)ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT);
             if (*program_info == nullptr) {
                 result = EBPF_NO_MEMORY;
@@ -693,7 +714,12 @@ ebpf_store_load_section_information(
 
         if (section_info_array.size() > 0) {
             // Copy the vector data to a new array.
-            auto size = section_info_array.size() * sizeof(ebpf_section_definition_t*);
+            size_t size = 0;
+            if (ebpf_safe_size_t_multiply(section_info_array.size(), sizeof(ebpf_section_definition_t*), &size) !=
+                EBPF_SUCCESS) {
+                result = EBPF_ARITHMETIC_OVERFLOW;
+                goto Exit;
+            }
             *section_info = (ebpf_section_definition_t**)ebpf_allocate_with_tag(size, EBPF_POOL_TAG_DEFAULT);
             if (*section_info == nullptr) {
                 result = EBPF_NO_MEMORY;
@@ -742,6 +768,8 @@ ebpf_store_load_global_helper_information(
     ebpf_helper_function_prototype_t* helper_prototype = nullptr;
     uint32_t index = 0;
     ebpf_store_key_t store_key = nullptr;
+    size_t helper_name_length = 0;
+    size_t helper_prototype_length = 0;
 
     EBPF_LOG_ENTRY();
 
@@ -795,24 +823,38 @@ ebpf_store_load_global_helper_information(
     }
 
     // Add space for null terminator.
-    max_helper_name_size += 1;
+    if (cxplat_safe_uint32_t_add(max_helper_name_size, 1, &max_helper_name_size) != CXPLAT_STATUS_SUCCESS) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Exit;
+    }
 
-    helper_name = (wchar_t*)ebpf_allocate_with_tag(max_helper_name_size * sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
+    if (ebpf_safe_size_t_multiply(max_helper_name_size, sizeof(wchar_t), &helper_name_length) != EBPF_SUCCESS) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Exit;
+    }
+
+    helper_name = (wchar_t*)ebpf_allocate_with_tag(helper_name_length, EBPF_POOL_TAG_DEFAULT);
     if (helper_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
 
-    helper_prototype = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(
-        max_helpers_count * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_DEFAULT);
+    if (ebpf_safe_size_t_multiply(
+            max_helpers_count, sizeof(ebpf_helper_function_prototype_t), &helper_prototype_length) != EBPF_SUCCESS) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Exit;
+    }
+
+    helper_prototype =
+        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_prototype_length, EBPF_POOL_TAG_DEFAULT);
     if (helper_prototype == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
-    memset(helper_prototype, 0, max_helpers_count * sizeof(ebpf_helper_function_prototype_t));
+    memset(helper_prototype, 0, helper_prototype_length);
 
     for (index = 0; index < max_helpers_count; index++) {
-        memset(helper_name, 0, max_helper_name_size * sizeof(wchar_t));
+        memset(helper_name, 0, helper_name_length);
         key_size = max_helper_name_size;
         status = RegEnumKeyEx(global_helpers_key, index, helper_name, &key_size, nullptr, nullptr, nullptr, nullptr);
         if (status != ERROR_SUCCESS) {

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -569,20 +569,12 @@ _update_global_helpers_for_program_information(
 
         if (program_info->count_of_program_type_specific_helpers > 0) {
             size_t destination_helper_count = 0;
-            size_t helper_copy_size = 0;
             result = ebpf_safe_size_t_subtract(total_helper_count, global_helper_count, &destination_helper_count);
             if (result != EBPF_SUCCESS) {
                 goto Exit;
             }
             if (program_info->count_of_program_type_specific_helpers > destination_helper_count) {
                 result = EBPF_INVALID_ARGUMENT;
-                goto Exit;
-            }
-            result = ebpf_safe_size_t_multiply(
-                program_info->count_of_program_type_specific_helpers,
-                sizeof(ebpf_helper_function_prototype_t),
-                &helper_copy_size);
-            if (result != EBPF_SUCCESS) {
                 goto Exit;
             }
 

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -537,7 +537,11 @@ _update_global_helpers_for_program_information(
             result = EBPF_ARITHMETIC_OVERFLOW;
             goto Exit;
         }
-        total_helper_size = total_helper_count * sizeof(ebpf_helper_function_prototype_t);
+        result = ebpf_safe_size_t_multiply(
+            total_helper_count, sizeof(ebpf_helper_function_prototype_t), &total_helper_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         new_helpers =
             (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(total_helper_size, EBPF_POOL_TAG_DEFAULT);
         if (new_helpers == nullptr) {
@@ -564,10 +568,18 @@ _update_global_helpers_for_program_information(
 #pragma warning(pop)
 
         if (program_info->count_of_program_type_specific_helpers > 0) {
+            size_t helper_copy_size = 0;
+            result = ebpf_safe_size_t_multiply(
+                program_info->count_of_program_type_specific_helpers,
+                sizeof(ebpf_helper_function_prototype_t),
+                &helper_copy_size);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
             memcpy(
                 new_helpers + global_helper_count,
                 program_info->program_type_specific_helper_prototype,
-                (program_info->count_of_program_type_specific_helpers * sizeof(ebpf_helper_function_prototype_t)));
+                helper_copy_size);
             ebpf_free((void*)program_info->program_type_specific_helper_prototype);
         }
 

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -568,7 +568,16 @@ _update_global_helpers_for_program_information(
 #pragma warning(pop)
 
         if (program_info->count_of_program_type_specific_helpers > 0) {
+            size_t destination_helper_count = 0;
             size_t helper_copy_size = 0;
+            result = ebpf_safe_size_t_subtract(total_helper_count, global_helper_count, &destination_helper_count);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+            if (program_info->count_of_program_type_specific_helpers > destination_helper_count) {
+                result = EBPF_INVALID_ARGUMENT;
+                goto Exit;
+            }
             result = ebpf_safe_size_t_multiply(
                 program_info->count_of_program_type_specific_helpers,
                 sizeof(ebpf_helper_function_prototype_t),
@@ -576,10 +585,13 @@ _update_global_helpers_for_program_information(
             if (result != EBPF_SUCCESS) {
                 goto Exit;
             }
-            memcpy(
-                new_helpers + global_helper_count,
-                program_info->program_type_specific_helper_prototype,
-                helper_copy_size);
+
+            ebpf_helper_function_prototype_t* source_helpers =
+                (ebpf_helper_function_prototype_t*)program_info->program_type_specific_helper_prototype;
+            for (size_t i = 0; i < program_info->count_of_program_type_specific_helpers; i++) {
+#pragma warning(suppress : 6385) // Source helper array length matches count_of_program_type_specific_helpers.
+                new_helpers[global_helper_count + i] = source_helpers[i];
+            }
             ebpf_free((void*)program_info->program_type_specific_helper_prototype);
         }
 

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -537,8 +537,8 @@ _update_global_helpers_for_program_information(
             result = EBPF_ARITHMETIC_OVERFLOW;
             goto Exit;
         }
-        result = ebpf_safe_size_t_multiply(
-            total_helper_count, sizeof(ebpf_helper_function_prototype_t), &total_helper_size);
+        result =
+            ebpf_safe_size_t_multiply(total_helper_count, sizeof(ebpf_helper_function_prototype_t), &total_helper_size);
         if (result != EBPF_SUCCESS) {
             goto Exit;
         }

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2452,12 +2452,13 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
      */
     long bytes_written = -1;
     const char* p;
+    const char* output_end = output + strlen(output);
     int specifier_count = 0;
     for (p = output; *p; p++) {
         if (*p != '%') {
             continue;
         }
-        if (p[1] == 0) {
+        if ((p + 1) > output_end) {
             break;
         }
         if (p[1] == '%') {
@@ -2474,9 +2475,10 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
             continue;
         }
 
-        if (p[1] != 'l' || p[2] == 0) {
+        if (((p + 2) > output_end) || (p[1] != 'l')) {
             break;
         }
+#pragma warning(suppress : 6385) // p[2] is guarded by the explicit output_end bounds check above.
         if (strchr(PRINTK_SPECIFIER_CHARS, p[2])) {
             // We found a legal two character specifier.
             p += 2;
@@ -2484,7 +2486,7 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
             continue;
         }
 
-        if (p[2] != 'l' || p[3] == 0) {
+        if (((p + 3) > output_end) || (p[2] != 'l')) {
             break;
         }
         if (strchr(PRINTK_SPECIFIER_CHARS, p[3])) {

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -563,7 +563,11 @@ _ebpf_core_protocol_create_map(
 
     if (request->header.length > EBPF_OFFSET_OF(ebpf_operation_create_map_request_t, data)) {
         map_name.value = (uint8_t*)request->data;
-        map_name.length = ((uint8_t*)request) + request->header.length - ((uint8_t*)request->data);
+        retval = ebpf_safe_size_t_subtract(
+            request->header.length, EBPF_OFFSET_OF(ebpf_operation_create_map_request_t, data), &map_name.length);
+        if (retval != EBPF_SUCCESS) {
+            EBPF_RETURN_RESULT(retval);
+        }
     }
 
     retval = ebpf_core_create_map(&map_name, &request->ebpf_map_definition, request->inner_map_handle, &reply->handle);
@@ -1262,8 +1266,14 @@ _ebpf_core_protocol_query_program_info(
         goto Done;
     }
 
+    uint32_t section_name_offset = 0;
     reply->file_name_offset = EBPF_OFFSET_OF(struct _ebpf_operation_query_program_info_reply, data);
-    reply->section_name_offset = reply->file_name_offset + (uint16_t)file_name.length;
+    retval = ebpf_safe_uint32_t_add(reply->file_name_offset, (uint32_t)file_name.length, &section_name_offset);
+    if ((retval != EBPF_SUCCESS) || (section_name_offset > UINT16_MAX)) {
+        retval = EBPF_ARITHMETIC_OVERFLOW;
+        goto Done;
+    }
+    reply->section_name_offset = (uint16_t)section_name_offset;
 
     memcpy(reply->data, file_name.value, file_name.length);
     memcpy(reply->data + file_name.length, section_name.value, section_name.length);
@@ -1896,8 +1906,13 @@ _ebpf_core_protocol_get_next_pinned_program_path(
     result = ebpf_pinning_table_get_next_path(_ebpf_core_map_pinning_table, &object_type, &start_path, &next_path);
 
     if (result == EBPF_SUCCESS) {
-        reply->header.length =
-            (uint16_t)next_path.length + EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path);
+        size_t required_reply_length = 0;
+        result = ebpf_safe_size_t_add(
+            next_path.length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path), &required_reply_length);
+        if ((result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
+            EBPF_RETURN_RESULT(EBPF_ARITHMETIC_OVERFLOW);
+        }
+        reply->header.length = (uint16_t)required_reply_length;
     }
     EBPF_RETURN_RESULT(result);
 }
@@ -1935,8 +1950,13 @@ _ebpf_core_protocol_get_next_pinned_object_path(
     result = ebpf_pinning_table_get_next_path(_ebpf_core_map_pinning_table, &object_type, &start_path, &next_path);
 
     if (result == EBPF_SUCCESS) {
-        reply->header.length =
-            (uint16_t)next_path.length + EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path);
+        size_t required_reply_length = 0;
+        result = ebpf_safe_size_t_add(
+            next_path.length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path), &required_reply_length);
+        if ((result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
+            EBPF_RETURN_RESULT(EBPF_ARITHMETIC_OVERFLOW);
+        }
+        reply->header.length = (uint16_t)required_reply_length;
         reply->type = object_type;
     }
     EBPF_RETURN_RESULT(result);

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -663,7 +663,12 @@ _ebpf_core_protocol_load_native_programs(
     }
 
     if (count_of_map_handles) {
-        map_handles = ebpf_allocate_with_tag(sizeof(ebpf_handle_t) * count_of_map_handles, EBPF_POOL_TAG_CORE);
+        size_t map_handles_length = 0;
+        result = ebpf_safe_size_t_multiply(sizeof(ebpf_handle_t), count_of_map_handles, &map_handles_length);
+        if (result != EBPF_SUCCESS) {
+            goto Done;
+        }
+        map_handles = ebpf_allocate_with_tag(map_handles_length, EBPF_POOL_TAG_CORE);
         if (map_handles == NULL) {
             result = EBPF_NO_MEMORY;
             goto Done;
@@ -671,7 +676,12 @@ _ebpf_core_protocol_load_native_programs(
     }
 
     if (count_of_program_handles) {
-        program_handles = ebpf_allocate_with_tag(sizeof(ebpf_handle_t) * count_of_program_handles, EBPF_POOL_TAG_CORE);
+        size_t program_handles_length = 0;
+        result = ebpf_safe_size_t_multiply(sizeof(ebpf_handle_t), count_of_program_handles, &program_handles_length);
+        if (result != EBPF_SUCCESS) {
+            goto Done;
+        }
+        program_handles = ebpf_allocate_with_tag(program_handles_length, EBPF_POOL_TAG_CORE);
         if (program_handles == NULL) {
             result = EBPF_NO_MEMORY;
             goto Done;
@@ -812,7 +822,11 @@ _ebpf_core_protocol_map_update_element_batch(
         goto Done;
     }
 
-    key_and_value_length = (size_t)map_definition->key_size + (size_t)map_definition->value_size;
+    retval = ebpf_safe_size_t_add(
+        (size_t)map_definition->key_size, (size_t)map_definition->value_size, &key_and_value_length);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     if (key_and_value_length == 0) {
         retval = EBPF_INVALID_ARGUMENT;
@@ -1627,11 +1641,16 @@ _ebpf_core_protocol_convert_pinning_entries_to_map_info_array(
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_map_info_internal_t* local_map_info = NULL;
     uint16_t index;
-    size_t allocation_size = sizeof(ebpf_map_info_internal_t) * entry_count;
+    size_t allocation_size = 0;
 
     ebpf_assert(map_info);
     ebpf_assert(entry_count);
     ebpf_assert(pinning_entries);
+
+    result = ebpf_safe_size_t_multiply(sizeof(ebpf_map_info_internal_t), entry_count, &allocation_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
 
     local_map_info = (ebpf_map_info_internal_t*)ebpf_allocate_with_tag(allocation_size, EBPF_POOL_TAG_CORE);
     if (local_map_info == NULL) {
@@ -2367,7 +2386,12 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
     }
 
     // Make a copy of the original format string.
-    char* output = (char*)ebpf_allocate_with_tag(fmt_size + 1, EBPF_POOL_TAG_CORE);
+    size_t output_length = 0;
+    if (ebpf_safe_size_t_add(fmt_size, 1, &output_length) != EBPF_SUCCESS) {
+        return -1;
+    }
+
+    char* output = (char*)ebpf_allocate_with_tag(output_length, EBPF_POOL_TAG_CORE);
     if (output == NULL) {
         return -1;
     }

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1627,10 +1627,11 @@ _ebpf_core_protocol_get_program_info(
         program_info, reply->data, serialization_buffer_size, &reply->size, &required_length);
 
     if (retval != EBPF_SUCCESS) {
+        ebpf_result_t length_result;
         size_t required_reply_length = 0;
-        retval = ebpf_safe_size_t_add(
+        length_result = ebpf_safe_size_t_add(
             required_length, EBPF_OFFSET_OF(ebpf_operation_get_program_info_reply_t, data), &required_reply_length);
-        if ((retval != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
+        if ((length_result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
             reply->header.length = UINT16_MAX;
         } else {
             reply->header.length = (uint16_t)required_reply_length;
@@ -1720,12 +1721,13 @@ _ebpf_core_protocol_serialize_map_info_reply(
         &required_serialization_length);
 
     if (result != EBPF_SUCCESS) {
+        ebpf_result_t length_result;
         size_t required_reply_length = 0;
-        result = ebpf_safe_size_t_add(
+        length_result = ebpf_safe_size_t_add(
             required_serialization_length,
             EBPF_OFFSET_OF(ebpf_operation_get_pinned_map_info_reply_t, data),
             &required_reply_length);
-        if ((result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
+        if ((length_result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
             map_info_reply->header.length = UINT16_MAX;
         } else {
             map_info_reply->header.length = (uint16_t)required_reply_length;
@@ -2458,7 +2460,7 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
         if (*p != '%') {
             continue;
         }
-        if ((p + 1) > output_end) {
+        if ((p + 1) >= output_end) {
             break;
         }
         if (p[1] == '%') {
@@ -2475,7 +2477,7 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
             continue;
         }
 
-        if (((p + 2) > output_end) || (p[1] != 'l')) {
+        if (((p + 2) >= output_end) || (p[1] != 'l')) {
             break;
         }
 #pragma warning(suppress : 6385) // p[2] is guarded by the explicit output_end bounds check above.
@@ -2486,7 +2488,7 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, i
             continue;
         }
 
-        if (((p + 3) > output_end) || (p[2] != 'l')) {
+        if (((p + 3) >= output_end) || (p[2] != 'l')) {
             break;
         }
         if (strchr(PRINTK_SPECIFIER_CHARS, p[3])) {

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1627,8 +1627,14 @@ _ebpf_core_protocol_get_program_info(
         program_info, reply->data, serialization_buffer_size, &reply->size, &required_length);
 
     if (retval != EBPF_SUCCESS) {
-        reply->header.length =
-            (uint16_t)(required_length + EBPF_OFFSET_OF(ebpf_operation_get_program_info_reply_t, data));
+        size_t required_reply_length = 0;
+        retval = ebpf_safe_size_t_add(
+            required_length, EBPF_OFFSET_OF(ebpf_operation_get_program_info_reply_t, data), &required_reply_length);
+        if ((retval != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
+            reply->header.length = UINT16_MAX;
+        } else {
+            reply->header.length = (uint16_t)required_reply_length;
+        }
         goto Done;
     }
 
@@ -1714,8 +1720,16 @@ _ebpf_core_protocol_serialize_map_info_reply(
         &required_serialization_length);
 
     if (result != EBPF_SUCCESS) {
-        map_info_reply->header.length = (uint16_t)(required_serialization_length +
-                                                   EBPF_OFFSET_OF(ebpf_operation_get_pinned_map_info_reply_t, data));
+        size_t required_reply_length = 0;
+        result = ebpf_safe_size_t_add(
+            required_serialization_length,
+            EBPF_OFFSET_OF(ebpf_operation_get_pinned_map_info_reply_t, data),
+            &required_reply_length);
+        if ((result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
+            map_info_reply->header.length = UINT16_MAX;
+        } else {
+            map_info_reply->header.length = (uint16_t)required_reply_length;
+        }
     } else {
         map_info_reply->map_count = map_count;
     }
@@ -1908,7 +1922,9 @@ _ebpf_core_protocol_get_next_pinned_program_path(
     if (result == EBPF_SUCCESS) {
         size_t required_reply_length = 0;
         result = ebpf_safe_size_t_add(
-            next_path.length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path), &required_reply_length);
+            next_path.length,
+            EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_program_path_reply_t, next_path),
+            &required_reply_length);
         if ((result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
             EBPF_RETURN_RESULT(EBPF_ARITHMETIC_OVERFLOW);
         }
@@ -1952,7 +1968,9 @@ _ebpf_core_protocol_get_next_pinned_object_path(
     if (result == EBPF_SUCCESS) {
         size_t required_reply_length = 0;
         result = ebpf_safe_size_t_add(
-            next_path.length, EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path), &required_reply_length);
+            next_path.length,
+            EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_object_path_reply_t, next_path),
+            &required_reply_length);
         if ((result != EBPF_SUCCESS) || (required_reply_length > UINT16_MAX)) {
             EBPF_RETURN_RESULT(EBPF_ARITHMETIC_OVERFLOW);
         }
@@ -2395,7 +2413,7 @@ _ebpf_core_is_current_admin(_In_ const void* ctx)
 static long
 _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size, int arg_count, ...)
 {
-    if (fmt_size > MAX_PRINTK_STRING_SIZE - 1) {
+    if ((fmt_size < 2) || (fmt_size > MAX_PRINTK_STRING_SIZE - 1)) {
         // Disallow large fmt_size values.
         return -1;
     }

--- a/libs/execution_context/ebpf_core_jit.c
+++ b/libs/execution_context/ebpf_core_jit.c
@@ -83,9 +83,19 @@ ebpf_core_protocol_create_program(
     file_name = (uint8_t*)request->data;
     section_name = ((uint8_t*)request) + request->section_name_offset;
     program_name = ((uint8_t*)request) + request->program_name_offset;
-    file_name_length = section_name - file_name;
-    section_name_length = program_name - section_name;
-    program_name_length = ((uint8_t*)request) + request->header.length - program_name;
+    retval = ebpf_safe_size_t_subtract(
+        request->section_name_offset, EBPF_OFFSET_OF(ebpf_operation_create_program_request_t, data), &file_name_length);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+    retval = ebpf_safe_size_t_subtract(request->program_name_offset, request->section_name_offset, &section_name_length);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+    retval = ebpf_safe_size_t_subtract(request->header.length, request->program_name_offset, &program_name_length);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     parameters.program_type = request->program_type;
     parameters.program_name.value = program_name;
@@ -180,8 +190,17 @@ ebpf_core_protocol_resolve_map(
         goto Done;
     }
     uint32_t count_of_maps = (uint32_t)(map_handle_length / sizeof(request->map_handle[0]));
-    size_t required_reply_length =
-        EBPF_OFFSET_OF(ebpf_operation_resolve_map_reply_t, address) + count_of_maps * sizeof(reply->address[0]);
+    size_t map_address_array_length = 0;
+    size_t required_reply_length = 0;
+    return_value = ebpf_safe_size_t_multiply(count_of_maps, sizeof(reply->address[0]), &map_address_array_length);
+    if (return_value != EBPF_SUCCESS) {
+        goto Done;
+    }
+    return_value = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_operation_resolve_map_reply_t, address), map_address_array_length, &required_reply_length);
+    if (return_value != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     if (reply_length < required_reply_length) {
         return EBPF_INVALID_ARGUMENT;

--- a/libs/execution_context/ebpf_core_jit.c
+++ b/libs/execution_context/ebpf_core_jit.c
@@ -88,7 +88,8 @@ ebpf_core_protocol_create_program(
     if (retval != EBPF_SUCCESS) {
         goto Done;
     }
-    retval = ebpf_safe_size_t_subtract(request->program_name_offset, request->section_name_offset, &section_name_length);
+    retval =
+        ebpf_safe_size_t_subtract(request->program_name_offset, request->section_name_offset, &section_name_length);
     if (retval != EBPF_SUCCESS) {
         goto Done;
     }

--- a/libs/execution_context/ebpf_core_jit.c
+++ b/libs/execution_context/ebpf_core_jit.c
@@ -113,14 +113,25 @@ ebpf_core_protocol_resolve_helper(
     uint32_t* request_helper_ids = NULL;
     size_t required_reply_length = 0;
     size_t helper_id_length;
+    size_t helper_addresses_length = 0;
+    size_t request_helper_ids_length = 0;
     ebpf_result_t return_value = ebpf_safe_size_t_subtract(
         request->header.length, EBPF_OFFSET_OF(ebpf_operation_resolve_helper_request_t, helper_id), &helper_id_length);
     if (return_value != EBPF_SUCCESS) {
         goto Done;
     }
     size_t count_of_helpers = helper_id_length / sizeof(request->helper_id[0]);
-    required_reply_length =
-        EBPF_OFFSET_OF(ebpf_operation_resolve_helper_reply_t, address) + count_of_helpers * sizeof(reply->address[0]);
+    return_value = ebpf_safe_size_t_multiply(count_of_helpers, sizeof(reply->address[0]), &helper_addresses_length);
+    if (return_value != EBPF_SUCCESS) {
+        goto Done;
+    }
+    return_value = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_operation_resolve_helper_reply_t, address),
+        helper_addresses_length,
+        &required_reply_length);
+    if (return_value != EBPF_SUCCESS) {
+        goto Done;
+    }
     size_t helper_index;
 
     if (reply_length < required_reply_length) {
@@ -129,7 +140,11 @@ ebpf_core_protocol_resolve_helper(
     }
 
     if (count_of_helpers != 0) {
-        request_helper_ids = (uint32_t*)ebpf_allocate_with_tag(count_of_helpers * sizeof(uint32_t), EBPF_POOL_TAG_CORE);
+        return_value = ebpf_safe_size_t_multiply(count_of_helpers, sizeof(uint32_t), &request_helper_ids_length);
+        if (return_value != EBPF_SUCCESS) {
+            goto Done;
+        }
+        request_helper_ids = (uint32_t*)ebpf_allocate_with_tag(request_helper_ids_length, EBPF_POOL_TAG_CORE);
         if (request_helper_ids == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Done;

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2302,8 +2302,16 @@ _create_queue_map(
     if (inner_map_handle != ebpf_handle_invalid || map_definition->key_size != 0) {
         return EBPF_INVALID_ARGUMENT;
     }
-    size_t circular_map_size =
-        EBPF_OFFSET_OF(ebpf_core_circular_map_t, slots) + map_definition->max_entries * sizeof(uint8_t*);
+    size_t circular_map_size = 0;
+    result = ebpf_safe_size_t_multiply(map_definition->max_entries, sizeof(uint8_t*), &circular_map_size);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+    result =
+        ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_core_circular_map_t, slots), circular_map_size, &circular_map_size);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
     result = _create_array_map_with_map_struct_size(circular_map_size, map_definition, 0, map);
     if (result == EBPF_SUCCESS) {
         ebpf_core_circular_map_t* circular_map = EBPF_FROM_FIELD(ebpf_core_circular_map_t, core_map, *map);
@@ -2322,8 +2330,16 @@ _create_stack_map(
     if (inner_map_handle != ebpf_handle_invalid || map_definition->key_size != 0) {
         return EBPF_INVALID_ARGUMENT;
     }
-    size_t circular_map_size =
-        EBPF_OFFSET_OF(ebpf_core_circular_map_t, slots) + map_definition->max_entries * sizeof(uint8_t*);
+    size_t circular_map_size = 0;
+    result = ebpf_safe_size_t_multiply(map_definition->max_entries, sizeof(uint8_t*), &circular_map_size);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+    result =
+        ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_core_circular_map_t, slots), circular_map_size, &circular_map_size);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
     result = _create_array_map_with_map_struct_size(circular_map_size, map_definition, 0, map);
     if (result == EBPF_SUCCESS) {
         ebpf_core_circular_map_t* circular_map = EBPF_FROM_FIELD(ebpf_core_circular_map_t, core_map, *map);
@@ -3110,8 +3126,16 @@ _create_perf_event_array_map(
         goto Exit;
     }
 
-    size_t perf_event_array_map_size =
-        EBPF_OFFSET_OF(ebpf_core_perf_event_array_map_t, rings) + cpu_count * sizeof(ebpf_core_perf_ring_t);
+    size_t perf_event_array_map_size = 0;
+    result = ebpf_safe_size_t_multiply(cpu_count, sizeof(ebpf_core_perf_ring_t), &perf_event_array_map_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    result = ebpf_safe_size_t_add(
+        EBPF_OFFSET_OF(ebpf_core_perf_event_array_map_t, rings), perf_event_array_map_size, &perf_event_array_map_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
 
     perf_event_array_map = ebpf_epoch_allocate_with_tag(perf_event_array_map_size, EBPF_POOL_TAG_MAP);
     if (perf_event_array_map == NULL) {
@@ -4168,8 +4192,17 @@ ebpf_map_get_next_key_and_value_batch(
 
     // Copy as many key/value pairs as we can fit in the output buffer.
     for (;;) {
+        size_t record_length = 0;
+        size_t value_offset = 0;
+
+        result = ebpf_safe_size_t_add(key_size, value_size, &record_length);
+        if (result != EBPF_SUCCESS) {
+            break;
+        }
+
         // Check if we have enough space to write the next key and value.
-        if ((output_length + key_size + value_size) > maximum_output_length) {
+        result = ebpf_safe_size_t_add(output_length, record_length, &value_offset);
+        if (result != EBPF_SUCCESS || value_offset > maximum_output_length) {
             // Output buffer is full.
             break;
         }
@@ -4183,12 +4216,17 @@ ebpf_map_get_next_key_and_value_batch(
             break;
         }
 
+        result = ebpf_safe_size_t_add(output_length, key_size, &value_offset);
+        if (result != EBPF_SUCCESS) {
+            break;
+        }
+
         if (IS_NESTED_MAP(map->ebpf_map_definition.type)) {
             // Get the ID from the object.
             ebpf_core_object_t* object = (ebpf_core_object_t*)ReadULong64NoFence((volatile const uint64_t*)next_value);
-            *(uint32_t*)(key_and_value + output_length + key_size) = object ? object->id : 0;
+            *(uint32_t*)(key_and_value + value_offset) = object ? object->id : 0;
         } else {
-            memcpy(key_and_value + output_length + key_size, next_value, value_size);
+            memcpy(key_and_value + value_offset, next_value, value_size);
         }
 
         if ((flags & EBPF_MAP_FIND_FLAG_DELETE) && (previous_key != NULL)) {
@@ -4204,7 +4242,10 @@ ebpf_map_get_next_key_and_value_batch(
         previous_key = key_and_value + output_length;
 
         // Advance the output buffer pointer.
-        output_length += key_size + value_size;
+        result = ebpf_safe_size_t_add(value_offset, value_size, &output_length);
+        if (result != EBPF_SUCCESS) {
+            break;
+        }
     }
 
     if (result == EBPF_NO_MORE_KEYS && output_length != 0) {

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2171,7 +2171,9 @@ _create_lpm_map(
     ebpf_result_t result = EBPF_SUCCESS;
     // Key is uint32_t prefix length plus space for a max length prefix.
     // - Only the prefix length plus prefix_length bits are actually used in an lpm key.
-    size_t max_prefix_length = (map_definition->key_size - sizeof(uint32_t)) * 8;
+    size_t key_suffix_size = 0;
+    size_t max_prefix_length = 0;
+    size_t prefix_length_bit_count = 0;
     size_t prefix_bitmap_size = 0;
     size_t lpm_data_size = 0;
     ebpf_core_lpm_map_t* lpm_map = NULL;
@@ -2185,7 +2187,25 @@ _create_lpm_map(
         goto Exit;
     }
 
-    prefix_bitmap_size = ebpf_bitmap_size(max_prefix_length + 1);
+    if (map_definition->key_size < sizeof(uint32_t)) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    result = ebpf_safe_size_t_subtract(map_definition->key_size, sizeof(uint32_t), &key_suffix_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    result = ebpf_safe_size_t_multiply(key_suffix_size, 8, &max_prefix_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    result = ebpf_safe_size_t_add(max_prefix_length, 1, &prefix_length_bit_count);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
+    prefix_bitmap_size = ebpf_bitmap_size(prefix_length_bit_count);
     if (prefix_bitmap_size == MAXSIZE_T) {
         result = EBPF_ARITHMETIC_OVERFLOW;
         goto Exit;
@@ -2210,7 +2230,7 @@ _create_lpm_map(
     }
     lpm_map->max_prefix = (uint32_t)max_prefix_length;
     // Add one to max_prefix_length to account for max length prefixes in the prefix_length bitmap.
-    result = ebpf_bitmap_initialize((ebpf_bitmap_t*)lpm_map->data, max_prefix_length + 1);
+    result = ebpf_bitmap_initialize((ebpf_bitmap_t*)lpm_map->data, prefix_length_bit_count);
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1609,9 +1609,20 @@ _create_lru_hash_map(
 
     // Align the supplemental value to 8 byte boundary.
     // Pad value_size to next 8 byte boundary and subtract the value_size to get the padding.
+    size_t padded_value_size = 0;
+    size_t value_padding = 0;
     size_t supplemental_value_size;
+    retval = ebpf_safe_size_t_add(map_definition->value_size, 7, &padded_value_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    padded_value_size &= ~((size_t)7);
+    retval = ebpf_safe_size_t_subtract(padded_value_size, map_definition->value_size, &value_padding);
+    if (retval != EBPF_SUCCESS) {
+        goto Exit;
+    }
     retval = ebpf_safe_size_t_add(
-        lru_entry_size, EBPF_PAD_8(map_definition->value_size) - map_definition->value_size, &supplemental_value_size);
+        lru_entry_size, value_padding, &supplemental_value_size);
     if (retval != EBPF_SUCCESS) {
         goto Exit;
     }
@@ -3276,7 +3287,12 @@ ebpf_perf_event_array_map_output_with_capture(
     ebpf_core_perf_ring_t* ring = &perf_event_array_map->rings[cpu_id];
 
     uint8_t* record_data;
-    result = ebpf_ring_buffer_reserve_exclusive(ring->ring, &record_data, length + extra_length);
+    size_t total_length = 0;
+    result = ebpf_safe_size_t_add(length, extra_length, &total_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    result = ebpf_ring_buffer_reserve_exclusive(ring->ring, &record_data, total_length);
     if (result != EBPF_SUCCESS) {
         // Non-atomic increment is safe: per-CPU counter updated at DISPATCH_LEVEL.
         ebpf_perf_event_array_producer_page_t* producer_page = ebpf_perf_event_array_get_producer_page(ring->ring);
@@ -4041,7 +4057,9 @@ ebpf_map_get_info(
     ebpf_assert(sizeof(info->name) >= map->name.length);
     strncpy_s(info->name, sizeof(info->name), (char*)map->name.value, map->name.length);
     if (map->name.length < sizeof(info->name)) {
-        memset(info->name + map->name.length, 0, sizeof(info->name) - map->name.length);
+        size_t remaining_name_length = 0;
+        ebpf_assert_success(ebpf_safe_size_t_subtract(sizeof(info->name), map->name.length, &remaining_name_length));
+        memset(info->name + map->name.length, 0, remaining_name_length);
     }
 
     // Copy the local map info to the user supplied buffer, as much as will fit.

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -714,7 +714,14 @@ _update_array_map_entry(
         return EBPF_INVALID_ARGUMENT;
     }
 
-    uint8_t* entry = &map->data[key_value * map->ebpf_map_definition.value_size];
+    size_t entry_offset = 0;
+    ebpf_result_t result =
+        ebpf_safe_size_t_multiply((size_t)key_value, map->ebpf_map_definition.value_size, &entry_offset);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+
+    uint8_t* entry = &map->data[entry_offset];
     if (data) {
         memcpy(entry, data, map->ebpf_map_definition.value_size);
     } else {
@@ -1601,12 +1608,6 @@ _create_lru_hash_map(
 
     size_t lru_entry_size = EBPF_LRU_ENTRY_SIZE(partition_count, map_definition->key_size);
 
-    // Add the key size to the entry size.
-    retval = ebpf_safe_size_t_add(lru_entry_size, map_definition->key_size, &lru_entry_size);
-    if (retval != EBPF_SUCCESS) {
-        goto Exit;
-    }
-
     // Align the supplemental value to 8 byte boundary.
     // Pad value_size to next 8 byte boundary and subtract the value_size to get the padding.
     size_t padded_value_size = 0;
@@ -1621,8 +1622,7 @@ _create_lru_hash_map(
     if (retval != EBPF_SUCCESS) {
         goto Exit;
     }
-    retval = ebpf_safe_size_t_add(
-        lru_entry_size, value_padding, &supplemental_value_size);
+    retval = ebpf_safe_size_t_add(lru_entry_size, value_padding, &supplemental_value_size);
     if (retval != EBPF_SUCCESS) {
         goto Exit;
     }
@@ -3682,7 +3682,19 @@ ebpf_map_create(
     }
 
     if (properties->per_cpu) {
-        local_map_definition.value_size = cpu_count * EBPF_PAD_8(local_map_definition.value_size);
+        size_t padded_value_size = 0;
+        size_t per_cpu_value_size = 0;
+        result = ebpf_safe_size_t_add(local_map_definition.value_size, 7, &padded_value_size);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+        padded_value_size &= ~((size_t)7);
+        result = ebpf_safe_size_t_multiply(cpu_count, padded_value_size, &per_cpu_value_size);
+        if ((result != EBPF_SUCCESS) || (per_cpu_value_size > UINT32_MAX)) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Exit;
+        }
+        local_map_definition.value_size = (uint32_t)per_cpu_value_size;
     }
 
     if (map_name->length >= BPF_OBJ_NAME_LEN) {

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2172,6 +2172,8 @@ _create_lpm_map(
     // Key is uint32_t prefix length plus space for a max length prefix.
     // - Only the prefix length plus prefix_length bits are actually used in an lpm key.
     size_t max_prefix_length = (map_definition->key_size - sizeof(uint32_t)) * 8;
+    size_t prefix_bitmap_size = 0;
+    size_t lpm_data_size = 0;
     ebpf_core_lpm_map_t* lpm_map = NULL;
 
     EBPF_LOG_ENTRY();
@@ -2183,8 +2185,18 @@ _create_lpm_map(
         goto Exit;
     }
 
+    prefix_bitmap_size = ebpf_bitmap_size(max_prefix_length + 1);
+    if (prefix_bitmap_size == MAXSIZE_T) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Exit;
+    }
+    result = ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_core_lpm_map_t, data), prefix_bitmap_size, &lpm_data_size);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
     result = _create_hash_map_internal(
-        EBPF_OFFSET_OF(ebpf_core_lpm_map_t, data) + ebpf_bitmap_size(max_prefix_length + 1),
+        lpm_data_size,
         map_definition,
         0,
         0,
@@ -2198,7 +2210,10 @@ _create_lpm_map(
     }
     lpm_map->max_prefix = (uint32_t)max_prefix_length;
     // Add one to max_prefix_length to account for max length prefixes in the prefix_length bitmap.
-    ebpf_bitmap_initialize((ebpf_bitmap_t*)lpm_map->data, max_prefix_length + 1);
+    result = ebpf_bitmap_initialize((ebpf_bitmap_t*)lpm_map->data, max_prefix_length + 1);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
 
     *map = &lpm_map->core_map;
 

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1429,8 +1429,14 @@ _ebpf_native_initialize_global_variables(
     }
 
     // Initialize global variables data.
+    size_t global_variable_section_data_length = 0;
+    result = ebpf_safe_size_t_multiply(
+        global_variable_count, sizeof(global_variable_section_data_t), &global_variable_section_data_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
     program->runtime_context.global_variable_section_data = (global_variable_section_data_t*)ebpf_allocate_with_tag(
-        global_variable_count * sizeof(global_variable_section_data_t), EBPF_POOL_TAG_NATIVE);
+        global_variable_section_data_length, EBPF_POOL_TAG_NATIVE);
     if (program->runtime_context.global_variable_section_data == NULL) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
@@ -1492,8 +1498,12 @@ _ebpf_native_create_maps(_Inout_ ebpf_native_module_instance_t* instance)
         EBPF_RETURN_RESULT(EBPF_SUCCESS);
     }
 
-    instance->maps =
-        (ebpf_native_map_t*)ebpf_allocate_with_tag(map_count * sizeof(ebpf_native_map_t), EBPF_POOL_TAG_NATIVE);
+    size_t native_map_array_length = 0;
+    result = ebpf_safe_size_t_multiply(map_count, sizeof(ebpf_native_map_t), &native_map_array_length);
+    if (result != EBPF_SUCCESS) {
+        EBPF_RETURN_RESULT(result);
+    }
+    instance->maps = (ebpf_native_map_t*)ebpf_allocate_with_tag(native_map_array_length, EBPF_POOL_TAG_NATIVE);
     if (instance->maps == NULL) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
@@ -1602,13 +1612,23 @@ _ebpf_native_resolve_maps_for_program(
         }
     }
 
-    map_handles = ebpf_allocate_with_tag(map_count * sizeof(ebpf_handle_t), EBPF_POOL_TAG_NATIVE);
+    size_t map_handles_length = 0;
+    result = ebpf_safe_size_t_multiply(map_count, sizeof(ebpf_handle_t), &map_handles_length);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    map_handles = ebpf_allocate_with_tag(map_handles_length, EBPF_POOL_TAG_NATIVE);
     if (map_handles == NULL) {
         result = EBPF_NO_MEMORY;
         goto Done;
     }
 
-    map_addresses = ebpf_allocate_with_tag(map_count * sizeof(uintptr_t), EBPF_POOL_TAG_NATIVE);
+    size_t map_addresses_length = 0;
+    result = ebpf_safe_size_t_multiply(map_count, sizeof(uintptr_t), &map_addresses_length);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    map_addresses = ebpf_allocate_with_tag(map_addresses_length, EBPF_POOL_TAG_NATIVE);
     if (map_addresses == NULL) {
         result = EBPF_NO_MEMORY;
         goto Done;
@@ -1649,14 +1669,23 @@ _ebpf_native_resolve_helpers_for_program(
     bool implicit_context_supported = false;
 
     if (helper_count > 0) {
-        helper_ids = ebpf_allocate_with_tag(helper_count * sizeof(uint32_t), EBPF_POOL_TAG_NATIVE);
+        size_t helper_ids_length = 0;
+        size_t helper_addresses_length = 0;
+        result = ebpf_safe_size_t_multiply(helper_count, sizeof(uint32_t), &helper_ids_length);
+        if (result != EBPF_SUCCESS) {
+            goto Done;
+        }
+        helper_ids = ebpf_allocate_with_tag(helper_ids_length, EBPF_POOL_TAG_NATIVE);
         if (helper_ids == NULL) {
             result = EBPF_NO_MEMORY;
             goto Done;
         }
 
-        helper_addresses =
-            ebpf_allocate_with_tag(helper_count * sizeof(helper_function_address_t), EBPF_POOL_TAG_NATIVE);
+        result = ebpf_safe_size_t_multiply(helper_count, sizeof(helper_function_address_t), &helper_addresses_length);
+        if (result != EBPF_SUCCESS) {
+            goto Done;
+        }
+        helper_addresses = ebpf_allocate_with_tag(helper_addresses_length, EBPF_POOL_TAG_NATIVE);
         if (helper_addresses == NULL) {
             result = EBPF_NO_MEMORY;
             goto Done;
@@ -1742,8 +1771,14 @@ _ebpf_native_initialize_programs(_Inout_ ebpf_native_module_instance_t* instance
         // versioned sub-struct.
         if (native_program->program_entry.helper_count > 0) {
             const helper_function_entry_t* helper_info = native_program->program_entry.helpers;
-            native_program->program_entry.helpers = (helper_function_entry_t*)ebpf_allocate_with_tag(
-                native_program->program_entry.helper_count * sizeof(helper_function_entry_t), EBPF_POOL_TAG_NATIVE);
+            size_t helper_info_length = 0;
+            result = ebpf_safe_size_t_multiply(
+                native_program->program_entry.helper_count, sizeof(helper_function_entry_t), &helper_info_length);
+            if (result != EBPF_SUCCESS) {
+                goto Done;
+            }
+            native_program->program_entry.helpers =
+                (helper_function_entry_t*)ebpf_allocate_with_tag(helper_info_length, EBPF_POOL_TAG_NATIVE);
             if (native_program->program_entry.helpers == NULL) {
                 result = EBPF_NO_MEMORY;
                 goto Done;
@@ -1783,8 +1818,12 @@ _ebpf_native_load_programs(_Inout_ ebpf_native_module_instance_t* instance)
         EBPF_RETURN_RESULT(EBPF_SUCCESS);
     }
 
-    instance->programs = (ebpf_native_program_t**)ebpf_allocate_with_tag(
-        program_count * sizeof(ebpf_native_program_t*), EBPF_POOL_TAG_NATIVE);
+    size_t native_programs_length = 0;
+    result = ebpf_safe_size_t_multiply(program_count, sizeof(ebpf_native_program_t*), &native_programs_length);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+    instance->programs = (ebpf_native_program_t**)ebpf_allocate_with_tag(native_programs_length, EBPF_POOL_TAG_NATIVE);
     if (instance->programs == NULL) {
         return EBPF_NO_MEMORY;
     }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1025,7 +1025,7 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t
     // Before we acquire any references, make sure
     // all maps can be associated.
     for (index = 0; index < maps_count; index++) {
-        ebpf_map_t* map = program_maps[index];
+        ebpf_map_t* map = maps[index];
         result = ebpf_map_associate_program(map, program);
         if (result != EBPF_SUCCESS) {
             goto Done;
@@ -1045,7 +1045,7 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t
     program_maps = NULL;
     program->count_of_maps = maps_count;
     for (index = 0; index < maps_count; index++) {
-        EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)program->maps[index]);
+        EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)maps[index]);
     }
     ebpf_lock_unlock(&program->lock, state);
 

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -961,17 +961,29 @@ ebpf_program_associate_additional_map(ebpf_program_t* program, ebpf_map_t* map)
 
     ebpf_lock_state_t state = ebpf_lock_lock(&program->lock);
 
-    uint32_t map_count = program->count_of_maps + 1;
+    uint32_t map_count = 0;
     ebpf_map_t** program_maps;
+    size_t old_map_size = 0;
+    size_t new_map_size = 0;
+    result = ebpf_safe_size_t_add(program->count_of_maps, 1, &new_map_size);
+    if (result != EBPF_SUCCESS || new_map_size > UINT32_MAX) {
+        ebpf_lock_unlock(&program->lock, state);
+        EBPF_RETURN_RESULT(result != EBPF_SUCCESS ? result : EBPF_ARITHMETIC_OVERFLOW);
+    }
+    map_count = (uint32_t)new_map_size;
+    result = ebpf_safe_size_t_multiply(program->count_of_maps, sizeof(ebpf_map_t*), &old_map_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    result = ebpf_safe_size_t_multiply(map_count, sizeof(ebpf_map_t*), &new_map_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
     if (program->maps) {
         program_maps = ebpf_reallocate(
-            program->maps,
-            CXPLAT_POOL_FLAG_NON_PAGED,
-            program->count_of_maps * sizeof(ebpf_map_t*),
-            map_count * sizeof(ebpf_map_t*),
-            EBPF_POOL_TAG_PROGRAM);
+            program->maps, CXPLAT_POOL_FLAG_NON_PAGED, old_map_size, new_map_size, EBPF_POOL_TAG_PROGRAM);
     } else {
-        program_maps = ebpf_allocate_with_tag(map_count * sizeof(ebpf_map_t*), EBPF_POOL_TAG_PROGRAM);
+        program_maps = ebpf_allocate_with_tag(new_map_size, EBPF_POOL_TAG_PROGRAM);
     }
     if (program_maps == NULL) {
         result = EBPF_NO_MEMORY;
@@ -993,16 +1005,22 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count)
 {
     ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_map_t** program_maps = NULL;
     EBPF_LOG_ENTRY();
 
     size_t index;
-    ebpf_map_t** program_maps = ebpf_allocate_with_tag(maps_count * sizeof(ebpf_map_t*), EBPF_POOL_TAG_PROGRAM);
+    size_t program_maps_length = 0;
+    result = ebpf_safe_size_t_multiply(maps_count, sizeof(ebpf_map_t*), &program_maps_length);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    program_maps = ebpf_allocate_with_tag(program_maps_length, EBPF_POOL_TAG_PROGRAM);
     if (!program_maps) {
         result = EBPF_NO_MEMORY;
         goto Done;
     }
 
-    memcpy(program_maps, maps, sizeof(ebpf_map_t*) * maps_count);
+    memcpy(program_maps, maps, program_maps_length);
 
     // Before we acquire any references, make sure
     // all maps can be associated.
@@ -1109,8 +1127,13 @@ _Requires_lock_held_(program->lock) static ebpf_result_t _ebpf_program_update_he
         // We _can_ have instances of ebpf programs that do not need to call any helper functions.
         // Such programs are valid and the 'program->helper_function_count' member for such programs will be 0 (Zero).
         if (program->helper_function_count) {
-            helper_function_addresses = ebpf_allocate_with_tag(
-                program->helper_function_count * sizeof(helper_function_address_t), EBPF_POOL_TAG_PROGRAM);
+            size_t helper_function_addresses_length = 0;
+            result = ebpf_safe_size_t_multiply(
+                program->helper_function_count, sizeof(helper_function_address_t), &helper_function_addresses_length);
+            if (result != EBPF_SUCCESS) {
+                goto Done;
+            }
+            helper_function_addresses = ebpf_allocate_with_tag(helper_function_addresses_length, EBPF_POOL_TAG_PROGRAM);
             if (helper_function_addresses == NULL) {
                 result = EBPF_NO_MEMORY;
                 goto Done;
@@ -1244,8 +1267,13 @@ _ebpf_program_update_jit_helpers(
             goto Exit;
         }
         total_helper_function_addresses->helper_function_count = (uint32_t)total_helper_count;
+        size_t helper_function_address_length = 0;
+        return_value = ebpf_safe_size_t_multiply(sizeof(uint64_t), total_helper_count, &helper_function_address_length);
+        if (return_value != EBPF_SUCCESS) {
+            goto Exit;
+        }
         total_helper_function_addresses->helper_function_address =
-            (uint64_t*)ebpf_allocate_with_tag(sizeof(uint64_t) * total_helper_count, EBPF_POOL_TAG_DEFAULT);
+            (uint64_t*)ebpf_allocate_with_tag(helper_function_address_length, EBPF_POOL_TAG_DEFAULT);
         if (total_helper_function_addresses->helper_function_address == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
@@ -1260,8 +1288,12 @@ _ebpf_program_update_jit_helpers(
         }
 
         __analysis_assume(total_helper_count > 0);
-        total_helper_function_ids =
-            (uint32_t*)ebpf_allocate_with_tag(sizeof(uint32_t) * total_helper_count, EBPF_POOL_TAG_DEFAULT);
+        size_t helper_function_id_length = 0;
+        return_value = ebpf_safe_size_t_multiply(sizeof(uint32_t), total_helper_count, &helper_function_id_length);
+        if (return_value != EBPF_SUCCESS) {
+            goto Exit;
+        }
+        total_helper_function_ids = (uint32_t*)ebpf_allocate_with_tag(helper_function_id_length, EBPF_POOL_TAG_DEFAULT);
         if (total_helper_function_ids == NULL) {
             return_value = EBPF_NO_MEMORY;
             goto Exit;
@@ -1394,11 +1426,13 @@ _Requires_lock_held_(program->lock) static ebpf_result_t _ebpf_program_load_byte
         goto Done;
     }
 
-    if (ubpf_load(
-            program->code_or_vm.vm,
-            instructions,
-            (uint32_t)(instruction_count * sizeof(ebpf_instruction_t)),
-            &error_message) != 0) {
+    size_t instruction_bytes = 0;
+    return_value = ebpf_safe_size_t_multiply(instruction_count, sizeof(ebpf_instruction_t), &instruction_bytes);
+    if (return_value != EBPF_SUCCESS || instruction_bytes > UINT32_MAX) {
+        return_value = return_value != EBPF_SUCCESS ? return_value : EBPF_ARITHMETIC_OVERFLOW;
+        goto Done;
+    }
+    if (ubpf_load(program->code_or_vm.vm, instructions, (uint32_t)instruction_bytes, &error_message) != 0) {
         EBPF_LOG_MESSAGE_STRING(
             EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_PROGRAM, "ubpf_load failed", error_message);
         ebpf_free(error_message);
@@ -1801,8 +1835,12 @@ ebpf_program_set_helper_function_ids(
     }
 
     program->helper_function_count = helper_function_count;
-    program->helper_function_ids =
-        ebpf_allocate_with_tag(sizeof(uint32_t) * helper_function_count, EBPF_POOL_TAG_PROGRAM);
+    size_t helper_function_id_length = 0;
+    result = ebpf_safe_size_t_multiply(sizeof(uint32_t), helper_function_count, &helper_function_id_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    program->helper_function_ids = ebpf_allocate_with_tag(helper_function_id_length, EBPF_POOL_TAG_PROGRAM);
     if (program->helper_function_ids == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -1978,8 +2016,14 @@ ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_
     if (total_count_of_helpers > 0) {
         // Allocate buffer and make a shallow copy of the combined global and program-type specific helper function
         // prototypes.
-        ebpf_helper_function_prototype_t* helper_prototype = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(
-            total_count_of_helpers * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_PROGRAM);
+        size_t helper_prototype_length = 0;
+        result = ebpf_safe_size_t_multiply(
+            total_count_of_helpers, sizeof(ebpf_helper_function_prototype_t), &helper_prototype_length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+        ebpf_helper_function_prototype_t* helper_prototype =
+            (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_prototype_length, EBPF_POOL_TAG_PROGRAM);
         if (helper_prototype == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -2073,7 +2117,11 @@ ebpf_program_get_info(
     if ((input_info->map_ids != 0) && (input_info->nr_map_ids > 0) && (program->count_of_maps > 0)) {
         // Fill in map ids before we overwrite the info buffer.
         uint32_t max_nr_map_ids = input_info->nr_map_ids;
-        size_t length = max_nr_map_ids * sizeof(ebpf_id_t);
+        size_t length = 0;
+        result = ebpf_safe_size_t_multiply(max_nr_map_ids, sizeof(ebpf_id_t), &length);
+        if (result != EBPF_SUCCESS) {
+            EBPF_RETURN_RESULT(result);
+        }
 
         __try {
             ebpf_probe_for_write(map_ids, length, sizeof(ebpf_id_t));
@@ -2228,8 +2276,14 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
 
     // It is possible that a program does not invoke any helper function.
     if (helper_function_count) {
-        helper_id_to_index = (ebpf_helper_id_to_index_t*)ebpf_allocate_with_tag(
-            helper_function_count * sizeof(ebpf_helper_id_to_index_t), EBPF_POOL_TAG_PROGRAM);
+        size_t helper_id_to_index_length = 0;
+        result = ebpf_safe_size_t_multiply(
+            helper_function_count, sizeof(ebpf_helper_id_to_index_t), &helper_id_to_index_length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+        helper_id_to_index =
+            (ebpf_helper_id_to_index_t*)ebpf_allocate_with_tag(helper_id_to_index_length, EBPF_POOL_TAG_PROGRAM);
         if (helper_id_to_index == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1025,7 +1025,8 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t
     // Before we acquire any references, make sure
     // all maps can be associated.
     for (index = 0; index < maps_count; index++) {
-        ebpf_map_t* map = maps[index];
+#pragma warning(suppress : 6385) // program_maps was allocated and populated for maps_count entries above.
+        ebpf_map_t* map = program_maps[index];
         result = ebpf_map_associate_program(map, program);
         if (result != EBPF_SUCCESS) {
             goto Done;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1042,11 +1042,12 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t
     }
     // Now go through again and acquire references.
     program->maps = program_maps;
-    program_maps = NULL;
     program->count_of_maps = maps_count;
     for (index = 0; index < maps_count; index++) {
-        EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)maps[index]);
+#pragma warning(suppress : 6385) // program_maps was allocated and populated for maps_count entries above.
+        EBPF_OBJECT_ACQUIRE_REFERENCE((ebpf_core_object_t*)program_maps[index]);
     }
+    program_maps = NULL;
     ebpf_lock_unlock(&program->lock, state);
 
 Done:

--- a/libs/runtime/ebpf_bitmap.c
+++ b/libs/runtime/ebpf_bitmap.c
@@ -56,14 +56,22 @@ static_assert(sizeof(ebpf_bitmap_cursor_internal_t) == sizeof(ebpf_bitmap_cursor
 size_t
 ebpf_bitmap_size(size_t bit_count)
 {
-    return EBPF_OFFSET_OF(ebpf_bitmap_t, data) + BIT_COUNT_TO_BLOCK_COUNT(bit_count) * sizeof(size_t);
+    size_t bitmap_data_length = 0;
+    size_t bitmap_size = 0;
+    ebpf_assert_success(
+        ebpf_safe_size_t_multiply(BIT_COUNT_TO_BLOCK_COUNT(bit_count), sizeof(size_t), &bitmap_data_length));
+    ebpf_assert_success(ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_bitmap_t, data), bitmap_data_length, &bitmap_size));
+    return bitmap_size;
 }
 
 void
 ebpf_bitmap_initialize(_Out_ ebpf_bitmap_t* bitmap, size_t bit_count)
 {
+    size_t bitmap_data_length = 0;
     bitmap->bit_count = bit_count;
-    memset(bitmap->data, 0, BIT_COUNT_TO_BLOCK_COUNT(bit_count) * sizeof(size_t));
+    ebpf_assert_success(
+        ebpf_safe_size_t_multiply(BIT_COUNT_TO_BLOCK_COUNT(bit_count), sizeof(size_t), &bitmap_data_length));
+    memset(bitmap->data, 0, bitmap_data_length);
 }
 
 bool

--- a/libs/runtime/ebpf_bitmap.c
+++ b/libs/runtime/ebpf_bitmap.c
@@ -56,22 +56,34 @@ static_assert(sizeof(ebpf_bitmap_cursor_internal_t) == sizeof(ebpf_bitmap_cursor
 size_t
 ebpf_bitmap_size(size_t bit_count)
 {
+    size_t adjusted_bit_count = 0;
+    size_t block_count = 0;
     size_t bitmap_data_length = 0;
     size_t bitmap_size = 0;
-    ebpf_assert_success(
-        ebpf_safe_size_t_multiply(BIT_COUNT_TO_BLOCK_COUNT(bit_count), sizeof(size_t), &bitmap_data_length));
-    ebpf_assert_success(ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_bitmap_t, data), bitmap_data_length, &bitmap_size));
+    if (ebpf_safe_size_t_add(bit_count, BITS_IN_BLOCK - 1, &adjusted_bit_count) != EBPF_SUCCESS) {
+        return MAXSIZE_T;
+    }
+    block_count = adjusted_bit_count / BITS_IN_BLOCK;
+    if (ebpf_safe_size_t_multiply(block_count, sizeof(uint64_t), &bitmap_data_length) != EBPF_SUCCESS) {
+        return MAXSIZE_T;
+    }
+    if (ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_bitmap_t, data), bitmap_data_length, &bitmap_size) != EBPF_SUCCESS) {
+        return MAXSIZE_T;
+    }
     return bitmap_size;
 }
 
-void
+ebpf_result_t
 ebpf_bitmap_initialize(_Out_ ebpf_bitmap_t* bitmap, size_t bit_count)
 {
-    size_t bitmap_data_length = 0;
+    size_t bitmap_size = ebpf_bitmap_size(bit_count);
+    if (bitmap_size == MAXSIZE_T) {
+        return EBPF_ARITHMETIC_OVERFLOW;
+    }
+
     bitmap->bit_count = bit_count;
-    ebpf_assert_success(
-        ebpf_safe_size_t_multiply(BIT_COUNT_TO_BLOCK_COUNT(bit_count), sizeof(size_t), &bitmap_data_length));
-    memset(bitmap->data, 0, bitmap_data_length);
+    memset(bitmap->data, 0, bitmap_size - EBPF_OFFSET_OF(ebpf_bitmap_t, data));
+    return EBPF_SUCCESS;
 }
 
 bool

--- a/libs/runtime/ebpf_bitmap.h
+++ b/libs/runtime/ebpf_bitmap.h
@@ -14,7 +14,7 @@ extern "C"
      * @brief Compute the size in bytes required to hold a ebpf_bitmap_t.
      *
      * @param[in] bit_count Count of bits the bitmap will hold.
-     * @return Size in bytes required.
+     * @return Size in bytes required, or MAXSIZE_T on overflow.
      */
     size_t
     ebpf_bitmap_size(size_t bit_count);
@@ -24,8 +24,10 @@ extern "C"
      *
      * @param[out] bitmap Pointer to the bitmap.
      * @param[in] bit_count Count of bits to be stored.
+     * @retval EBPF_SUCCESS The bitmap was initialized.
+     * @retval EBPF_ARITHMETIC_OVERFLOW The bitmap size overflowed.
      */
-    void
+    ebpf_result_t
     ebpf_bitmap_initialize(_Out_ ebpf_bitmap_t* bitmap, size_t bit_count);
 
     /**

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -428,9 +428,12 @@ __drv_allocatesMem(Mem) _Must_inspect_result_
 {
     ebpf_assert(size);
     ebpf_epoch_allocation_header_t* header;
+    size_t allocation_size = 0;
 
-    size += sizeof(ebpf_epoch_allocation_header_t);
-    header = (ebpf_epoch_allocation_header_t*)ebpf_allocate_with_tag(size, tag);
+    if (ebpf_safe_size_t_add(size, sizeof(ebpf_epoch_allocation_header_t), &allocation_size) != EBPF_SUCCESS) {
+        return NULL;
+    }
+    header = (ebpf_epoch_allocation_header_t*)ebpf_allocate_with_tag(allocation_size, tag);
     if (header) {
         header++;
     }
@@ -449,9 +452,12 @@ _Ret_writes_maybenull_(size) void* ebpf_epoch_allocate_cache_aligned_with_tag(si
 {
     ebpf_assert(size);
     ebpf_epoch_allocation_header_t* header;
+    size_t allocation_size = 0;
 
-    size += EBPF_CACHE_LINE_SIZE;
-    header = (ebpf_epoch_allocation_header_t*)ebpf_allocate_cache_aligned_with_tag(size, tag);
+    if (ebpf_safe_size_t_add(size, EBPF_CACHE_LINE_SIZE, &allocation_size) != EBPF_SUCCESS) {
+        return NULL;
+    }
+    header = (ebpf_epoch_allocation_header_t*)ebpf_allocate_cache_aligned_with_tag(allocation_size, tag);
     if (header) {
         header = (ebpf_epoch_allocation_header_t*)((uint8_t*)header + EBPF_CACHE_LINE_SIZE);
     }
@@ -990,7 +996,7 @@ _IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_messenger_worker(
         return;
     }
 
-    if (message->message_type > EBPF_COUNT_OF(_ebpf_epoch_messenger_workers) || message->message_type < 0) {
+    if (message->message_type >= EBPF_COUNT_OF(_ebpf_epoch_messenger_workers) || message->message_type < 0) {
         ebpf_assert(!"Invalid message type");
         return;
     }

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -502,6 +502,40 @@ Done:
 }
 
 /**
+ * @brief Validate that deleting an entry from a bucket will not encounter arithmetic overflow.
+ *
+ * This must happen before a PRE_FREE notification so the remaining delete path cannot fail while the bucket lock is
+ * held.
+ *
+ * @param[in] hash_table The hash table.
+ * @param[in] old_bucket The immutable old bucket to validate.
+ * @retval EBPF_SUCCESS The delete path is valid.
+ * @retval EBPF_ARITHMETIC_OVERFLOW Arithmetic overflow occurred while computing bucket entry offsets.
+ */
+static ebpf_result_t
+_ebpf_hash_table_bucket_delete_validate(
+    _In_ const ebpf_hash_table_t* hash_table, _In_ const ebpf_hash_bucket_header_t* old_bucket)
+{
+    ebpf_hash_bucket_entry_t* last_entry =
+        _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, old_bucket->count - 1);
+    if (last_entry == NULL) {
+        return EBPF_ARITHMETIC_OVERFLOW;
+    }
+
+    if (old_bucket->count == 1) {
+        return EBPF_SUCCESS;
+    }
+
+    ebpf_hash_bucket_header_t* backup_bucket = last_entry->backup_bucket;
+    ebpf_assert(backup_bucket != NULL);
+    ebpf_assert(backup_bucket->count == old_bucket->count - 1);
+
+    return (_ebpf_hash_table_bucket_entry(hash_table->key_size, backup_bucket, old_bucket->count - 2) == NULL)
+               ? EBPF_ARITHMETIC_OVERFLOW
+               : EBPF_SUCCESS;
+}
+
+/**
  * @brief Build a replacement bucket with the given entry removed.
  * Caller must free the old bucket.
  * Memory from the last entry's backup_bucket is used to build the new bucket.
@@ -578,7 +612,7 @@ _ebpf_hash_table_bucket_delete(
     *new_bucket = backup_bucket;
 
 Done:
-    if (hash_table->max_entry_count != EBPF_HASH_TABLE_NO_LIMIT) {
+    if (result == EBPF_SUCCESS && hash_table->max_entry_count != EBPF_HASH_TABLE_NO_LIMIT) {
         ebpf_interlocked_decrement_int64_no_fence((volatile int64_t*)&hash_table->entry_count);
     }
 
@@ -766,6 +800,10 @@ _ebpf_hash_table_replace_bucket(
         if (index == old_bucket_count) {
             result = EBPF_KEY_NOT_FOUND;
         } else {
+            result = _ebpf_hash_table_bucket_delete_validate(hash_table, old_bucket);
+            if (result != EBPF_SUCCESS) {
+                break;
+            }
             if (hash_table->notification_callback &&
                 (hash_table->notification_flags & EBPF_HASH_TABLE_NOTIFICATION_TYPE_PRE_FREE)) {
                 result = hash_table->notification_callback(
@@ -780,8 +818,8 @@ _ebpf_hash_table_replace_bucket(
                     break;
                 }
             }
-            // No failure path after successful delete notification.
             result = _ebpf_hash_table_bucket_delete(hash_table, old_bucket, index, &new_bucket);
+            ebpf_assert(result == EBPF_SUCCESS);
         }
         break;
     default:

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -506,12 +506,13 @@ Done:
  * Caller must free the old bucket.
  * Memory from the last entry's backup_bucket is used to build the new bucket.
  * Caller must ensure that the entry is in the bucket.
- * Operation can't fail.
  *
  * @param[in] hash_table The hash table.
  * @param[in] old_bucket The immutable old bucket to copy.
  * @param[in] key_index Location of the key to remove.
  * @param[out] new_bucket The new bucket with the entry removed. On success the caller owns this memory.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_ARITHMETIC_OVERFLOW Arithmetic overflow occurred while computing bucket entry offsets.
  */
 static ebpf_result_t
 _ebpf_hash_table_bucket_delete(

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -343,9 +343,12 @@ static ebpf_hash_bucket_entry_t*
 _ebpf_hash_table_bucket_entry(size_t key_size, _In_ const ebpf_hash_bucket_header_t* bucket, size_t index)
 {
     uint8_t* offset = (uint8_t*)bucket->entries;
-    size_t entry_size = EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key) + key_size;
+    size_t entry_size = 0;
+    size_t entry_offset = 0;
+    ebpf_assert_success(ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key), key_size, &entry_size));
+    ebpf_assert_success(ebpf_safe_size_t_multiply(index, entry_size, &entry_offset));
 
-    return (ebpf_hash_bucket_entry_t*)(offset + (size_t)index * entry_size);
+    return (ebpf_hash_bucket_entry_t*)(offset + entry_offset);
 }
 
 /**
@@ -397,12 +400,42 @@ _ebpf_hash_table_bucket_insert(
     _Outptr_ ebpf_hash_bucket_header_t** new_bucket)
 {
     ebpf_result_t result;
-    size_t entry_size = EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key) + hash_table->key_size;
-    size_t old_bucket_size = old_bucket ? entry_size * old_bucket->count + sizeof(ebpf_hash_bucket_header_t) : 0;
-    size_t new_bucket_size =
-        entry_size * ((old_bucket ? old_bucket->count : 0) + 1) + sizeof(ebpf_hash_bucket_header_t);
+    size_t entry_size = 0;
+    size_t old_bucket_size = 0;
+    size_t new_bucket_size = 0;
+    size_t old_bucket_entry_count = old_bucket ? old_bucket->count : 0;
+    size_t new_bucket_entry_count = 0;
     ebpf_hash_bucket_header_t* local_new_bucket = NULL;
     ebpf_hash_bucket_header_t* backup_bucket = NULL;
+
+    result = ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key), hash_table->key_size, &entry_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    if (old_bucket != NULL) {
+        result = ebpf_safe_size_t_multiply(entry_size, old_bucket_entry_count, &old_bucket_size);
+        if (result != EBPF_SUCCESS) {
+            goto Done;
+        }
+        result = ebpf_safe_size_t_add(old_bucket_size, sizeof(ebpf_hash_bucket_header_t), &old_bucket_size);
+        if (result != EBPF_SUCCESS) {
+            goto Done;
+        }
+    }
+
+    result = ebpf_safe_size_t_add(old_bucket_entry_count, 1, &new_bucket_entry_count);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    result = ebpf_safe_size_t_multiply(entry_size, new_bucket_entry_count, &new_bucket_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    result = ebpf_safe_size_t_add(new_bucket_size, sizeof(ebpf_hash_bucket_header_t), &new_bucket_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     if (hash_table->max_entry_count != EBPF_HASH_TABLE_NO_LIMIT) {
         size_t new_entry_count = ebpf_interlocked_increment_int64_no_fence((volatile int64_t*)&hash_table->entry_count);
@@ -552,9 +585,22 @@ _ebpf_hash_table_bucket_update(
     _Outptr_ ebpf_hash_bucket_header_t** new_bucket)
 {
     ebpf_result_t result;
-    size_t entry_size = EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key) + hash_table->key_size;
-    size_t old_bucket_size = entry_size * old_bucket->count + sizeof(ebpf_hash_bucket_header_t);
+    size_t entry_size = 0;
+    size_t old_bucket_size = 0;
     ebpf_hash_bucket_header_t* local_new_bucket = NULL;
+
+    result = ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key), hash_table->key_size, &entry_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    result = ebpf_safe_size_t_multiply(entry_size, old_bucket->count, &old_bucket_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+    result = ebpf_safe_size_t_add(old_bucket_size, sizeof(ebpf_hash_bucket_header_t), &old_bucket_size);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     // Allocate new bucket.
     local_new_bucket = hash_table->allocate(old_bucket_size, hash_table->allocation_tag);

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -345,8 +345,12 @@ _ebpf_hash_table_bucket_entry(size_t key_size, _In_ const ebpf_hash_bucket_heade
     uint8_t* offset = (uint8_t*)bucket->entries;
     size_t entry_size = 0;
     size_t entry_offset = 0;
-    ebpf_assert_success(ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key), key_size, &entry_size));
-    ebpf_assert_success(ebpf_safe_size_t_multiply(index, entry_size, &entry_offset));
+    if (ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key), key_size, &entry_size) != EBPF_SUCCESS) {
+        return NULL;
+    }
+    if (ebpf_safe_size_t_multiply(index, entry_size, &entry_offset) != EBPF_SUCCESS) {
+        return NULL;
+    }
 
     return (ebpf_hash_bucket_entry_t*)(offset + entry_offset);
 }
@@ -468,6 +472,10 @@ _ebpf_hash_table_bucket_insert(
     // Append new key, data, and backup bucket.
     ebpf_hash_bucket_entry_t* entry =
         _ebpf_hash_table_bucket_entry(hash_table->key_size, local_new_bucket, local_new_bucket->count);
+    if (entry == NULL) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Done;
+    }
 
     entry->backup_bucket = backup_bucket;
     backup_bucket = NULL;
@@ -505,15 +513,21 @@ Done:
  * @param[in] key_index Location of the key to remove.
  * @param[out] new_bucket The new bucket with the entry removed. On success the caller owns this memory.
  */
-static void
+static ebpf_result_t
 _ebpf_hash_table_bucket_delete(
     _Inout_ ebpf_hash_table_t* hash_table,
     _In_ const ebpf_hash_bucket_header_t* old_bucket,
     size_t key_index,
     _Outptr_result_maybenull_ ebpf_hash_bucket_header_t** new_bucket)
 {
-    ebpf_hash_bucket_header_t* backup_bucket =
-        _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, old_bucket->count - 1)->backup_bucket;
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_hash_bucket_entry_t* last_entry =
+        _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, old_bucket->count - 1);
+    if (last_entry == NULL) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Done;
+    }
+    ebpf_hash_bucket_header_t* backup_bucket = last_entry->backup_bucket;
 
     // Delete the bucket if removing last entry.
     if (old_bucket->count == 1) {
@@ -535,6 +549,10 @@ _ebpf_hash_table_bucket_delete(
             _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, index);
         ebpf_hash_bucket_entry_t* new_entry =
             _ebpf_hash_table_bucket_entry(hash_table->key_size, backup_bucket, backup_bucket->count);
+        if (old_entry == NULL || new_entry == NULL) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Done;
+        }
 
         new_entry->data = old_entry->data;
         memcpy(new_entry->key, old_entry->key, hash_table->key_size);
@@ -545,6 +563,10 @@ _ebpf_hash_table_bucket_delete(
     for (size_t index = 0; index < old_bucket->count - 1; index++) {
         ebpf_hash_bucket_entry_t* old_entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, index);
         ebpf_hash_bucket_entry_t* new_entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, backup_bucket, index);
+        if (old_entry == NULL || new_entry == NULL) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Done;
+        }
 
         new_entry->backup_bucket = old_entry->backup_bucket;
         // Bucket at index N > 0 should have a backup bucket of size N - 1.
@@ -559,7 +581,7 @@ Done:
         ebpf_interlocked_decrement_int64_no_fence((volatile int64_t*)&hash_table->entry_count);
     }
 
-    return;
+    return result;
 }
 
 /**
@@ -613,6 +635,10 @@ _ebpf_hash_table_bucket_update(
     memcpy(local_new_bucket, old_bucket, old_bucket_size);
 
     ebpf_hash_bucket_entry_t* entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, local_new_bucket, key_index);
+    if (entry == NULL) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Done;
+    }
 
     entry->data = data;
 
@@ -703,6 +729,10 @@ _ebpf_hash_table_replace_bucket(
     // Find the entry in the bucket, if any.
     for (index = 0; index < old_bucket_count; index++) {
         ebpf_hash_bucket_entry_t* entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, index);
+        if (entry == NULL) {
+            result = EBPF_ARITHMETIC_OVERFLOW;
+            goto Done;
+        }
         if (_ebpf_hash_table_compare(hash_table, key, entry->key) == 0) {
             old_data = entry->data;
             break;
@@ -750,8 +780,7 @@ _ebpf_hash_table_replace_bucket(
                 }
             }
             // No failure path after successful delete notification.
-            _ebpf_hash_table_bucket_delete(hash_table, old_bucket, index, &new_bucket);
-            result = EBPF_SUCCESS;
+            result = _ebpf_hash_table_bucket_delete(hash_table, old_bucket, index, &new_bucket);
         }
         break;
     default:
@@ -904,6 +933,9 @@ ebpf_hash_table_destroy(_In_opt_ _Post_ptr_invalid_ ebpf_hash_table_t* hash_tabl
             for (inner_index = 0; inner_index < bucket->count; inner_index++) {
                 ebpf_hash_bucket_entry_t* entry =
                     _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, inner_index);
+                if (entry == NULL) {
+                    break;
+                }
                 hash_table->free(entry->data);
                 hash_table->free(entry->backup_bucket);
             }
@@ -937,6 +969,10 @@ ebpf_hash_table_find(_In_ const ebpf_hash_table_t* hash_table, _In_ const uint8_
 
     for (index = 0; index < bucket->count; index++) {
         ebpf_hash_bucket_entry_t* entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, index);
+        if (entry == NULL) {
+            retval = EBPF_INVALID_ARGUMENT;
+            goto Done;
+        }
         if (_ebpf_hash_table_compare(hash_table, key, entry->key) == 0) {
             data = entry->data;
             break;
@@ -1047,6 +1083,10 @@ ebpf_hash_table_next_key_pointer_and_value(
         // Pick first entry if no previous key.
         if (!previous_key) {
             next_entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, 0);
+            if (!next_entry) {
+                result = EBPF_INVALID_ARGUMENT;
+                goto Done;
+            }
             break;
         }
 

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -527,7 +527,7 @@ _ebpf_hash_table_bucket_delete_validate(
     }
 
     ebpf_hash_bucket_header_t* backup_bucket = last_entry->backup_bucket;
-    ebpf_assert(backup_bucket != NULL);
+    ebpf_assert_assume(backup_bucket != NULL);
     ebpf_assert(backup_bucket->count == old_bucket->count - 1);
 
     return (_ebpf_hash_table_bucket_entry(hash_table->key_size, backup_bucket, old_bucket->count - 2) == NULL)

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -818,6 +818,7 @@ _ebpf_hash_table_replace_bucket(
                     break;
                 }
             }
+            // No failure path after successful delete notification.
             result = _ebpf_hash_table_bucket_delete(hash_table, old_bucket, index, &new_bucket);
             ebpf_assert(result == EBPF_SUCCESS);
         }

--- a/libs/runtime/ebpf_interlocked.c
+++ b/libs/runtime/ebpf_interlocked.c
@@ -45,6 +45,12 @@ ebpf_interlocked_increment_int32(_Inout_ volatile int32_t* addend)
     return InterlockedIncrement((volatile long*)addend);
 }
 
+uint32_t
+ebpf_interlocked_increment_uint32(_Inout_ volatile uint32_t* addend)
+{
+    return (uint32_t)InterlockedIncrement((volatile long*)addend);
+}
+
 int32_t
 ebpf_interlocked_decrement_int32(_Inout_ volatile int32_t* addend)
 {

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -211,7 +211,7 @@ ebpf_object_initialize(
     object->notify_reference_count_zeroed = notify_reference_count_zeroed;
     object->notify_user_reference_count_zeroed = notify_user_reference_count_zeroed;
     object->get_program_type = get_program_type;
-    object->id = ebpf_interlocked_increment_int32((volatile int32_t*)&_ebpf_next_id);
+    object->id = ebpf_interlocked_increment_uint32(&_ebpf_next_id);
 
     ebpf_list_initialize(&object->object_list_entry);
     ebpf_epoch_work_item_t* free_object_work_item = NULL;

--- a/libs/runtime/ebpf_pinning_table.c
+++ b/libs/runtime/ebpf_pinning_table.c
@@ -268,9 +268,15 @@ ebpf_pinning_table_enumerate_entries(
         goto Exit;
     }
 
+    size_t pinning_entries_length = 0;
+    result = ebpf_safe_size_t_multiply(sizeof(ebpf_pinning_entry_t), entries_array_length, &pinning_entries_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
     // Allocate the output array for storing the pinning entries.
-    local_pinning_entries = (ebpf_pinning_entry_t*)ebpf_allocate_with_tag(
-        sizeof(ebpf_pinning_entry_t) * entries_array_length, EBPF_POOL_TAG_DEFAULT);
+    local_pinning_entries =
+        (ebpf_pinning_entry_t*)ebpf_allocate_with_tag(pinning_entries_length, EBPF_POOL_TAG_DEFAULT);
     if (local_pinning_entries == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -236,7 +236,8 @@ _Ret_maybenull_ ebpf_process_state_t*
 ebpf_allocate_process_state()
 {
     // Skipping fault injection as call to ebpf_allocate_with_tag(, EBPF_POOL_TAG_DEFAULT) covers it.
-    ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate_with_tag(sizeof(ebpf_process_state_t), EBPF_POOL_TAG_DEFAULT);
+    ebpf_process_state_t* state =
+        (ebpf_process_state_t*)ebpf_allocate_with_tag(sizeof(ebpf_process_state_t), EBPF_POOL_TAG_DEFAULT);
     return state;
 }
 
@@ -336,7 +337,13 @@ ebpf_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ wch
         return EBPF_INVALID_ARGUMENT;
     }
 
-    unicode_string = (wchar_t*)ebpf_allocate_with_tag(unicode_byte_count + sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
+    size_t unicode_string_size = 0;
+    retval = ebpf_safe_size_t_add(unicode_byte_count, sizeof(wchar_t), &unicode_string_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    unicode_string = (wchar_t*)ebpf_allocate_with_tag(unicode_string_size, EBPF_POOL_TAG_DEFAULT);
     if (unicode_string == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -464,7 +471,8 @@ ebpf_allocate_timer_work_item(
     _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
     _Inout_opt_ void* work_item_context)
 {
-    *timer_work_item = (ebpf_timer_work_item_t*)ebpf_allocate_with_tag(sizeof(ebpf_timer_work_item_t), EBPF_POOL_TAG_DEFAULT);
+    *timer_work_item =
+        (ebpf_timer_work_item_t*)ebpf_allocate_with_tag(sizeof(ebpf_timer_work_item_t), EBPF_POOL_TAG_DEFAULT);
     if (*timer_work_item == NULL) {
         return EBPF_NO_MEMORY;
     }

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -374,6 +374,16 @@ extern "C"
     ebpf_interlocked_increment_int32(_Inout_ volatile int32_t* addend);
 
     /**
+     * @brief Atomically increase the value of addend by 1 and return the new
+     *  value.
+     *
+     * @param[in, out] addend Value to increase by 1.
+     * @return The new value.
+     */
+    uint32_t
+    ebpf_interlocked_increment_uint32(_Inout_ volatile uint32_t* addend);
+
+    /**
      * @brief Atomically decrease the value of addend by 1 and return the new
      *  value.
      *

--- a/libs/runtime/ebpf_trampoline.c
+++ b/libs/runtime/ebpf_trampoline.c
@@ -31,6 +31,7 @@ ebpf_allocate_trampoline_table(size_t entry_count, _Outptr_ ebpf_trampoline_tabl
     EBPF_LOG_ENTRY();
     ebpf_result_t return_value;
     ebpf_trampoline_table_t* local_trampoline_table = NULL;
+    size_t trampoline_table_length = 0;
 
     local_trampoline_table = ebpf_allocate_with_tag(sizeof(ebpf_trampoline_table_t), EBPF_POOL_TAG_DEFAULT);
     if (!local_trampoline_table) {
@@ -39,7 +40,11 @@ ebpf_allocate_trampoline_table(size_t entry_count, _Outptr_ ebpf_trampoline_tabl
     }
 
     local_trampoline_table->entry_count = entry_count;
-    local_trampoline_table->memory_descriptor = ebpf_map_memory(entry_count * sizeof(ebpf_trampoline_entry_t));
+    return_value = ebpf_safe_size_t_multiply(entry_count, sizeof(ebpf_trampoline_entry_t), &trampoline_table_length);
+    if (return_value != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    local_trampoline_table->memory_descriptor = ebpf_map_memory(trampoline_table_length);
     if (!local_trampoline_table->memory_descriptor) {
         return_value = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -30,6 +30,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
 {
     EBPF_LOG_ENTRY();
     NTSTATUS status;
+    ebpf_result_t result;
 
     ebpf_ring_descriptor_t* ring_descriptor =
         ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t), EBPF_POOL_TAG_DEFAULT);
@@ -43,7 +44,13 @@ ebpf_allocate_ring_buffer_memory(size_t length)
 
     const size_t kernel_pages = 1;
     const size_t user_pages = 2; // consumer, producer
-    if (length % PAGE_SIZE != 0 || length > (MAXUINT32 / 2 - (kernel_pages + user_pages) * PAGE_SIZE)) {
+    size_t requested_page_count = 0;
+    size_t mapped_memory_length = 0;
+    size_t data_mapped_length = 0;
+    size_t total_mapped_size = 0;
+    size_t user_mdl_producer_length = 0;
+
+    if (length % PAGE_SIZE != 0) {
         status = STATUS_NO_MEMORY;
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR,
@@ -54,9 +61,23 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     }
 
     size_t data_pages = length / PAGE_SIZE;
-    size_t requested_page_count = kernel_pages + user_pages + data_pages;
-
-    if (requested_page_count < data_pages) {
+    result = ebpf_safe_size_t_add(kernel_pages, user_pages, &requested_page_count);
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_add(requested_page_count, data_pages, &requested_page_count);
+    }
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_multiply(requested_page_count, PAGE_SIZE, &mapped_memory_length);
+    }
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_multiply(length, 2, &data_mapped_length);
+    }
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_add((kernel_pages + user_pages) * PAGE_SIZE, data_mapped_length, &total_mapped_size);
+    }
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_add(PAGE_SIZE, data_mapped_length, &user_mdl_producer_length);
+    }
+    if ((result != EBPF_SUCCESS) || (total_mapped_size > MAXULONG) || (user_mdl_producer_length > MAXULONG)) {
         status = STATUS_NO_MEMORY;
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Ring buffer length is too large", length);
@@ -64,7 +85,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     }
 
     // Allocate pages using ebpf_map_memory.
-    ring_descriptor->memory = ebpf_map_memory(requested_page_count * PAGE_SIZE);
+    ring_descriptor->memory = ebpf_map_memory(mapped_memory_length);
     if (!ring_descriptor->memory) {
         status = STATUS_NO_MEMORY;
         goto Done;
@@ -72,8 +93,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     source_mdl = ring_descriptor->memory;
 
     // Create a MDL big enough to include the header and double-mapped pages.
-    uint32_t total_mapped_size = (uint32_t)((kernel_pages + user_pages) * PAGE_SIZE + length * 2);
-    ring_descriptor->kernel_mdl = IoAllocateMdl(NULL, total_mapped_size, FALSE, FALSE, NULL);
+    ring_descriptor->kernel_mdl = IoAllocateMdl(NULL, (ULONG)total_mapped_size, FALSE, FALSE, NULL);
     if (!ring_descriptor->kernel_mdl) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, IoAllocateMdl, STATUS_NO_MEMORY);
         status = STATUS_NO_MEMORY;
@@ -88,7 +108,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
         goto Done;
     }
 
-    ring_descriptor->user_mdl_producer = IoAllocateMdl(NULL, PAGE_SIZE + ((ULONG)length * 2), FALSE, FALSE, NULL);
+    ring_descriptor->user_mdl_producer = IoAllocateMdl(NULL, (ULONG)user_mdl_producer_length, FALSE, FALSE, NULL);
     if (!ring_descriptor->user_mdl_producer) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, IoAllocateMdl, STATUS_NO_MEMORY);
         status = STATUS_NO_MEMORY;
@@ -434,7 +454,16 @@ _convert_utf8_string_to_unicode_string(
     }
 
     // Add space for null terminator.
-    ULONG required_bytes = bytes_in_unicode_string + sizeof(wchar_t);
+    uint32_t required_bytes = 0;
+    if (cxplat_safe_uint32_t_add(bytes_in_unicode_string, sizeof(wchar_t), &required_bytes) != CXPLAT_STATUS_SUCCESS) {
+        result = EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_BASE,
+            "_convert_utf8_string_to_unicode_string: File path too long");
+        goto Done;
+    }
+
     if (required_bytes > USHORT_MAX) {
         result = EBPF_INVALID_ARGUMENT;
         EBPF_LOG_MESSAGE(

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -47,6 +47,8 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     size_t requested_page_count = 0;
     size_t mapped_memory_length = 0;
     size_t data_mapped_length = 0;
+    size_t header_page_count = 0;
+    size_t header_mapped_length = 0;
     size_t total_mapped_size = 0;
     size_t user_mdl_producer_length = 0;
 
@@ -72,7 +74,13 @@ ebpf_allocate_ring_buffer_memory(size_t length)
         result = ebpf_safe_size_t_multiply(length, 2, &data_mapped_length);
     }
     if (result == EBPF_SUCCESS) {
-        result = ebpf_safe_size_t_add((kernel_pages + user_pages) * PAGE_SIZE, data_mapped_length, &total_mapped_size);
+        result = ebpf_safe_size_t_add(kernel_pages, user_pages, &header_page_count);
+    }
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_multiply(header_page_count, PAGE_SIZE, &header_mapped_length);
+    }
+    if (result == EBPF_SUCCESS) {
+        result = ebpf_safe_size_t_add(header_mapped_length, data_mapped_length, &total_mapped_size);
     }
     if (result == EBPF_SUCCESS) {
         result = ebpf_safe_size_t_add(PAGE_SIZE, data_mapped_length, &user_mdl_producer_length);

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1553,7 +1553,7 @@ bitmap_test()
     std::vector<uint8_t> data(ebpf_bitmap_size(bit_count));
 
     ebpf_bitmap_t* bitmap = reinterpret_cast<ebpf_bitmap_t*>(data.data());
-    ebpf_bitmap_initialize(bitmap, bit_count);
+    REQUIRE(ebpf_bitmap_initialize(bitmap, bit_count) == EBPF_SUCCESS);
 
     // Set every bit.
     for (size_t i = 0; i < bit_count; i++) {

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -90,12 +90,15 @@ ebpf_allocate_ring_buffer_memory(size_t length)
 
     size_t kernel_pages = 1;
     size_t user_pages = 2;
-    size_t header_length = (kernel_pages + user_pages) * PAGE_SIZE;
+    size_t total_page_count = 0;
+    size_t header_length = 0;
     size_t data_section_length = 0;
     size_t total_mapped_size = 0;
     size_t view_length = 0;
 
-    if ((ebpf_safe_size_t_multiply(length, 2, &data_section_length) != EBPF_SUCCESS) ||
+    if ((ebpf_safe_size_t_add(kernel_pages, user_pages, &total_page_count) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_multiply(total_page_count, PAGE_SIZE, &header_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_multiply(length, 2, &data_section_length) != EBPF_SUCCESS) ||
         (ebpf_safe_size_t_add(header_length, data_section_length, &total_mapped_size) != EBPF_SUCCESS) ||
         (ebpf_safe_size_t_add(header_length, length, &view_length) != EBPF_SUCCESS) || (view_length > UINT32_MAX)) {
         EBPF_LOG_MESSAGE_UINT64(

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -11,7 +11,6 @@
 
 #include <TraceLoggingProvider.h>
 #include <functional>
-#include <intsafe.h>
 #include <map>
 #include <mutex>
 #include <queue>
@@ -92,14 +91,18 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     size_t kernel_pages = 1;
     size_t user_pages = 2;
     size_t header_length = (kernel_pages + user_pages) * PAGE_SIZE;
+    size_t data_section_length = 0;
+    size_t total_mapped_size = 0;
+    size_t view_length = 0;
 
-    if (length > (MAXUINT64 - header_length) / 2) {
+    if ((ebpf_safe_size_t_multiply(length, 2, &data_section_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_add(header_length, data_section_length, &total_mapped_size) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_add(header_length, length, &view_length) != EBPF_SUCCESS) || (view_length > UINT32_MAX)) {
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Ring buffer length exceeds maximum", length);
         return nullptr;
     }
 
-    size_t total_mapped_size = header_length + length * 2;
 
     ebpf_ring_descriptor_t* descriptor =
         (ebpf_ring_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t), EBPF_POOL_TAG_DEFAULT);
@@ -126,20 +129,20 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     //
     // Split the part of the placeholder region after the header into two regions of equal size.
     //
-    result = VirtualFree(placeholder1, header_length + length, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER);
+    result = VirtualFree(placeholder1, view_length, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER);
     if (result == FALSE) {
         EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, VirtualFree);
         goto Exit;
     }
 #pragma warning(pop)
-    placeholder2 = placeholder1 + header_length + length;
+    placeholder2 = placeholder1 + view_length;
 
     //
     // Create a pagefile-backed section for the buffer.
     //
 
     section = CreateFileMapping(
-        INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, static_cast<unsigned long>(header_length + length), nullptr);
+        INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, static_cast<unsigned long>(view_length), nullptr);
     if (section == nullptr) {
         EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, CreateFileMapping);
         goto Exit;
@@ -149,7 +152,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     // Map the header + data into the first placeholder region.
     //
     view1 = MapViewOfFile3(
-        section, nullptr, placeholder1, 0, header_length + length, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0);
+        section, nullptr, placeholder1, 0, view_length, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0);
     if (view1 == nullptr) {
         EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, MapViewOfFile3);
         goto Exit;

--- a/libs/runtime/user/kernel_um.cpp
+++ b/libs/runtime/user/kernel_um.cpp
@@ -510,7 +510,12 @@ RtlULongAdd(
     _Out_ _Deref_out_range_(==, augend + addend) unsigned long* result)
 {
     // Skip Fault Injection.
-    *result = augend + addend;
+    uint32_t local_result = 0;
+    if (cxplat_safe_uint32_t_add((uint32_t)augend, (uint32_t)addend, &local_result) != CXPLAT_STATUS_SUCCESS) {
+        return STATUS_INTEGER_OVERFLOW;
+    }
+
+    *result = local_result;
     return STATUS_SUCCESS;
 }
 

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -223,9 +223,8 @@ _resolve_maps_in_byte_code(
              &request_buffer_length) != EBPF_SUCCESS) ||
         (ebpf_safe_size_t_multiply(map_fds.size(), sizeof(uint64_t), &reply_address_array_length) != EBPF_SUCCESS) ||
         (ebpf_safe_size_t_add(
-             offsetof(ebpf_operation_resolve_map_reply_t, address),
-             reply_address_array_length,
-             &reply_buffer_length) != EBPF_SUCCESS)) {
+             offsetof(ebpf_operation_resolve_map_reply_t, address), reply_address_array_length, &reply_buffer_length) !=
+         EBPF_SUCCESS)) {
         return EBPF_ARITHMETIC_OVERFLOW;
     }
 

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -62,12 +62,28 @@ _resolve_helper_functions(
         helper_id_to_address[instruction.imm] = {0};
     }
 
-    ebpf_protocol_buffer_t request_buffer(
-        offsetof(ebpf_operation_resolve_helper_request_t, helper_id) + sizeof(uint32_t) * helper_id_to_address.size());
+    size_t helper_id_array_length = 0;
+    size_t request_buffer_length = 0;
+    size_t reply_address_array_length = 0;
+    size_t reply_buffer_length = 0;
+    if ((ebpf_safe_size_t_multiply(helper_id_to_address.size(), sizeof(uint32_t), &helper_id_array_length) !=
+         EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_add(
+             offsetof(ebpf_operation_resolve_helper_request_t, helper_id),
+             helper_id_array_length,
+             &request_buffer_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_multiply(
+             helper_id_to_address.size(), sizeof(helper_function_address_t), &reply_address_array_length) !=
+         EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_add(
+             offsetof(ebpf_operation_resolve_helper_reply_t, address),
+             reply_address_array_length,
+             &reply_buffer_length) != EBPF_SUCCESS)) {
+        return EBPF_ARITHMETIC_OVERFLOW;
+    }
 
-    ebpf_protocol_buffer_t reply_buffer(
-        offsetof(ebpf_operation_resolve_helper_reply_t, address) +
-        sizeof(helper_function_address_t) * helper_id_to_address.size());
+    ebpf_protocol_buffer_t request_buffer(request_buffer_length);
+    ebpf_protocol_buffer_t reply_buffer(reply_buffer_length);
 
     auto request = reinterpret_cast<ebpf_operation_resolve_helper_request_t*>(request_buffer.data());
     auto reply = reinterpret_cast<ebpf_operation_resolve_helper_reply_t*>(reply_buffer.data());
@@ -196,11 +212,25 @@ _resolve_maps_in_byte_code(
         return EBPF_SUCCESS;
     }
 
-    ebpf_protocol_buffer_t request_buffer(
-        offsetof(ebpf_operation_resolve_map_request_t, map_handle) + sizeof(uint64_t) * map_fds.size());
+    size_t map_handle_array_length = 0;
+    size_t request_buffer_length = 0;
+    size_t reply_address_array_length = 0;
+    size_t reply_buffer_length = 0;
+    if ((ebpf_safe_size_t_multiply(map_fds.size(), sizeof(uint64_t), &map_handle_array_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_add(
+             offsetof(ebpf_operation_resolve_map_request_t, map_handle),
+             map_handle_array_length,
+             &request_buffer_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_multiply(map_fds.size(), sizeof(uint64_t), &reply_address_array_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_add(
+             offsetof(ebpf_operation_resolve_map_reply_t, address),
+             reply_address_array_length,
+             &reply_buffer_length) != EBPF_SUCCESS)) {
+        return EBPF_ARITHMETIC_OVERFLOW;
+    }
 
-    ebpf_protocol_buffer_t reply_buffer(
-        offsetof(ebpf_operation_resolve_map_reply_t, address) + sizeof(uint64_t) * map_fds.size());
+    ebpf_protocol_buffer_t request_buffer(request_buffer_length);
+    ebpf_protocol_buffer_t reply_buffer(reply_buffer_length);
 
     auto request = reinterpret_cast<ebpf_operation_resolve_map_request_t*>(request_buffer.data());
     auto reply = reinterpret_cast<ebpf_operation_resolve_map_reply_t*>(reply_buffer.data());

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -542,14 +542,20 @@ ebpf_deserialize_program_info(
     }
 
     // Check if sufficient buffer is remaining for program type descriptor name.
-    if (buffer_left < sizeof(serialized_program_type_descriptor->name_length)) {
+    if (buffer_left < serialized_program_type_descriptor->name_length) {
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
 
     // Allocate and deserialize program type descriptor name.
+    size_t program_type_descriptor_name_allocation_length = 0;
+    result = ebpf_safe_size_t_add(
+        serialized_program_type_descriptor->name_length, 1, &program_type_descriptor_name_allocation_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
     local_program_type_descriptor_name =
-        (char*)ebpf_allocate_with_tag(serialized_program_type_descriptor->name_length + 1, EBPF_POOL_TAG_DEFAULT);
+        (char*)ebpf_allocate_with_tag(program_type_descriptor_name_allocation_length, EBPF_POOL_TAG_DEFAULT);
     if (local_program_type_descriptor_name == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -558,6 +564,7 @@ ebpf_deserialize_program_info(
         local_program_type_descriptor_name,
         serialized_program_type_descriptor->name,
         serialized_program_type_descriptor->name_length);
+    local_program_type_descriptor_name[serialized_program_type_descriptor->name_length] = '\0';
     local_program_type_descriptor->name = local_program_type_descriptor_name;
 
     // Adjust remaining buffer length.
@@ -650,13 +657,20 @@ ebpf_deserialize_program_info(
         }
 
         // Allocate buffer and serialize helper function name.
+        size_t helper_function_name_allocation_length = 0;
+        result =
+            ebpf_safe_size_t_add(serialized_helper_prototype->name_length, 1, &helper_function_name_allocation_length);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
         local_helper_function_name =
-            (char*)ebpf_allocate_with_tag(serialized_helper_prototype->name_length + 1, EBPF_POOL_TAG_DEFAULT);
+            (char*)ebpf_allocate_with_tag(helper_function_name_allocation_length, EBPF_POOL_TAG_DEFAULT);
         if (local_helper_function_name == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
         memcpy(local_helper_function_name, serialized_helper_prototype->name, serialized_helper_prototype->name_length);
+        local_helper_function_name[serialized_helper_prototype->name_length] = '\0';
         helper_prototype->name = local_helper_function_name;
 
         // Adjust remaining buffer length.

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -225,7 +225,10 @@ ebpf_deserialize_map_info_array(
 
         if (source->pin_path_length > 0) {
             // Allocate the buffer to hold the pin path in destination map info structure.
-            destination_pin_path_length = ((size_t)source->pin_path_length) + 1;
+            result = ebpf_safe_size_t_add((size_t)source->pin_path_length, 1, &destination_pin_path_length);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
             destination->pin_path = ebpf_allocate_with_tag(destination_pin_path_length, EBPF_POOL_TAG_DEFAULT);
             if (destination->pin_path == NULL) {
                 result = EBPF_NO_MEMORY;

--- a/libs/shared/ebpf_shared_framework.h
+++ b/libs/shared/ebpf_shared_framework.h
@@ -99,6 +99,62 @@ __forceinline __drv_allocatesMem(Mem) _Must_inspect_result_
 #define ebpf_safe_size_t_multiply(multiplicand, multiplier, result) \
     ebpf_result_from_cxplat_status(cxplat_safe_size_t_multiply(multiplicand, multiplier, result))
 
+#define ebpf_safe_uint8_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint8_t_add(augend, addend, result))
+#define ebpf_safe_uint8_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint8_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_uint8_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint8_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_int8_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int8_t_add(augend, addend, result))
+#define ebpf_safe_int8_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int8_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_int8_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int8_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_uint16_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint16_t_add(augend, addend, result))
+#define ebpf_safe_uint16_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint16_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_uint16_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint16_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_int16_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int16_t_add(augend, addend, result))
+#define ebpf_safe_int16_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int16_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_int16_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int16_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_uint32_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint32_t_add(augend, addend, result))
+#define ebpf_safe_uint32_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint32_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_uint32_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint32_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_int32_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int32_t_add(augend, addend, result))
+#define ebpf_safe_int32_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int32_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_int32_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int32_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_uint64_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint64_t_add(augend, addend, result))
+#define ebpf_safe_uint64_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint64_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_uint64_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_uint64_t_multiply(multiplicand, multiplier, result))
+
+#define ebpf_safe_int64_t_add(augend, addend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int64_t_add(augend, addend, result))
+#define ebpf_safe_int64_t_subtract(minuend, subtrahend, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int64_t_subtract(minuend, subtrahend, result))
+#define ebpf_safe_int64_t_multiply(multiplicand, multiplier, result) \
+    ebpf_result_from_cxplat_status(cxplat_safe_int64_t_multiply(multiplicand, multiplier, result))
+
 ebpf_result_t
 ebpf_result_from_cxplat_status(cxplat_status_t status);
 

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -443,8 +443,13 @@ _duplicate_helper_function_prototype_array(
     // The ebpf_helper_function_prototype_t struct gets padded at arguments[5] field.
     helper_prototype_size = EBPF_PAD_8(helper_prototype_array[0].header.size);
 
-    local_helper_prototype_array = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(
-        count * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_DEFAULT);
+    size_t helper_array_length = 0;
+    result = ebpf_safe_size_t_multiply(count, sizeof(ebpf_helper_function_prototype_t), &helper_array_length);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+    local_helper_prototype_array =
+        (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(helper_array_length, EBPF_POOL_TAG_DEFAULT);
     if (local_helper_prototype_array == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -236,8 +236,7 @@ ebpf_convert_string_to_guid(_In_z_ const wchar_t* string, _Out_ GUID* guid)
     // The UUID string read from registry also contains the opening and closing braces.
     // Remove those before converting to UUID.
     wchar_t truncated_string[GUID_STRING_LENGTH + 1] = {0};
-    if ((string_length < 2) ||
-        (ebpf_safe_size_t_subtract(string_length, 2, &truncated_length) != EBPF_SUCCESS) ||
+    if ((string_length < 2) || (ebpf_safe_size_t_subtract(string_length, 2, &truncated_length) != EBPF_SUCCESS) ||
         (ebpf_safe_size_t_multiply(truncated_length, sizeof(wchar_t), &copy_length) != EBPF_SUCCESS) ||
         (copy_length >= sizeof(truncated_string))) {
         return EBPF_INVALID_ARGUMENT;

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -24,7 +24,12 @@ wchar_t*
 ebpf_get_wstring_from_string(_In_ const char* text)
 {
     int length = MultiByteToWideChar(CP_UTF8, 0, text, -1, nullptr, 0);
-    wchar_t* wide = (wchar_t*)ebpf_allocate_with_tag(length * sizeof(wchar_t), EBPF_POOL_TAG_DEFAULT);
+    size_t wide_length = 0;
+    if (length <= 0 || ebpf_safe_size_t_multiply((size_t)length, sizeof(wchar_t), &wide_length) != EBPF_SUCCESS) {
+        return nullptr;
+    }
+
+    wchar_t* wide = (wchar_t*)ebpf_allocate_with_tag(wide_length, EBPF_POOL_TAG_DEFAULT);
     if (wide == nullptr) {
         return nullptr;
     }

--- a/libs/store_helper/user/ebpf_registry_helper.cpp
+++ b/libs/store_helper/user/ebpf_registry_helper.cpp
@@ -68,7 +68,14 @@ ebpf_write_registry_value_string(ebpf_store_key_t key, _In_z_ const wchar_t* val
     ebpf_assert(value_name);
     ebpf_assert(value);
 
-    auto length = (wcslen(value) + 1) * sizeof(wchar_t);
+    size_t character_count = 0;
+    size_t length = 0;
+    if ((ebpf_safe_size_t_add(wcslen(value), 1, &character_count) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_multiply(character_count, sizeof(wchar_t), &length) != EBPF_SUCCESS) ||
+        (length > ULONG_MAX)) {
+        return EBPF_ARITHMETIC_OVERFLOW;
+    }
+
     return _EBPF_RESULT(RegSetValueEx(key, value_name, 0, REG_SZ, (uint8_t*)value, (unsigned long)length));
 }
 
@@ -222,11 +229,20 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_convert_string_to_guid(_In_z_ const wchar_t* string, _Out_ GUID* guid)
 {
     ebpf_result_t result = EBPF_SUCCESS;
+    size_t string_length = wcslen(string);
+    size_t truncated_length = 0;
+    size_t copy_length = 0;
 
     // The UUID string read from registry also contains the opening and closing braces.
     // Remove those before converting to UUID.
     wchar_t truncated_string[GUID_STRING_LENGTH + 1] = {0};
-    memcpy(truncated_string, string + 1, (wcslen(string) - 2) * sizeof(wchar_t));
+    if ((string_length < 2) ||
+        (ebpf_safe_size_t_subtract(string_length, 2, &truncated_length) != EBPF_SUCCESS) ||
+        (ebpf_safe_size_t_multiply(truncated_length, sizeof(wchar_t), &copy_length) != EBPF_SUCCESS) ||
+        (copy_length >= sizeof(truncated_string))) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+    memcpy(truncated_string, string + 1, copy_length);
 
     // Convert program type string to GUID
     auto rpc_status = UuidFromString((RPC_WSTR)truncated_string, guid);

--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -16,8 +16,18 @@
 
 #include <stdlib.h>
 
+static void*
+_ebpf_ubpf_calloc(size_t count, size_t size)
+{
+    size_t allocation_length = 0;
+    if (cxplat_safe_size_t_multiply(count, size, &allocation_length) != CXPLAT_STATUS_SUCCESS) {
+        return NULL;
+    }
+    return ebpf_allocate_with_tag(allocation_length, EBPF_POOL_TAG_DEFAULT);
+}
+
 #define malloc(X) ebpf_allocate_with_tag((X), EBPF_POOL_TAG_DEFAULT)
-#define calloc(X, Y) ebpf_allocate_with_tag(((X) * (Y)), EBPF_POOL_TAG_DEFAULT)
+#define calloc(X, Y) _ebpf_ubpf_calloc((X), (Y))
 #define free(X) ebpf_free(X)
 
 #include <endian.h>

--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -17,11 +17,20 @@
 #pragma warning(disable : 4267)
 
 #include <endian.h>
-
 #include <stdlib.h>
 
+static void*
+_ebpf_ubpf_calloc(size_t count, size_t size)
+{
+    size_t allocation_length = 0;
+    if (cxplat_safe_size_t_multiply(count, size, &allocation_length) != CXPLAT_STATUS_SUCCESS) {
+        return NULL;
+    }
+    return ebpf_allocate_with_tag(allocation_length, EBPF_POOL_TAG_DEFAULT);
+}
+
 #define malloc(X) ebpf_allocate_with_tag((X), EBPF_POOL_TAG_DEFAULT)
-#define calloc(X, Y) ebpf_allocate_with_tag(((X) * (Y)), EBPF_POOL_TAG_DEFAULT)
+#define calloc(X, Y) _ebpf_ubpf_calloc((X), (Y))
 #define free(X) ebpf_free(X)
 
 #pragma warning(push)

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -1072,34 +1072,33 @@ net_ebpf_ext_remove_client_context(
     _In_ const struct _net_ebpf_extension_hook_client* hook_client)
 {
     KIRQL old_irql;
-    uint32_t index;
+    uint32_t index = 0;
     bool found = FALSE;
 
     old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
 
     for (index = 0; index < filter_context->client_context_count; index++) {
         if (filter_context->client_contexts[index] == hook_client) {
-            filter_context->client_contexts[index] = NULL;
             filter_context->client_context_count--;
             found = TRUE;
             break;
         }
     }
-    ASSERT(found == TRUE);
-    if (index != filter_context->client_context_count) {
-        size_t client_contexts_length = 0;
-        ASSERT(NT_SUCCESS(RtlSizeTMult(
-            filter_context->client_context_count - index,
-            sizeof(net_ebpf_extension_hook_client_t*),
-            &client_contexts_length)));
-        memmove(
-            &filter_context->client_contexts[index],
-            &filter_context->client_contexts[index + 1],
-            client_contexts_length);
-
-        filter_context->client_contexts[filter_context->client_context_count] = NULL;
+    if (!found) {
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "net_ebpf_ext_remove_client_context: Client context not found");
+        ASSERT(FALSE);
+        goto Exit;
     }
 
+    for (; index < filter_context->client_context_count; index++) {
+        filter_context->client_contexts[index] = filter_context->client_contexts[index + 1];
+    }
+    filter_context->client_contexts[filter_context->client_context_count] = NULL;
+
+Exit:
     ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
 }
 

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -401,6 +401,7 @@ net_ebpf_extension_delete_wfp_filters(
     EBPF_EXT_LOG_EXIT();
 }
 
+#pragma warning(suppress : 6386) // filter_ids receives a separately allocated buffer sized for filter_count entries.
 _Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_add_wfp_filters(
     _In_ HANDLE wfp_engine_handle,
@@ -409,12 +410,14 @@ net_ebpf_extension_add_wfp_filters(
     uint32_t condition_count,
     _In_opt_count_(condition_count) const FWPM_FILTER_CONDITION* conditions,
     _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context,
-    _Outptr_result_buffer_maybenull_(filter_count) net_ebpf_ext_wfp_filter_id_t** filter_ids)
+    _Outptr_result_bytebuffer_maybenull_(filter_count * sizeof(net_ebpf_ext_wfp_filter_id_t))
+        net_ebpf_ext_wfp_filter_id_t** filter_ids)
 {
     NTSTATUS status = STATUS_SUCCESS;
     ebpf_result_t result = EBPF_SUCCESS;
     bool is_in_transaction = FALSE;
     net_ebpf_ext_wfp_filter_id_t* local_filter_ids = NULL;
+    net_ebpf_ext_wfp_filter_id_t* current_filter_id = NULL;
     size_t filter_ids_length = 0;
     *filter_ids = NULL;
 
@@ -440,6 +443,8 @@ net_ebpf_extension_add_wfp_filters(
         EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, local_filter_ids, "local_filter_ids", result);
 
     memset(local_filter_ids, 0, filter_ids_length);
+    current_filter_id = local_filter_ids;
+    __analysis_assume(filter_ids_length >= sizeof(*local_filter_ids) * filter_count);
 
     status = FwpmTransactionBegin(wfp_engine_handle, 0);
     if (!NT_SUCCESS(status)) {
@@ -483,15 +488,16 @@ net_ebpf_extension_add_wfp_filters(
             result = EBPF_INVALID_ARGUMENT;
             goto Exit;
         } else {
-            local_filter_ids[index].id = local_filter_id;
-            local_filter_ids[index].name = (wchar_t*)filter_parameter->name;
-            local_filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_ADDED;
+            current_filter_id->id = local_filter_id;
+            current_filter_id->name = (wchar_t*)filter_parameter->name;
+            current_filter_id->state = NET_EBPF_EXT_WFP_FILTER_ADDED;
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                 EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
                 EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
                 "Added WFP filter: ",
                 index,
                 local_filter_id);
+            current_filter_id++;
         }
     }
 

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -1092,7 +1092,7 @@ net_ebpf_ext_remove_client_context(
             filter_context->client_context_count - index,
             sizeof(net_ebpf_extension_hook_client_t*),
             &client_contexts_length)));
-        memcpy(
+        memmove(
             &filter_context->client_contexts[index],
             &filter_context->client_contexts[index + 1],
             client_contexts_length);

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -223,6 +223,7 @@ net_ebpf_extension_wfp_filter_context_create(
     ebpf_result_t result = EBPF_SUCCESS;
     net_ebpf_extension_wfp_filter_context_t* local_filter_context = NULL;
     uint32_t client_context_count_max = NET_EBPF_EXT_MAX_CLIENTS_PER_HOOK_SINGLE_ATTACH;
+    size_t client_contexts_length = 0;
 
     EBPF_EXT_LOG_ENTRY();
 
@@ -241,18 +242,21 @@ net_ebpf_extension_wfp_filter_context_create(
 
     memset(local_filter_context, 0, filter_context_size);
 
+    status = RtlSizeTMult(client_context_count_max, sizeof(net_ebpf_extension_hook_client_t*), &client_contexts_length);
+    if (!NT_SUCCESS(status)) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Exit;
+    }
+
     local_filter_context->client_contexts = (net_ebpf_extension_hook_client_t**)ExAllocatePoolUninitialized(
-        NonPagedPoolNx,
-        client_context_count_max * sizeof(net_ebpf_extension_hook_client_t*),
-        NET_EBPF_EXTENSION_POOL_TAG);
+        NonPagedPoolNx, client_contexts_length, NET_EBPF_EXTENSION_POOL_TAG);
     EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
         EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
         local_filter_context->client_contexts,
         "local_filter_context - client_contexts",
         result);
 
-    memset(
-        local_filter_context->client_contexts, 0, client_context_count_max * sizeof(net_ebpf_extension_hook_client_t*));
+    memset(local_filter_context->client_contexts, 0, client_contexts_length);
     local_filter_context->client_context_count_max = client_context_count_max;
     local_filter_context->context_deleting = FALSE;
     InitializeListHead(&local_filter_context->link);
@@ -411,6 +415,7 @@ net_ebpf_extension_add_wfp_filters(
     ebpf_result_t result = EBPF_SUCCESS;
     bool is_in_transaction = FALSE;
     net_ebpf_ext_wfp_filter_id_t* local_filter_ids = NULL;
+    size_t filter_ids_length = 0;
     *filter_ids = NULL;
 
     EBPF_EXT_LOG_ENTRY();
@@ -423,12 +428,18 @@ net_ebpf_extension_add_wfp_filters(
         goto Exit;
     }
 
+    status = RtlSizeTMult(sizeof(net_ebpf_ext_wfp_filter_id_t), filter_count, &filter_ids_length);
+    if (!NT_SUCCESS(status)) {
+        result = EBPF_ARITHMETIC_OVERFLOW;
+        goto Exit;
+    }
+
     local_filter_ids = (net_ebpf_ext_wfp_filter_id_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, (sizeof(net_ebpf_ext_wfp_filter_id_t) * filter_count), NET_EBPF_EXTENSION_POOL_TAG);
+        NonPagedPoolNx, filter_ids_length, NET_EBPF_EXTENSION_POOL_TAG);
     EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
         EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, local_filter_ids, "local_filter_ids", result);
 
-    memset(local_filter_ids, 0, (sizeof(net_ebpf_ext_wfp_filter_id_t) * filter_count));
+    memset(local_filter_ids, 0, filter_ids_length);
 
     status = FwpmTransactionBegin(wfp_engine_handle, 0);
     if (!NT_SUCCESS(status)) {
@@ -1070,10 +1081,15 @@ net_ebpf_ext_remove_client_context(
     }
     ASSERT(found == TRUE);
     if (index != filter_context->client_context_count) {
+        size_t client_contexts_length = 0;
+        ASSERT(NT_SUCCESS(RtlSizeTMult(
+            filter_context->client_context_count - index,
+            sizeof(net_ebpf_extension_hook_client_t*),
+            &client_contexts_length)));
         memcpy(
             &filter_context->client_contexts[index],
             &filter_context->client_contexts[index + 1],
-            (filter_context->client_context_count - index) * sizeof(net_ebpf_extension_hook_client_t*));
+            client_contexts_length);
 
         filter_context->client_contexts[filter_context->client_context_count] = NULL;
     }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -1085,9 +1085,9 @@ net_ebpf_ext_remove_client_context(
         }
     }
     if (!found) {
-        NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
             "net_ebpf_ext_remove_client_context: Client context not found");
         ASSERT(FALSE);
         goto Exit;

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -296,7 +296,8 @@ net_ebpf_extension_add_wfp_filters(
     uint32_t condition_count,
     _In_opt_count_(condition_count) const FWPM_FILTER_CONDITION* conditions,
     _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context,
-    _Outptr_result_buffer_maybenull_(filter_count) net_ebpf_ext_wfp_filter_id_t** filter_ids);
+    _Outptr_result_bytebuffer_maybenull_(filter_count * sizeof(net_ebpf_ext_wfp_filter_id_t))
+        net_ebpf_ext_wfp_filter_id_t** filter_ids);
 
 /**
  * @brief Deletes WFP filters with specified filter IDs.


### PR DESCRIPTION
## Summary
- migrate overflow-sensitive API buffer sizing and batch offset math to cxplat safe integer helpers
- use checked arithmetic in user and kernel ring-buffer sizing paths
- update the user-mode RtlULongAdd mock to report integer overflow instead of doing unchecked addition

## Validation
- msbuild /m /p:Configuration=Debug /p:Platform=x64 ebpf-for-windows.sln
- x64\\Debug\\unit_tests.exe *(existing end-to-end/program-loading failures in this environment)*

## Tracking
Fixes: #5202