### PR TITLE
Miscellaneous Bug Fixes for 26_05 

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -163,7 +163,7 @@ jobs:
         id: install_procdump
         if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
         env:
-          PROCDUMP_EXPECTED_HASH: '863E7F078B35327CEDC5A1101C60E26C2A9E7F76388D0D0FFE44018B381784B4'
+          PROCDUMP_EXPECTED_HASH: '28588D9CFD3354A3A71204A570B9B60129761962F505B3CFE26DAA9A5175C14A'
         run: |
           curl.exe -L -o ${{github.workspace}}\Procdump.zip https://download.sysinternals.com/files/Procdump.zip
           $actualHash = (Get-FileHash -Path ${{github.workspace}}\Procdump.zip -Algorithm SHA256).Hash

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -495,6 +495,15 @@ _ebpf_driver_io_device_control(
                         goto Done;
                     }
                     user_reply = output_buffer;
+
+                    // Zero any output buffer bytes beyond the input data to prevent
+                    // leaking uninitialized kernel pool memory to user-mode.
+                    if (actual_output_length > actual_input_length) {
+                        memset(
+                            (uint8_t*)output_buffer + actual_input_length,
+                            0,
+                            actual_output_length - actual_input_length);
+                    }
                 }
 
                 if (async) {

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -679,7 +679,11 @@ ebpf_ring_buffer_map_map_buffer_with_index(
  */
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_unmap_buffer_with_index(
-    fd_t map_fd, uint64_t index, _In_ void* consumer, _In_ const void* producer, _In_ const void* data) noexcept;
+    fd_t map_fd,
+    uint64_t index,
+    _In_opt_ void* consumer,
+    _In_opt_ const void* producer,
+    _In_opt_ const void* data) noexcept;
 
 /**
  * @brief Get list of programs and stats in an ELF eBPF file.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4513,7 +4513,7 @@ typedef struct _ebpf_map_async_query_context
 {
     _ebpf_map_async_query_context()
         : async_ioctl_failed(false), async_ioctl_completion(nullptr), buffer(nullptr), reply({}), cpu_id(0),
-          subscription(nullptr), lost_count_total(0)
+          subscription(nullptr), lost_count_total(0), consumer_advance_posted(false)
     {
     }
 
@@ -4534,6 +4534,9 @@ typedef struct _ebpf_map_async_query_context
     size_t lost_count_total;
     async_ioctl_completion_t* async_ioctl_completion;
     bool async_ioctl_failed;
+    // Set to true when we have posted a final consumer-advance IOCTL after unsubscribe to ensure
+    // the kernel's consumer offset is updated before the subscription is torn down.
+    bool consumer_advance_posted;
     ebpf_operation_map_async_query_reply_t reply;
     ebpf_map_subscription_t* subscription;
 
@@ -4687,6 +4690,43 @@ _ebpf_map_async_query_completion(_Inout_ void* completion_context) NO_EXCEPT_TRY
         std::scoped_lock lock{subscription->lock};
 
         if (subscription->unsubscribed) {
+            // If this was a successful (non-canceled) completion and we haven't yet advanced the
+            // kernel's consumer offset, do so now by posting one final IOCTL with the updated
+            // consumer value, then immediately cancel it.  The kernel calls ebpf_map_return_buffer
+            // on IOCTL receipt (before waiting for new data), so this advances the kernel's consumer
+            // even though the IOCTL will complete with EBPF_CANCELED.  Without this, a new
+            // subscriber on the same map would replay already-delivered records.
+            if (!async_query_context->consumer_advance_posted && result == EBPF_SUCCESS) {
+                async_query_context->consumer_advance_posted = true;
+
+                ebpf_result_t advance_result =
+                    register_wait_async_ioctl_operation(async_query_context->async_ioctl_completion);
+                if (advance_result == EBPF_SUCCESS) {
+                    ebpf_operation_map_async_query_request_t advance_request{
+                        sizeof(advance_request),
+                        ebpf_operation_id_t::EBPF_OPERATION_MAP_ASYNC_QUERY,
+                        subscription->map_handle,
+                        cpu_id,
+                        consumer};
+                    memset(&async_query_context->reply, 0, sizeof(ebpf_operation_map_async_query_reply_t));
+                    advance_result = win32_error_code_to_ebpf_result(invoke_ioctl(
+                        advance_request,
+                        async_query_context->reply,
+                        get_async_ioctl_operation_overlapped(async_query_context->async_ioctl_completion)));
+                    if (advance_result == EBPF_PENDING || advance_result == EBPF_SUCCESS) {
+                        // Immediately cancel: we only need the kernel to process the consumer_offset
+                        // in the request (via ebpf_map_return_buffer); we don't want to wait for data.
+                        cancel_async_ioctl(
+                            get_async_ioctl_operation_overlapped(async_query_context->async_ioctl_completion));
+                        // The next callback (EBPF_CANCELED) will erase the context via the else
+                        // branch of consumer_advance_posted below.
+                        EBPF_RETURN_RESULT(EBPF_SUCCESS);
+                    }
+                }
+                // Failed to post the advance IOCTL - fall through to erase immediately.
+                async_query_context->consumer_advance_posted = false;
+            }
+
             result = EBPF_CANCELED;
 
             // If the user has unsubscribed, remove the async query context.
@@ -5310,7 +5350,7 @@ CATCH_NO_MEMORY_EBPF_RESULT
 // The kernel uses its internally-stored addresses for unmapping, so no user-space
 // addresses need to be provided.
 static _Must_inspect_result_ ebpf_result_t
-ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index)
+ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index) 
     NO_EXCEPT_TRY
 {
     ebpf_operation_ring_buffer_map_unmap_buffer_request_t request{

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -5295,18 +5295,16 @@ ebpf_ring_buffer_map_unmap_buffer_with_index(
     fd_t map_fd, uint64_t index, _In_ void* consumer, _In_ const void* producer, _In_ const void* data) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
+    UNREFERENCED_PARAMETER(consumer);
+    UNREFERENCED_PARAMETER(producer);
+    UNREFERENCED_PARAMETER(data);
+
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_handle_t map_handle = _get_handle_from_file_descriptor(map_fd);
     if (map_handle == ebpf_handle_invalid)
         return EBPF_INVALID_FD;
     ebpf_operation_ring_buffer_map_unmap_buffer_request_t request{
-        sizeof(request),
-        ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER,
-        map_handle,
-        index,
-        reinterpret_cast<uint64_t>(consumer),
-        reinterpret_cast<uint64_t>(producer),
-        reinterpret_cast<uint64_t>(data)};
+        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER, map_handle, index};
     result = win32_error_code_to_ebpf_result(invoke_ioctl(request));
     EBPF_RETURN_RESULT(result);
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4924,7 +4924,7 @@ _map_write(ebpf_handle_t map_handle, _In_reads_bytes_(data_length) const void* d
 CATCH_NO_MEMORY_EBPF_RESULT
 
 static _Must_inspect_result_ ebpf_result_t
-ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index);
+ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index) noexcept;
 
 bool
 ebpf_map_unsubscribe(_In_ _Post_invalid_ ebpf_map_subscription_t* subscription) NO_EXCEPT_TRY
@@ -5311,11 +5311,13 @@ CATCH_NO_MEMORY_EBPF_RESULT
 // addresses need to be provided.
 static _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index)
+    NO_EXCEPT_TRY
 {
     ebpf_operation_ring_buffer_map_unmap_buffer_request_t request{
         sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER, map_handle, index};
     return win32_error_code_to_ebpf_result(invoke_ioctl(request));
 }
+CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_unmap_buffer_with_index(

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -5292,7 +5292,8 @@ CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_unmap_buffer_with_index(
-    fd_t map_fd, uint64_t index, _In_ void* consumer, _In_ const void* producer, _In_ const void* data) NO_EXCEPT_TRY
+    fd_t map_fd, uint64_t index, _In_opt_ void* consumer, _In_opt_ const void* producer, _In_opt_ const void* data)
+    NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
     UNREFERENCED_PARAMETER(consumer);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4923,6 +4923,9 @@ _map_write(ebpf_handle_t map_handle, _In_reads_bytes_(data_length) const void* d
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
+static _Must_inspect_result_ ebpf_result_t
+ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index);
+
 bool
 ebpf_map_unsubscribe(_In_ _Post_invalid_ ebpf_map_subscription_t* subscription) NO_EXCEPT_TRY
 {
@@ -4930,8 +4933,15 @@ ebpf_map_unsubscribe(_In_ _Post_invalid_ ebpf_map_subscription_t* subscription) 
     ebpf_assert(subscription);
     boolean cancel_result = true;
 
+    // Collect CPU IDs before cancellation erases contexts from the map.
+    std::vector<uint32_t> cpu_ids_to_unmap;
+
     {
         std::scoped_lock lock{subscription->lock};
+
+        for (const auto& [cpu_id, ctx] : subscription->async_query_contexts) {
+            cpu_ids_to_unmap.push_back(cpu_id);
+        }
 
         // Set the unsubscribed flag, so that if a completion callback is ongoing, it does not issue another async
         // IOCTL.
@@ -4980,6 +4990,12 @@ ebpf_map_unsubscribe(_In_ _Post_invalid_ ebpf_map_subscription_t* subscription) 
         subscription->cleanup_complete_event.wait(lock_wait, all_done_or_failed);
         // Clean up remaining (failed) contexts.
         subscription->async_query_contexts.clear();
+    }
+
+    // Unmap per-CPU ring buffers so the kernel clears the user-mode mappings,
+    // allowing future perf_buffer__new / ring_buffer__new calls on the same map within this process.
+    for (uint32_t cpu_id : cpu_ids_to_unmap) {
+        (void)ebpf_ring_buffer_map_unmap_buffer_with_handle(subscription->map_handle, cpu_id);
     }
 
     delete subscription;
@@ -5290,6 +5306,17 @@ ebpf_ring_buffer_map_map_buffer(
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
+// Shared helper: send unmap IOCTL by map handle and index.
+// The kernel uses its internally-stored addresses for unmapping, so no user-space
+// addresses need to be provided.
+static _Must_inspect_result_ ebpf_result_t
+ebpf_ring_buffer_map_unmap_buffer_with_handle(ebpf_handle_t map_handle, uint64_t index)
+{
+    ebpf_operation_ring_buffer_map_unmap_buffer_request_t request{
+        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER, map_handle, index};
+    return win32_error_code_to_ebpf_result(invoke_ioctl(request));
+}
+
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_unmap_buffer_with_index(
     fd_t map_fd, uint64_t index, _In_opt_ void* consumer, _In_opt_ const void* producer, _In_opt_ const void* data)
@@ -5299,14 +5326,10 @@ ebpf_ring_buffer_map_unmap_buffer_with_index(
     UNREFERENCED_PARAMETER(consumer);
     UNREFERENCED_PARAMETER(producer);
     UNREFERENCED_PARAMETER(data);
-
-    ebpf_result_t result = EBPF_SUCCESS;
     ebpf_handle_t map_handle = _get_handle_from_file_descriptor(map_fd);
     if (map_handle == ebpf_handle_invalid)
         return EBPF_INVALID_FD;
-    ebpf_operation_ring_buffer_map_unmap_buffer_request_t request{
-        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_RING_BUFFER_MAP_UNMAP_BUFFER, map_handle, index};
-    result = win32_error_code_to_ebpf_result(invoke_ioctl(request));
+    ebpf_result_t result = ebpf_ring_buffer_map_unmap_buffer_with_handle(map_handle, index);
     EBPF_RETURN_RESULT(result);
 }
 CATCH_NO_MEMORY_EBPF_RESULT

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2558,12 +2558,7 @@ _ebpf_core_protocol_ring_buffer_map_unmap_buffer(
     result = EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (result != EBPF_SUCCESS)
         return result;
-    result = ebpf_ring_buffer_map_unmap_user(
-        map,
-        request->index,
-        (const void*)request->consumer,
-        (const void*)request->producer,
-        (const void*)request->data);
+    result = ebpf_ring_buffer_map_unmap_user(map, request->index);
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
     return result;
 }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -529,12 +529,7 @@ typedef struct _ebpf_map_metadata_table_properties
         _Outptr_ void** producer,
         _Outptr_result_buffer_(*data_size) uint8_t** data,
         _Out_ size_t* data_size);
-    ebpf_result_t (*unmap_ring_buffer)(
-        _In_ const ebpf_core_map_t* map,
-        uint64_t index,
-        _In_ const void* consumer,
-        _In_ const void* producer,
-        _In_ const void* data);
+    ebpf_result_t (*unmap_ring_buffer)(_In_ const ebpf_core_map_t* map, uint64_t index);
     ebpf_result_t (*set_wait_handle)(
         _In_ const ebpf_core_map_t* map, uint64_t index, _In_ ebpf_handle_t handle, uint64_t flags);
     int zero_length_key : 1;
@@ -2684,16 +2679,11 @@ _map_user_ring_buffer_map(
 }
 
 static ebpf_result_t
-_unmap_user_ring_buffer_map(
-    _In_ const ebpf_core_map_t* map,
-    uint64_t index,
-    _In_ const void* consumer,
-    _In_ const void* producer,
-    _In_ const void* data)
+_unmap_user_ring_buffer_map(_In_ const ebpf_core_map_t* map, uint64_t index)
 {
     UNREFERENCED_PARAMETER(index);
     ebpf_ring_buffer_t* ring_buffer = (ebpf_ring_buffer_t*)map->data;
-    return ebpf_ring_buffer_unmap_user(ring_buffer, consumer, producer, data);
+    return ebpf_ring_buffer_unmap_user(ring_buffer);
 }
 
 static ebpf_result_t
@@ -2770,12 +2760,7 @@ _map_user_perf_event_array_map(
 }
 
 static ebpf_result_t
-_unmap_user_perf_event_array_map(
-    _In_ const ebpf_core_map_t* map,
-    uint64_t index,
-    _In_ const void* consumer,
-    _In_ const void* producer,
-    _In_ const void* data)
+_unmap_user_perf_event_array_map(_In_ const ebpf_core_map_t* map, uint64_t index)
 {
     ebpf_core_perf_event_array_map_t* perf_event_array_map =
         EBPF_FROM_FIELD(ebpf_core_perf_event_array_map_t, core_map, map);
@@ -2784,7 +2769,7 @@ _unmap_user_perf_event_array_map(
         return EBPF_INVALID_ARGUMENT;
     }
     ebpf_core_perf_ring_t* ring = &perf_event_array_map->rings[cpu_id];
-    return ebpf_ring_buffer_unmap_user(ring->ring, consumer, producer, data);
+    return ebpf_ring_buffer_unmap_user(ring->ring);
 }
 
 static ebpf_result_t
@@ -2993,18 +2978,13 @@ ebpf_ring_buffer_map_map_user(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_ring_buffer_map_unmap_user(
-    _In_ const ebpf_map_t* map,
-    uint64_t index,
-    _In_ const void* consumer,
-    _In_ const void* producer,
-    _In_ const void* data)
+ebpf_ring_buffer_map_unmap_user(_In_ const ebpf_map_t* map, uint64_t index)
 {
     if ((map->properties == NULL) || (map->properties->unmap_ring_buffer == NULL)) {
         return EBPF_INVALID_ARGUMENT;
     }
 
-    return map->properties->unmap_ring_buffer((const ebpf_core_map_t*)map, index, consumer, producer, data);
+    return map->properties->unmap_ring_buffer((const ebpf_core_map_t*)map, index);
 }
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -246,19 +246,11 @@ extern "C"
      *
      * @param[in] map Map to unmap.
      * @param[in] index Index of map buffer to unmap from user space.
-     * @param[in] consumer Pointer to the consumer buffer.
-     * @param[in] producer Pointer to the producer buffer.
-     * @param[in] data Pointer to the data buffer.
      * @retval EBPF_SUCCESS Successfully unmapped the buffer.
      * @retval EBPF_INVALID_ARGUMENT The operation is not supported on this map.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_ring_buffer_map_unmap_user(
-        _In_ const ebpf_map_t* map,
-        uint64_t index,
-        _In_ const void* consumer,
-        _In_ const void* producer,
-        _In_ const void* data);
+    ebpf_ring_buffer_map_unmap_user(_In_ const ebpf_map_t* map, uint64_t index);
 
     /**
      * @brief Set the wait handle for a map.

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -608,9 +608,6 @@ typedef struct _ebpf_operation_ring_buffer_map_unmap_buffer_request
     struct _ebpf_operation_header header;
     ebpf_handle_t map_handle;
     uint64_t index;
-    uint64_t consumer;
-    uint64_t producer;
-    uint64_t data;
 } ebpf_operation_ring_buffer_map_unmap_buffer_request_t;
 
 typedef struct _ebpf_operation_epoch_synchronize_request

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1265,9 +1265,7 @@ TEST_CASE("ring_buffer_sync_query", "[execution_context][ring_buffer]")
     REQUIRE(*(uint64_t*)(record->data) == value);
 
     // Unmap the ring buffer.
-    REQUIRE(
-        ebpf_ring_buffer_map_unmap_user(
-            map.get(), 0, (const void*)consumer, (const void*)producer, (const void*)data) == EBPF_SUCCESS);
+    REQUIRE(ebpf_ring_buffer_map_unmap_user(map.get(), 0) == EBPF_SUCCESS);
 }
 
 TEST_CASE("perf_event_array_unsupported_ops", "[execution_context][perf_event_array][negative]")

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1895,12 +1895,7 @@ TEST_CASE("perf_event_array_sync_query", "[execution_context][perf_event_array]"
             for (auto& ring : mapped_rings) {
                 if (ring.mapped) {
                     (void)ebpf_map_set_wait_handle_internal(map.get(), ring.cpu_id, ebpf_handle_invalid, 0);
-                    (void)ebpf_ring_buffer_map_unmap_user(
-                        map.get(),
-                        ring.cpu_id,
-                        (const void*)ring.consumer,
-                        (const void*)ring.producer,
-                        (const void*)ring.data);
+                    (void)ebpf_ring_buffer_map_unmap_user(map.get(), ring.cpu_id);
                     ring.mapped = false;
                 }
             }

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1314,6 +1314,127 @@ TEST_CASE("perf_event_array_unsupported_ops", "[execution_context][perf_event_ar
     REQUIRE(ebpf_map_peek_entry(map.get(), 0, nullptr, 0) == EBPF_OPERATION_NOT_SUPPORTED);
 }
 
+// Test: Perf event array per-CPU ring map-unmap-remap cycle.
+// Validates that after unmapping a per-CPU ring, it can be re-mapped successfully.
+// This is the kernel-side prerequisite for the user-mode fix in ebpf_map_unsubscribe
+// that sends unmap IOCTLs after cancelling async subscriptions.
+TEST_CASE("perf_event_array_map_unmap_remap", "[execution_context][perf_event_array]")
+{
+    _ebpf_core_initializer core;
+    core.initialize();
+    ebpf_map_definition_in_memory_t map_definition{BPF_MAP_TYPE_PERF_EVENT_ARRAY, 0, 0, 64 * 1024};
+    map_ptr map;
+    {
+        ebpf_map_t* local_map;
+        cxplat_utf8_string_t map_name = {0};
+        REQUIRE(
+            ebpf_map_create(&map_name, &map_definition, (uintptr_t)ebpf_handle_invalid, &local_map) == EBPF_SUCCESS);
+        map.reset(local_map);
+    }
+
+    _wait_event event;
+    REQUIRE(ebpf_map_set_wait_handle_internal(map.get(), 0, event.handle(), 0) == EBPF_SUCCESS);
+
+    // RAII guard: track whether the ring is mapped and unmap on scope exit.
+    bool ring_mapped = false;
+    auto unmap_guard = std::unique_ptr<void, std::function<void(void*)>>(reinterpret_cast<void*>(1), [&](void*) {
+        if (ring_mapped) {
+            (void)ebpf_ring_buffer_map_unmap_user(map.get(), 0);
+        }
+    });
+
+    // First map of CPU 0's ring.
+    volatile size_t* consumer1 = nullptr;
+    volatile size_t* producer1 = nullptr;
+    uint8_t* data1 = nullptr;
+    size_t data_size1 = 0;
+    REQUIRE(
+        ebpf_ring_buffer_map_map_user(
+            map.get(), 0, (void**)&consumer1, (void**)&producer1, (const uint8_t**)&data1, &data_size1) ==
+        EBPF_SUCCESS);
+    ring_mapped = true;
+    REQUIRE(consumer1 != nullptr);
+    REQUIRE(data1 != nullptr);
+
+    // Unmap CPU 0's ring.
+    REQUIRE(ebpf_ring_buffer_map_unmap_user(map.get(), 0) == EBPF_SUCCESS);
+    ring_mapped = false;
+
+    // Re-map CPU 0's ring — must succeed after unmap cleared the guard.
+    volatile size_t* consumer2 = nullptr;
+    volatile size_t* producer2 = nullptr;
+    uint8_t* data2 = nullptr;
+    size_t data_size2 = 0;
+    REQUIRE(
+        ebpf_ring_buffer_map_map_user(
+            map.get(), 0, (void**)&consumer2, (void**)&producer2, (const uint8_t**)&data2, &data_size2) ==
+        EBPF_SUCCESS);
+    ring_mapped = true;
+    REQUIRE(consumer2 != nullptr);
+    REQUIRE(data2 != nullptr);
+    // unmap_guard handles cleanup on scope exit.
+}
+
+// Test: Ring buffer map-unmap-remap cycle.
+// Validates that after unmapping a ring buffer, it can be re-mapped successfully.
+// Mirrors perf_event_array_map_unmap_remap for BPF_MAP_TYPE_RINGBUF.
+TEST_CASE("ring_buffer_map_unmap_remap", "[execution_context][ring_buffer]")
+{
+    _ebpf_core_initializer core;
+    core.initialize();
+    ebpf_map_definition_in_memory_t map_definition{BPF_MAP_TYPE_RINGBUF, 0, 0, 64 * 1024};
+    map_ptr map;
+    {
+        ebpf_map_t* local_map;
+        cxplat_utf8_string_t map_name = {0};
+        REQUIRE(
+            ebpf_map_create(&map_name, &map_definition, (uintptr_t)ebpf_handle_invalid, &local_map) == EBPF_SUCCESS);
+        map.reset(local_map);
+    }
+
+    _wait_event event;
+    REQUIRE(ebpf_map_set_wait_handle_internal(map.get(), 0, event.handle(), 0) == EBPF_SUCCESS);
+
+    // RAII guard: track whether the ring is mapped and unmap on scope exit.
+    bool ring_mapped = false;
+    auto unmap_guard = std::unique_ptr<void, std::function<void(void*)>>(reinterpret_cast<void*>(1), [&](void*) {
+        if (ring_mapped) {
+            (void)ebpf_ring_buffer_map_unmap_user(map.get(), 0);
+        }
+    });
+
+    // First map.
+    volatile size_t* consumer1 = nullptr;
+    volatile size_t* producer1 = nullptr;
+    uint8_t* data1 = nullptr;
+    size_t data_size1 = 0;
+    REQUIRE(
+        ebpf_ring_buffer_map_map_user(
+            map.get(), 0, (void**)&consumer1, (void**)&producer1, (const uint8_t**)&data1, &data_size1) ==
+        EBPF_SUCCESS);
+    ring_mapped = true;
+    REQUIRE(consumer1 != nullptr);
+    REQUIRE(data1 != nullptr);
+
+    // Unmap.
+    REQUIRE(ebpf_ring_buffer_map_unmap_user(map.get(), 0) == EBPF_SUCCESS);
+    ring_mapped = false;
+
+    // Re-map — must succeed after unmap cleared the guard.
+    volatile size_t* consumer2 = nullptr;
+    volatile size_t* producer2 = nullptr;
+    uint8_t* data2 = nullptr;
+    size_t data_size2 = 0;
+    REQUIRE(
+        ebpf_ring_buffer_map_map_user(
+            map.get(), 0, (void**)&consumer2, (void**)&producer2, (const uint8_t**)&data2, &data_size2) ==
+        EBPF_SUCCESS);
+    ring_mapped = true;
+    REQUIRE(consumer2 != nullptr);
+    REQUIRE(data2 != nullptr);
+    // unmap_guard handles cleanup on scope exit.
+}
+
 struct perf_event_array_test_async_context_t
 {
     uint8_t* buffer = NULL;

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -171,15 +171,11 @@ extern "C"
      * @brief Unmap the memory of a ring buffer.
      *
      * @param[in] ring Ring buffer to unmap.
-     * @param[in] consumer Address of the consumer mapping.
-     * @param[in] producer Address of the producer mapping.
-     * @param[in] data Address of the data mapping.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT Unable to unmap the buffer.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_ring_unmap_user(
-        _In_ ebpf_ring_descriptor_t* ring, _In_ const void* consumer, _In_ const void* producer, _In_ const void* data);
+    ebpf_ring_unmap_user(_In_ ebpf_ring_descriptor_t* ring);
 
     /**
      * @brief Allocate and copy a UTF-8 string.

--- a/libs/runtime/ebpf_ring_buffer.c
+++ b/libs/runtime/ebpf_ring_buffer.c
@@ -625,10 +625,9 @@ ebpf_ring_buffer_map_user(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_ring_buffer_unmap_user(
-    _In_ const ebpf_ring_buffer_t* ring, _In_ const void* consumer, _In_ const void* producer, _In_ const void* data)
+ebpf_ring_buffer_unmap_user(_In_ const ebpf_ring_buffer_t* ring)
 {
-    return ebpf_ring_unmap_user(ring->ring_descriptor, consumer, producer, data);
+    return ebpf_ring_unmap_user(ring->ring_descriptor);
 }
 
 _Must_inspect_result_ _Ret_maybenull_ const ebpf_ring_buffer_record_t*

--- a/libs/runtime/ebpf_ring_buffer.h
+++ b/libs/runtime/ebpf_ring_buffer.h
@@ -218,18 +218,12 @@ ebpf_ring_buffer_map_user(
  * @brief Unmap the memory of a ring buffer.
  *
  * @param[in] ring_buffer Ring buffer to unmap.
- * @param[in] consumer Address of the consumer mapping.
- * @param[in] producer Address of the producer mapping.
- * @param[in] data Address of the data mapping.
+ * @param[in] ring_buffer Ring buffer to unmap.
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT Unable to unmap the buffer.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_ring_buffer_unmap_user(
-    _In_ const ebpf_ring_buffer_t* ring_buffer,
-    _In_ const void* consumer,
-    _In_ const void* producer,
-    _In_ const void* data);
+ebpf_ring_buffer_unmap_user(_In_ const ebpf_ring_buffer_t* ring_buffer);
 
 /**
  * @brief Get the next record in the ring buffer's data buffer, skipping any discarded records.

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -167,6 +167,8 @@ ebpf_free_ring_buffer_memory(_Frees_ptr_opt_ ebpf_ring_descriptor_t* ring)
     }
 
     // Release process reference if still held (user never called unmap).
+    // False positive: ring is allocated via ebpf_allocate_with_tag/cxplat_allocate and is zero-initialized.
+#pragma warning(suppress : 6001)
     if (ring->user_process != NULL) {
         ObDereferenceObject(ring->user_process);
         ring->user_process = NULL;

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -15,6 +15,10 @@ struct _ebpf_ring_descriptor
     MDL* user_mdl_producer;
     MDL* memory;
     void* base_address;
+    // User-mode mapping state: captures the process and addresses returned from MmMapLockedPagesSpecifyCache.
+    PEPROCESS user_process;
+    void* user_consumer_address;
+    void* user_producer_address;
 };
 typedef struct _ebpf_ring_descriptor ebpf_ring_descriptor_t;
 
@@ -162,6 +166,12 @@ ebpf_free_ring_buffer_memory(_Frees_ptr_opt_ ebpf_ring_descriptor_t* ring)
         EBPF_RETURN_VOID();
     }
 
+    // Release process reference if still held (user never called unmap).
+    if (ring->user_process != NULL) {
+        ObDereferenceObject(ring->user_process);
+        ring->user_process = NULL;
+    }
+
     IoFreeMdl(ring->user_mdl_consumer);
     IoFreeMdl(ring->user_mdl_producer);
 
@@ -190,6 +200,11 @@ ebpf_ring_map_user(
     *producer = NULL;
     *data = NULL;
 
+    // Check if already mapped.
+    if (ring->user_consumer_address != NULL) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
     __try {
         *consumer =
             MmMapLockedPagesSpecifyCache(ring->user_mdl_consumer, UserMode, MmCached, NULL, FALSE, NormalPagePriority);
@@ -212,18 +227,38 @@ ebpf_ring_map_user(
         return EBPF_INVALID_ARGUMENT;
     }
 
+    // Capture process reference and addresses for secure unmapping.
+    ring->user_process = PsGetCurrentProcess();
+    ObReferenceObject(ring->user_process);
+    ring->user_consumer_address = *consumer;
+    ring->user_producer_address = *producer;
+
     *data = (uint8_t*)*producer + PAGE_SIZE;
     return EBPF_SUCCESS;
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_ring_unmap_user(
-    _In_ ebpf_ring_descriptor_t* ring, _In_ const void* consumer, _In_ const void* producer, _In_ const void* data)
+ebpf_ring_unmap_user(_In_ ebpf_ring_descriptor_t* ring)
 {
-    UNREFERENCED_PARAMETER(data);
-    MmUnmapLockedPages((void*)consumer, ring->user_mdl_consumer);
-    MmUnmapLockedPages((void*)producer, ring->user_mdl_producer);
-    // No-op for data, as it's part of the same mapping.
+    // Verify that the ring was mapped to user mode.
+    if (ring->user_consumer_address == NULL) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    // Verify the call is from the same process that mapped the ring.
+    if (PsGetCurrentProcess() != ring->user_process) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    // Use the stored addresses, not the user-provided ones.
+    MmUnmapLockedPages(ring->user_consumer_address, ring->user_mdl_consumer);
+    MmUnmapLockedPages(ring->user_producer_address, ring->user_mdl_producer);
+
+    ObDereferenceObject(ring->user_process);
+    ring->user_process = NULL;
+    ring->user_consumer_address = NULL;
+    ring->user_producer_address = NULL;
+
     return EBPF_SUCCESS;
 }
 

--- a/libs/runtime/user/ebpf_platform_user.cpp
+++ b/libs/runtime/user/ebpf_platform_user.cpp
@@ -101,7 +101,8 @@ ebpf_allocate_ring_buffer_memory(size_t length)
 
     size_t total_mapped_size = header_length + length * 2;
 
-    ebpf_ring_descriptor_t* descriptor = (ebpf_ring_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t), EBPF_POOL_TAG_DEFAULT);
+    ebpf_ring_descriptor_t* descriptor =
+        (ebpf_ring_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ring_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (!descriptor) {
         goto Exit;
     }
@@ -244,14 +245,10 @@ ebpf_ring_map_user(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_ring_unmap_user(
-    _In_ ebpf_ring_descriptor_t* ring, _In_ const void* consumer, _In_ const void* producer, _In_ const void* data)
+ebpf_ring_unmap_user(_In_ ebpf_ring_descriptor_t* ring)
 {
     EBPF_LOG_ENTRY();
     UNREFERENCED_PARAMETER(ring);
-    UNREFERENCED_PARAMETER(consumer);
-    UNREFERENCED_PARAMETER(producer);
-    UNREFERENCED_PARAMETER(data);
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1881,6 +1881,28 @@ class perf_buffer_test_helper
         }
     }
 
+    /**
+     * @brief Release the perf buffer without closing the map fd.
+     * Use this to test re-creating a perf buffer on the same map.
+     */
+    void
+    release_perf_buffer()
+    {
+        if (_buffer != nullptr) {
+            perf_buffer__free(_buffer);
+            _buffer = nullptr;
+        }
+        // Reset context counters and promise for the next perf buffer.
+        context.event_count = 0;
+        context.lost_count = 0;
+        context.completion_promise = nullptr;
+        _completion_promise = std::promise<void>();
+        {
+            std::lock_guard<std::mutex> guard(context.lock);
+            context.received_data.clear();
+        }
+    }
+
   private:
     perf_buffer* _buffer = nullptr;
     fd_t _map_fd = ebpf_fd_invalid;
@@ -2044,7 +2066,217 @@ TEST_CASE("perf_buffer_async_lost_callback", "[perf_buffer]")
     REQUIRE((helper.context.event_count + helper.context.lost_count) == total_events);
 }
 
-// Test synchronous perf buffer API with real program.
+// Test: Re-creating a perf buffer on the same map in async mode.
+// Validates the fix in ebpf_map_unsubscribe that sends unmap IOCTLs for per-CPU rings,
+// allowing a second perf_buffer__new to succeed on the same map within the same process.
+TEST_CASE("perf_buffer_async_reopen", "[perf_buffer]")
+{
+    perf_buffer_test_helper helper(true);
+    fd_t map_fd;
+    REQUIRE(helper.initialize_map(map_fd, "test_reopen", 64 * 1024) == 0);
+
+    std::vector<std::string> test_messages = {"First open message 1", "First open message 2"};
+
+    // First open: create perf buffer in async mode, write events, verify receipt.
+    {
+        auto completion_future = helper.enable_async_completion(static_cast<uint32_t>(test_messages.size()));
+        auto* pb = helper.create_perf_buffer(map_fd, EBPF_PERFBUF_FLAG_AUTO_CALLBACK);
+        REQUIRE(pb != nullptr);
+
+        for (const auto& msg : test_messages) {
+            REQUIRE(ebpf_perf_event_array_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        REQUIRE(completion_future.wait_for(5s) == std::future_status::ready);
+        REQUIRE(helper.context.event_count == test_messages.size());
+    }
+
+    // Release the first perf buffer (triggers ebpf_map_unsubscribe → unmap IOCTLs).
+    helper.release_perf_buffer();
+
+    // Second open: create a new perf buffer on the SAME map — must succeed.
+    std::vector<std::string> test_messages2 = {"Second open message 1", "Second open message 2"};
+    {
+        auto completion_future = helper.enable_async_completion(static_cast<uint32_t>(test_messages2.size()));
+        auto* pb2 = helper.create_perf_buffer(map_fd, EBPF_PERFBUF_FLAG_AUTO_CALLBACK);
+        REQUIRE(pb2 != nullptr);
+
+        for (const auto& msg : test_messages2) {
+            REQUIRE(ebpf_perf_event_array_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        REQUIRE(completion_future.wait_for(5s) == std::future_status::ready);
+        REQUIRE(helper.context.event_count == test_messages2.size());
+        REQUIRE(helper.context.lost_count == 0);
+        helper.validate_data_unordered(test_messages2);
+    }
+}
+
+// Test: Re-creating a perf buffer on the same map in sync mode.
+TEST_CASE("perf_buffer_sync_reopen", "[perf_buffer]")
+{
+    perf_buffer_test_helper helper(true);
+    fd_t map_fd;
+    REQUIRE(helper.initialize_map(map_fd, "test_reopen_sync", 64 * 1024) == 0);
+
+    std::vector<std::string> test_messages = {"Sync first 1", "Sync first 2"};
+
+    // First open: create perf buffer in sync mode, write events, poll and verify.
+    {
+        auto* pb = helper.create_perf_buffer(map_fd);
+        REQUIRE(pb != nullptr);
+
+        for (const auto& msg : test_messages) {
+            REQUIRE(ebpf_perf_event_array_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        helper.poll_until_count(pb, test_messages.size());
+        REQUIRE(helper.context.event_count == test_messages.size());
+    }
+
+    // Release the first perf buffer.
+    helper.release_perf_buffer();
+
+    // Second open: create a new perf buffer on the SAME map — must succeed.
+    std::vector<std::string> test_messages2 = {"Sync second 1", "Sync second 2"};
+    {
+        auto* pb2 = helper.create_perf_buffer(map_fd);
+        REQUIRE(pb2 != nullptr);
+
+        for (const auto& msg : test_messages2) {
+            REQUIRE(ebpf_perf_event_array_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        helper.poll_until_count(pb2, test_messages2.size());
+        REQUIRE(helper.context.event_count == test_messages2.size());
+        REQUIRE(helper.context.lost_count == 0);
+        helper.validate_data_unordered(test_messages2);
+    }
+}
+
+// Test: Re-creating a ring buffer on the same map in async mode.
+// Validates that ebpf_map_unsubscribe sends unmap IOCTLs for ring buffer maps,
+// allowing a second ebpf_ring_buffer__new to succeed on the same map within the same process.
+TEST_CASE("ring_buffer_async_reopen", "[ring_buffer]")
+{
+    fd_t map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, "test_rb_reopen", 0, 0, 64 * 1024, nullptr);
+    REQUIRE(map_fd > 0);
+    auto map_cleanup =
+        std::unique_ptr<void, std::function<void(void*)>>(reinterpret_cast<void*>(1), [&](void*) { _close(map_fd); });
+
+    struct rb_context
+    {
+        std::atomic<uint32_t> event_count{0};
+        uint32_t expected{0};
+        std::promise<void> promise;
+    };
+
+    auto sample_cb = [](void* ctx, void*, size_t) -> int {
+        auto* c = reinterpret_cast<rb_context*>(ctx);
+        if (++c->event_count == c->expected) {
+            c->promise.set_value();
+        }
+        return 0;
+    };
+
+    // First open: create ring buffer in async mode, write events, verify receipt.
+    {
+        rb_context ctx;
+        ctx.expected = 3;
+        auto future = ctx.promise.get_future();
+
+        ebpf_ring_buffer_opts opts{.sz = sizeof(opts), .flags = EBPF_RINGBUF_FLAG_AUTO_CALLBACK};
+        auto* ring = ebpf_ring_buffer__new(map_fd, sample_cb, &ctx, &opts);
+        REQUIRE(ring != nullptr);
+        auto ring_cleanup = std::unique_ptr<ring_buffer, decltype(&ring_buffer__free)>(ring, ring_buffer__free);
+
+        std::vector<std::string> messages = {"rb_async_1", "rb_async_2", "rb_async_3"};
+        for (const auto& msg : messages) {
+            REQUIRE(ebpf_ring_buffer_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        REQUIRE(future.wait_for(5s) == std::future_status::ready);
+        REQUIRE(ctx.event_count == 3);
+    }
+
+    // Second open: create a new ring buffer on the SAME map — must succeed.
+    {
+        rb_context ctx;
+        ctx.expected = 2;
+        auto future = ctx.promise.get_future();
+
+        ebpf_ring_buffer_opts opts{.sz = sizeof(opts), .flags = EBPF_RINGBUF_FLAG_AUTO_CALLBACK};
+        auto* ring = ebpf_ring_buffer__new(map_fd, sample_cb, &ctx, &opts);
+        REQUIRE(ring != nullptr);
+        auto ring_cleanup = std::unique_ptr<ring_buffer, decltype(&ring_buffer__free)>(ring, ring_buffer__free);
+
+        std::vector<std::string> messages = {"rb_async_reopen_1", "rb_async_reopen_2"};
+        for (const auto& msg : messages) {
+            REQUIRE(ebpf_ring_buffer_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        REQUIRE(future.wait_for(5s) == std::future_status::ready);
+        REQUIRE(ctx.event_count == 2);
+    }
+}
+
+// Test: Re-creating a ring buffer on the same map in sync mode.
+TEST_CASE("ring_buffer_sync_reopen", "[ring_buffer]")
+{
+    fd_t map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, "test_rb_reopen_s", 0, 0, 64 * 1024, nullptr);
+    REQUIRE(map_fd > 0);
+    auto map_cleanup =
+        std::unique_ptr<void, std::function<void(void*)>>(reinterpret_cast<void*>(1), [&](void*) { _close(map_fd); });
+
+    struct rb_sync_context
+    {
+        uint32_t event_count = 0;
+        std::vector<std::string> received_data;
+    };
+
+    auto sample_cb = [](void* ctx, void* data, size_t size) -> int {
+        auto* c = reinterpret_cast<rb_sync_context*>(ctx);
+        c->received_data.emplace_back(reinterpret_cast<const char*>(data), size);
+        c->event_count++;
+        return 0;
+    };
+
+    // First open: create ring buffer in sync mode, write events, consume and verify.
+    {
+        rb_sync_context ctx;
+        ebpf_ring_buffer_opts opts{.sz = sizeof(opts), .flags = 0};
+        auto* ring = ebpf_ring_buffer__new(map_fd, sample_cb, &ctx, &opts);
+        REQUIRE(ring != nullptr);
+        auto ring_cleanup = std::unique_ptr<ring_buffer, decltype(&ring_buffer__free)>(ring, ring_buffer__free);
+
+        std::vector<std::string> messages = {"rb_sync_1", "rb_sync_2"};
+        for (const auto& msg : messages) {
+            REQUIRE(ebpf_ring_buffer_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        int consumed = ring_buffer__consume(ring);
+        REQUIRE(consumed >= 0);
+        REQUIRE(ctx.event_count == messages.size());
+    }
+
+    // Second open: create a new ring buffer on the SAME map — must succeed.
+    {
+        rb_sync_context ctx;
+        ebpf_ring_buffer_opts opts{.sz = sizeof(opts), .flags = 0};
+        auto* ring = ebpf_ring_buffer__new(map_fd, sample_cb, &ctx, &opts);
+        REQUIRE(ring != nullptr);
+        auto ring_cleanup = std::unique_ptr<ring_buffer, decltype(&ring_buffer__free)>(ring, ring_buffer__free);
+
+        std::vector<std::string> messages = {"rb_sync_reopen_1", "rb_sync_reopen_2"};
+        for (const auto& msg : messages) {
+            REQUIRE(ebpf_ring_buffer_map_write(map_fd, msg.c_str(), msg.length()) == EBPF_SUCCESS);
+        }
+
+        int consumed = ring_buffer__consume(ring);
+        REQUIRE(consumed >= 0);
+        REQUIRE(ctx.event_count == messages.size());
+    }
+}
 TEMPLATE_TEST_CASE("perf_buffer_sync_api", "[perf_buffer]", ENABLED_EXECUTION_TYPES)
 {
     ebpf_execution_type_t execution_type = TestType::value;


### PR DESCRIPTION
## Description
This PR bundles several fixes around ring/perf buffer lifecycle handling (map unmap/unsubscribe/reopen), improves kernel/user IOCTL safety, and updates CI tooling integrity checks.

Changes:

Add tests to validate perf buffer / ring buffer can be closed and re-opened on the same map within the same process.
Simplify ring-buffer unmap protocol/API to no longer accept user-provided mapping addresses; kernel tracks mapping addresses + process for secure unmapping.
Harden kernel IOCTL handling by zeroing output-buffer bytes beyond provided input to prevent leaking uninitialized pool memory.

_Describe the purpose of and changes within this Pull Request._
_Please reference an issue with a keyword such as Fixes #abc, Closes #xyz, etc., so the work can be tracked._
Fixes #5254 
Fixes #5144

## Testing

_Do any existing tests cover this change? Are new tests needed?_
Yes
_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.

## Documentation

_Is there any documentation impact for this change?_
No
## Installation

_Is there any installer impact for this change?_
No