### PR TITLE
build: add SkipNugetPackages opt-out for solution-level builds

### DIFF
--- a/.azure/reusable-build.yml
+++ b/.azure/reusable-build.yml
@@ -117,7 +117,7 @@ jobs:
         displayName: 'Configuring repo for first build'
 
       - script: |
-          "$(MSBUILD_PATH)\msbuild.exe" /m /p:Configuration=$(BUILD_CONFIGURATION) /p:Platform=$(BUILD_PLATFORM) $(SOLUTION_FILE_PATH) $(BUILD_OPTIONS)
+          "$(MSBUILD_PATH)\msbuild.exe" /m /p:Configuration=$(BUILD_CONFIGURATION) /p:Platform=$(BUILD_PLATFORM) /p:SkipNugetPackages=true $(SOLUTION_FILE_PATH) $(BUILD_OPTIONS)
         workingDirectory: $(Build.SourcesDirectory)
         displayName: 'Build'
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -243,7 +243,11 @@ jobs:
       - name: Build
         if: steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:HostPlatform=${{env.BUILD_PLATFORM}} ${{env.BUILD_OPTIONS}} ${{env.SOLUTION_FILE_PATH}}  /bl:out.binlog
+        # /p:SkipNugetPackages=true: the generic solution build doesn't need
+        # to produce the .nupkg as a side effect. The explicit
+        # /t:tools\nuget and /t:tools\redist-package steps below run only
+        # for Release/NativeOnlyRelease and rebuild the package on demand.
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:HostPlatform=${{env.BUILD_PLATFORM}} /p:SkipNugetPackages=true ${{env.BUILD_OPTIONS}} ${{env.SOLUTION_FILE_PATH}}  /bl:out.binlog
 
       - name: Check DLL dependencies for distributed binaries
         if: steps.skip_check.outputs.should_skip != 'true' && ((inputs.build_artifact == 'Build-x64' && matrix.configurations == 'Debug') || (inputs.build_artifact == 'Build-x64-native-only' && matrix.configurations == 'NativeOnlyRelease'))

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -153,7 +153,15 @@ powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archiv
 popd $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemGroup>
+  <!-- Skip the nuget pack step when the consumer signals it isn't interested
+       in the .nupkg artifact (e.g. test / signing / sanitize pipelines that
+       build the full solution but only consume the loose binaries). The
+       default behaviour is unchanged - the .nupkg is still built in every
+       configuration the .sln maps this project into, so devs running the
+       solution locally and any explicit `/t:tools\nuget` invocations
+       continue to produce a package. Downstream callers can opt out with
+       `msbuild ... /p:SkipNugetPackages=true`. -->
+  <ItemGroup Condition="'$(SkipNugetPackages)'!='true'">
     <CustomBuild Include="ebpf-for-windows.nuspec.in">
       <FileType>Document</FileType>
       <Outputs>$(OutDir)eBPF-for-Windows.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg</Outputs>

--- a/tools/redist-package/redist-package.vcxproj
+++ b/tools/redist-package/redist-package.vcxproj
@@ -121,8 +121,11 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <!-- In accordance to what is defined in sample.vcxproj, the build is disabled for the 'Analysis' CI/CD build, as it does not generate the printk.sys artifact. -->
-  <ItemGroup Condition="'$(Analysis)'==''">
+  <!-- In accordance to what is defined in sample.vcxproj, the build is disabled for the 'Analysis' CI/CD build, as it does not generate the printk.sys artifact.
+       Additionally, downstream consumers (test / signing / sanitize pipelines
+       that build the full solution but only consume the loose binaries) can
+       skip the redist nupkg pack step with `msbuild ... /p:SkipNugetPackages=true`. -->
+  <ItemGroup Condition="'$(Analysis)'=='' AND '$(SkipNugetPackages)'!='true'">
     <CustomBuild Include="ebpf-for-windows-redist.nuspec.in">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -ConfigSuffix '$(NugetConfigSuffix)'


### PR DESCRIPTION
## What

Add an opt-out property `SkipNugetPackages` to `tools/nuget/nuget.vcxproj` and
`tools/redist-package/redist-package.vcxproj` so that consumers of the .sln who
don't need the `.nupkg` artifact can suppress the `NuGet.exe pack` CustomBuild
step.

Default behaviour is **unchanged** - the `.nupkg` is still produced in every
configuration the .sln maps these projects into, both locally and in CI. The
opt-out only kicks in when the caller explicitly passes
`/p:SkipNugetPackages=true`.

Also updates the CI workflows to use the new property:

- `.github/workflows/reusable-build.yml`: pass `/p:SkipNugetPackages=true` on
  the generic `.sln` build (line ~246). The explicit `/t:tools\nuget` and
  `/t:tools\redist-package` steps that follow are gated to `Release` /
  `NativeOnlyRelease` and don't pass the flag, so the `.nupkg` is still
  produced exactly where it's uploaded as an artifact.
- `.azure/reusable-build.yml`: same change on its generic `.sln` build.

## Why

Two motivations:

1. **CI cost** - the workflows already only upload the `.nupkg` when
   `Configuration in {Release, NativeOnlyRelease}` (see e.g.
   [reusable-build.yml#L322-L350](https://github.com/microsoft/ebpf-for-windows/blob/main/.github/workflows/reusable-build.yml#L322-L350)),
   so the Debug / NativeOnlyDebug / FuzzerDebug / Sanitize / Analysis
   pack invocations are wasted work. They build a `.nupkg` that is then
   discarded.

2. **Downstream signing pipelines** - when a downstream pipeline builds the
   full `.sln` and then signs the loose binaries in the output directory,
   the binaries that were copied *into* the freshly packed `.nupkg` remain
   unsigned. Microsoft's CodeSign Validation (Guardian) walks into `.nupkg`
   archives and flags the inner unsigned binaries, breaking compliance gates
   even though the actual shippable binaries are signed correctly. Today
   such pipelines have to either re-pack the `.nupkg` from the signed loose
   binaries (fragile, requires walking the project graph) or fork the
   projects. With this change they can pass
   `/p:SkipNugetPackages=true` on solution-level builds and avoid producing
   the unsigned-inner-bin artifact in the first place. (They still build
   the `.nupkg` explicitly when they actually want a signed package.)

## How it works

The `<CustomBuild Include="ebpf-for-windows*.nuspec.in">` ItemGroup that
runs the `NuGet.exe pack` step is now wrapped in:

```xml
<ItemGroup Condition="'$(SkipNugetPackages)'!='true'">
  ...
</ItemGroup>
```

When the property is unset (default) the condition is true and the
CustomBuild item is included exactly as before. When the property is
`true` the item is omitted and msbuild treats the project as having no
custom build step beyond the inherited targets - the project still builds
successfully, just without a `.nupkg` output.

`redist-package.vcxproj` retains its existing `'$(Analysis)'==''`
guard; the new condition is ANDed in.

## Verification

- Local: `msbuild ebpf-for-windows.sln /p:Configuration=Debug /p:Platform=x64`
  → `.nupkg` produced (default behaviour unchanged).
- Local: `msbuild ... /p:SkipNugetPackages=true` → no `.nupkg`, build succeeds.
- CI: existing workflows continue to upload Release / NativeOnlyRelease
  `.nupkg` artifacts via the explicit `/t:tools\nuget` step, which doesn't
  pass the flag.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
