### PR TITLE
ebpf_program: Add NULL check for global_helper_function_addresses

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -355,7 +355,11 @@ _ebpf_program_general_program_information_attach_provider(
 
     program->general_helper_program_data = program_data;
 
-    program->global_helper_function_count = program_data->global_helper_function_addresses->helper_function_count;
+    if (program_data->global_helper_function_addresses != NULL) {
+        program->global_helper_function_count = program_data->global_helper_function_addresses->helper_function_count;
+    } else {
+        program->global_helper_function_count = 0;
+    }
 
     ebpf_lock_unlock(&program->lock, state);
     lock_held = false;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -215,7 +215,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
     _Out_ size_t* hash_length);
 
 static bool
-_ebpf_program_match_provider_data_module_id(_In_ const PNPI_MODULEID npi_module_id, _In_ const GUID* expected_module_id)
+_ebpf_program_match_provider_data_module_id(_In_ PNPI_MODULEID npi_module_id, _In_ const GUID* expected_module_id)
 {
     bool match = false;
     // Verify the NPI module ID is a GUID.
@@ -247,7 +247,7 @@ enum ebpf_program_info_provider_type
 static bool
 _ebpf_program_verify_provider_program_data(
     _In_ enum ebpf_program_info_provider_type provider_type,
-    _In_ const PNPI_MODULEID npi_module_id,
+    _In_ PNPI_MODULEID npi_module_id,
     _In_opt_ const ebpf_program_data_t* program_data)
 {
     bool program_data_valid = false;
@@ -356,7 +356,7 @@ Done:
 
 bool
 ebpf_program_is_valid_general_helper_provider_data(
-    _In_ const PNPI_MODULEID npi_module_id, _In_opt_ const ebpf_program_data_t* program_data)
+    _In_ PNPI_MODULEID npi_module_id, _In_opt_ const ebpf_program_data_t* program_data)
 {
     return _ebpf_program_verify_provider_program_data(
         EBPF_PROGRAM_INFO_PROVIDER_TYPE_GENERAL_HELPER, npi_module_id, program_data);

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -263,7 +263,51 @@ _ebpf_program_verify_provider_program_data(
     }
 
     // Perform validation of the program data.
-    if (!is_general_helper_program_data) {
+    if (is_general_helper_program_data) {
+        const ebpf_program_info_t* program_info = program_data->program_info;
+        uint32_t count_of_global_helpers = 0;
+
+        if (program_info == NULL) {
+            EBPF_LOG_MESSAGE_GUID(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_PROGRAM,
+                "The general helper program information provider data is missing program info.",
+                &npi_module_id->Guid);
+            goto Done;
+        }
+
+        count_of_global_helpers = program_info->count_of_global_helpers;
+        if (!ebpf_validate_helper_function_prototype_array(
+                program_info->global_helper_prototype, count_of_global_helpers)) {
+            EBPF_LOG_MESSAGE_GUID(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_PROGRAM,
+                "The general helper program information provider data has invalid helper prototypes.",
+                &npi_module_id->Guid);
+            goto Done;
+        }
+
+        if (count_of_global_helpers > 0) {
+            if (program_data->global_helper_function_addresses == NULL) {
+                EBPF_LOG_MESSAGE_GUID(
+                    EBPF_TRACELOG_LEVEL_ERROR,
+                    EBPF_TRACELOG_KEYWORD_PROGRAM,
+                    "The general helper program information provider data is missing helper addresses.",
+                    &npi_module_id->Guid);
+                goto Done;
+            }
+
+            if ((program_data->global_helper_function_addresses->helper_function_address == NULL) ||
+                (program_data->global_helper_function_addresses->helper_function_count != count_of_global_helpers)) {
+                EBPF_LOG_MESSAGE_GUID(
+                    EBPF_TRACELOG_LEVEL_ERROR,
+                    EBPF_TRACELOG_KEYWORD_PROGRAM,
+                    "The general helper program information provider data has inconsistent helper addresses.",
+                    &npi_module_id->Guid);
+                goto Done;
+            }
+        }
+    } else {
         if (!ebpf_validate_program_data(program_data)) {
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR,
@@ -310,6 +354,14 @@ Done:
     return program_data_valid;
 }
 
+bool
+ebpf_program_is_valid_general_helper_provider_data(
+    _In_ const PNPI_MODULEID npi_module_id, _In_opt_ const ebpf_program_data_t* program_data)
+{
+    return _ebpf_program_verify_provider_program_data(
+        EBPF_PROGRAM_INFO_PROVIDER_TYPE_GENERAL_HELPER, npi_module_id, program_data);
+}
+
 static NTSTATUS
 _ebpf_program_general_program_information_attach_provider(
     _In_ HANDLE nmr_binding_handle,
@@ -354,12 +406,7 @@ _ebpf_program_general_program_information_attach_provider(
     }
 
     program->general_helper_program_data = program_data;
-
-    if (program_data->global_helper_function_addresses != NULL) {
-        program->global_helper_function_count = program_data->global_helper_function_addresses->helper_function_count;
-    } else {
-        program->global_helper_function_count = 0;
-    }
+    program->global_helper_function_count = program_data->global_helper_function_addresses->helper_function_count;
 
     ebpf_lock_unlock(&program->lock, state);
     lock_held = false;

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -31,7 +31,7 @@ extern "C"
 
     bool
     ebpf_program_is_valid_general_helper_provider_data(
-        _In_ const PNPI_MODULEID npi_module_id, _In_opt_ const ebpf_program_data_t* program_data);
+        _In_ PNPI_MODULEID npi_module_id, _In_opt_ const ebpf_program_data_t* program_data);
 }
 
 struct scoped_cpu_affinity

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -28,6 +28,10 @@ extern "C"
     void
     ebpf_program_get_header_context_descriptor(
         _In_ const void* program_context, _Outptr_ const ebpf_ctx_descriptor_t** context_descriptor);
+
+    bool
+    ebpf_program_is_valid_general_helper_provider_data(
+        _In_ const PNPI_MODULEID npi_module_id, _In_opt_ const ebpf_program_data_t* program_data);
 }
 
 struct scoped_cpu_affinity
@@ -2691,6 +2695,48 @@ TEST_CASE("INVALID_PROGRAM_DATA", "[execution_context][negative]")
     // Invalidate the helper function prototype by removing the name of the helper function.
     _test_helper_function_prototype[0].name = nullptr;
     test_register_provider(&provider_characteristics);
+}
+
+TEST_CASE("INVALID_GENERAL_HELPER_PROGRAM_DATA", "[execution_context][negative]")
+{
+    ebpf_program_type_descriptor_t general_helper_program_type_descriptor = {
+        EBPF_PROGRAM_TYPE_DESCRIPTOR_HEADER,
+        "global_helper",
+        nullptr,
+        ebpf_general_helper_function_module_id.Guid,
+        0,
+        0};
+
+    ebpf_helper_function_prototype_t general_helper_prototype[] = {
+        {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
+         1,
+         "general_helper",
+         EBPF_RETURN_TYPE_INTEGER,
+         {EBPF_ARGUMENT_TYPE_DONTCARE}}};
+
+    ebpf_program_info_t general_helper_program_info = {
+        EBPF_PROGRAM_INFORMATION_HEADER,
+        &general_helper_program_type_descriptor,
+        0,
+        nullptr,
+        1,
+        general_helper_prototype};
+
+    ebpf_program_data_t invalid_general_helper_program_data = {
+        EBPF_PROGRAM_DATA_HEADER, &general_helper_program_info, nullptr, nullptr, nullptr, nullptr, 0, {0}};
+
+    REQUIRE(!ebpf_program_is_valid_general_helper_provider_data(
+        &ebpf_general_helper_function_module_id, &invalid_general_helper_program_data));
+
+    const void* general_helper_functions[] = {reinterpret_cast<const void*>(1)};
+    ebpf_helper_function_addresses_t general_helper_function_addresses = {
+        EBPF_HELPER_FUNCTION_ADDRESSES_HEADER,
+        EBPF_COUNT_OF(general_helper_functions),
+        (uint64_t*)general_helper_functions};
+    invalid_general_helper_program_data.global_helper_function_addresses = &general_helper_function_addresses;
+
+    REQUIRE(ebpf_program_is_valid_general_helper_provider_data(
+        &ebpf_general_helper_function_module_id, &invalid_general_helper_program_data));
 }
 
 // TODO: Add more native module loading IOCTL negative tests.


### PR DESCRIPTION
Fixes #5292

## Summary

\_ebpf_program_general_program_information_attach_provider\ dereferenced \program_data->global_helper_function_addresses\ without a NULL check. If a provider registers with NULL \global_helper_function_addresses\, this would cause a kernel NULL pointer dereference.

## Changes

- **\libs/execution_context/ebpf_program.c\**: Added NULL check before dereferencing \global_helper_function_addresses\. When NULL, \global_helper_function_count\ defaults to 0.

## Testing

- All 49 \[execution_context]\ tests pass (39,105 assertions).