### PR TITLE
Fix official_main artifact layout for ADO test pipeline

### DIFF
--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -215,14 +215,23 @@ function Install-eBPFComponents
     # Copy the VC debug runtime DLLs to the system32 directory,
     # so that debug versions of the MSI can be installed (i.e., export_program_info.exe will not fail).
     Write-Log("Copying VC debug runtime DLLs to the $system32Path directory...")
-    # Test if the VC debug runtime DLLs are present in the working directory (indicating a debug build).
-    $VCDebugRuntime = $VCDebugRuntime | Where-Object { Test-Path (Join-Path $WorkingDirectory $_) }
+    # Test if the VC debug runtime DLLs are present in the working directory
+    # (indicating a debug build). Some artifact layouts place them in a 'bin'
+    # subdirectory (e.g. the official_main pipeline), so check there as well.
+    $VCDebugRuntimeSourceDir = $WorkingDirectory
+    if (-not ($VCDebugRuntime | Where-Object { Test-Path (Join-Path $WorkingDirectory $_) })) {
+        $binDir = Join-Path $WorkingDirectory "bin"
+        if ($VCDebugRuntime | Where-Object { Test-Path (Join-Path $binDir $_) }) {
+            $VCDebugRuntimeSourceDir = $binDir
+        }
+    }
+    $VCDebugRuntime = $VCDebugRuntime | Where-Object { Test-Path (Join-Path $VCDebugRuntimeSourceDir $_) }
     if (-not $VCDebugRuntime) {
         Write-Log("VC debug runtime DLLs not found in the working directory (i.e., release build). Skipping this step.") -ForegroundColor Yellow
     } else {
         $system32Path = Join-Path $env:SystemRoot "System32"
         $VCDebugRuntime | ForEach-Object {
-            $sourcePath = Join-Path $WorkingDirectory $_
+            $sourcePath = Join-Path $VCDebugRuntimeSourceDir $_
             $destinationPath = Join-Path $system32Path $_
             Write-Log("Copying '$sourcePath' to '$destinationPath'...")
             Copy-Item -Path $sourcePath -Destination $destinationPath -Force
@@ -254,6 +263,8 @@ function Install-eBPFComponents
                 "$pwd\{0}" -f $_.Value.Name
             } elseif (Test-Path -Path ("$pwd\drivers\{0}" -f $_.Value.Name)) {
                 "$pwd\drivers\{0}" -f $_.Value.Name
+            } elseif (Test-Path -Path ("$pwd\bin\{0}" -f $_.Value.Name)) {
+                "$pwd\bin\{0}" -f $_.Value.Name
             } else {
                 throw ("Driver file not found for $($_.Key).")
             }
@@ -303,6 +314,8 @@ function Install-eBPFComponents
                         "$pwd\{0}" -f $_.Value.Name
                     } elseif (Test-Path -Path ("$pwd\drivers\{0}" -f $_.Value.Name)) {
                         "$pwd\drivers\{0}" -f $_.Value.Name
+                    } elseif (Test-Path -Path ("$pwd\bin\{0}" -f $_.Value.Name)) {
+                        "$pwd\bin\{0}" -f $_.Value.Name
                     } else {
                         throw ("Driver file not found for $($_.Key).")
                     }

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -57,7 +57,23 @@ $BinariesToCopy = @(
     "connect_redirect_tests.exe",
     "connect_redirect_tests.pdb",
     "tcp_udp_listener.exe",
-    "tcp_udp_listener.pdb"
+    "tcp_udp_listener.pdb",
+    # VC debug runtime DLLs (present only for NativeOnlyDebug builds; copied
+    # by tools\onebranch\onebranch.vcxproj PostBuildEvent for that config).
+    # install_ebpf.psm1 copies these into System32 on the test VM so that
+    # debug-built binaries (e.g. export_program_info.exe, which runs as an
+    # MSI custom action) can load. Missing files are warned-and-skipped
+    # below, so listing them is safe for Release configs.
+    "concrt140d.dll",
+    "msvcp140d.dll",
+    "msvcp140d_atomic_wait.dll",
+    "msvcp140d_codecvt_ids.dll",
+    "msvcp140_1d.dll",
+    "msvcp140_2d.dll",
+    "vccorlib140d.dll",
+    "vcruntime140d.dll",
+    "vcruntime140_1d.dll",
+    "ucrtbased.dll"
 )
 
 function CopyPackages {

--- a/tools/onebranch/onebranch.vcxproj
+++ b/tools/onebranch/onebranch.vcxproj
@@ -45,7 +45,12 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyDebug' And '$(BuildOneBranch)'=='True'">
     <PostBuildEvent>
-      <Command>xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug</Command>
+      <Command Condition="'$(Platform)'=='x64'">xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug
+xcopy /D /Y "$(VC_DebugCppRuntimeFilesPath_x64)\Microsoft.VC143.DebugCRT\*" "$(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug"
+xcopy /D /Y "$(UniversalDebugCRT_ExecutablePath_x64)\ucrtbased.dll" "$(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug"</Command>
+      <Command Condition="'$(Platform)'=='ARM64'">xcopy /yie $(OutDir) $(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug
+xcopy /D /Y "$(VC_DebugCppRuntimeFilesPath_ARM64)\Microsoft.VC143.DebugCRT\*" "$(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug"
+xcopy /D /Y "$(UniversalDebugCRT_ExecutablePath_ARM64)\ucrtbased.dll" "$(SolutionDir)build\bin\$(Platform)_NativeOnlyDebug"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='NativeOnlyRelease' And '$(BuildOneBranch)'=='True'">


### PR DESCRIPTION
## Summary

The Azure DevOps `official_main` pipeline (defined in
[microsoft/undock/ES](https://microsoft.visualstudio.com/undock/_git/ES))
builds via `/t:tools\onebranch /p:BuildOneBranch=True` and produces an
artifact where binaries live under a `bin/` subdirectory. Two gaps
caused the ES-side test pipeline (`Official.ebpf-for-windows.test`,
def 190695) to fail when consuming these artifacts:

1. **`scripts/install_ebpf.psm1`** searched `$pwd\<driver>` and
   `$pwd\drivers\<driver>` only. `sample_ebpf_ext.sys` lives at
   `$pwd\bin\sample_ebpf_ext.sys` in the new layout, so the script
   threw `Driver file not found for SampleEbpfExt` on every Release
   driver-test job.

2. For **NativeOnlyDebug**, the VC debug runtime DLLs (`msvcp140d.dll`,
   `vcruntime140d.dll`, `ucrtbased.dll`, etc.) were not packaged at all,
   because `scripts/setup_build/setup_build.vcxproj` (which copies them
   in the public GitHub CI build) is not referenced by
   `tools/onebranch/onebranch.vcxproj`. Without them, the MSI custom
   action `Clear_eBPF_store_HKLM` -- which runs the debug-built
   `export_program_info.exe --clear` -- fails to load its dependent
   DLLs and `msiexec` returns `1603`.

## Changes

- **`scripts/install_ebpf.psm1`** -- also search a `bin\` subdirectory
  for drivers and for VC debug runtime DLLs. Falls through to the
  existing search paths when the artifact uses the flat layout, so
  public GitHub CI builds remain unaffected.

- **`tools/onebranch/onebranch.vcxproj`** -- for NativeOnlyDebug
  (x64 and ARM64), extend the PostBuildEvent to xcopy the VC debug
  CRT and `ucrtbased.dll` into `build\bin\$(Platform)_NativeOnlyDebug`,
  mirroring what `scripts/setup_build/setup_build.vcxproj` already
  does in the public CI build.

- **`scripts/onebranch/post-build.ps1`** -- include the VC debug
  runtime DLL names in the `$BinariesToCopy` list so they land in the
  artifact's `bin/` subdirectory. Missing entries (Release configs)
  are warned-and-skipped by the existing loop, so this is safe for
  NativeOnlyRelease as well.

## Scope / non-impact

- The `bin\` search fallback in `install_ebpf.psm1` is additive; the
  existing flat-layout search paths are checked first, so public GitHub
  CI runs continue to find files exactly where they do today.
- The `onebranch.vcxproj` PostBuildEvent change is gated on
  `'$(Configuration)'=='NativeOnlyDebug' And '$(BuildOneBranch)'=='True'`,
  which is only true on the OneBranch `official_main` pipeline.
- The `$BinariesToCopy` additions are filenames; for Release builds
  none of the files exist and `post-build.ps1`'s existing
  `Test-Path -Path $sourcePath` check emits a `Warning:` and moves on.

## Verification

Inspected the failing artifacts from ADO build 147907624
(`drop_official_main_build_x64_NativeOnlyRelease.zip` and
`...NativeOnlyDebug.zip`):

- `bin/sample_ebpf_ext.sys` is present (confirms #1 fix path is correct).
- `msvcp140d.dll` etc. are absent in the current artifacts (confirms #2
  is a real packaging gap, not a layout-only issue).

With these changes, `install_ebpf.psm1` discovers `bin/<driver>.sys`
and `bin/msvcp140d.dll` on the test VM, and the MSI installer's
debug-built custom action loads successfully.

## How to validate

After merge, re-queue the ES-side test pipeline against a build of
this repo. No ES-side changes are required; the existing
ES PR ([microsoft/undock/ES!15662259](https://microsoft.visualstudio.com/undock/_git/ES/pullrequest/15662259))
already builds these artifacts via `official_main`.
