### PR TITLE
ebpf_program: Fix rollback of program state on NmrClientAttachProvider failure

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -569,7 +569,13 @@ _ebpf_program_type_specific_program_information_attach_provider(
         state = ebpf_lock_lock(&program->lock);
         lock_held = true;
 
-        program->general_helper_program_data = NULL;
+        // Roll back the program state that was set before the NmrClientAttachProvider call.
+        // Reclaim extension_program_data so it gets freed at Done.
+        extension_program_data = (ebpf_program_data_t*)program->extension_program_data;
+        program->extension_program_data = NULL;
+        program->program_type_specific_helper_function_count = 0;
+        program->bpf_prog_type = 0;
+
         ebpf_lock_unlock(&program->lock, state);
         lock_held = false;
         goto Done;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -571,10 +571,10 @@ _ebpf_program_type_specific_program_information_attach_provider(
 
         // Roll back the program state that was set before the NmrClientAttachProvider call.
         // Reclaim extension_program_data so it gets freed at Done.
-        extension_program_data = (ebpf_program_data_t*)program->extension_program_data;
+        extension_program_data = program->extension_program_data;
         program->extension_program_data = NULL;
         program->program_type_specific_helper_function_count = 0;
-        program->bpf_prog_type = 0;
+        program->bpf_prog_type = BPF_PROG_TYPE_UNSPEC;
 
         ebpf_lock_unlock(&program->lock, state);
         lock_held = false;


### PR DESCRIPTION
## Summary

When \NmrClientAttachProvider\ fails in \_ebpf_program_type_specific_program_information_attach_provider\, the error path incorrectly cleared \general_helper_program_data\ (wrong field) instead of rolling back the state set before the call.

## Issues Fixed

1. **Wrong field cleared** — error path cleared \general_helper_program_data\ instead of \xtension_program_data\.
2. **Memory ownership** — \xtension_program_data\ was committed to the program (\program->extension_program_data = extension_program_data; extension_program_data = NULL;\) but not reclaimed on failure, so the \Done:\ label's \bpf_program_data_free(extension_program_data)\ was a no-op.
3. **Stale state** — \pf_prog_type\ and \program_type_specific_helper_function_count\ were not reset, leaving the program in an inconsistent state.

Note: The program destructor (\_ebpf_program_free\) already frees \xtension_program_data\, so the memory leak was bounded by program lifetime. The more significant issue was stale program state that could affect subsequent attach attempts.

## Changes

- **\libs/execution_context/ebpf_program.c\**: Fixed the NmrClientAttachProvider failure path to reclaim \xtension_program_data\, clear \program->extension_program_data\, and reset \program_type_specific_helper_function_count\ and \pf_prog_type\.

## Testing

- All 49 \[execution_context]\ tests pass (39,105 assertions).
- Existing fault injection tests cover this path via \cxplat_fault_injection_inject_fault()\ in usersim's \NmrClientAttachProvider\.