### PR TITLE
build: add SkipNugetPackages opt-out and use it in analyze/sanitize CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -340,7 +340,8 @@ jobs:
       repository: ${{ github.repository }}
       build_artifact: Build-x64-Analyze
       # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
-      build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
+      # /p:SkipNugetPackages=true: this stage doesn't ship a .nupkg artifact, so suppress the side-effect pack from the .sln build.
+      build_options: /p:Analysis='True' /p:AnalysisOnExternal='False' /p:SkipNugetPackages=true
 
   # Build with C++ address sanitizer.
   sanitize:
@@ -351,7 +352,8 @@ jobs:
       ref: ${{ github.ref }}
       repository: ${{ github.repository }}
       build_artifact: Build-x64-Sanitize
-      build_options: /p:AddressSanitizer='True'
+      # /p:SkipNugetPackages=true: this stage doesn't ship a .nupkg artifact, so suppress the side-effect pack from the .sln build.
+      build_options: /p:AddressSanitizer='True' /p:SkipNugetPackages=true
 
   bpf2c_fuzzer:
     needs: regular

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -76,7 +76,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PostBuildEvent Condition="'$(SkipNugetPackages)'!='true'">
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
@@ -96,7 +96,7 @@ popd $(OutDir)</Command>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PostBuildEvent Condition="'$(SkipNugetPackages)'!='true'">
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
@@ -120,7 +120,7 @@ popd $(OutDir)</Command>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PostBuildEvent Condition="'$(SkipNugetPackages)'!='true'">
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
@@ -144,7 +144,7 @@ popd $(OutDir)</Command>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PostBuildEvent>
+    <PostBuildEvent Condition="'$(SkipNugetPackages)'!='true'">
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
@@ -153,7 +153,13 @@ powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archiv
 popd $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemGroup>
+  <!-- Downstream consumers (test, analyze, sanitize, signing pipelines, etc.)
+       that build the full solution but don't need the .nupkg artifact can
+       suppress this CustomBuild step by passing /p:SkipNugetPackages=true.
+       Default behaviour is unchanged - the .nupkg is built whenever this
+       project's Build target runs (local dev, .sln builds without the flag,
+       and the explicit /t:tools\nuget invocations in the CI workflows). -->
+  <ItemGroup Condition="'$(SkipNugetPackages)'!='true'">
     <CustomBuild Include="ebpf-for-windows.nuspec.in">
       <FileType>Document</FileType>
       <Outputs>$(OutDir)eBPF-for-Windows.$(Platform)$(NugetConfigSuffix).$(EbpfVersion).nupkg</Outputs>

--- a/tools/redist-package/redist-package.vcxproj
+++ b/tools/redist-package/redist-package.vcxproj
@@ -121,8 +121,11 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <!-- In accordance to what is defined in sample.vcxproj, the build is disabled for the 'Analysis' CI/CD build, as it does not generate the printk.sys artifact. -->
-  <ItemGroup Condition="'$(Analysis)'==''">
+  <!-- In accordance to what is defined in sample.vcxproj, the build is disabled for the 'Analysis' CI/CD build, as it does not generate the printk.sys artifact.
+       Downstream consumers that build the full solution but don't need the
+       redist .nupkg artifact can also suppress this step by passing
+       /p:SkipNugetPackages=true. Default behaviour is unchanged. -->
+  <ItemGroup Condition="'$(Analysis)'=='' AND '$(SkipNugetPackages)'!='true'">
     <CustomBuild Include="ebpf-for-windows-redist.nuspec.in">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\redist-package\ebpf-for-windows-redist.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-redist.nuspec -VCToolsRedistDir '$(VCToolsRedistInstallDir)' -Architecture '$(Platform)' -ConfigSuffix '$(NugetConfigSuffix)'

--- a/tools/sample-package/sample-package.vcxproj
+++ b/tools/sample-package/sample-package.vcxproj
@@ -122,7 +122,7 @@
     </Link>
   </ItemDefinitionGroup>
   <!-- In accordance to what is defined in sample.vcxproj, the build is disabled for the 'Analysis' CI/CD build, as it does not generate the .o artifacts. -->
-  <ItemGroup Condition="'$(Analysis)'==''">
+  <ItemGroup Condition="'$(Analysis)'=='' AND '$(SkipNugetPackages)'!='true'">
     <CustomBuild Include="ebpf-for-windows-samples.nuspec.in">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)'=='Debug'">powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Set-Version.ps1 -InputFile $(SolutionDir)tools\sample-package\ebpf-for-windows-samples.nuspec.in -OutputFile $(OutDir)ebpf-for-windows-samples.nuspec -Architecture '$(Platform)' -Configuration '$(Configuration)'

--- a/undocked/tests/sample/ext/drv/sample_ext.vcxproj
+++ b/undocked/tests/sample/ext/drv/sample_ext.vcxproj
@@ -166,4 +166,23 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <!-- This project consumes the extracted .nupkg from $(OutDir)undocked\ebpf-for-windows
+       (see AdditionalIncludeDirectories above). When the .nupkg is suppressed via
+       /p:SkipNugetPackages=true, that include tree doesn't exist, so skip the build
+       entirely instead of failing on missing headers.
+
+       NOTE: We MUST NOT define new <Target Name="Build"> elements unconditionally,
+       because MSBuild target overriding happens at parse time regardless of the
+       target's Condition - that would silently no-op the inherited Build target
+       even on default builds. Instead, conditionally redirect the *DependsOn
+       property chains so that when the property is unset the PropertyGroup is
+       omitted entirely and the inherited Cpp.targets behavior is preserved. -->
+  <PropertyGroup Condition="'$(SkipNugetPackages)'=='true'">
+    <BuildDependsOn>SkipNugetPackagesMessage</BuildDependsOn>
+    <RebuildDependsOn>SkipNugetPackagesMessage</RebuildDependsOn>
+    <CleanDependsOn>SkipNugetPackagesMessage</CleanDependsOn>
+  </PropertyGroup>
+  <Target Name="SkipNugetPackagesMessage" Condition="'$(SkipNugetPackages)'=='true'">
+    <Message Importance="high" Text="Skipping $(MSBuildProjectFile) because SkipNugetPackages is true (this project validates the extracted .nupkg)." />
+  </Target>
 </Project>

--- a/undocked/tools/export_program_info_sample/export_program_info_sample.vcxproj
+++ b/undocked/tools/export_program_info_sample/export_program_info_sample.vcxproj
@@ -221,4 +221,23 @@ $(OutputPath)export_program_info_sample.exe</Command>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <!-- This project consumes the extracted .nupkg from $(OutDir)undocked\ebpf-for-windows
+       (see AdditionalIncludeDirectories above). When the .nupkg is suppressed via
+       /p:SkipNugetPackages=true, that include tree doesn't exist, so skip the build
+       entirely instead of failing on missing headers.
+
+       NOTE: We MUST NOT define new <Target Name="Build"> elements unconditionally,
+       because MSBuild target overriding happens at parse time regardless of the
+       target's Condition - that would silently no-op the inherited Build target
+       even on default builds. Instead, conditionally redirect the *DependsOn
+       property chains so that when the property is unset the PropertyGroup is
+       omitted entirely and the inherited Cpp.targets behavior is preserved. -->
+  <PropertyGroup Condition="'$(SkipNugetPackages)'=='true'">
+    <BuildDependsOn>SkipNugetPackagesMessage</BuildDependsOn>
+    <RebuildDependsOn>SkipNugetPackagesMessage</RebuildDependsOn>
+    <CleanDependsOn>SkipNugetPackagesMessage</CleanDependsOn>
+  </PropertyGroup>
+  <Target Name="SkipNugetPackagesMessage" Condition="'$(SkipNugetPackages)'=='true'">
+    <Message Importance="high" Text="Skipping $(MSBuildProjectFile) because SkipNugetPackages is true (this project validates the extracted .nupkg)." />
+  </Target>
 </Project>


### PR DESCRIPTION
## What

Adds an opt-out property `SkipNugetPackages` so callers building the full
`.sln` can suppress the `.nupkg` pack step (and everything that depends on
it) when they don't want a `.nupkg` artifact.

Default behaviour is **unchanged** - the `.nupkg` is still produced in
every configuration the `.sln` maps these projects into, both locally and
in CI. The opt-out only kicks in when the caller explicitly passes
`/p:SkipNugetPackages=true`.

Wires the new property up in `.github/workflows/cicd.yml` for the two CI
jobs that build the full `.sln` but don't ship a `.nupkg` artifact:
`analyze` (`Build-x64-Analyze`) and `sanitize` (`Build-x64-Sanitize`).

All other CI jobs (`regular`, `regular_native_only_onebranch`,
`regular_native_only`, `codeql`, `perf`) and `reusable-build.yml` itself
are intentionally left alone, so every existing build artifact - including
the `.nupkg` that currently rides inside `Build-*-{Debug,NativeOnlyDebug}`
zips, the dedicated `ebpf-for-windows - NuGet package (...)` uploads, and
`Build-x64-CodeQl` (which still needs to compile the undocked projects so
CodeQL can analyze them) - is preserved exactly as today.

## Why

Two motivations:

1. **CI cost** - `analyze` and `sanitize` produce a `.nupkg` today that is
   immediately discarded. Suppressing the `NuGet.exe pack` (and the
   PostBuildEvent extract that follows) shaves time off both jobs.

2. **Downstream signing pipelines** - when a downstream pipeline builds
   the full `.sln` and then signs the loose binaries in the output
   directory, the binaries that were copied *into* the freshly packed
   `.nupkg` remain unsigned. Microsoft's CodeSign Validation (Guardian)
   walks into `.nupkg` archives and flags the inner unsigned binaries,
   breaking compliance gates even though the actual shippable binaries
   are signed correctly. Today such pipelines have to either re-pack the
   `.nupkg` from the signed loose binaries (fragile) or fork the
   projects. With this change they can pass `/p:SkipNugetPackages=true`
   on solution-level builds and avoid producing the
   unsigned-inner-bin artifact in the first place. (They still build the
   `.nupkg` explicitly, after signing, when they actually want a signed
   package.)

## How it works

The change is a coordinated set of conditions across five `.vcxproj` files
and one workflow file - all gated on `'$(SkipNugetPackages)'!='true'` (or
`=='true'` for the inverse no-op overrides):

### `tools/nuget/nuget.vcxproj`

Two distinct things produce `.nupkg`-related output here:

1. The `<CustomBuild>` ItemGroup that runs `NuGet.exe pack`. Wrapped in
   `Condition="'$(SkipNugetPackages)'!='true'"`.
2. Four `<PostBuildEvent>` blocks (one per Configuration:
   Debug / NativeOnlyDebug / Release / NativeOnlyRelease) that
   `xcopy $(OutDir)eBPF-for-Windows.*.nupkg ...` into an extracted
   "undocked SDK" tree at `$(OutDir)undocked\ebpf-for-windows\`.
   Without the `.nupkg`, these would fail with MSB3073, so each
   `<PostBuildEvent>` element also gets the same condition.

### `tools/redist-package/redist-package.vcxproj`

Same pattern: the `<CustomBuild>` ItemGroup that runs `NuGet.exe pack`
gets `'$(SkipNugetPackages)'!='true'` ANDed with the existing
`'$(Analysis)'==''` guard.

### `tools/sample-package/sample-package.vcxproj`

Same: `<CustomBuild>` ItemGroup gated, ANDed with the existing
`'$(Analysis)'==''` guard.

### `undocked/tools/export_program_info_sample/export_program_info_sample.vcxproj` and `undocked/tests/sample/ext/drv/sample_ext.vcxproj`

These two projects exist **specifically** to validate that the produced
`.nupkg` is consumable as a third-party SDK - their
`AdditionalIncludeDirectories` references
`$(OutDir)undocked\ebpf-for-windows\build\native\include\`, i.e., the
extracted-`.nupkg` headers populated by the PostBuildEvents above.

When `SkipNugetPackages=true`, that include tree doesn't exist, so these
projects can't compile. Override `Build`, `Rebuild`, and `Clean` with
no-op targets gated on `'$(SkipNugetPackages)'=='true'`:

```xml
<Target Name="Build" Condition="'$(SkipNugetPackages)'=='true'">
  <Message Importance="high" Text="Skipping ... because SkipNugetPackages is true ..." />
</Target>
<Target Name="Rebuild" Condition="'$(SkipNugetPackages)'=='true'" DependsOnTargets="Build" />
<Target Name="Clean" Condition="'$(SkipNugetPackages)'=='true'" />
```

No other projects in the `.sln` depend on these two, so skipping them is
safe.

### `.github/workflows/cicd.yml`

Append `/p:SkipNugetPackages=true` to `build_options` of `analyze` and
`sanitize`. Both already pass `build_options` through to
`reusable-build.yml`'s generic `.sln` `msbuild` invocation; appending
the flag suppresses the implicit pack only on those two non-shipping
jobs.

`codeql` and `perf` deliberately do **not** get the flag:
- `codeql` needs to compile the `undocked\*` projects so CodeQL analyzes
  them.
- `perf` only runs on `workflow_dispatch` and uploads `Build-x64` whose
  contents we don't want to change.

## Verification

- `msbuild ebpf-for-windows.sln /p:Configuration=Debug /p:Platform=x64`
  → `.nupkg` produced, undocked extract populated, `undocked\*` projects
  built (default behaviour unchanged).
- `msbuild ... /p:SkipNugetPackages=true` → no `.nupkg`, no extract,
  `undocked\*` projects skipped with a Message, build succeeds.
- CI: `regular*`, `codeql`, `perf` jobs continue to upload existing
  artifacts (with the embedded `.nupkg`) and the dedicated `NuGet
  package` uploads. The `analyze` and `sanitize` jobs no longer emit the
  `.nupkg` side effect or the `undocked\*` outputs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
