### PR TITLE
Fix native PE parsing to support multiple eBPF programs sharing the same PE section

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2597,15 +2597,20 @@ ebpf_free_programs(_In_opt_ _Post_invalid_ ebpf_api_program_info_t* infos) noexc
 
 typedef struct _ebpf_pe_context
 {
+    struct native_program_metadata_t
+    {
+        std::string elf_section_name;
+        std::string program_name;
+        GUID program_type;
+        GUID attach_type;
+    };
+
     ebpf_result_t result;
     ebpf_object_t* object;
     const char* pin_root_path;
     uintptr_t image_base;
     ebpf_api_program_info_t* infos;
-    std::map<std::string, std::string> section_names;
-    std::map<std::string, std::string> program_names;
-    std::map<std::string, GUID> section_program_types;
-    std::map<std::string, GUID> section_attach_types;
+    std::map<std::string, std::vector<native_program_metadata_t>> programs_by_pe_section;
     uintptr_t rdata_base;
     size_t rdata_size;
     const bounded_buffer* rdata_buffer;
@@ -2777,25 +2782,29 @@ _ebpf_pe_get_section_names(
                 _ebpf_get_section_string(pe_context, (uintptr_t)program->pe_section_name, section_header, buffer);
             const char* elf_section_name =
                 _ebpf_get_section_string(pe_context, (uintptr_t)program->section_name, section_header, buffer);
-            pe_context->section_names[pe_section_name] = elf_section_name;
 
             const char* program_name =
                 _ebpf_get_section_string(pe_context, (uintptr_t)program->program_name, section_header, buffer);
-            pe_context->program_names[pe_section_name] = program_name;
 
             uintptr_t program_type_guid_address = (uintptr_t)program->program_type;
             ebpf_assert(
                 program_type_guid_address >= pe_context->data_base &&
                 program_type_guid_address < pe_context->data_base + pe_context->data_size);
             uintptr_t offset = program_type_guid_address - pe_context->data_base;
-            pe_context->section_program_types[pe_section_name] = *(GUID*)(pe_context->data_buffer->buf + offset);
+            GUID program_type = *(GUID*)(pe_context->data_buffer->buf + offset);
 
             uintptr_t attach_type_guid_address = (uintptr_t)program->expected_attach_type;
             ebpf_assert(
                 attach_type_guid_address >= pe_context->data_base &&
                 attach_type_guid_address < pe_context->data_base + pe_context->data_size);
             offset = attach_type_guid_address - pe_context->data_base;
-            pe_context->section_attach_types[pe_section_name] = *(GUID*)(pe_context->data_buffer->buf + offset);
+            GUID attach_type = *(GUID*)(pe_context->data_buffer->buf + offset);
+
+            pe_context->programs_by_pe_section[pe_section_name].push_back(
+                {.elf_section_name = elf_section_name,
+                 .program_name = program_name,
+                 .program_type = program_type,
+                 .attach_type = attach_type});
         }
     }
 
@@ -2824,68 +2833,67 @@ _ebpf_pe_add_section(
     }
     ebpf_pe_context_t* pe_context = (ebpf_pe_context_t*)context;
 
-    // Get ELF section name.
-    if (!pe_context->section_names.contains(pe_section_name)) {
+    if (!pe_context->programs_by_pe_section.contains(pe_section_name)) {
         // Not an eBPF program section.
         EBPF_LOG_EXIT();
         return 0;
     }
 
-    std::string elf_section_name = pe_context->section_names[pe_section_name];
-    std::string program_name = pe_context->program_names[pe_section_name];
+    const auto& section_programs = pe_context->programs_by_pe_section[pe_section_name];
 
-    ebpf_api_program_info_t* info =
-        (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info), EBPF_POOL_TAG_DEFAULT);
-    if (info == nullptr) {
-        pe_context->result = EBPF_NO_MEMORY;
-        return_value = 1;
-        goto Exit;
-    }
+    for (const auto& metadata : section_programs) {
+        std::string elf_section_name = metadata.elf_section_name;
+        std::string program_name = metadata.program_name;
 
-    memset(info, 0, sizeof(*info));
-    info->section_name = cxplat_duplicate_string(elf_section_name.c_str());
-    if (info->section_name == nullptr) {
-        pe_context->result = EBPF_NO_MEMORY;
-        return_value = 1;
-        goto Exit;
-    }
+        ebpf_api_program_info_t* info =
+            (ebpf_api_program_info_t*)ebpf_allocate_with_tag(sizeof(*info), EBPF_POOL_TAG_DEFAULT);
+        if (info == nullptr) {
+            pe_context->result = EBPF_NO_MEMORY;
+            return_value = 1;
+            goto Exit;
+        }
 
-    info->program_name = cxplat_duplicate_string(program_name.c_str());
-    if (info->program_name == nullptr) {
-        pe_context->result = EBPF_NO_MEMORY;
-        return_value = 1;
-        goto Exit;
-    }
+        memset(info, 0, sizeof(*info));
+        info->section_name = cxplat_duplicate_string(elf_section_name.c_str());
+        if (info->section_name == nullptr) {
+            _ebpf_free_api_program_info(info);
+            pe_context->result = EBPF_NO_MEMORY;
+            return_value = 1;
+            goto Exit;
+        }
 
-    info->program_type = pe_context->section_program_types[pe_section_name];
-    info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
+        info->program_name = cxplat_duplicate_string(program_name.c_str());
+        if (info->program_name == nullptr) {
+            _ebpf_free_api_program_info(info);
+            pe_context->result = EBPF_NO_MEMORY;
+            return_value = 1;
+            goto Exit;
+        }
 
-    info->raw_data_size = section_header.Misc.VirtualSize;
-    info->raw_data = (char*)ebpf_allocate_with_tag(section_header.Misc.VirtualSize, EBPF_POOL_TAG_DEFAULT);
-    if (info->raw_data == nullptr || info->section_name == nullptr) {
-        pe_context->result = EBPF_NO_MEMORY;
-        return_value = 1;
-        goto Exit;
-    }
-    memcpy(info->raw_data, buffer->buf, section_header.Misc.VirtualSize);
+        info->program_type = metadata.program_type;
+        info->expected_attach_type = metadata.attach_type;
 
-    {
+        info->raw_data_size = section_header.Misc.VirtualSize;
+        info->raw_data = (char*)ebpf_allocate_with_tag(section_header.Misc.VirtualSize, EBPF_POOL_TAG_DEFAULT);
+        if (info->raw_data == nullptr) {
+            _ebpf_free_api_program_info(info);
+            pe_context->result = EBPF_NO_MEMORY;
+            return_value = 1;
+            goto Exit;
+        }
+        memcpy(info->raw_data, buffer->buf, section_header.Misc.VirtualSize);
+
         // Append to existing list.
         ebpf_api_program_info_t** pnext = &pe_context->infos;
         while (*pnext) {
             pnext = &(*pnext)->next;
         }
         *pnext = info;
-        info = nullptr;
     }
 
     return_value = 0;
 
 Exit:
-    if (info) {
-        _ebpf_free_api_program_info(info);
-    }
-
     EBPF_LOG_EXIT();
     return return_value;
 }

--- a/tests/sample/undocked/multi_prog_same_bind.c
+++ b/tests/sample/undocked/multi_prog_same_bind.c
@@ -1,0 +1,24 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Sample program to validate native parsing when multiple top-level programs
+// share the same short section name (<= 8 chars).
+
+#include "bpf_helpers.h"
+#include "ebpf_nethooks.h"
+
+SEC("bind")
+bind_action_t
+ShortBindEntryOne(bind_md_t* ctx)
+{
+    (void)ctx;
+    return BIND_PERMIT_SOFT;
+}
+
+SEC("bind")
+bind_action_t
+ShortBindEntryTwo(bind_md_t* ctx)
+{
+    (void)ctx;
+    return BIND_REDIRECT;
+}

--- a/tests/sample/undocked/multi_prog_same_section.c
+++ b/tests/sample/undocked/multi_prog_same_section.c
@@ -9,16 +9,14 @@
 
 SEC("bind")
 bind_action_t
-ShortBindEntryOne(bind_md_t* ctx)
+prog1(bind_md_t* ctx)
 {
-    (void)ctx;
     return BIND_PERMIT_SOFT;
 }
 
 SEC("bind")
 bind_action_t
-ShortBindEntryTwo(bind_md_t* ctx)
+prog2(bind_md_t* ctx)
 {
-    (void)ctx;
     return BIND_REDIRECT;
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2096,6 +2096,48 @@ TEST_CASE("good_tail_call_same_section-native", "[libbpf]")
     ebpf_test_tail_call("tail_call_same_section_um.dll", 42);
 }
 
+static void
+_test_multi_prog_same_bind(ebpf_execution_type_t execution_type)
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+    program_info_provider_t bind_program_info;
+    REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
+
+    const char* file_name =
+        (execution_type == EBPF_EXECUTION_NATIVE ? "multi_prog_same_bind_um.dll" : "multi_prog_same_bind.o");
+    struct bpf_object* object = bpf_object__open(file_name);
+    REQUIRE(object != nullptr);
+
+    // Verify both programs are found by name.
+    struct bpf_program* prog1 = bpf_object__find_program_by_name(object, "ShortBindEntryOne");
+    REQUIRE(prog1 != nullptr);
+    struct bpf_program* prog2 = bpf_object__find_program_by_name(object, "ShortBindEntryTwo");
+    REQUIRE(prog2 != nullptr);
+
+    // Both programs should be in the "bind" section.
+    REQUIRE(strcmp(bpf_program__section_name(prog1), "bind") == 0);
+    REQUIRE(strcmp(bpf_program__section_name(prog2), "bind") == 0);
+
+    // Verify program names.
+    REQUIRE(strcmp(bpf_program__name(prog1), "ShortBindEntryOne") == 0);
+    REQUIRE(strcmp(bpf_program__name(prog2), "ShortBindEntryTwo") == 0);
+
+    // Verify programs are distinct.
+    REQUIRE(prog1 != prog2);
+
+    // Load the programs.
+    REQUIRE(bpf_object__load(object) == 0);
+
+    // Verify both programs were loaded successfully.
+    REQUIRE(bpf_program__fd(const_cast<const bpf_program*>(prog1)) > 0);
+    REQUIRE(bpf_program__fd(const_cast<const bpf_program*>(prog2)) > 0);
+
+    bpf_object__close(object);
+}
+
+DECLARE_ALL_TEST_CASES("multi_prog_same_bind", "[libbpf]", _test_multi_prog_same_bind);
+
 TEST_CASE("bad_tail_call-native", "[libbpf]")
 {
     ebpf_test_tail_call("tail_call_bad_um.dll", (uint32_t)(-EBPF_INVALID_ARGUMENT));

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2097,7 +2097,7 @@ TEST_CASE("good_tail_call_same_section-native", "[libbpf]")
 }
 
 static void
-_test_multi_prog_same_bind(ebpf_execution_type_t execution_type)
+_test_multi_prog_same_section(ebpf_execution_type_t execution_type)
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
@@ -2105,14 +2105,14 @@ _test_multi_prog_same_bind(ebpf_execution_type_t execution_type)
     REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
 
     const char* file_name =
-        (execution_type == EBPF_EXECUTION_NATIVE ? "multi_prog_same_bind_um.dll" : "multi_prog_same_bind.o");
+        (execution_type == EBPF_EXECUTION_NATIVE ? "multi_prog_same_section_um.dll" : "multi_prog_same_section.o");
     struct bpf_object* object = bpf_object__open(file_name);
     REQUIRE(object != nullptr);
 
     // Verify both programs are found by name.
-    struct bpf_program* prog1 = bpf_object__find_program_by_name(object, "ShortBindEntryOne");
+    struct bpf_program* prog1 = bpf_object__find_program_by_name(object, "prog1");
     REQUIRE(prog1 != nullptr);
-    struct bpf_program* prog2 = bpf_object__find_program_by_name(object, "ShortBindEntryTwo");
+    struct bpf_program* prog2 = bpf_object__find_program_by_name(object, "prog2");
     REQUIRE(prog2 != nullptr);
 
     // Both programs should be in the "bind" section.
@@ -2120,8 +2120,8 @@ _test_multi_prog_same_bind(ebpf_execution_type_t execution_type)
     REQUIRE(strcmp(bpf_program__section_name(prog2), "bind") == 0);
 
     // Verify program names.
-    REQUIRE(strcmp(bpf_program__name(prog1), "ShortBindEntryOne") == 0);
-    REQUIRE(strcmp(bpf_program__name(prog2), "ShortBindEntryTwo") == 0);
+    REQUIRE(strcmp(bpf_program__name(prog1), "prog1") == 0);
+    REQUIRE(strcmp(bpf_program__name(prog2), "prog2") == 0);
 
     // Verify programs are distinct.
     REQUIRE(prog1 != prog2);
@@ -2136,7 +2136,7 @@ _test_multi_prog_same_bind(ebpf_execution_type_t execution_type)
     bpf_object__close(object);
 }
 
-DECLARE_ALL_TEST_CASES("multi_prog_same_bind", "[libbpf]", _test_multi_prog_same_bind);
+DECLARE_ALL_TEST_CASES("multi_prog_same_section", "[libbpf]", _test_multi_prog_same_section);
 
 TEST_CASE("bad_tail_call-native", "[libbpf]")
 {


### PR DESCRIPTION
Fixes #5278

## Description

Fix a bug in the native PE parser where multiple eBPF programs sharing the same short PE section name (≤ 8 chars, e.g., `SEC("bind")`) would silently drop all but the last program.

The root cause is that `_ebpf_pe_context` stored per-program metadata in four separate `std::map<std::string, ...>` maps keyed by PE section name. When multiple programs mapped to the same PE section name, later entries overwrote
earlier ones.

PR #3557 fixed the ELF pipeline, libbpf APIs, bpf2c, verifier, and netsh, but the native PE parser was only partially updated
— it received type renames but the underlying map-based data structure was left unchanged. Programs with long ELF section names (> 8 chars) worked by accident because the PE linker disambiguates them with `~N` suffixes (e.g.,
`cgroup/connect4` → `cgroup~1`), but short names like `bind` produced identical PE section names with no suffix, causing key collisions.

**Changes:**
- Consolidate the four per-program metadata maps in `_ebpf_pe_context` into a   single `std::map<std::string, std::vector<native_program_metadata_t>>`, where `native_program_metadata_t` is a new inner struct.
- In `_ebpf_pe_get_section_names`, append metadata to the vector instead of overwriting.
- In `_ebpf_pe_add_section`, iterate over all programs in the vector, creating an `ebpf_api_program_info_t` for each, with proper cleanup on allocation failure.
- Minor rename of `VerifierOptions` → `ebpf_verifier_options_t` to match an upstream verifier API change.

## Testing

- [x] Unit tests are added.

Added `_test_multi_prog_same_section` test case (JIT/native/interpret variants) that opens a sample with two programs both under `SEC("bind")`, verifies both are discovered by name, checks section names, and confirms both load
successfully.

Added `tests/sample/undocked/multi_prog_same_section.c` — a sample BPF program with two programs `prog1`, `prog2`) both declared under `SEC("bind")`.

## Documentation

NA

## Installation

NA