### PR TITLE
Fix JIT / interpret flow for bpf2bpf, add tests

### DIFF
--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -145,6 +145,11 @@ _build_helper_id_to_address_map(
         if (instruction.opcode != prevail::INST_OP_CALL) {
             continue;
         }
+        // Skip local function calls (src == INST_CALL_LOCAL) — their imm field
+        // is a relative offset to the callee, not a helper ID.
+        if (instruction.src == 1) {
+            continue;
+        }
         instruction.imm = helper_id_mapping[instruction.imm];
     }
     for (auto& [old_helper_id, new_helper_id] : helper_id_mapping) {

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -145,9 +145,9 @@ _build_helper_id_to_address_map(
         if (instruction.opcode != prevail::INST_OP_CALL) {
             continue;
         }
-        // Skip local function calls (src == INST_CALL_LOCAL) — their imm field
-        // is a relative offset to the callee, not a helper ID.
-        if (instruction.src == 1) {
+        // Skip calls other than static helper calls — their imm field is a relative offset
+        // to the callee, not a helper ID.
+        if (instruction.src != prevail::INST_CALL_STATIC_HELPER) {
             continue;
         }
         instruction.imm = helper_id_mapping[instruction.imm];

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
@@ -1,0 +1,304 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from bpf2bpf_loop.o
+
+#include "bpf2c.h"
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers.
+#include <windows.h>
+
+#define metadata_table bpf2bpf_loop##_metadata_table
+extern metadata_table_t metadata_table;
+
+bool APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) metadata_table_t*
+get_metadata_table()
+{
+    return &metadata_table;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {
+     {0, 0},
+     {
+         1,                  // Current Version.
+         80,                 // Struct size up to the last field.
+         80,                 // Total struct size including padding.
+     },
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         10,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "bpf2bpf_loop_map"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 1;
+}
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_info_t** global_variable_sections,
+    _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
+static helper_function_entry_t caller_with_loop_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     2,
+     "helper_id_2",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID caller_with_loop_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID caller_with_loop_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t caller_with_loop_maps[] = {
+    0,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+caller_with_loop(void* context, const program_runtime_context_t* runtime_context)
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+{
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    // Prologue.
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r0 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r1 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r2 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r3 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r4 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r5 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r6 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r10 = 0;
+
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (uintptr_t)context;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=0
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r0 offset=-4 imm=0
+#line 30 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
+    // EBPF_OP_STXW pc=2 dst=r10 src=r0 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-12));
+    // EBPF_OP_LDXW pc=3 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_LSH64_IMM pc=4 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=5 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_IMM pc=6 dst=r1 src=r0 offset=10 imm=9
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if ((int64_t)r1 > IMMEDIATE(9)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_2;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r6 src=r0 offset=0 imm=10
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r6 = IMMEDIATE(10);
+label_1:
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r1 = r0;
+    // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=18
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r0 = increment(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_ADD64_IMM pc=11 dst=r1 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=12 dst=r10 src=r1 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-12));
+    // EBPF_OP_LDXW pc=13 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_LSH64_IMM pc=14 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=15 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=16 dst=r6 src=r1 offset=-9 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if ((int64_t)r6 > (int64_t)r1) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_1;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+label_2:
+    // EBPF_OP_STXW pc=17 dst=r10 src=r0 offset=-8 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-8));
+    // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=19 dst=r2 src=r0 offset=0 imm=-4
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=20 dst=r3 src=r10 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=21 dst=r3 src=r0 offset=0 imm=-8
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=22 dst=r1 src=r1 offset=0 imm=1
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r1 = POINTER(runtime_context->map_data[0].address);
+    // EBPF_OP_MOV64_IMM pc=24 dst=r4 src=r0 offset=0 imm=0
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
+    // EBPF_OP_LDXW pc=26 dst=r0 src=r10 offset=-8 imm=0
+#line 38 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r0, r10, OFFSET(-8));
+    // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
+#line 38 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)r10;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r0 src=r1 offset=0 imm=0
+#line 20 "sample/undocked/bpf2bpf_loop.c"
+    r0 = r1;
+    // EBPF_OP_ADD64_IMM pc=1 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    r0 += IMMEDIATE(1);
+    // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+}
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        {1, 144, 144}, // Version header.
+        caller_with_loop,
+        "sample~1",
+        "sample_ext",
+        "caller_with_loop",
+        caller_with_loop_maps,
+        1,
+        caller_with_loop_helpers,
+        1,
+        28,
+        &caller_with_loop_program_type_guid,
+        &caller_with_loop_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 1;
+    version->minor = 3;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t bpf2bpf_loop_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
@@ -1,0 +1,274 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from bpf2bpf_loop.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {
+     {0, 0},
+     {
+         1,                  // Current Version.
+         80,                 // Struct size up to the last field.
+         80,                 // Total struct size including padding.
+     },
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         10,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "bpf2bpf_loop_map"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 1;
+}
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_info_t** global_variable_sections,
+    _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
+static helper_function_entry_t caller_with_loop_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     2,
+     "helper_id_2",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID caller_with_loop_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID caller_with_loop_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t caller_with_loop_maps[] = {
+    0,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+caller_with_loop(void* context, const program_runtime_context_t* runtime_context)
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+{
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    // Prologue.
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r0 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r1 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r2 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r3 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r4 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r5 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r6 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r10 = 0;
+
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (uintptr_t)context;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=0
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r0 offset=-4 imm=0
+#line 30 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
+    // EBPF_OP_STXW pc=2 dst=r10 src=r0 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-12));
+    // EBPF_OP_LDXW pc=3 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_LSH64_IMM pc=4 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=5 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_IMM pc=6 dst=r1 src=r0 offset=10 imm=9
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if ((int64_t)r1 > IMMEDIATE(9)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_2;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r6 src=r0 offset=0 imm=10
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r6 = IMMEDIATE(10);
+label_1:
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r1 = r0;
+    // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=18
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r0 = increment(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_ADD64_IMM pc=11 dst=r1 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=12 dst=r10 src=r1 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-12));
+    // EBPF_OP_LDXW pc=13 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_LSH64_IMM pc=14 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=15 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=16 dst=r6 src=r1 offset=-9 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if ((int64_t)r6 > (int64_t)r1) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_1;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+label_2:
+    // EBPF_OP_STXW pc=17 dst=r10 src=r0 offset=-8 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-8));
+    // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=19 dst=r2 src=r0 offset=0 imm=-4
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=20 dst=r3 src=r10 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=21 dst=r3 src=r0 offset=0 imm=-8
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=22 dst=r1 src=r1 offset=0 imm=1
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r1 = POINTER(runtime_context->map_data[0].address);
+    // EBPF_OP_MOV64_IMM pc=24 dst=r4 src=r0 offset=0 imm=0
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
+    // EBPF_OP_LDXW pc=26 dst=r0 src=r10 offset=-8 imm=0
+#line 38 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r0, r10, OFFSET(-8));
+    // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
+#line 38 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)r10;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r0 src=r1 offset=0 imm=0
+#line 20 "sample/undocked/bpf2bpf_loop.c"
+    r0 = r1;
+    // EBPF_OP_ADD64_IMM pc=1 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    r0 += IMMEDIATE(1);
+    // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+}
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        {1, 144, 144}, // Version header.
+        caller_with_loop,
+        "sample~1",
+        "sample_ext",
+        "caller_with_loop",
+        caller_with_loop_maps,
+        1,
+        caller_with_loop_helpers,
+        1,
+        28,
+        &caller_with_loop_program_type_guid,
+        &caller_with_loop_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 1;
+    version->minor = 3;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t bpf2bpf_loop_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
@@ -1,0 +1,429 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from bpf2bpf_loop.o
+
+#define NO_CRT
+#include "bpf2c.h"
+
+#include <guiddef.h>
+#include <wdm.h>
+#include <wsk.h>
+
+DRIVER_INITIALIZE DriverEntry;
+DRIVER_UNLOAD DriverUnload;
+RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
+
+#define metadata_table bpf2bpf_loop##_metadata_table
+
+static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
+                             0xc847aac8,
+                             0xa6f2,
+                             0x4b53,
+                             {0xae, 0xa3, 0xf4, 0xa9, 0x4b, 0x9a, 0x80, 0xcb}};
+static NPI_MODULEID _bpf2c_module_id = {sizeof(_bpf2c_module_id), MIT_GUID, {0}};
+static HANDLE _bpf2c_nmr_client_handle;
+static HANDLE _bpf2c_nmr_provider_handle;
+extern metadata_table_t metadata_table;
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context);
+
+static const NPI_CLIENT_CHARACTERISTICS _bpf2c_npi_client_characteristics = {
+    0,                                  // Version
+    sizeof(NPI_CLIENT_CHARACTERISTICS), // Length
+    _bpf2c_npi_client_attach_provider,
+    _bpf2c_npi_client_detach_provider,
+    NULL,
+    {0,                                 // Version
+     sizeof(NPI_REGISTRATION_INSTANCE), // Length
+     &_bpf2c_npi_id,
+     &_bpf2c_module_id,
+     0,
+     NULL}};
+
+static NTSTATUS
+_bpf2c_query_npi_module_id(
+    _In_ const wchar_t* value_name,
+    unsigned long value_type,
+    _In_ const void* value_data,
+    unsigned long value_length,
+    _Inout_ void* context,
+    _Inout_ void* entry_context)
+{
+    UNREFERENCED_PARAMETER(value_name);
+    UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(entry_context);
+
+    if (value_type != REG_BINARY) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (value_length != sizeof(_bpf2c_module_id.Guid)) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    memcpy(&_bpf2c_module_id.Guid, value_data, value_length);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_path)
+{
+    NTSTATUS status;
+    RTL_QUERY_REGISTRY_TABLE query_table[] = {
+        {
+            NULL,                      // Query routine
+            RTL_QUERY_REGISTRY_SUBKEY, // Flags
+            L"Parameters",             // Name
+            NULL,                      // Entry context
+            REG_NONE,                  // Default type
+            NULL,                      // Default data
+            0,                         // Default length
+        },
+        {
+            _bpf2c_query_npi_module_id,  // Query routine
+            RTL_QUERY_REGISTRY_REQUIRED, // Flags
+            L"NpiModuleId",              // Name
+            NULL,                        // Entry context
+            REG_NONE,                    // Default type
+            NULL,                        // Default data
+            0,                           // Default length
+        },
+        {0}};
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, registry_path->Buffer, query_table, NULL, NULL);
+    if (!NT_SUCCESS(status)) {
+        goto Exit;
+    }
+
+    status = NmrRegisterClient(&_bpf2c_npi_client_characteristics, NULL, &_bpf2c_nmr_client_handle);
+
+Exit:
+    if (NT_SUCCESS(status)) {
+        driver_object->DriverUnload = DriverUnload;
+    }
+
+    return status;
+}
+
+void
+DriverUnload(_In_ DRIVER_OBJECT* driver_object)
+{
+    NTSTATUS status = NmrDeregisterClient(_bpf2c_nmr_client_handle);
+    if (status == STATUS_PENDING) {
+        NmrWaitForClientDeregisterComplete(_bpf2c_nmr_client_handle);
+    }
+    UNREFERENCED_PARAMETER(driver_object);
+}
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    void* provider_binding_context = NULL;
+    void* provider_dispatch_table = NULL;
+
+    UNREFERENCED_PARAMETER(client_context);
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+
+    if (_bpf2c_nmr_provider_handle != NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    status = NmrClientAttachProvider(
+        nmr_binding_handle, client_context, &metadata_table, &provider_binding_context, &provider_dispatch_table);
+    if (status != STATUS_SUCCESS) {
+        goto Done;
+    }
+    _bpf2c_nmr_provider_handle = nmr_binding_handle;
+
+Done:
+    return status;
+}
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
+{
+    _bpf2c_nmr_provider_handle = NULL;
+    UNREFERENCED_PARAMETER(client_binding_context);
+    return STATUS_SUCCESS;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {
+     {0, 0},
+     {
+         1,                  // Current Version.
+         80,                 // Struct size up to the last field.
+         80,                 // Total struct size including padding.
+     },
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         10,                 // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "bpf2bpf_loop_map"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 1;
+}
+
+static void
+_get_global_variable_sections(
+    _Outptr_result_buffer_maybenull_(*count) global_variable_section_info_t** global_variable_sections,
+    _Out_ size_t* count)
+{
+    *global_variable_sections = NULL;
+    *count = 0;
+}
+
+static helper_function_entry_t caller_with_loop_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     2,
+     "helper_id_2",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID caller_with_loop_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID caller_with_loop_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static uint16_t caller_with_loop_maps[] = {
+    0,
+};
+
+#pragma code_seg(push, "sample~1")
+static uint64_t
+caller_with_loop(void* context, const program_runtime_context_t* runtime_context)
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+{
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    // Prologue.
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r0 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r1 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r2 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r3 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r4 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r5 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r6 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r10 = 0;
+
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (uintptr_t)context;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=0
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r0 offset=-4 imm=0
+#line 30 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
+    // EBPF_OP_STXW pc=2 dst=r10 src=r0 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-12));
+    // EBPF_OP_LDXW pc=3 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_LSH64_IMM pc=4 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=5 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_IMM pc=6 dst=r1 src=r0 offset=10 imm=9
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if ((int64_t)r1 > IMMEDIATE(9)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_2;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=7 dst=r6 src=r0 offset=0 imm=10
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r6 = IMMEDIATE(10);
+label_1:
+    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r1 = r0;
+    // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=18
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r0 = increment(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    // EBPF_OP_LDXW pc=10 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_ADD64_IMM pc=11 dst=r1 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=12 dst=r10 src=r1 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-12));
+    // EBPF_OP_LDXW pc=13 dst=r1 src=r10 offset=-12 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r1, r10, OFFSET(-12));
+    // EBPF_OP_LSH64_IMM pc=14 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=15 dst=r1 src=r0 offset=0 imm=32
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=16 dst=r6 src=r1 offset=-9 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if ((int64_t)r6 > (int64_t)r1) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_1;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+label_2:
+    // EBPF_OP_STXW pc=17 dst=r10 src=r0 offset=-8 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-8));
+    // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=19 dst=r2 src=r0 offset=0 imm=-4
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=20 dst=r3 src=r10 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=21 dst=r3 src=r0 offset=0 imm=-8
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=22 dst=r1 src=r1 offset=0 imm=1
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r1 = POINTER(runtime_context->map_data[0].address);
+    // EBPF_OP_MOV64_IMM pc=24 dst=r4 src=r0 offset=0 imm=0
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=2
+#line 37 "sample/undocked/bpf2bpf_loop.c"
+    r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
+    // EBPF_OP_LDXW pc=26 dst=r0 src=r10 offset=-8 imm=0
+#line 38 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_32(r0, r10, OFFSET(-8));
+    // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
+#line 38 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)r10;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r0 src=r1 offset=0 imm=0
+#line 20 "sample/undocked/bpf2bpf_loop.c"
+    r0 = r1;
+    // EBPF_OP_ADD64_IMM pc=1 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    r0 += IMMEDIATE(1);
+    // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+}
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        {1, 144, 144}, // Version header.
+        caller_with_loop,
+        "sample~1",
+        "sample_ext",
+        "caller_with_loop",
+        caller_with_loop_maps,
+        1,
+        caller_with_loop_helpers,
+        1,
+        28,
+        &caller_with_loop_program_type_guid,
+        &caller_with_loop_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 1;
+    version->minor = 3;
+    version->revision = 0;
+}
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = NULL;
+    *count = 0;
+}
+
+metadata_table_t bpf2bpf_loop_metadata_table = {
+    sizeof(metadata_table_t),
+    _get_programs,
+    _get_maps,
+    _get_hash,
+    _get_version,
+    _get_map_initial_values,
+    _get_global_variable_sections,
+};

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -545,6 +545,40 @@ _bindmonitor_bpf2bpf_test(ebpf_execution_type_t execution_type)
     REQUIRE(emulate_bind(invoke, 2, "fake_app_2") == BIND_PERMIT_SOFT);
 }
 
+// Test noinline subprogram call inside a loop — 10 increments, map should contain 10.
+static void
+_bpf2bpf_loop_test(ebpf_execution_type_t execution_type)
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "bpf2bpf_loop_um.dll" : "bpf2bpf_loop.o");
+    program_load_attach_helper_t program_helper;
+    program_helper.initialize(file_name, BPF_PROG_TYPE_SAMPLE, "caller_with_loop", execution_type, nullptr, 0, hook);
+
+    INITIALIZE_SAMPLE_CONTEXT;
+
+    uint32_t hook_result = 0;
+    REQUIRE(hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
+
+    // The program returns the counter value (should be 10).
+    REQUIRE(hook_result == 10);
+
+    // Verify the map also contains 10 — proves the loop body ran 10 times.
+    fd_t map_fd = bpf_object__find_map_fd_by_name(program_helper.get_object(), "bpf2bpf_loop_map");
+    REQUIRE(map_fd > 0);
+    uint32_t key = 0;
+    uint32_t value = 0;
+    REQUIRE(bpf_map_lookup_elem(map_fd, &key, &value) == 0);
+    REQUIRE(value == 10);
+}
+
 static void
 _callgraph_bpf2bpf_test(ebpf_execution_type_t execution_type)
 {
@@ -1100,7 +1134,8 @@ DECLARE_ALL_TEST_CASES("droppacket", "[end_to_end]", droppacket_test);
 DECLARE_ALL_TEST_CASES("divide_by_zero", "[end_to_end]", divide_by_zero_test_um);
 DECLARE_ALL_TEST_CASES("bindmonitor", "[end_to_end]", bindmonitor_test);
 DECLARE_ALL_TEST_CASES("bindmonitor-bpf2bpf", "[end_to_end]", _bindmonitor_bpf2bpf_test);
-DECLARE_NATIVE_TEST("callgraph-bpf2bpf", "[end_to_end]", _callgraph_bpf2bpf_test);
+DECLARE_ALL_TEST_CASES("bpf2bpf-loop", "[end_to_end]", _bpf2bpf_loop_test);
+DECLARE_ALL_TEST_CASES("callgraph-bpf2bpf", "[end_to_end]", _callgraph_bpf2bpf_test);
 
 // Regression test: Verify that reloading a helper provider (triggering the
 // helper-address-change callback) works correctly for native programs that

--- a/tests/sample/undocked/bpf2bpf_loop.c
+++ b/tests/sample/undocked/bpf2bpf_loop.c
@@ -1,0 +1,39 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// Test: noinline subprogram call inside a loop.
+// Validates that the Prevail verifier handles noinline calls inside loops.
+
+#include "bpf_helpers.h"
+#include "sample_ext_helpers.h"
+
+struct
+{
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, uint32_t);
+    __type(value, uint32_t);
+    __uint(max_entries, 1);
+} bpf2bpf_loop_map SEC(".maps");
+
+// Noinline subprogram: increments the supplied value by 1 and returns it.
+__attribute__((noinline)) uint32_t
+increment(uint32_t value)
+{
+    return value + 1;
+}
+
+// Noinline call INSIDE a loop — 10 increments, writes 10 to map.
+SEC("sample_ext")
+uint32_t
+caller_with_loop(sample_program_context_t* ctx)
+{
+    uint32_t key = 0;
+    uint32_t counter = 0;
+
+    for (volatile int i = 0; i < 10; i++) {
+        counter = increment(counter);
+    }
+
+    bpf_map_update_elem(&bpf2bpf_loop_map, &key, &counter, 0);
+    return counter;
+}


### PR DESCRIPTION
Fixes #5317

## Description

PR #5335 pulled latest commit from prevail that also contains a fix for making bpf2bpf calls in a loop. As a follow up for that PR, this PR adds the following:
1. Add sample BPF program and test case for bpf2bpf function calls in a loop.
2. Fix interpret / JIT case for bpf2bpf programs invoking helper functions.

## Testing

This PR adds new tests.

_If new tests were added:_
- [x] Unit tests are added.
- [ ] Driver tests are added.

## Documentation

No

## Installation

No
