### PR TITLE
tools/onebranch: copy test-support scripts/wprp into artifact

### DIFF
--- a/tools/onebranch/onebranch.vcxproj
+++ b/tools/onebranch/onebranch.vcxproj
@@ -106,4 +106,38 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+
+  <!--
+    Copy test-support files (scripts, ETW recording profile, GUID/JSON config
+    files, etc.) from the source tree into the OneBranch artifact directory.
+
+    The ProjectReferences above only contribute compiled binary outputs to
+    $(OutDir). The driver test jobs running in the downstream test pipeline
+    additionally need the .ps1/.psm1 helpers under scripts\ (setup, cleanup,
+    run_driver_tests, tracing) and ebpfforwindows.wprp (used by wpr.exe to
+    start ETW tracing during tests). The legacy 'native_only_test' build stage
+    relied on scripts\setup_build\setup_build.vcxproj to gather these via
+    <CopyFileToFolders>, but that project is not a dependency of this target
+    (and has no ARM64 configuration), so /t:tools\onebranch skipped it.
+
+    Mirror the file list maintained by setup_build.vcxproj so the official
+    build artifact contains everything the driver tests expect.
+  -->
+  <Target Name="CopyTestSupportFiles" AfterTargets="Build" Condition="'$(BuildOneBranch)'=='True'">
+    <ItemGroup>
+      <_TestSupportFiles Include="$(SolutionDir)scripts\*.ps1" />
+      <_TestSupportFiles Include="$(SolutionDir)scripts\*.psm1" />
+      <_TestSupportFiles Include="$(SolutionDir)scripts\*.wprp" />
+      <_TestSupportFiles Include="$(SolutionDir)scripts\*.guid" />
+      <_TestSupportFiles Include="$(SolutionDir)scripts\test_execution.json" />
+      <_TestSupportFiles Include="$(SolutionDir)scripts\run_tests.bat" />
+      <_TestSupportFiles Include="$(SolutionDir)scripts\ebpf_tracing.cmd" />
+      <_TestSupportFiles Include="$(SolutionDir)external\usersim\scripts\Test-FaultInjection.ps1"
+                         Condition="Exists('$(SolutionDir)external\usersim\scripts\Test-FaultInjection.ps1')" />
+    </ItemGroup>
+    <Message Importance="high" Text="onebranch: copying %(_TestSupportFiles.Identity) -&gt; $(SolutionDir)build\bin\$(Platform)_$(Configuration)" />
+    <Copy SourceFiles="@(_TestSupportFiles)"
+          DestinationFolder="$(SolutionDir)build\bin\$(Platform)_$(Configuration)"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes test failures observed on the downstream test pipeline after the recent consolidation onto the `official_main` build artifact (microsoft/ES PR #15662259 and follow-on builds like 147654461).

## Problem

The official `onebranch` build target (`/t:tools\onebranch /p:BuildOneBranch=True`) produces a single artifact via `tools\onebranch\onebranch.vcxproj`'s PostBuildEvent `xcopy /yie $(OutDir) ...`. That captures binary outputs from the project's `ProjectReferences`, but does NOT capture loose source-tree files.

The downstream driver-test jobs (`driver_native_only_*`, `km_ebpfcore_restart`, `km_mt_stress*`, `km_ioctl_stress`, `regression_driver_ws2022`) need additional support files at runtime:

- `scripts\ebpfforwindows.wprp` -- used by `wpr.exe -start` for ETW tracing. Missing this file causes the test job's `Start ETW tracing` step to fail with `The system cannot find the file specified`.
- `scripts\cleanup_ebpf_cicd_tests.ps1` -- post-test cleanup. Missing this causes the `Run post-test command` step to fail.
- Plus the full chain of `.psm1` modules it imports (`common`, `install_ebpf`, `tracing_utils`, `config_test_vm`, `run_driver_tests`, `vm_run_tests`), the `setup_ebpf_cicd_tests.ps1` / `execute_ebpf_cicd_tests.ps1` entry points, `.guid` files, `test_execution.json`, and `Run-Test.ps1`.

The legacy `native_only_test` build stage gathered all of these via `scripts\setup_build\setup_build.vcxproj`'s `<CopyFileToFolders>` items, but that project is not a `ProjectReference` of `tools\onebranch.vcxproj` (and lacks an ARM64 configuration), so `/t:tools\onebranch` skipped it.

## Fix

Add a `CopyTestSupportFiles` MSBuild target to `tools\onebranch\onebranch.vcxproj`, gated on `/p:BuildOneBranch=True`, that copies the same file set `setup_build.vcxproj` maintains directly into the OneBranch artifact directory (`build\bin\$(Platform)_$(Configuration)`, the destination already used by the existing PostBuildEvent xcopy).

File list mirrors `scripts\setup_build\setup_build.vcxproj`:
- `scripts\*.ps1`
- `scripts\*.psm1`
- `scripts\*.wprp`
- `scripts\*.guid`
- `scripts\test_execution.json`
- `scripts\run_tests.bat`
- `scripts\ebpf_tracing.cmd`
- `external\usersim\scripts\Test-FaultInjection.ps1` (when present)

The target uses `<Copy>` with `SkipUnchangedFiles=true` for incremental-build friendliness. Works on both x64 and ARM64 (no per-platform config block required).

## Validation

The destination directory is the same one already populated by the existing PostBuildEvent xcopy lines, so the artifact upload step continues to pick up everything in one pass. No changes needed in OneBranch.yml or the downstream test pipeline.
