### PR TITLE
ebpf_platform: Add missing SeReleaseSubjectContext calls

### DIFF
--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -372,6 +372,7 @@ ebpf_access_check(
     }
 
     SeUnlockSubjectContext(&subject_context);
+    SeReleaseSubjectContext(&subject_context);
     return result;
 }
 
@@ -411,6 +412,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t
     if (access_token == NULL) {
         EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "SeQuerySubjectContextToken failed");
 
+        SeReleaseSubjectContext(&context);
         return EBPF_FAILED;
     }
 
@@ -419,11 +421,13 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, SeQueryAuthenticationIdToken, status);
 
+        SeReleaseSubjectContext(&context);
         return EBPF_FAILED;
     }
 
     *authentication_id = *(uint64_t*)&local_authentication_id;
 
+    SeReleaseSubjectContext(&context);
     return EBPF_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes #5295

## Summary

\SeCaptureSubjectContext\ captures token references that must be released via \SeReleaseSubjectContext\. Two functions were missing this call, leaking kernel token object references on every invocation:

- **\bpf_access_check\** — called \SeUnlockSubjectContext\ but not \SeReleaseSubjectContext\
- **\bpf_platform_get_authentication_id\** — no \SeReleaseSubjectContext\ on any return path

## Changes

- **\libs/runtime/kernel/ebpf_platform_kernel.c\**: Added \SeReleaseSubjectContext\ after \SeUnlockSubjectContext\ in \bpf_access_check\, and on all three return paths in \bpf_platform_get_authentication_id\.

## Testing

- \ccess_check\ test passes (12 assertions).
- All 30 \[platform]\ tests pass (5,492 assertions).