### PR TITLE
Fuzz CONNECT_AUTHORIZATION hook in netebpfext_fuzzer

### DIFF
--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -121,6 +121,8 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         (void)helper.test_cgroup_inet6_recv_accept(&parameters);
         (void)helper.test_cgroup_inet4_connect(&parameters);
         (void)helper.test_cgroup_inet6_connect(&parameters);
+        (void)helper.test_cgroup_inet4_connect_authorization(&parameters);
+        (void)helper.test_cgroup_inet6_connect_authorization(&parameters);
         break;
     case BPF_PROG_TYPE_SOCK_OPS:
         (void)helper.test_sock_ops_v4(&parameters, nullptr);


### PR DESCRIPTION
## Description

Closes #5298 

Add netebpfext fuzzer support for connect_authorization hooks (IPv4 & IPv6).

Invokes test_cgroup_inet4_connect_authorization and test_cgroup_inet6_connect_authorization from the BPF_PROG_TYPE_CGROUP_SOCK_ADDR arm of the netebpfext libfuzzer harness.

## Testing

Just adds connect auth (user-mode) fuzzing tests.

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.

## Documentation

N/A

## Installation

N/A
