### PR TITLE
Bump external/ubpf to close ubpf_fuzzer ASAN crash

### DIFF
--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -163,3 +163,42 @@ void __cdecl abort(void) { KeBugCheck(PAGE_FAULT_IN_NONPAGED_AREA); }
 #include "ubpf_instruction_valid.c"
 #include "ubpf_jit.c"
 #pragma warning(pop)
+
+// eBPF for Windows uses only the default (legacy) ubpf execution profile; it does not use
+// ubpf's opt-in "safe" execution profile. ubpf_vm.c references these safe-profile entry points
+// unconditionally, so stub them out rather than compiling vm/ubpf_safe.c (which duplicates
+// ubpf_vm.c's file-static interpreter helpers and so cannot be amalgamated into this translation
+// unit). This mirrors how the unused ubpf JIT is thunked out above.
+#pragma warning(push)
+#pragma warning(disable : 4100) // unreferenced formal parameter
+int
+ubpf_set_execution_profile_impl(struct ubpf_vm* vm, enum ubpf_execution_profile profile)
+{
+    return (profile == UBPF_EXECUTION_PROFILE_LEGACY) ? 0 : -1;
+}
+
+int
+ubpf_register_safe_helper_impl(struct ubpf_vm* vm, const struct ubpf_safe_helper_descriptor* descriptor)
+{
+    return -1;
+}
+
+int
+ubpf_register_safe_region_impl(struct ubpf_vm* vm, const struct ubpf_safe_region* region)
+{
+    return -1;
+}
+
+int
+ubpf_exec_ex_safe(
+    const struct ubpf_vm* vm,
+    void* mem,
+    size_t mem_len,
+    uint64_t* bpf_return_value,
+    uint8_t* stack_start,
+    size_t stack_length)
+{
+    // Unreachable: the safe profile is never selected (ubpf_set_execution_profile_impl rejects it).
+    return -1;
+}
+#pragma warning(pop)

--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -49,3 +49,42 @@ _ebpf_ubpf_calloc(size_t count, size_t size)
 #include "ubpf_jit_x86_64.c"
 #include "ubpf_vm.c"
 #pragma warning(pop)
+
+// eBPF for Windows uses only the default (legacy) ubpf execution profile; it does not use
+// ubpf's opt-in "safe" execution profile. ubpf_vm.c references these safe-profile entry points
+// unconditionally, so stub them out rather than compiling vm/ubpf_safe.c (which duplicates
+// ubpf_vm.c's file-static interpreter helpers and so cannot be amalgamated into this translation
+// unit).
+#pragma warning(push)
+#pragma warning(disable : 4100) // unreferenced formal parameter
+int
+ubpf_set_execution_profile_impl(struct ubpf_vm* vm, enum ubpf_execution_profile profile)
+{
+    return (profile == UBPF_EXECUTION_PROFILE_LEGACY) ? 0 : -1;
+}
+
+int
+ubpf_register_safe_helper_impl(struct ubpf_vm* vm, const struct ubpf_safe_helper_descriptor* descriptor)
+{
+    return -1;
+}
+
+int
+ubpf_register_safe_region_impl(struct ubpf_vm* vm, const struct ubpf_safe_region* region)
+{
+    return -1;
+}
+
+int
+ubpf_exec_ex_safe(
+    const struct ubpf_vm* vm,
+    void* mem,
+    size_t mem_len,
+    uint64_t* bpf_return_value,
+    uint8_t* stack_start,
+    size_t stack_length)
+{
+    // Unreachable: the safe profile is never selected (ubpf_set_execution_profile_impl rejects it).
+    return -1;
+}
+#pragma warning(pop)


### PR DESCRIPTION
## Summary

Bumps `external/ubpf` to the current upstream `main` tip to pick up the merged
fix that closes an ASAN access-violation in `ubpf_fuzzer.exe` discovered via
internal fuzz testing:

* `libfuzzer/libfuzz_harness.cc`: the `ubpf_get_helper_prototype` stub returned
  a default-constructed `EbpfHelperPrototype{}` whose `.name` is a null pointer;
  verifier paths assigning `.name` to a `std::string` then dereferenced NULL.
  The stub now throws `std::runtime_error` instead, matching the sibling
  "not implemented" stubs in the same file.

Upstream fix: iovisor/ubpf#794 (merged).

This moves `external/ubpf` from `96a348c` to `cf7ebf7a`, which also pulls in
intervening commits including iovisor/ubpf#793 (adds `vm/ubpf_safe.c`, an
opt-in "safe" execution profile) and iovisor/ubpf#801.

Since eBPF for Windows uses only the default (legacy) profile, the ubpf
wrappers stub the safe-profile entry points instead of compiling
`vm/ubpf_safe.c`, matching how the unused ubpf JIT is already stubbed.
