### PR TITLE
Test infra: add listen error and socket family support to test framework

### DIFF
--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -973,11 +973,17 @@ TEST_CASE("cgroup_sock_addr compartment parameter", "[netsh][programs]")
     // Load program with pinpath and compaetment=1.
     std::string output = run_netsh_command_with_args(
         handle_ebpf_add_program, &result, 4, L"cgroup_sock_addr.o", L"cgroup/connect4", L"mypinpath", L"compartment=1");
-    REQUIRE(strcmp(output.c_str(), "Loaded with ID 6\n") == 0);
+    // Parse the program ID from the output (format: "Loaded with ID <N>\n").
+    // The ID depends on the number of maps/programs in the .o file, so we don't hardcode it.
+    unsigned int program_id = 0;
+    REQUIRE(sscanf_s(output.c_str(), "Loaded with ID %u\n", &program_id) == 1);
+    REQUIRE(program_id > 0);
     REQUIRE(result == NO_ERROR);
-    output = _run_netsh_command(handle_ebpf_delete_program, L"6", nullptr, nullptr, &result);
+    std::string id_str = std::to_string(program_id);
+    std::wstring id_wstr(id_str.begin(), id_str.end());
+    output = _run_netsh_command(handle_ebpf_delete_program, id_wstr.c_str(), nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
-    REQUIRE(output == "Unpinned 6 from BPF:\\mypinpath\n");
+    REQUIRE(output == "Unpinned " + id_str + " from BPF:\\mypinpath\n");
     verify_no_programs_exist();
 
     // (Negative) Load program with incorrect compartment id.

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -500,8 +500,13 @@ _stream_client_socket::complete_async_send(int timeout_in_ms, expected_result_t 
 }
 
 _server_socket::_server_socket(
-    int _sock_type, int _protocol, uint16_t _port, _In_ const sockaddr_storage& local_address, int expected_bind_error)
-    : _base_socket{_sock_type, _protocol, _port, Dual, local_address, expected_bind_error}, overlapped{}
+    int sock_type,
+    int protocol,
+    uint16_t port,
+    _In_ const sockaddr_storage& local_address,
+    int expected_bind_error,
+    socket_family_t family)
+    : _base_socket{sock_type, protocol, port, family, local_address, expected_bind_error}, overlapped{}
 {
     overlapped.hEvent = NULL;
     receive_message = nullptr;
@@ -797,12 +802,23 @@ _datagram_server_socket::close()
 }
 
 _stream_server_socket::_stream_server_socket(
-    int _sock_type, int _protocol, uint16_t _port, _In_ const sockaddr_storage& local_address, int expected_bind_error)
-    : _server_socket{_sock_type, _protocol, _port, local_address, expected_bind_error}, acceptex(nullptr),
+    int sock_type,
+    int protocol,
+    uint16_t port,
+    _In_ const sockaddr_storage& local_address,
+    int expected_bind_error,
+    int expected_listen_error,
+    socket_family_t family)
+    : _server_socket{sock_type, protocol, port, local_address, expected_bind_error, family}, acceptex(nullptr),
       accept_socket(INVALID_SOCKET), message_length(recv_buffer.size() - 2 * (sizeof(sockaddr_storage) + 16))
 {
     if ((sock_type != SOCK_STREAM) || (protocol != IPPROTO_TCP)) {
         FAIL("stream_socket only supports these combinations (SOCK_STREAM, IPPROTO_TCP)");
+    }
+
+    // If bind failed, skip listen setup.
+    if (expected_bind_error != 0) {
+        return;
     }
 
     GUID guid = WSAID_ACCEPTEX;
@@ -823,7 +839,25 @@ _stream_server_socket::_stream_server_socket(
     }
 
     // Post listen.
-    listen(socket, SOMAXCONN);
+    int listen_result = listen(socket, SOMAXCONN);
+    int listen_error = (listen_result != 0) ? WSAGetLastError() : 0;
+
+    if (expected_listen_error != 0) {
+        // Expect listen to fail.
+        if (listen_result == 0) {
+            FAIL("listen() was expected to fail but succeeded");
+        }
+        if (listen_error != expected_listen_error) {
+            FAIL("listen() failed with unexpected error " << listen_error << ", expected " << expected_listen_error);
+        }
+        // Listen failed as expected, don't continue setup.
+        return;
+    } else {
+        // Expect listen to succeed.
+        if (listen_result != 0) {
+            FAIL("listen() failed with error " << listen_error);
+        }
+    }
 
     // Create accept socket.
     initialize_accept_socket();
@@ -835,13 +869,21 @@ _stream_server_socket::initialize_accept_socket()
     // Close a previous accept socket, if present.
     clean_up_socket(accept_socket);
 
-    // Create accept socket.
-    accept_socket = WSASocket(AF_INET6, sock_type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
-    uint32_t ipv6_option = 0;
-    int error = setsockopt(
-        accept_socket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&ipv6_option), sizeof(unsigned long));
-    if (error != 0) {
-        FAIL("Could not enable dual family endpoint on accept socket: " << WSAGetLastError());
+    // Create accept socket matching the listen socket's address family.
+    // AcceptEx requires the accept socket to have the same address family as the listen socket.
+    ADDRESS_FAMILY accept_family = (family == IPv4) ? AF_INET : AF_INET6;
+    accept_socket = WSASocket(accept_family, sock_type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
+    if (family == Dual) {
+        uint32_t ipv6_option = 0;
+        int error = setsockopt(
+            accept_socket,
+            IPPROTO_IPV6,
+            IPV6_V6ONLY,
+            reinterpret_cast<const char*>(&ipv6_option),
+            sizeof(unsigned long));
+        if (error != 0) {
+            FAIL("Could not enable dual family endpoint on accept socket: " << WSAGetLastError());
+        }
     }
 }
 

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -263,18 +263,20 @@ typedef class _server_socket : public _base_socket
     /**
      * @brief Construct a server socket.
      *
-     * @param[in] _sock_type Socket type (SOCK_STREAM, SOCK_DGRAM).
-     * @param[in] _protocol Protocol (IPPROTO_TCP, IPPROTO_UDP).
+     * @param[in] sock_type Socket type (SOCK_STREAM, SOCK_DGRAM).
+     * @param[in] protocol Protocol (IPPROTO_TCP, IPPROTO_UDP).
      * @param[in] port Port to bind to.
      * @param[in] local_address Local address to bind to (optional).
      * @param[in] expected_bind_error Expected bind error code (0 = expect success).
+     * @param[in] family Socket family (IPv4, IPv6, or Dual). Default is Dual.
      */
     _server_socket(
-        int _sock_type,
-        int _protocol,
+        int sock_type,
+        int protocol,
         uint16_t port,
         _In_ const sockaddr_storage& local_address = {},
-        int expected_bind_error = 0);
+        int expected_bind_error = 0,
+        socket_family_t family = Dual);
     ~_server_socket() noexcept;
 
     /**
@@ -409,18 +411,22 @@ typedef class _stream_server_socket : public _server_socket
     /**
      * @brief Construct a stream server socket.
      *
-     * @param[in] _sock_type Socket type (SOCK_STREAM).
-     * @param[in] _protocol Protocol (IPPROTO_TCP).
+     * @param[in] sock_type Socket type (SOCK_STREAM).
+     * @param[in] protocol Protocol (IPPROTO_TCP).
      * @param[in] port Port to bind to.
      * @param[in] local_address Local address to bind to (optional).
      * @param[in] expected_bind_error Expected bind error code (0 = expect success).
+     * @param[in] expected_listen_error Expected listen error code (0 = expect success).
+     * @param[in] family Socket family (IPv4, IPv6, or Dual). Default is Dual.
      */
     _stream_server_socket(
-        int _sock_type,
-        int _protocol,
+        int sock_type,
+        int protocol,
         uint16_t port,
         _In_ const sockaddr_storage& local_address = {},
-        int expected_bind_error = 0);
+        int expected_bind_error = 0,
+        int expected_listen_error = 0,
+        socket_family_t family = Dual);
     ~_stream_server_socket();
     void
     post_async_receive();

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -115,12 +115,26 @@ struct connection_test_params
 };
 
 /**
+ * @brief Program attach method for the connection test framework.
+ *
+ * Selects which user-mode API is used to attach the program. Both ultimately
+ * invoke the same kernel attach IOCTL, but they pass different attach
+ * parameters and exercise different libbpf-compat translation paths.
+ */
+enum class attach_method_t
+{
+    ebpf_program_attach, ///< Native API with NULL attach parameter (wildcard / no compartment).
+    bpf_prog_attach,     ///< libbpf-compat API with 4-byte attach parameter containing compartment_id=0.
+};
+
+/**
  * @brief Program specification for attaching.
  */
 struct program_spec
 {
-    std::string_view program_name; ///< Name of the program.
-    bpf_attach_type attach_type;   ///< Attach type for the program.
+    std::string_view program_name;                                       ///< Name of the program.
+    bpf_attach_type attach_type;                                         ///< Attach type for the program.
+    attach_method_t attach_method{attach_method_t::ebpf_program_attach}; ///< Which API to use for attachment.
 };
 
 /**
@@ -151,6 +165,12 @@ struct connection_test_case
 
     std::vector<wfp_test_filter_spec> wfp_filters{}; ///< WFP filters to apply before the tests.
     std::vector<connection_test_params> tests{};     ///< Individual test parameters to execute in order.
+
+    /// Server-side bind address. If unset, the framework chooses a family-appropriate wildcard
+    /// (INADDR_ANY for IPv4-only listen tests, dual-stack/unspecified for other cases). When set,
+    /// the server socket binds to this address and the listen-policy map key uses it for
+    /// `local_ip`. The address family must match `address_family`.
+    std::optional<sockaddr_storage> server_bind_address{};
 };
 
 /**
@@ -349,12 +369,15 @@ execute_connection_test(_In_ const connection_test_case& test_case)
     }
 
     // Determine server socket family. For listen enforcement tests, the server socket must use the
-    // test's address family so that listen() triggers the correct WFP layer (V4 or V6). For all
-    // other tests (connect, recv_accept, bind), dual-stack is correct because the server needs to
+    // test's address family so that listen() triggers the correct WFP layer (V4 or V6). When the
+    // caller specifies an explicit server_bind_address, also restrict to the test's family (the
+    // server is binding a specific address and shouldn't accept the other family). For all other
+    // tests (connect, recv_accept, bind), dual-stack is correct because the server needs to
     // accept connections from both V4 and V6 clients.
     bool is_listen_test = std::any_of(
         test_case.tests.begin(), test_case.tests.end(), [](const auto& t) { return t.listen_verdict.has_value(); });
-    socket_family_t server_family = is_listen_test ? (test_case.address_family == AF_INET ? IPv4 : IPv6) : Dual;
+    bool use_specific_family = is_listen_test || test_case.server_bind_address.has_value();
+    socket_family_t server_family = use_specific_family ? (test_case.address_family == AF_INET ? IPv4 : IPv6) : Dual;
 
     // Attach all programs before executing tests.
     for (auto& mod : loaded_modules) {
@@ -365,9 +388,17 @@ execute_connection_test(_In_ const connection_test_case& test_case)
                 std::string(loaded_program.spec.program_name),
                 loaded_program.spec.attach_type,
                 bpf_program__fd(loaded_program.program));
-            ebpf_attach_type_t attach_type_guid{};
-            SAFE_REQUIRE(ebpf_get_ebpf_attach_type(loaded_program.spec.attach_type, &attach_type_guid) == EBPF_SUCCESS);
-            SAFE_REQUIRE(ebpf_program_attach(program, &attach_type_guid, nullptr, 0, nullptr) == EBPF_SUCCESS);
+            if (loaded_program.spec.attach_method == attach_method_t::bpf_prog_attach) {
+                // libbpf-compat path: passes a 4-byte attach parameter containing compartment_id=0.
+                int rc = ::bpf_prog_attach(bpf_program__fd(program), 0, loaded_program.spec.attach_type, 0);
+                SAFE_REQUIRE(rc == 0);
+            } else {
+                // Native API path: passes NULL attach parameter (wildcard / unspecified compartment).
+                ebpf_attach_type_t attach_type_guid{};
+                SAFE_REQUIRE(
+                    ebpf_get_ebpf_attach_type(loaded_program.spec.attach_type, &attach_type_guid) == EBPF_SUCCESS);
+                SAFE_REQUIRE(ebpf_program_attach(program, &attach_type_guid, nullptr, 0, nullptr) == EBPF_SUCCESS);
+            }
         }
     }
 
@@ -411,9 +442,19 @@ execute_connection_test(_In_ const connection_test_case& test_case)
         if (test.listen_verdict) {
             SAFE_REQUIRE(listen_map != nullptr);
             // Setup tuple for listen operation — key uses local address/port.
-            // Server socket binds to INADDR_ANY by default, so local_ip stays zero
-            // to match what WFP reports for listen on unspecified address.
+            // When server_bind_address is provided, populate local_ip from it; otherwise the
+            // server binds to INADDR_ANY and WFP reports local_ip as zero.
             connection_tuple_t listen_tuple = {0};
+            if (test_case.server_bind_address) {
+                if (test_case.address_family == AF_INET) {
+                    const sockaddr_in* addr4 = reinterpret_cast<const sockaddr_in*>(&(*test_case.server_bind_address));
+                    listen_tuple.local_ip.ipv4 = addr4->sin_addr.s_addr;
+                } else {
+                    const sockaddr_in6* addr6 =
+                        reinterpret_cast<const sockaddr_in6*>(&(*test_case.server_bind_address));
+                    memcpy(listen_tuple.local_ip.ipv6, &addr6->sin6_addr, sizeof(listen_tuple.local_ip.ipv6));
+                }
+            }
             listen_tuple.local_port = htons(SOCKET_TEST_PORT);
             listen_tuple.protocol = tuple.protocol;
             SAFE_REQUIRE(
@@ -425,12 +466,16 @@ execute_connection_test(_In_ const connection_test_case& test_case)
             int server_bind_error = test.expected_server_bind_error.value_or(0);
             int server_listen_error = test.expected_listen_error.value_or(0);
 
+            // Honor explicit server bind address when provided; otherwise pass an empty sockaddr_storage
+            // which the socket helper interprets as wildcard (INADDR_ANY / dual-stack-as-applicable).
+            sockaddr_storage server_local = test_case.server_bind_address.value_or(sockaddr_storage{});
+
             if (test_case.protocol == IPPROTO_TCP) {
                 server = std::make_unique<stream_server_socket_t>(
                     static_cast<uint16_t>(SOCK_STREAM),
                     IPPROTO_TCP,
                     static_cast<uint16_t>(SOCKET_TEST_PORT),
-                    sockaddr_storage{},
+                    server_local,
                     server_bind_error,
                     server_listen_error,
                     server_family);
@@ -439,7 +484,7 @@ execute_connection_test(_In_ const connection_test_case& test_case)
                     static_cast<uint16_t>(SOCK_DGRAM),
                     IPPROTO_UDP,
                     static_cast<uint16_t>(SOCKET_TEST_PORT),
-                    sockaddr_storage{},
+                    server_local,
                     server_bind_error);
             }
 

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -100,11 +100,15 @@ struct connection_test_params
     // Expected bind error for server socket (0 = expect success).
     std::optional<int> expected_server_bind_error{};
 
+    // Expected listen error for server socket (0 = expect success).
+    std::optional<int> expected_listen_error{};
+
     // Expected outcome.
     connection_test_result expected_result{connection_test_result::block};
 
     std::optional<uint32_t> egress_verdict{};  ///< Egress verdict for connect hook.
     std::optional<uint32_t> ingress_verdict{}; ///< Ingress verdict for recv_accept hook.
+    std::optional<uint32_t> listen_verdict{};  ///< Listen verdict for listen enforcement (sock_addr).
     std::optional<bind_policy> bind_policy{};  ///< Bind policy to apply for this test.
     std::optional<bind_action_t>
         bind_verdict{}; ///< Simplified bind policy (uses current process, test port, test protocol).
@@ -300,10 +304,12 @@ execute_connection_test(_In_ const connection_test_case& test_case)
         }
     }
 
-    // Get policy maps (sock_addr or bind).
+    // Get policy maps (sock_addr, bind, or sockops).
     bpf_map* ingress_map = nullptr;
     bpf_map* egress_map = nullptr;
     bpf_map* bind_policy_map = nullptr;
+    bpf_map* connection_map = nullptr;
+    bpf_map* listen_map = nullptr;
 
     for (const auto& mod : loaded_modules) {
         if (!ingress_map) {
@@ -314,6 +320,12 @@ execute_connection_test(_In_ const connection_test_case& test_case)
         }
         if (!bind_policy_map) {
             bind_policy_map = bpf_object__find_map_by_name(mod.object.get(), "bind_policy_map");
+        }
+        if (!connection_map) {
+            connection_map = bpf_object__find_map_by_name(mod.object.get(), "connection_map");
+        }
+        if (!listen_map) {
+            listen_map = bpf_object__find_map_by_name(mod.object.get(), "listen_connection_policy_map");
         }
     }
 
@@ -335,6 +347,14 @@ execute_connection_test(_In_ const connection_test_case& test_case)
     if (egress_map) {
         SAFE_REQUIRE(bpf_map_update_elem(bpf_map__fd(egress_map), &tuple, &sock_addr_reject_verdict, EBPF_ANY) == 0);
     }
+
+    // Determine server socket family. For listen enforcement tests, the server socket must use the
+    // test's address family so that listen() triggers the correct WFP layer (V4 or V6). For all
+    // other tests (connect, recv_accept, bind), dual-stack is correct because the server needs to
+    // accept connections from both V4 and V6 clients.
+    bool is_listen_test = std::any_of(
+        test_case.tests.begin(), test_case.tests.end(), [](const auto& t) { return t.listen_verdict.has_value(); });
+    socket_family_t server_family = is_listen_test ? (test_case.address_family == AF_INET ? IPv4 : IPv6) : Dual;
 
     // Attach all programs before executing tests.
     for (auto& mod : loaded_modules) {
@@ -388,10 +408,22 @@ execute_connection_test(_In_ const connection_test_case& test_case)
                 static_cast<uint8_t>(test_case.protocol),
                 *test.bind_verdict);
         }
+        if (test.listen_verdict) {
+            SAFE_REQUIRE(listen_map != nullptr);
+            // Setup tuple for listen operation — key uses local address/port.
+            // Server socket binds to INADDR_ANY by default, so local_ip stays zero
+            // to match what WFP reports for listen on unspecified address.
+            connection_tuple_t listen_tuple = {0};
+            listen_tuple.local_port = htons(SOCKET_TEST_PORT);
+            listen_tuple.protocol = tuple.protocol;
+            SAFE_REQUIRE(
+                bpf_map_update_elem(bpf_map__fd(listen_map), &listen_tuple, &(*test.listen_verdict), EBPF_ANY) == 0);
+        }
 
         // Create sockets on init or after reset.
         if (!server) {
             int server_bind_error = test.expected_server_bind_error.value_or(0);
+            int server_listen_error = test.expected_listen_error.value_or(0);
 
             if (test_case.protocol == IPPROTO_TCP) {
                 server = std::make_unique<stream_server_socket_t>(
@@ -399,7 +431,9 @@ execute_connection_test(_In_ const connection_test_case& test_case)
                     IPPROTO_TCP,
                     static_cast<uint16_t>(SOCKET_TEST_PORT),
                     sockaddr_storage{},
-                    server_bind_error);
+                    server_bind_error,
+                    server_listen_error,
+                    server_family);
             } else if (test_case.protocol == IPPROTO_UDP) {
                 server = std::make_unique<datagram_server_socket_t>(
                     static_cast<uint16_t>(SOCK_DGRAM),
@@ -409,8 +443,8 @@ execute_connection_test(_In_ const connection_test_case& test_case)
                     server_bind_error);
             }
 
-            // If bind was expected to fail, skip connection testing.
-            if (server_bind_error != 0) {
+            // If bind or listen was expected to fail, skip connection testing.
+            if (server_bind_error != 0 || server_listen_error != 0) {
                 server.reset();
                 client.reset();
                 continue;


### PR DESCRIPTION
## Description

This PR extends the socket test helpers to support the listen hook tests for #4480

No behavioral changes for existing test helper consumers.
 
 ## Commit 1 — Socket family + listen error support
 
 - **socket_helper.cpp/h**: add `expected_listen_error` parameter so the
   server socket helper can assert specific listen() failure codes; add
   `socket_family_t` parameter to control IPv4 / IPv6 / dual-stack server
   socket creation; fix AcceptEx family handling.
 - **socket_tests.cpp**: thread `listen_verdict` and `expected_listen_error`
   through `connection_test_params`; add `listen_map` lookup for listen
   connection policy.
 - **netsh_test.cpp**: switch the compartment test to dynamic program-ID
   parsing instead of a hardcoded value.
 
 ## Commit 2 — `attach_method` and `server_bind_address`
 
 Extend `execute_connection_test` with two optional parameters:
 
 - `program_spec::attach_method` selects between
   `ebpf_program_attach` (native, default — preserves existing behavior)
   and `bpf_prog_attach` (libbpf-compat). Both eventually invoke the same
   kernel IOCTL but pass different attach parameters; tests that want to
   verify either user-mode surface can now stay in the framework.
 - `connection_test_case::server_bind_address` specifies an explicit local
   address for the server socket and the listen-policy map key. When unset
   (default), the framework continues to bind wildcard / dual-stack as
   before. When set, it forces the server family to match `address_family`.
 
 All existing framework consumers behave identically — defaults preserve
 the original attach API and INADDR_ANY bind.
 
Part of #4480 (test infrastructure for listen hook tests)

## Testing

This PR only makes non-functional test changes (to prep for new listen hook tests).

## Documentation

N/A

## Installation

N/A
