### PR TITLE
Fix OneBranch signed-nupkg repack

### DIFF
--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -128,8 +128,8 @@ Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\
 Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"  -DevCmdArguments "-arch=$OneBranchArch -host_arch=x64"
 Set-Location $scriptPath\..\..
 $SolutionDir = Get-Location
-msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\tools\nuget\nuget.vcxproj
-msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\tools\redist-package\redist-package.vcxproj
+msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false /p:ForceRepack=true .\tools\nuget\nuget.vcxproj
+msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false /p:ForceRepack=true .\tools\redist-package\redist-package.vcxproj
 msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\installer\ebpf-for-windows.wixproj
 
 # After building the packages

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -178,4 +178,9 @@ popd $(OutDir)</Command>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <!-- Delete the nupkg before the up-to-date check so nuget pack always re-runs.
+       Used by scripts/onebranch/post-build.ps1 to repack with signed binaries. -->
+  <Target Name="ForceRepack" BeforeTargets="CustomBuild" Condition="'$(ForceRepack)'=='true'">
+    <Delete Files="$(OutDir)eBPF-for-Windows.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg" />
+  </Target>
 </Project>

--- a/tools/redist-package/redist-package.vcxproj
+++ b/tools/redist-package/redist-package.vcxproj
@@ -163,4 +163,9 @@ NuGet.exe pack $(OutDir)ebpf-for-windows-redist.nuspec -OutputDirectory $(OutDir
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <!-- Delete the nupkg before the up-to-date check so nuget pack always re-runs.
+       Used by scripts/onebranch/post-build.ps1 to repack with signed binaries. -->
+  <Target Name="ForceRepack" BeforeTargets="CustomBuild" Condition="'$(ForceRepack)'=='true'">
+    <Delete Files="$(OutDir)eBPF-for-Windows-Redist.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Description

Fix post-signing nupkg repack regression introduced by #5131.

#5131 made nuget.vcxproj and redist-package.vcxproj incrementally correct, but this caused the post-signing repack in scripts/onebranch/post-build.ps1 to no-op — MSBuild sees the initial nupkg as up-to-date since signing doesn't modify any tracked AdditionalInputs.

Add a ForceRepack target to both vcxprojs that deletes the existing nupkg before the up-to-date check, gated on /p:ForceRepack=true. Update post-build.ps1 to pass this property on its repack calls. Normal incremental builds are unaffected.

Fixes #5209 

## Testing

- Verified normal build skips repack: All outputs are up-to-date
- Verified /p:ForceRepack=true deletes the nupkg and re-runs nuget pack: Successfully created package

## Documentation

N/A

## Installation

N/A
