### PR TITLE
Deprecate BPF_PROG_TYPE_BIND in favor of BPF_PROG_TYPE_CGROUP_SOCK_ADDR

### DIFF
--- a/docs/BindHook.md
+++ b/docs/BindHook.md
@@ -48,6 +48,11 @@ the multi-attach requirement from [issue #5180](https://github.com/microsoft/ebp
 
 ## Relationship to the Legacy Bind Hook
 
+> **⚠️ DEPRECATED:** The legacy `EBPF_PROGRAM_TYPE_BIND` / `EBPF_ATTACH_TYPE_BIND`
+> hook is deprecated and will be removed in a future release. New programs should use
+> `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` with `BPF_CGROUP_INET4_BIND` / `BPF_CGROUP_INET6_BIND`
+> attach types. See the [Migration Guide](#migration-guide) below.
+
 eBPF for Windows continues to support the legacy `EBPF_PROGRAM_TYPE_BIND` /
 `EBPF_ATTACH_TYPE_BIND` hook with the Windows-specific `bind_md_t` context. Existing
 programs that use the legacy hook continue to work without changes — the legacy hook
@@ -64,9 +69,42 @@ and the new sock_addr-aligned bind hook coexist at the same WFP layers.
 | Address modification | Declared via `BIND_REDIRECT` but not actually enforced by WFP | Not supported |
 | Release / unbind notifications | Yes (`BIND_OPERATION_UNBIND`) | No |
 
-Choose the legacy hook when you need release/unbind notifications or are extending an
-existing Windows-specific program. Choose the new sock_addr-aligned hook for any new
-work, especially when cross-platform compatibility with Linux is desired.
+Choose the legacy hook **only** when you need release/unbind notifications. For all new
+work, use the sock_addr-aligned bind hook for cross-platform compatibility with Linux.
+
+### Migration Guide
+
+To migrate a program from the legacy bind hook to the new sock_addr bind hook:
+
+1. **Change program type and attach type:**
+   - Replace `BPF_PROG_TYPE_BIND` / `BPF_ATTACH_TYPE_BIND` with
+     `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` and `BPF_CGROUP_INET4_BIND` or `BPF_CGROUP_INET6_BIND`
+   - Use `SEC("cgroup/bind4")` or `SEC("cgroup/bind6")` ELF section names
+
+2. **Map context fields (`bind_md_t` → `bpf_sock_addr_t`):**
+
+   | `bind_md_t` field | `bpf_sock_addr_t` equivalent | Notes |
+   |---|---|---|
+   | `socket_address` | `user_ip4` / `user_ip6` | Network byte order in both |
+   | `socket_address_length` | Implied by `family` | `AF_INET`=4 bytes, `AF_INET6`=16 bytes |
+   | `protocol` | `protocol` | Same semantics |
+   | `process_id` | Use `bpf_get_current_pid_tgid()` helper | |
+   | `app_id_start` / `app_id_end` | Not directly available | Use helper functions |
+   | `operation` | Not available | New hook only fires for bind, not unbind |
+
+3. **Map return values (`bind_action_t` → `ebpf_sock_addr_verdict_t`):**
+
+   | `bind_action_t` | `ebpf_sock_addr_verdict_t` | Notes |
+   |---|---|---|
+   | `BIND_PERMIT_SOFT` | `BPF_SOCK_ADDR_VERDICT_PROCEED_SOFT` | |
+   | `BIND_PERMIT_HARD` | `BPF_SOCK_ADDR_VERDICT_PROCEED_HARD` | |
+   | `BIND_DENY` | `BPF_SOCK_ADDR_VERDICT_REJECT` | |
+   | `BIND_REDIRECT` | Not supported | New hook does not support address modification |
+
+4. **Limitations of the new hook:**
+   - No unbind/release notifications (`BIND_OPERATION_UNBIND` has no equivalent)
+   - No address modification (`BIND_REDIRECT` has no equivalent)
+   - Separate IPv4 and IPv6 attach types (instead of a single combined hook)
 
 ## Design Rationale
 

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -11,7 +11,12 @@
 #endif
 
 // BIND hook.
+// @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
 
+/**
+ * @brief Operations reported by the legacy bind hook.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
+ */
 typedef enum _bind_operation
 {
     BIND_OPERATION_BIND,      ///< Entry to bind.
@@ -19,6 +24,11 @@ typedef enum _bind_operation
     BIND_OPERATION_UNBIND,    ///< Release port.
 } bind_operation_t;
 
+/**
+ * @brief Context structure for the legacy bind hook.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
+ * Use bpf_sock_addr_t as the context structure for the replacement hook.
+ */
 typedef struct _bind_md
 {
     uint8_t* app_id_start;         ///< Pointer to start of App ID.
@@ -32,6 +42,8 @@ typedef struct _bind_md
 
 /**
  * @brief Actions that can be returned by a bind hook program.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
+ * Use ebpf_sock_addr_verdict_t as the return type for the replacement hook.
  */
 typedef enum _bind_action
 {
@@ -76,6 +88,7 @@ typedef enum _bind_action
 
 /**
  * @brief Handle IPv4 and IPv6 socket bind operations.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
  *
  * This function type defines the signature for eBPF programs that handle socket bind operations.
  * The program is called before the bind operation completes and can inspect the socket metadata
@@ -95,8 +108,14 @@ typedef enum _bind_action
  * @retval BIND_DENY Deny the bind operation.
  * @retval BIND_REDIRECT Change the bind endpoint.
  */
+#ifdef _MSC_VER
+typedef __declspec(deprecated("Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with "
+                              "BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.")) bind_action_t
+bind_hook_t(bind_md_t* context);
+#else
 typedef bind_action_t
 bind_hook_t(bind_md_t* context);
+#endif
 
 //
 // CGROUP_SOCK_ADDR.

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -13,7 +13,12 @@
 #endif
 
 // BIND hook.
+// @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
 
+/**
+ * @brief Operations reported by the legacy bind hook.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
+ */
 typedef enum _bind_operation
 {
     BIND_OPERATION_BIND,      ///< Entry to bind.
@@ -21,6 +26,11 @@ typedef enum _bind_operation
     BIND_OPERATION_UNBIND,    ///< Release port.
 } bind_operation_t;
 
+/**
+ * @brief Context structure for the legacy bind hook.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
+ * Use bpf_sock_addr_t as the context structure for the replacement hook.
+ */
 typedef struct _bind_md
 {
     uint8_t* app_id_start;         ///< Pointer to start of App ID.
@@ -34,6 +44,8 @@ typedef struct _bind_md
 
 /**
  * @brief Actions that can be returned by a bind hook program.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
+ * Use ebpf_sock_addr_verdict_t as the return type for the replacement hook.
  */
 typedef enum _bind_action
 {
@@ -78,6 +90,7 @@ typedef enum _bind_action
 
 /**
  * @brief Handle IPv4 and IPv6 socket bind operations.
+ * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
  *
  * This function type defines the signature for eBPF programs that handle socket bind operations.
  * The program is called before the bind operation completes and can inspect the socket metadata
@@ -97,8 +110,14 @@ typedef enum _bind_action
  * @retval BIND_DENY Deny the bind operation.
  * @retval BIND_REDIRECT Change the bind endpoint.
  */
+#ifdef _MSC_VER
+typedef __declspec(deprecated("Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with "
+                              "BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.")) bind_action_t
+bind_hook_t(bind_md_t* context);
+#else
 typedef bind_action_t
 bind_hook_t(bind_md_t* context);
+#endif
 
 //
 // CGROUP_SOCK_ADDR.

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -110,14 +110,8 @@ typedef enum _bind_action
  * @retval BIND_DENY Deny the bind operation.
  * @retval BIND_REDIRECT Change the bind endpoint.
  */
-#ifdef _MSC_VER
-typedef __declspec(deprecated("Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with "
-                              "BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.")) bind_action_t
-bind_hook_t(bind_md_t* context);
-#else
 typedef bind_action_t
 bind_hook_t(bind_md_t* context);
-#endif
 
 //
 // CGROUP_SOCK_ADDR.

--- a/include/ebpf_program_attach_type_guids.h
+++ b/include/ebpf_program_attach_type_guids.h
@@ -21,20 +21,16 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_XDP = {
         0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 
-#define EBPF_ATTACH_TYPE_BIND_GUID                                                     \
-    {                                                                                  \
-        0xb9707e04, 0x8127, 0x4c72, { 0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96 } \
-    }
+#define EBPF_ATTACH_TYPE_BIND_GUID {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}}
     /** @brief Attach type for handling socket bind operations.
+     * @deprecated Use EBPF_ATTACH_TYPE_CGROUP_INET4_BIND / EBPF_ATTACH_TYPE_CGROUP_INET6_BIND instead.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_BIND
      */
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_BIND = EBPF_ATTACH_TYPE_BIND_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID                                     \
-    {                                                                                  \
-        0xa82e37b1, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID \
+    {0xa82e37b1, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
     /** @brief The programs attached to the INET4_CONNECT hook will be invoked for
      * connect() calls on TCP or UDP sockets or when a UDP socket sends a packet to
      * a unique remote address/port tuple.
@@ -44,10 +40,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT =
         EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION_GUID                       \
-    {                                                                                  \
-        0x6076c13a, 0xf04f, 0x4ff8, { 0x83, 0x80, 0x90, 0x85, 0x53, 0xf2, 0x22, 0x76 } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION_GUID \
+    {0x6076c13a, 0xf04f, 0x4ff8, {0x83, 0x80, 0x90, 0x85, 0x53, 0xf2, 0x22, 0x76}}
     /**
      * @brief The program attached to the INET4_CONNECT_AUTHORIZATION hook will be invoked for
      * connect() calls on TCP or UDP sockets before the connection is authorized.
@@ -57,10 +51,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION =
         EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID                                     \
-    {                                                                                  \
-        0xa82e37b2, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID \
+    {0xa82e37b2, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
     /** @brief The programs attached to the INET6_CONNECT hook will be invoked for
      * connect() calls on TCP or UDP sockets or when a UDP socket sends a packet to
      * a unique remote address/port tuple.
@@ -70,10 +62,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT =
         EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION_GUID                       \
-    {                                                                                  \
-        0x54b0b6ed, 0x432a, 0x4674, { 0x8b, 0x27, 0x8d, 0x9f, 0x5b, 0x40, 0xc6, 0x75 } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION_GUID \
+    {0x54b0b6ed, 0x432a, 0x4674, {0x8b, 0x27, 0x8d, 0x9f, 0x5b, 0x40, 0xc6, 0x75}}
     /**
      * @brief The program attached to the INET6_CONNECT_AUTHORIZATION hook will be invoked for
      * connect() calls on TCP or UDP sockets before the connection is authorized.
@@ -83,10 +73,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION =
         EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID                                 \
-    {                                                                                  \
-        0xa82e37b3, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID \
+    {0xa82e37b3, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
     /** @brief The programs attached to the INET4_RECV_ACCEPT hook will get invoked for
      *  TCP accept() calls or for the first unicast UDP packet from a unique remote
      *  address/port tuple.
@@ -96,10 +84,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT =
         EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID                                 \
-    {                                                                                  \
-        0xa82e37b4, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID \
+    {0xa82e37b4, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
     /** @brief The programs attached to the INET6_RECV_ACCEPT hook will get invoked for
      *  TCP accept() calls or for the first unicast UDP packet from a unique remote
      *  address/port tuple.
@@ -109,20 +95,16 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT =
         EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID                                          \
-    {                                                                                  \
-        0x837d02cd, 0x3251, 0x4632, { 0x8d, 0x94, 0x60, 0xd3, 0xb4, 0x57, 0x69, 0xf2 } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID \
+    {0x837d02cd, 0x3251, 0x4632, {0x8d, 0x94, 0x60, 0xd3, 0xb4, 0x57, 0x69, 0xf2}}
     /** @brief Attach type for handling socket event notifications.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_SOCK_OPS
      */
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS = EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_BIND_GUID                                        \
-    {                                                                                  \
-        0x0d7ce21a, 0x7773, 0x405c, { 0x93, 0xb6, 0xd5, 0xbf, 0xb9, 0x2e, 0x74, 0xbc } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_BIND_GUID \
+    {0x0d7ce21a, 0x7773, 0x405c, {0x93, 0xb6, 0xd5, 0xbf, 0xb9, 0x2e, 0x74, 0xbc}}
     /** @brief The programs attached to the INET4_BIND hook will be invoked
      * when an IPv4 socket is bound to an address/port.
      *
@@ -131,10 +113,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_BIND =
         EBPF_ATTACH_TYPE_CGROUP_INET4_BIND_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_BIND_GUID                                        \
-    {                                                                                  \
-        0x81de64c0, 0x2973, 0x468d, { 0x83, 0x82, 0x67, 0x69, 0xf0, 0x33, 0xd7, 0x59 } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_BIND_GUID \
+    {0x81de64c0, 0x2973, 0x468d, {0x83, 0x82, 0x67, 0x69, 0xf0, 0x33, 0xd7, 0x59}}
     /** @brief The programs attached to the INET6_BIND hook will be invoked
      * when an IPv6 socket is bound to an address/port.
      *
@@ -143,10 +123,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_BIND =
         EBPF_ATTACH_TYPE_CGROUP_INET6_BIND_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN_GUID                                      \
-    {                                                                                  \
-        0xe1b0cb3d, 0xd70c, 0x4ee2, { 0xb2, 0x3a, 0x07, 0x42, 0xbe, 0xdb, 0x06, 0xd6 } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN_GUID \
+    {0xe1b0cb3d, 0xd70c, 0x4ee2, {0xb2, 0x3a, 0x07, 0x42, 0xbe, 0xdb, 0x06, 0xd6}}
     /** @brief Attach type for handling IPv4 socket listen operations.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
@@ -154,10 +132,8 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN =
         EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN_GUID                                      \
-    {                                                                                  \
-        0x4e72f92e, 0x5ed0, 0x4fe5, { 0xb8, 0x51, 0xb1, 0x24, 0xfe, 0x14, 0x07, 0x4d } \
-    }
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN_GUID \
+    {0x4e72f92e, 0x5ed0, 0x4fe5, {0xb8, 0x51, 0xb1, 0x24, 0xfe, 0x14, 0x07, 0x4d}}
     /** @brief Attach type for handling IPv6 socket listen operations.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
@@ -165,10 +141,7 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN =
         EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN_GUID;
 
-#define EBPF_ATTACH_TYPE_SAMPLE_GUID                                                   \
-    {                                                                                  \
-        0xf788ef4b, 0x207d, 0x4dc3, { 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c } \
-    }
+#define EBPF_ATTACH_TYPE_SAMPLE_GUID {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}}
 
     /** @brief Attach type implemented by eBPF Sample Extension driver, used for testing.
      *
@@ -176,10 +149,7 @@ extern "C"
      */
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_SAMPLE = EBPF_ATTACH_TYPE_SAMPLE_GUID;
 
-#define EBPF_ATTACH_TYPE_XDP_TEST_GUID                                                 \
-    {                                                                                  \
-        0x0dccc15d, 0xa5f9, 0x4dc1, { 0xac, 0x79, 0xfa, 0x25, 0xee, 0xf2, 0x15, 0xc3 } \
-    }
+#define EBPF_ATTACH_TYPE_XDP_TEST_GUID {0x0dccc15d, 0xa5f9, 0x4dc1, {0xac, 0x79, 0xfa, 0x25, 0xee, 0xf2, 0x15, 0xc3}}
     /** @brief Attach type for handling incoming packets as early as possible.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_XDP_TEST
@@ -192,10 +162,7 @@ extern "C"
 
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_UNSPECIFIED = {0};
 
-#define EBPF_PROGRAM_TYPE_XDP_GUID                                                     \
-    {                                                                                  \
-        0xf1832a85, 0x85d5, 0x45b0, { 0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0 } \
-    }
+#define EBPF_PROGRAM_TYPE_XDP_GUID {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}}
 
     /** @brief Program type for handling incoming packets as early as possible.
      *
@@ -207,12 +174,11 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_XDP = EBPF_PROGRAM_TYPE_XDP_GUID;
 
-#define EBPF_PROGRAM_TYPE_BIND_GUID                                                    \
-    {                                                                                  \
-        0x608c517c, 0x6c52, 0x4a26, { 0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf } \
-    }
+#define EBPF_PROGRAM_TYPE_BIND_GUID {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}}
 
     /** @brief Program type for handling socket bind operations.
+     * @deprecated Use EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR with EBPF_ATTACH_TYPE_CGROUP_INET4_BIND /
+     * EBPF_ATTACH_TYPE_CGROUP_INET6_BIND instead.
      *
      * eBPF program prototype: \ref bind_hook_t
      *
@@ -222,10 +188,8 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_BIND = EBPF_PROGRAM_TYPE_BIND_GUID;
 
-#define EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID                                        \
-    {                                                                                  \
-        0x92ec8e39, 0xaeec, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
-    }
+#define EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID \
+    {0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
 
     /** @brief Program type for handling various socket operations such as connect(), accept() etc.
      *
@@ -242,10 +206,7 @@ extern "C"
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR =
         EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID;
 
-#define EBPF_PROGRAM_TYPE_SOCK_OPS_GUID                                                \
-    {                                                                                  \
-        0x43fb224d, 0x68f8, 0x46d6, { 0xaa, 0x3f, 0xc8, 0x56, 0x51, 0x8c, 0xbb, 0x32 } \
-    }
+#define EBPF_PROGRAM_TYPE_SOCK_OPS_GUID {0x43fb224d, 0x68f8, 0x46d6, {0xaa, 0x3f, 0xc8, 0x56, 0x51, 0x8c, 0xbb, 0x32}}
 
     /** @brief Program type for handling socket event notifications.
      *
@@ -253,10 +214,7 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SOCK_OPS = EBPF_PROGRAM_TYPE_SOCK_OPS_GUID;
 
-#define EBPF_PROGRAM_TYPE_SAMPLE_GUID                                                  \
-    {                                                                                  \
-        0xf788ef4a, 0x207d, 0x4dc3, { 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c } \
-    }
+#define EBPF_PROGRAM_TYPE_SAMPLE_GUID {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}}
 
     /** @brief Program type for handling calls from the eBPF sample extension. Used for
      * testing.
@@ -265,10 +223,7 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SAMPLE = EBPF_PROGRAM_TYPE_SAMPLE_GUID;
 
-#define EBPF_PROGRAM_TYPE_XDP_TEST_GUID                                                \
-    {                                                                                  \
-        0xce8ccef8, 0x4241, 0x4975, { 0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c } \
-    }
+#define EBPF_PROGRAM_TYPE_XDP_TEST_GUID {0xce8ccef8, 0x4241, 0x4975, {0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c}}
 
     /** @brief Program type for handling incoming packets as early as possible.
      *

--- a/include/ebpf_program_attach_type_guids.h
+++ b/include/ebpf_program_attach_type_guids.h
@@ -21,7 +21,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_XDP = {
         0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 
-#define EBPF_ATTACH_TYPE_BIND_GUID {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}}
+#define EBPF_ATTACH_TYPE_BIND_GUID                                                     \
+    {                                                                                  \
+        0xb9707e04, 0x8127, 0x4c72, { 0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96 } \
+    }
     /** @brief Attach type for handling socket bind operations.
      * @deprecated Use EBPF_ATTACH_TYPE_CGROUP_INET4_BIND / EBPF_ATTACH_TYPE_CGROUP_INET6_BIND instead.
      *
@@ -29,8 +32,10 @@ extern "C"
      */
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_BIND = EBPF_ATTACH_TYPE_BIND_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID \
-    {0xa82e37b1, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID                                     \
+    {                                                                                  \
+        0xa82e37b1, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
+    }
     /** @brief The programs attached to the INET4_CONNECT hook will be invoked for
      * connect() calls on TCP or UDP sockets or when a UDP socket sends a packet to
      * a unique remote address/port tuple.
@@ -40,8 +45,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT =
         EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION_GUID \
-    {0x6076c13a, 0xf04f, 0x4ff8, {0x83, 0x80, 0x90, 0x85, 0x53, 0xf2, 0x22, 0x76}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION_GUID                       \
+    {                                                                                  \
+        0x6076c13a, 0xf04f, 0x4ff8, { 0x83, 0x80, 0x90, 0x85, 0x53, 0xf2, 0x22, 0x76 } \
+    }
     /**
      * @brief The program attached to the INET4_CONNECT_AUTHORIZATION hook will be invoked for
      * connect() calls on TCP or UDP sockets before the connection is authorized.
@@ -51,8 +58,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION =
         EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT_AUTHORIZATION_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID \
-    {0xa82e37b2, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID                                     \
+    {                                                                                  \
+        0xa82e37b2, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
+    }
     /** @brief The programs attached to the INET6_CONNECT hook will be invoked for
      * connect() calls on TCP or UDP sockets or when a UDP socket sends a packet to
      * a unique remote address/port tuple.
@@ -62,8 +71,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT =
         EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION_GUID \
-    {0x54b0b6ed, 0x432a, 0x4674, {0x8b, 0x27, 0x8d, 0x9f, 0x5b, 0x40, 0xc6, 0x75}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION_GUID                       \
+    {                                                                                  \
+        0x54b0b6ed, 0x432a, 0x4674, { 0x8b, 0x27, 0x8d, 0x9f, 0x5b, 0x40, 0xc6, 0x75 } \
+    }
     /**
      * @brief The program attached to the INET6_CONNECT_AUTHORIZATION hook will be invoked for
      * connect() calls on TCP or UDP sockets before the connection is authorized.
@@ -73,8 +84,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION =
         EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT_AUTHORIZATION_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID \
-    {0xa82e37b3, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID                                 \
+    {                                                                                  \
+        0xa82e37b3, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
+    }
     /** @brief The programs attached to the INET4_RECV_ACCEPT hook will get invoked for
      *  TCP accept() calls or for the first unicast UDP packet from a unique remote
      *  address/port tuple.
@@ -84,8 +97,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT =
         EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID \
-    {0xa82e37b4, 0xaee7, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID                                 \
+    {                                                                                  \
+        0xa82e37b4, 0xaee7, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
+    }
     /** @brief The programs attached to the INET6_RECV_ACCEPT hook will get invoked for
      *  TCP accept() calls or for the first unicast UDP packet from a unique remote
      *  address/port tuple.
@@ -95,16 +110,20 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT =
         EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID \
-    {0x837d02cd, 0x3251, 0x4632, {0x8d, 0x94, 0x60, 0xd3, 0xb4, 0x57, 0x69, 0xf2}}
+#define EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID                                          \
+    {                                                                                  \
+        0x837d02cd, 0x3251, 0x4632, { 0x8d, 0x94, 0x60, 0xd3, 0xb4, 0x57, 0x69, 0xf2 } \
+    }
     /** @brief Attach type for handling socket event notifications.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_SOCK_OPS
      */
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS = EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_BIND_GUID \
-    {0x0d7ce21a, 0x7773, 0x405c, {0x93, 0xb6, 0xd5, 0xbf, 0xb9, 0x2e, 0x74, 0xbc}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_BIND_GUID                                        \
+    {                                                                                  \
+        0x0d7ce21a, 0x7773, 0x405c, { 0x93, 0xb6, 0xd5, 0xbf, 0xb9, 0x2e, 0x74, 0xbc } \
+    }
     /** @brief The programs attached to the INET4_BIND hook will be invoked
      * when an IPv4 socket is bound to an address/port.
      *
@@ -113,8 +132,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_BIND =
         EBPF_ATTACH_TYPE_CGROUP_INET4_BIND_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_BIND_GUID \
-    {0x81de64c0, 0x2973, 0x468d, {0x83, 0x82, 0x67, 0x69, 0xf0, 0x33, 0xd7, 0x59}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_BIND_GUID                                        \
+    {                                                                                  \
+        0x81de64c0, 0x2973, 0x468d, { 0x83, 0x82, 0x67, 0x69, 0xf0, 0x33, 0xd7, 0x59 } \
+    }
     /** @brief The programs attached to the INET6_BIND hook will be invoked
      * when an IPv6 socket is bound to an address/port.
      *
@@ -123,8 +144,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_BIND =
         EBPF_ATTACH_TYPE_CGROUP_INET6_BIND_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN_GUID \
-    {0xe1b0cb3d, 0xd70c, 0x4ee2, {0xb2, 0x3a, 0x07, 0x42, 0xbe, 0xdb, 0x06, 0xd6}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN_GUID                                      \
+    {                                                                                  \
+        0xe1b0cb3d, 0xd70c, 0x4ee2, { 0xb2, 0x3a, 0x07, 0x42, 0xbe, 0xdb, 0x06, 0xd6 } \
+    }
     /** @brief Attach type for handling IPv4 socket listen operations.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
@@ -132,8 +155,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN =
         EBPF_ATTACH_TYPE_CGROUP_INET4_LISTEN_GUID;
 
-#define EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN_GUID \
-    {0x4e72f92e, 0x5ed0, 0x4fe5, {0xb8, 0x51, 0xb1, 0x24, 0xfe, 0x14, 0x07, 0x4d}}
+#define EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN_GUID                                      \
+    {                                                                                  \
+        0x4e72f92e, 0x5ed0, 0x4fe5, { 0xb8, 0x51, 0xb1, 0x24, 0xfe, 0x14, 0x07, 0x4d } \
+    }
     /** @brief Attach type for handling IPv6 socket listen operations.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
@@ -141,7 +166,10 @@ extern "C"
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN =
         EBPF_ATTACH_TYPE_CGROUP_INET6_LISTEN_GUID;
 
-#define EBPF_ATTACH_TYPE_SAMPLE_GUID {0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}}
+#define EBPF_ATTACH_TYPE_SAMPLE_GUID                                                   \
+    {                                                                                  \
+        0xf788ef4b, 0x207d, 0x4dc3, { 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c } \
+    }
 
     /** @brief Attach type implemented by eBPF Sample Extension driver, used for testing.
      *
@@ -149,7 +177,10 @@ extern "C"
      */
     __declspec(selectany) ebpf_attach_type_t EBPF_ATTACH_TYPE_SAMPLE = EBPF_ATTACH_TYPE_SAMPLE_GUID;
 
-#define EBPF_ATTACH_TYPE_XDP_TEST_GUID {0x0dccc15d, 0xa5f9, 0x4dc1, {0xac, 0x79, 0xfa, 0x25, 0xee, 0xf2, 0x15, 0xc3}}
+#define EBPF_ATTACH_TYPE_XDP_TEST_GUID                                                 \
+    {                                                                                  \
+        0x0dccc15d, 0xa5f9, 0x4dc1, { 0xac, 0x79, 0xfa, 0x25, 0xee, 0xf2, 0x15, 0xc3 } \
+    }
     /** @brief Attach type for handling incoming packets as early as possible.
      *
      * Program type: \ref EBPF_PROGRAM_TYPE_XDP_TEST
@@ -162,7 +193,10 @@ extern "C"
 
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_UNSPECIFIED = {0};
 
-#define EBPF_PROGRAM_TYPE_XDP_GUID {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}}
+#define EBPF_PROGRAM_TYPE_XDP_GUID                                                     \
+    {                                                                                  \
+        0xf1832a85, 0x85d5, 0x45b0, { 0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0 } \
+    }
 
     /** @brief Program type for handling incoming packets as early as possible.
      *
@@ -174,7 +208,10 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_XDP = EBPF_PROGRAM_TYPE_XDP_GUID;
 
-#define EBPF_PROGRAM_TYPE_BIND_GUID {0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}}
+#define EBPF_PROGRAM_TYPE_BIND_GUID                                                    \
+    {                                                                                  \
+        0x608c517c, 0x6c52, 0x4a26, { 0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf } \
+    }
 
     /** @brief Program type for handling socket bind operations.
      * @deprecated Use EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR with EBPF_ATTACH_TYPE_CGROUP_INET4_BIND /
@@ -188,8 +225,10 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_BIND = EBPF_PROGRAM_TYPE_BIND_GUID;
 
-#define EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID \
-    {0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}}
+#define EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID                                        \
+    {                                                                                  \
+        0x92ec8e39, 0xaeec, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
+    }
 
     /** @brief Program type for handling various socket operations such as connect(), accept() etc.
      *
@@ -206,7 +245,10 @@ extern "C"
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR =
         EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID;
 
-#define EBPF_PROGRAM_TYPE_SOCK_OPS_GUID {0x43fb224d, 0x68f8, 0x46d6, {0xaa, 0x3f, 0xc8, 0x56, 0x51, 0x8c, 0xbb, 0x32}}
+#define EBPF_PROGRAM_TYPE_SOCK_OPS_GUID                                                \
+    {                                                                                  \
+        0x43fb224d, 0x68f8, 0x46d6, { 0xaa, 0x3f, 0xc8, 0x56, 0x51, 0x8c, 0xbb, 0x32 } \
+    }
 
     /** @brief Program type for handling socket event notifications.
      *
@@ -214,7 +256,10 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SOCK_OPS = EBPF_PROGRAM_TYPE_SOCK_OPS_GUID;
 
-#define EBPF_PROGRAM_TYPE_SAMPLE_GUID {0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}}
+#define EBPF_PROGRAM_TYPE_SAMPLE_GUID                                                  \
+    {                                                                                  \
+        0xf788ef4a, 0x207d, 0x4dc3, { 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c } \
+    }
 
     /** @brief Program type for handling calls from the eBPF sample extension. Used for
      * testing.
@@ -223,7 +268,10 @@ extern "C"
      */
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SAMPLE = EBPF_PROGRAM_TYPE_SAMPLE_GUID;
 
-#define EBPF_PROGRAM_TYPE_XDP_TEST_GUID {0xce8ccef8, 0x4241, 0x4975, {0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c}}
+#define EBPF_PROGRAM_TYPE_XDP_TEST_GUID                                                \
+    {                                                                                  \
+        0xce8ccef8, 0x4241, 0x4975, { 0x98, 0x4d, 0xbb, 0x39, 0x21, 0xdf, 0xa7, 0x3c } \
+    }
 
     /** @brief Program type for handling incoming packets as early as possible.
      *

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -198,6 +198,8 @@ enum bpf_prog_type
     BPF_PROG_TYPE_XDP,
 
     /** @brief Program type for handling socket bind operations.
+     * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND /
+     * BPF_CGROUP_INET6_BIND instead.
      *
      * **eBPF program prototype:** \ref bind_hook_t
      *
@@ -299,6 +301,7 @@ enum bpf_attach_type
     BPF_XDP,
 
     /** @brief Attach type for handling socket bind operations.
+     * @deprecated Use BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
      *
      * **Program type:** \ref BPF_PROG_TYPE_BIND
      */

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -199,6 +199,8 @@ enum bpf_prog_type
     BPF_PROG_TYPE_XDP,
 
     /** @brief Program type for handling socket bind operations.
+     * @deprecated Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND /
+     * BPF_CGROUP_INET6_BIND instead.
      *
      * **eBPF program prototype:** \ref bind_hook_t
      *
@@ -300,6 +302,7 @@ enum bpf_attach_type
     BPF_XDP,
 
     /** @brief Attach type for handling socket bind operations.
+     * @deprecated Use BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.
      *
      * **Program type:** \ref BPF_PROG_TYPE_BIND
      */

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3843,6 +3843,16 @@ _Requires_lock_not_held_(_ebpf_state_mutex) static ebpf_result_t
         load_info.execution_context = execution_context_kernel_mode;
         load_info.map_count = (uint32_t)object->maps.size();
 
+        // Emit deprecation warning for legacy bind program type.
+        if (IsEqualGUID(program->program_type, EBPF_PROGRAM_TYPE_BIND)) {
+            EBPF_LOG_MESSAGE_STRING(
+                EBPF_TRACELOG_LEVEL_WARNING,
+                EBPF_TRACELOG_KEYWORD_API,
+                "Loading deprecated program type BPF_PROG_TYPE_BIND. "
+                "Migrate to BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND.",
+                program->section_name ? program->section_name : "");
+        }
+
         if (load_info.map_count > 0) {
             for (auto& map : object->maps) {
                 ebpf_id_t inner_map_id = (map->inner_map) ? map->inner_map->map_id : EBPF_ID_NONE;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3892,6 +3892,16 @@ _Requires_lock_not_held_(_ebpf_state_mutex) static ebpf_result_t
         load_info.execution_context = execution_context_kernel_mode;
         load_info.map_count = (uint32_t)object->maps.size();
 
+        // Emit deprecation warning for legacy bind program type.
+        if (IsEqualGUID(program->program_type, EBPF_PROGRAM_TYPE_BIND)) {
+            EBPF_LOG_MESSAGE_STRING(
+                EBPF_TRACELOG_LEVEL_WARNING,
+                EBPF_TRACELOG_KEYWORD_API,
+                "Loading deprecated program type BPF_PROG_TYPE_BIND. "
+                "Migrate to BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND.",
+                program->section_name ? program->section_name : "");
+        }
+
         if (load_info.map_count > 0) {
             for (auto& map : object->maps) {
                 ebpf_id_t inner_map_id = (map->inner_map) ? map->inner_map->map_id : EBPF_ID_NONE;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1488,6 +1488,26 @@ Exit:
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
+/**
+ * @brief Emit a WARNING trace if the supplied program type has been deprecated.
+ *
+ * @param[in] program_type Program type being loaded.
+ * @param[in] program_name Optional name of the program being loaded.
+ */
+static void
+_ebpf_log_deprecated_program_type(
+    _In_ const ebpf_program_type_t* program_type, _In_opt_z_ const char* program_name) noexcept
+{
+    if (IsEqualGUID(*program_type, EBPF_PROGRAM_TYPE_BIND)) {
+        EBPF_LOG_MESSAGE_STRING(
+            EBPF_TRACELOG_LEVEL_WARNING,
+            EBPF_TRACELOG_KEYWORD_API,
+            "Loading deprecated program type BPF_PROG_TYPE_BIND. "
+            "Migrate to BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND.",
+            program_name != nullptr ? program_name : "");
+    }
+}
+
 #if !defined(CONFIG_BPF_JIT_DISABLED) || !defined(CONFIG_BPF_INTERPRETER_DISABLED)
 static ebpf_result_t
 _create_program(
@@ -1507,6 +1527,8 @@ _create_program(
     size_t program_name_offset = 0;
     ebpf_assert(program_handle);
     *program_handle = ebpf_handle_invalid;
+
+    _ebpf_log_deprecated_program_type(&program_type, program_name.c_str());
 
     result = _ebpf_safe_size_t_add3(
         offsetof(ebpf_operation_create_program_request_t, data),
@@ -2625,6 +2647,8 @@ _initialize_ebpf_programs_native(
         program_handles[i] = ebpf_handle_invalid;
         program->program_type = info.type_uuid;
         program->attach_type = info.attach_type_uuid;
+
+        _ebpf_log_deprecated_program_type(&program->program_type, program->program_name);
     }
 
 Exit:
@@ -3891,16 +3915,6 @@ _Requires_lock_not_held_(_ebpf_state_mutex) static ebpf_result_t
         load_info.instruction_count = program->instruction_count;
         load_info.execution_context = execution_context_kernel_mode;
         load_info.map_count = (uint32_t)object->maps.size();
-
-        // Emit deprecation warning for legacy bind program type.
-        if (IsEqualGUID(program->program_type, EBPF_PROGRAM_TYPE_BIND)) {
-            EBPF_LOG_MESSAGE_STRING(
-                EBPF_TRACELOG_LEVEL_WARNING,
-                EBPF_TRACELOG_KEYWORD_API,
-                "Loading deprecated program type BPF_PROG_TYPE_BIND. "
-                "Migrate to BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND.",
-                program->section_name ? program->section_name : "");
-        }
 
         if (load_info.map_count > 0) {
             for (auto& map : object->maps) {

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -198,6 +198,8 @@ net_ebpf_ext_bind_register_providers()
         &dispatch_table,
         ATTACH_CAPABILITY_SINGLE_ATTACH,
         NULL,
+        true,
+        "Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.",
         &_ebpf_bind_hook_provider_context);
     if (status != EBPF_SUCCESS) {
         EBPF_EXT_LOG_MESSAGE_NTSTATUS(

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -180,7 +180,6 @@ net_ebpf_ext_bind_register_providers()
         &dispatch_table,
         ATTACH_CAPABILITY_SINGLE_ATTACH,
         NULL,
-        true,
         "Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.",
         &_ebpf_bind_hook_provider_context);
     if (status != EBPF_SUCCESS) {

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -180,6 +180,8 @@ net_ebpf_ext_bind_register_providers()
         &dispatch_table,
         ATTACH_CAPABILITY_SINGLE_ATTACH,
         NULL,
+        true,
+        "Use BPF_PROG_TYPE_CGROUP_SOCK_ADDR with BPF_CGROUP_INET4_BIND / BPF_CGROUP_INET6_BIND instead.",
         &_ebpf_bind_hook_provider_context);
     if (status != EBPF_SUCCESS) {
         EBPF_EXT_LOG_MESSAGE_NTSTATUS(

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -416,6 +416,15 @@ _net_ebpf_extension_hook_provider_attach_client(
         goto Exit;
     }
 
+    // Emit deprecation warning if this hook provider is marked deprecated.
+    if (local_provider_context->deprecated) {
+        EBPF_EXT_LOG_MESSAGE_STRING(
+            EBPF_EXT_TRACELOG_LEVEL_WARNING,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "Attaching to deprecated hook provider. Migrate to replacement.",
+            local_provider_context->deprecation_message ? local_provider_context->deprecation_message : "");
+    }
+
     hook_client = (net_ebpf_extension_hook_client_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(net_ebpf_extension_hook_client_t), NET_EBPF_EXTENSION_POOL_TAG);
     EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, hook_client, "hook_client", status);
@@ -690,6 +699,8 @@ net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_dispatch_table_t* dispatch,
     net_ebpf_extension_hook_attach_capability_t attach_capability,
     _In_opt_ const void* custom_data,
+    bool deprecated,
+    _In_opt_z_ const char* deprecation_message,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -725,6 +736,8 @@ net_ebpf_extension_hook_provider_register(
     local_provider_context->dispatch = *dispatch;
     local_provider_context->custom_data = custom_data;
     local_provider_context->attach_capability = attach_capability;
+    local_provider_context->deprecated = deprecated;
+    local_provider_context->deprecation_message = deprecation_message;
     local_provider_context->attach_type = parameters->provider_module_id->Guid;
 
     status = NmrRegisterProvider(characteristics, local_provider_context, &local_provider_context->nmr_provider_handle);

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -452,6 +452,15 @@ _net_ebpf_extension_hook_provider_attach_client(
         goto Exit;
     }
 
+    // Emit deprecation warning if this hook provider is marked deprecated.
+    if (local_provider_context->deprecated) {
+        EBPF_EXT_LOG_MESSAGE_STRING(
+            EBPF_EXT_TRACELOG_LEVEL_WARNING,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "Attaching to deprecated hook provider. Migrate to replacement.",
+            local_provider_context->deprecation_message ? local_provider_context->deprecation_message : "");
+    }
+
     hook_client = (net_ebpf_extension_hook_client_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(net_ebpf_extension_hook_client_t), NET_EBPF_EXTENSION_POOL_TAG);
     EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, hook_client, "hook_client", status);
@@ -716,6 +725,8 @@ net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_dispatch_table_t* dispatch,
     net_ebpf_extension_hook_attach_capability_t attach_capability,
     _In_opt_ const void* custom_data,
+    bool deprecated,
+    _In_opt_z_ const char* deprecation_message,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -752,6 +763,8 @@ net_ebpf_extension_hook_provider_register(
     local_provider_context->dispatch = *dispatch;
     local_provider_context->custom_data = custom_data;
     local_provider_context->attach_capability = attach_capability;
+    local_provider_context->deprecated = deprecated;
+    local_provider_context->deprecation_message = deprecation_message;
     local_provider_context->attach_type = parameters->provider_module_id->Guid;
 
     status = NmrRegisterProvider(characteristics, local_provider_context, &local_provider_context->nmr_provider_handle);

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -452,13 +452,13 @@ _net_ebpf_extension_hook_provider_attach_client(
         goto Exit;
     }
 
-    // Emit deprecation warning if this hook provider is marked deprecated.
-    if (local_provider_context->deprecated) {
+    // Emit a warning trace if this hook provider has been deprecated.
+    if (local_provider_context->deprecation_message != NULL) {
         EBPF_EXT_LOG_MESSAGE_STRING(
             EBPF_EXT_TRACELOG_LEVEL_WARNING,
             EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-            "Attaching to deprecated hook provider. Migrate to replacement.",
-            local_provider_context->deprecation_message ? local_provider_context->deprecation_message : "");
+            "Attaching a client to a deprecated hook provider.",
+            local_provider_context->deprecation_message);
     }
 
     hook_client = (net_ebpf_extension_hook_client_t*)ExAllocatePoolUninitialized(
@@ -725,7 +725,6 @@ net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_dispatch_table_t* dispatch,
     net_ebpf_extension_hook_attach_capability_t attach_capability,
     _In_opt_ const void* custom_data,
-    bool deprecated,
     _In_opt_z_ const char* deprecation_message,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context)
 {
@@ -763,7 +762,6 @@ net_ebpf_extension_hook_provider_register(
     local_provider_context->dispatch = *dispatch;
     local_provider_context->custom_data = custom_data;
     local_provider_context->attach_capability = attach_capability;
-    local_provider_context->deprecated = deprecated;
     local_provider_context->deprecation_message = deprecation_message;
     local_provider_context->attach_type = parameters->provider_module_id->Guid;
 

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -66,6 +66,9 @@ net_ebpf_extension_hook_provider_unregister(
  * @param[in] dispatch Pointer to dispatch table.
  * @param[in] attach_capability Capability of the hook provider to attach clients.
  * @param[in] custom_data (Optional) Opaque pointer to hook-specific custom data.
+ * @param[in] deprecated If true, attaching clients will trigger a deprecation warning trace.
+ * @param[in] deprecation_message Human-readable message directing users to the replacement
+ *            (NULL if deprecated is false).
  * @param[in, out] provider_context Pointer to the provider context being registered.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
@@ -77,6 +80,8 @@ net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_dispatch_table_t* dispatch,
     net_ebpf_extension_hook_attach_capability_t attach_capability,
     _In_opt_ const void* custom_data,
+    bool deprecated,
+    _In_opt_z_ const char* deprecation_message,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context);
 
 /**

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -69,6 +69,9 @@ net_ebpf_extension_hook_provider_unregister(
  * @param[in] dispatch Pointer to dispatch table.
  * @param[in] attach_capability Capability of the hook provider to attach clients.
  * @param[in] custom_data (Optional) Opaque pointer to hook-specific custom data.
+ * @param[in] deprecated If true, attaching clients will trigger a deprecation warning trace.
+ * @param[in] deprecation_message Human-readable message directing users to the replacement
+ *            (NULL if deprecated is false).
  * @param[in, out] provider_context Pointer to the provider context being registered.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
@@ -80,6 +83,8 @@ net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_dispatch_table_t* dispatch,
     net_ebpf_extension_hook_attach_capability_t attach_capability,
     _In_opt_ const void* custom_data,
+    bool deprecated,
+    _In_opt_z_ const char* deprecation_message,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context);
 
 /**

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -69,9 +69,9 @@ net_ebpf_extension_hook_provider_unregister(
  * @param[in] dispatch Pointer to dispatch table.
  * @param[in] attach_capability Capability of the hook provider to attach clients.
  * @param[in] custom_data (Optional) Opaque pointer to hook-specific custom data.
- * @param[in] deprecated If true, attaching clients will trigger a deprecation warning trace.
- * @param[in] deprecation_message Human-readable message directing users to the replacement
- *            (NULL if deprecated is false).
+ * @param[in] deprecation_message (Optional) Message directing users of this hook to its replacement. If not NULL,
+ *            the hook is treated as deprecated and a warning trace is emitted whenever a client attaches to it.
+ *            Must point to a string with static lifetime.
  * @param[in, out] provider_context Pointer to the provider context being registered.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
@@ -83,7 +83,6 @@ net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_dispatch_table_t* dispatch,
     net_ebpf_extension_hook_attach_capability_t attach_capability,
     _In_opt_ const void* custom_data,
-    bool deprecated,
     _In_opt_z_ const char* deprecation_message,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context);
 

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -3,7 +3,10 @@
 #pragma once
 
 #include "ebpf_extension.h"
+#pragma warning(push)
+#pragma warning(disable : 4996) // Suppress deprecation warnings for legacy bind types used in implementation.
 #include "ebpf_nethooks.h"
+#pragma warning(pop)
 #include "ebpf_program_types.h"
 #include "ebpf_shared_framework.h"
 

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -3,10 +3,7 @@
 #pragma once
 
 #include "ebpf_extension.h"
-#pragma warning(push)
-#pragma warning(disable : 4996) // Suppress deprecation warnings for legacy bind types used in implementation.
 #include "ebpf_nethooks.h"
-#pragma warning(pop)
 #include "ebpf_program_types.h"
 #include "ebpf_shared_framework.h"
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1493,6 +1493,8 @@ net_ebpf_ext_sock_addr_register_providers()
             dispatch_table,
             attach_capability,
             &_net_ebpf_extension_sock_addr_wfp_filter_parameters[i],
+            false,
+            NULL,
             &_ebpf_sock_addr_hook_provider_context[i]);
         if (!NT_SUCCESS(status)) {
             EBPF_EXT_LOG_MESSAGE_NTSTATUS(

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1496,7 +1496,6 @@ net_ebpf_ext_sock_addr_register_providers()
             dispatch_table,
             attach_capability,
             &_net_ebpf_extension_sock_addr_wfp_filter_parameters[i],
-            false,
             NULL,
             &_ebpf_sock_addr_hook_provider_context[i]);
         if (!NT_SUCCESS(status)) {

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1496,6 +1496,8 @@ net_ebpf_ext_sock_addr_register_providers()
             dispatch_table,
             attach_capability,
             &_net_ebpf_extension_sock_addr_wfp_filter_parameters[i],
+            false,
+            NULL,
             &_ebpf_sock_addr_hook_provider_context[i]);
         if (!NT_SUCCESS(status)) {
             EBPF_EXT_LOG_MESSAGE_NTSTATUS(

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -367,6 +367,8 @@ net_ebpf_ext_sock_ops_register_providers()
         &dispatch_table,
         ATTACH_CAPABILITY_SINGLE_ATTACH_PER_HOOK,
         NULL,
+        false,
+        NULL,
         &_ebpf_sock_ops_hook_provider_context);
     if (status != EBPF_SUCCESS) {
         EBPF_EXT_LOG_MESSAGE_NTSTATUS(

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -360,6 +360,8 @@ net_ebpf_ext_sock_ops_register_providers()
         &dispatch_table,
         ATTACH_CAPABILITY_SINGLE_ATTACH_PER_HOOK,
         NULL,
+        false,
+        NULL,
         &_ebpf_sock_ops_hook_provider_context);
     if (status != EBPF_SUCCESS) {
         EBPF_EXT_LOG_MESSAGE_NTSTATUS(

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -360,7 +360,6 @@ net_ebpf_ext_sock_ops_register_providers()
         &dispatch_table,
         ATTACH_CAPABILITY_SINGLE_ATTACH_PER_HOOK,
         NULL,
-        false,
         NULL,
         &_ebpf_sock_ops_hook_provider_context);
     if (status != EBPF_SUCCESS) {

--- a/netebpfext/net_ebpf_ext_structs.h
+++ b/netebpfext/net_ebpf_ext_structs.h
@@ -128,6 +128,9 @@ typedef struct _net_ebpf_extension_hook_provider
     net_ebpf_extension_hook_provider_dispatch_table_t dispatch;    ///< Hook specific dispatch table.
     net_ebpf_extension_hook_attach_capability_t attach_capability; ///< Attach capability for specific hook provider.
     const void* custom_data; ///< Opaque pointer to hook specific data associated for this provider.
+    bool deprecated;         ///< If true, this hook is deprecated and attach emits a warning trace.
+    _Field_z_ const char*
+        deprecation_message; ///< Human-readable deprecation/migration message (NULL if not deprecated).
     _Guarded_by_(lock)
         LIST_ENTRY filter_context_list; ///< Linked list of filter contexts that are attached to this provider.
     LIST_ENTRY cleanup_list_entry;      ///< List entry for cleanup.

--- a/netebpfext/net_ebpf_ext_structs.h
+++ b/netebpfext/net_ebpf_ext_structs.h
@@ -130,6 +130,9 @@ typedef struct _net_ebpf_extension_hook_provider
     net_ebpf_extension_hook_provider_dispatch_table_t dispatch;    ///< Hook specific dispatch table.
     net_ebpf_extension_hook_attach_capability_t attach_capability; ///< Attach capability for specific hook provider.
     const void* custom_data; ///< Opaque pointer to hook specific data associated for this provider.
+    bool deprecated;         ///< If true, this hook is deprecated and attach emits a warning trace.
+    _Field_z_ const char*
+        deprecation_message; ///< Human-readable deprecation/migration message (NULL if not deprecated).
     _Guarded_by_(lock)
         LIST_ENTRY filter_context_list; ///< Linked list of filter contexts that are attached to this provider.
     _Guarded_by_(lock)

--- a/netebpfext/net_ebpf_ext_structs.h
+++ b/netebpfext/net_ebpf_ext_structs.h
@@ -129,10 +129,9 @@ typedef struct _net_ebpf_extension_hook_provider
     EX_PUSH_LOCK lock;                                             ///< Lock for serializing attach / detach calls.
     net_ebpf_extension_hook_provider_dispatch_table_t dispatch;    ///< Hook specific dispatch table.
     net_ebpf_extension_hook_attach_capability_t attach_capability; ///< Attach capability for specific hook provider.
-    const void* custom_data; ///< Opaque pointer to hook specific data associated for this provider.
-    bool deprecated;         ///< If true, this hook is deprecated and attach emits a warning trace.
-    _Field_z_ const char*
-        deprecation_message; ///< Human-readable deprecation/migration message (NULL if not deprecated).
+    const void* custom_data;                   ///< Opaque pointer to hook specific data associated for this provider.
+    _Field_z_ const char* deprecation_message; ///< Deprecation/migration message, or NULL if not deprecated.
+                                               ///< Must point to a string with static lifetime.
     _Guarded_by_(lock)
         LIST_ENTRY filter_context_list; ///< Linked list of filter contexts that are attached to this provider.
     _Guarded_by_(lock)


### PR DESCRIPTION
### Summary

Fixes #5353

Deprecates the legacy `BPF_PROG_TYPE_BIND` program type and its public API surface in favor of the Linux-compatible `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` with `BPF_CGROUP_INET4_BIND` / `BPF_CGROUP_INET6_BIND` attach types.

The legacy bind hook remains fully functional - existing programs continue to work without changes. This PR adds documentation and runtime deprecation signals to guide users toward migration.

### Deprecation Signals

| Signal | Mechanism | When |
|--------|-----------|------|
| Documentation | `@deprecated` doxygen on `bind_operation_t`, `bind_md_t`, `bind_action_t`, `bind_hook_t`, `BPF_PROG_TYPE_BIND`, `BPF_ATTACH_TYPE_BIND`, `EBPF_PROGRAM_TYPE_BIND`, and `EBPF_ATTACH_TYPE_BIND` | Reading the headers or generated docs |
| Load-time | WARNING trace via the ebpfapi provider | Loading a `BPF_PROG_TYPE_BIND` program |
| Attach-time | WARNING trace via the NetEbpfExt provider | Attaching to the deprecated bind hook |

### Load-Time Warning

`libs/api/ebpf_api.cpp` gains a shared `_ebpf_log_deprecated_program_type()` helper, called from the two points every load path funnels through:

- `_create_program()` - covers JIT / interpreter object loads and `ebpf_program_load_bytes()`
- `_initialize_ebpf_programs_native()` - covers native module loads, including `ebpf_object_load_native_by_fds()`

This means the warning is emitted for native programs as well, which is the recommended production execution mode and the only mode available in Release builds.

### Hook Provider Deprecation Infrastructure

Adds reusable deprecation support to the hook provider registration interface:

- New `deprecation_message` field on `net_ebpf_extension_hook_provider_t`. A non-NULL value marks the hook as deprecated; NULL means it is not. Encoding the state in a single field avoids an invalid `deprecated = true, message = NULL` combination.
- New `deprecation_message` parameter on `net_ebpf_extension_hook_provider_register()`. The string must have static lifetime, as the pointer is stored rather than copied.
- The generic attach path in `_net_ebpf_extension_hook_provider_attach_client()` emits a WARNING trace containing the message whenever a client attaches to a deprecated provider.

The bind hook provider supplies a migration message; the sock_addr and sock_ops providers pass NULL. Future hook deprecations need only pass a message - no changes to the attach path are required.

### Documentation

Updates `docs/BindHook.md` with:

- A prominent deprecation notice
- A migration guide with field-by-field mapping (`bind_md_t` -> `bpf_sock_addr_t`, `bind_action_t` -> `ebpf_sock_addr_verdict_t`)
- Known limitations of the replacement (no unbind notification, no address redirect, separate IPv4/IPv6 attach types)

### What This Does NOT Do

- Remove any functionality - the legacy hook is unchanged
- Break existing programs - all tests pass without modification
- Change enum values or GUIDs - binary compatibility is preserved
- Modify netsh output (deferred to a follow-up)

### Testing

- `drivers\netebpfext` and `libs\user\api` build clean (Debug|x64), no new warnings
- All changed files verified against clang-format 18.1.8
- Existing bind tests pass unchanged (backward compatibility preserved)

Follow-up to #333 - deprecation phase. Full removal of the legacy bind hook is planned for a future release.
