### PR TITLE
user mode test hook provider supporting multiple programs to be attached.

### DIFF
--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -33,6 +33,7 @@ namespace ebpf {
 #include <WinSock2.h>
 #include <in6addr.h>
 #include <array>
+#include <atomic>
 #include <cguid.h>
 #include <chrono>
 #include <lsalookup.h>
@@ -4915,4 +4916,202 @@ TEST_CASE("custom_maps_concurrent_insert_delete_and_query_postprocess", "[custom
 TEST_CASE("custom_maps_concurrent_insert_delete_and_query_preprocess", "[custom_maps]")
 {
     _test_custom_maps_concurrent_insert_delete_and_query(false);
+}
+
+TEST_CASE("multi_attach_sample_extension", "[sample_ext]")
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    // Create a hook provider for the sample extension.
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    // Native programs must be loaded from distinct binaries.
+    // Create a copy of the DLL for the second instance.
+    const char* file_name1 = "test_sample_ebpf_um.dll";
+    const char* file_name2 = "test_sample_ebpf_um_2.dll";
+    REQUIRE(CopyFileA(file_name1, file_name2, FALSE) != 0);
+
+    const char* error_message = nullptr;
+    bpf_object_ptr object1;
+    bpf_object_ptr object2;
+    fd_t program_fd1;
+    fd_t program_fd2;
+
+    int result = ebpf_program_load(
+        file_name1, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object1, &program_fd1, &error_message);
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+        error_message = nullptr;
+    }
+    REQUIRE(result == 0);
+
+    result = ebpf_program_load(
+        file_name2, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object2, &program_fd2, &error_message);
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+        error_message = nullptr;
+    }
+    REQUIRE(result == 0);
+
+    // Populate test_map for program 1: key 0 = "rainy", key 1 = "sunny".
+    const int VALUE_SIZE = 32;
+    fd_t map_fd1 = bpf_object__find_map_fd_by_name(object1.get(), "test_map");
+    REQUIRE(map_fd1 > 0);
+    uint8_t value_buf[VALUE_SIZE] = {};
+    uint32_t key = 0;
+    memcpy(value_buf, "rainy", 5);
+    REQUIRE(bpf_map_update_elem(map_fd1, &key, value_buf, EBPF_ANY) == EBPF_SUCCESS);
+    key = 1;
+    memset(value_buf, 0, VALUE_SIZE);
+    memcpy(value_buf, "sunny", 5);
+    REQUIRE(bpf_map_update_elem(map_fd1, &key, value_buf, EBPF_ANY) == EBPF_SUCCESS);
+
+    // Populate test_map for program 2: key 0 = "frowny", key 1 = "smiley".
+    fd_t map_fd2 = bpf_object__find_map_fd_by_name(object2.get(), "test_map");
+    REQUIRE(map_fd2 > 0);
+    key = 0;
+    memset(value_buf, 0, VALUE_SIZE);
+    memcpy(value_buf, "frowny", 6);
+    REQUIRE(bpf_map_update_elem(map_fd2, &key, value_buf, EBPF_ANY) == EBPF_SUCCESS);
+    key = 1;
+    memset(value_buf, 0, VALUE_SIZE);
+    memcpy(value_buf, "smiley", 6);
+    REQUIRE(bpf_map_update_elem(map_fd2, &key, value_buf, EBPF_ANY) == EBPF_SUCCESS);
+
+    // Attach program 1 with attach_data 0.
+    uint8_t attach_data0 = 0;
+    bpf_program* prog1 = bpf_object__find_program_by_name(object1.get(), "test_program_entry");
+    REQUIRE(prog1 != nullptr);
+    REQUIRE(hook.attach(prog1, &attach_data0, sizeof(attach_data0)) == EBPF_SUCCESS);
+
+    // Attach program 2 with attach_data 1.
+    uint8_t attach_data1 = 1;
+    bpf_program* prog2 = bpf_object__find_program_by_name(object2.get(), "test_program_entry");
+    REQUIRE(prog2 != nullptr);
+    REQUIRE(hook.attach(prog2, &attach_data1, sizeof(attach_data1)) == EBPF_SUCCESS);
+
+    // Fire program 1 — context data contains "rainy", expect replaced with "sunny".
+    uint8_t context_data1[VALUE_SIZE] = {};
+    memcpy(context_data1, "rainy", 5);
+    sample_program_context_header_t header1{};
+    sample_program_context_t* ctx1 = &header1.context;
+    ctx1->data_start = context_data1;
+    ctx1->data_end = context_data1 + VALUE_SIZE;
+    uint32_t hook_result = 0;
+    REQUIRE(hook.fire(&attach_data0, sizeof(attach_data0), ctx1, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook_result == 42);
+    REQUIRE(memcmp(context_data1, "sunny", 5) == 0);
+
+    // Fire program 2 — context data contains "frowny", expect replaced with "smiley".
+    uint8_t context_data2[VALUE_SIZE] = {};
+    memcpy(context_data2, "frowny", 6);
+    sample_program_context_header_t header2{};
+    sample_program_context_t* ctx2 = &header2.context;
+    ctx2->data_start = context_data2;
+    ctx2->data_end = context_data2 + VALUE_SIZE;
+    hook_result = 0;
+    REQUIRE(hook.fire(&attach_data1, sizeof(attach_data1), ctx2, &hook_result) == EBPF_SUCCESS);
+    REQUIRE(hook_result == 42);
+    REQUIRE(memcmp(context_data2, "smiley", 6) == 0);
+
+    // Verify that an unoccupied attach_data fails.
+    uint8_t attach_data2 = 2;
+    REQUIRE(hook.fire(&attach_data2, sizeof(attach_data2), ctx1, &hook_result) == EBPF_EXTENSION_FAILED_TO_LOAD);
+
+    // Detach and close.
+    (void)hook.detach(program_fd1, &attach_data0, sizeof(attach_data0));
+    (void)hook.detach(program_fd2, &attach_data1, sizeof(attach_data1));
+
+    bpf_object__close(object1.release());
+    bpf_object__close(object2.release());
+
+    // Clean up the copy.
+    DeleteFileA(file_name2);
+}
+
+TEST_CASE("multi_attach_fire_detach_race", "[sample_ext]")
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    const char* file_name = "test_sample_ebpf_um.dll";
+    const char* error_message = nullptr;
+    bpf_object_ptr object;
+    fd_t program_fd;
+
+    int result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object, &program_fd, &error_message);
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+        error_message = nullptr;
+    }
+    REQUIRE(result == 0);
+
+    // Populate test_map: key 0 = "rainy", key 1 = "sunny".
+    const int VALUE_SIZE = 32;
+    fd_t map_fd = bpf_object__find_map_fd_by_name(object.get(), "test_map");
+    REQUIRE(map_fd > 0);
+    uint8_t value_buf[VALUE_SIZE] = {};
+    uint32_t key = 0;
+    memcpy(value_buf, "rainy", 5);
+    REQUIRE(bpf_map_update_elem(map_fd, &key, value_buf, EBPF_ANY) == EBPF_SUCCESS);
+    key = 1;
+    memset(value_buf, 0, VALUE_SIZE);
+    memcpy(value_buf, "sunny", 5);
+    REQUIRE(bpf_map_update_elem(map_fd, &key, value_buf, EBPF_ANY) == EBPF_SUCCESS);
+
+    // Get bpf_program for attach calls.
+    bpf_program* prog = bpf_object__find_program_by_name(object.get(), "test_program_entry");
+    REQUIRE(prog != nullptr);
+
+    // Initial attach.
+    uint8_t attach_data = 0;
+    REQUIRE(hook.attach(prog, &attach_data, sizeof(attach_data)) == EBPF_SUCCESS);
+
+    std::atomic<bool> stop{false};
+
+    // Thread 1: fire in a tight loop.
+    std::thread fire_thread([&] {
+        while (!stop) {
+            uint8_t context_data[VALUE_SIZE] = {};
+            memcpy(context_data, "rainy", 5);
+            sample_program_context_header_t hdr{};
+            sample_program_context_t* ctx = &hdr.context;
+            ctx->data_start = context_data;
+            ctx->data_end = context_data + VALUE_SIZE;
+            uint32_t fire_result = 0;
+            // Ignore failures — detach may have raced.
+            (void)hook.fire(&attach_data, sizeof(attach_data), ctx, &fire_result);
+        }
+    });
+
+    // Thread 2: detach/reattach in a tight loop.
+    std::thread detach_thread([&] {
+        while (!stop) {
+            (void)hook.detach(program_fd, &attach_data, sizeof(attach_data));
+            (void)hook.attach(prog, &attach_data, sizeof(attach_data));
+        }
+    });
+
+    // Run for 1 second.
+    Sleep(1000);
+    stop = true;
+    fire_thread.join();
+    detach_thread.join();
+
+    // Clean up — detach whatever is attached.
+    (void)hook.detach(program_fd, &attach_data, sizeof(attach_data));
+    bpf_object__close(object.release());
 }

--- a/tests/end_to_end/end_to_end_jit.cpp
+++ b/tests/end_to_end/end_to_end_jit.cpp
@@ -112,7 +112,7 @@ cgroup_load_test(
 
     uint32_t compartment_id = 0;
     REQUIRE(hook.attach(program, &compartment_id, sizeof(compartment_id)) == EBPF_SUCCESS);
-    REQUIRE(hook.detach(ebpf_fd_invalid, &compartment_id, sizeof(compartment_id)) == EBPF_SUCCESS);
+    REQUIRE(hook.detach(program_fd, &compartment_id, sizeof(compartment_id)) == EBPF_SUCCESS);
 
     compartment_id = 1;
     REQUIRE(hook.attach(program, &compartment_id, sizeof(compartment_id)) == EBPF_SUCCESS);
@@ -549,7 +549,8 @@ test_invalid_bpf_get_socket_cookie(ebpf_execution_type_t execution_type)
     REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
 
     const char* file_name =
-        (execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_invalid_socket_cookie.dll" : "test_sample_invalid_socket_cookie.o");
+        (execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_invalid_socket_cookie.dll"
+                                                 : "test_sample_invalid_socket_cookie.o");
     result =
         ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, execution_type, &unique_object, &program_fd, &error_message);
 

--- a/tests/libfuzzer/verifier_fuzzer/verifier_fuzzer.vcxproj
+++ b/tests/libfuzzer/verifier_fuzzer/verifier_fuzzer.vcxproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\libs\thunk\mock\mock.cpp" />
     <ClCompile Include="..\..\end_to_end\test_helper.cpp" />
+    <ClCompile Include="..\..\libs\util\hook_provider.cpp" />
     <ClCompile Include="..\..\..\libs\shared\hash.cpp" />
     <ClCompile Include="libfuzz_harness.cpp" />
   </ItemGroup>

--- a/tests/libs/util/hook_helper.h
+++ b/tests/libs/util/hook_helper.h
@@ -113,7 +113,12 @@ typedef class _hook_helper
         bpf_link* link = nullptr;
         ebpf_result_t result = ebpf_program_attach_by_fd(program_fd, &_attach_type, params, params_size, &link);
         if (result == EBPF_SUCCESS && link != nullptr) {
-            _entries.push_back({link, program_fd, _copy_params(params, params_size)});
+            try {
+                _entries.push_back({link, program_fd, _copy_params(params, params_size)});
+            } catch (const std::bad_alloc&) {
+                bpf_link__destroy(link);
+                link = nullptr;
+            }
         }
         return link;
     }
@@ -124,8 +129,13 @@ typedef class _hook_helper
         bpf_link* link = nullptr;
         ebpf_result_t result = ebpf_program_attach(program, &_attach_type, params, params_size, &link);
         if (result == EBPF_SUCCESS && link != nullptr) {
-            fd_t fd = bpf_program__fd(program);
-            _entries.push_back({link, fd, _copy_params(params, params_size)});
+            try {
+                fd_t fd = bpf_program__fd(program);
+                _entries.push_back({link, fd, _copy_params(params, params_size)});
+            } catch (const std::bad_alloc&) {
+                bpf_link__destroy(link);
+                link = nullptr;
+            }
         }
         return link;
     }

--- a/tests/libs/util/hook_helper.h
+++ b/tests/libs/util/hook_helper.h
@@ -15,9 +15,23 @@
 #include "usersim/ex.h"
 #include "usersim/ke.h"
 
-// Prototype added as the libbpf headers cause conflicts with the execution context headers.
-int
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+// Prototypes added as the libbpf headers cause conflicts with the execution context headers.
+extern "C" int
 bpf_link__destroy(bpf_link* link);
+
+extern "C" int
+bpf_link__fd(const struct bpf_link* link);
+
+extern "C" int
+bpf_link_detach(int link_fd);
+
+extern "C" int
+bpf_program__fd(const struct bpf_program* prog);
 
 typedef struct _close_bpf_link
 {
@@ -30,10 +44,20 @@ typedef struct _close_bpf_link
 
 typedef std::unique_ptr<bpf_link, close_bpf_link_t> bpf_link_ptr;
 
+/**
+ * @brief Thin wrapper over eBPF attach/detach APIs.
+ *        Manages a collection of bpf_link objects. Links created via the attach() methods
+ *        are owned by this class and cleaned up in the destructor. Links created via
+ *        attach_link() are returned to the caller and not tracked internally.
+ */
 typedef class _hook_helper
 {
   public:
     _hook_helper(ebpf_attach_type_t attach_type) : _attach_type(attach_type) {}
+
+    ~_hook_helper() { detach_all(); }
+
+    // Existing methods (backward compat) — caller manages link lifetime.
 
     _Must_inspect_result_ ebpf_result_t
     attach_link(
@@ -63,171 +87,264 @@ typedef class _hook_helper
         return ebpf_program_attach_by_fd(program_fd, &_attach_type, attach_parameters, attach_parameters_size, link);
     }
 
-  private:
-    ebpf_attach_type_t _attach_type;
-} hook_helper_t;
-
-typedef class _single_instance_hook : public _hook_helper
-{
-  public:
-    _single_instance_hook(
-        ebpf_program_type_t program_type,
-        ebpf_attach_type_t attach_type,
-        bpf_link_type link_type = BPF_LINK_TYPE_UNSPEC)
-        : _hook_helper{attach_type}, client_binding_context(nullptr), client_data(nullptr),
-          client_dispatch_table(nullptr), link_object(nullptr), client_registration_instance(nullptr),
-          nmr_binding_handle(nullptr), nmr_provider_handle(nullptr)
-    {
-        attach_provider_data.header = EBPF_ATTACH_PROVIDER_DATA_HEADER;
-        attach_provider_data.supported_program_type = program_type;
-        attach_provider_data.bpf_attach_type = ebpf_get_bpf_attach_type(&attach_type);
-        this->attach_type = attach_type;
-        attach_provider_data.link_type = link_type;
-        module_id.Guid = attach_type;
-    }
-    ebpf_result_t
-    initialize()
-    {
-        NTSTATUS status = NmrRegisterProvider(&provider_characteristics, this, &nmr_provider_handle);
-        return (status == STATUS_SUCCESS) ? EBPF_SUCCESS : EBPF_FAILED;
-    }
-    ~_single_instance_hook()
-    {
-        // Best effort cleanup. Ignore errors.
-        if (link_object) {
-            (void)ebpf_link_detach(link_object);
-            (void)ebpf_link_close(link_object);
-        }
-        if (nmr_provider_handle != NULL) {
-            NTSTATUS status = NmrDeregisterProvider(nmr_provider_handle);
-            if (status == STATUS_PENDING) {
-                NmrWaitForProviderDeregisterComplete(nmr_provider_handle);
-            } else {
-                ebpf_assert(status == STATUS_SUCCESS);
-            }
-        }
-    }
-
-    uint32_t
-    attach(_In_ const bpf_program* program)
-    {
-        return ebpf_program_attach(program, &attach_type, nullptr, 0, &link_object);
-    }
-
-    uint32_t
-    attach(
-        _In_ const bpf_program* program,
-        _In_reads_bytes_(attach_parameters_size) void* attach_parameters,
-        size_t attach_parameters_size)
-    {
-        return ebpf_program_attach(program, &attach_type, attach_parameters, attach_parameters_size, &link_object);
-    }
-
-    void
-    detach()
-    {
-        if (link_object != nullptr) {
-            if (ebpf_link_detach(link_object) == EBPF_SUCCESS) {
-                throw std::runtime_error("ebpf_link_detach failed");
-            }
-            ebpf_link_close(link_object);
-            link_object = nullptr;
-        }
-    }
-
-    _Must_inspect_result_ ebpf_result_t
-    detach(
-        fd_t program_fd, _In_reads_bytes_(attach_parameter_size) void* attach_parameter, size_t attach_parameter_size)
-    {
-        ebpf_result_t result = ebpf_program_detach(program_fd, &attach_type, attach_parameter, attach_parameter_size);
-        if (result == EBPF_SUCCESS) {
-            ebpf_link_close(link_object);
-            link_object = nullptr;
-        }
-        return result;
-    }
-
     void
     detach_link(_Inout_ bpf_link* link)
     {
-        if (ebpf_link_detach(link) != EBPF_SUCCESS) {
-            throw std::runtime_error("ebpf_link_detach failed");
-        }
+        bpf_link_detach(bpf_link__fd(link));
     }
 
     void
     close_link(_Frees_ptr_ bpf_link* link)
     {
-#pragma warning(push)
-#pragma warning(disable : 6001) // Using uninitialized memory '*link'.
-        ebpf_link_close(link);
-#pragma warning(pop)
+        bpf_link__destroy(link);
     }
 
     void
     detach_and_close_link(_Inout_ bpf_link_ptr* unique_link)
     {
-        bpf_link* link = unique_link->release();
-        detach_link(link);
-        close_link(link);
+        unique_link->reset();
+    }
+
+    // New methods — hook_helper owns the link lifetime.
+
+    _Ret_maybenull_ bpf_link*
+    attach(fd_t program_fd, _In_reads_bytes_opt_(params_size) void* params, size_t params_size)
+    {
+        bpf_link* link = nullptr;
+        ebpf_result_t result = ebpf_program_attach_by_fd(program_fd, &_attach_type, params, params_size, &link);
+        if (result == EBPF_SUCCESS && link != nullptr) {
+            _entries.push_back({link, program_fd, _copy_params(params, params_size)});
+        }
+        return link;
+    }
+
+    _Ret_maybenull_ bpf_link*
+    attach(_In_ const bpf_program* program, _In_reads_bytes_opt_(params_size) void* params, size_t params_size)
+    {
+        bpf_link* link = nullptr;
+        ebpf_result_t result = ebpf_program_attach(program, &_attach_type, params, params_size, &link);
+        if (result == EBPF_SUCCESS && link != nullptr) {
+            fd_t fd = bpf_program__fd(program);
+            _entries.push_back({link, fd, _copy_params(params, params_size)});
+        }
+        return link;
+    }
+
+    void
+    detach(_In_ bpf_link* link)
+    {
+        auto it =
+            std::find_if(_entries.begin(), _entries.end(), [link](const link_entry_t& e) { return e.link == link; });
+        if (it != _entries.end()) {
+            _entries.erase(it);
+        }
+        bpf_link__destroy(link);
+    }
+
+    void
+    detach_first()
+    {
+        if (_entries.empty()) {
+            return;
+        }
+        bpf_link* link = _entries.front().link;
+        _entries.erase(_entries.begin());
+        bpf_link__destroy(link);
     }
 
     _Must_inspect_result_ ebpf_result_t
-    fire(_Inout_ void* context, _Out_ uint32_t* result)
+    detach(fd_t program_fd, _In_reads_bytes_(params_size) void* params, size_t params_size)
     {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
+        auto it = std::find_if(_entries.begin(), _entries.end(), [&](const link_entry_t& e) {
+            return e.program_fd == program_fd && e.params.size() == params_size &&
+                   (params_size == 0 || memcmp(e.params.data(), params, params_size) == 0);
+        });
+        if (it == _entries.end()) {
+            return EBPF_INVALID_ARGUMENT;
         }
-        ebpf_result_t (*invoke_program)(_In_ const void* link, _Inout_ void* context, _Out_ uint32_t* result) =
-            reinterpret_cast<decltype(invoke_program)>(client_dispatch_table->function[0]);
-
-        return invoke_program(client_binding_context, context, result);
+        bpf_link* link = it->link;
+        _entries.erase(it);
+        bpf_link__destroy(link);
+        return EBPF_SUCCESS;
     }
 
-    _Must_inspect_result_ ebpf_result_t
-    batch_begin(size_t state_size, _Out_writes_(state_size) void* state)
+    void
+    detach_all()
     {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
+        for (auto& entry : _entries) {
+            bpf_link__destroy(entry.link);
         }
-
-        ebpf_program_batch_begin_invoke_function_t batch_begin_function;
-        batch_begin_function = reinterpret_cast<decltype(batch_begin_function)>(client_dispatch_table->function[1]);
-
-        return batch_begin_function(state_size, state);
+        _entries.clear();
     }
 
-    _Must_inspect_result_ ebpf_result_t
-    batch_invoke(_Inout_ void* program_context, _Out_ uint32_t* result, _In_ const void* state)
+    ebpf_attach_type_t
+    get_attach_type() const
     {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
-        }
-
-        ebpf_program_batch_invoke_function_t batch_invoke_function;
-        batch_invoke_function = reinterpret_cast<decltype(batch_invoke_function)>(client_dispatch_table->function[2]);
-        return batch_invoke_function(client_binding_context, program_context, result, state);
-    }
-
-    _Must_inspect_result_ ebpf_result_t
-    batch_end(_In_ void* state)
-    {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
-        }
-
-        ebpf_program_batch_end_invoke_function_t batch_end_function;
-        batch_end_function = reinterpret_cast<decltype(batch_end_function)>(client_dispatch_table->function[3]);
-        return batch_end_function(state);
-    }
-
-    _Ret_maybenull_ const ebpf_extension_data_t*
-    get_client_data() const
-    {
-        return client_data;
+        return _attach_type;
     }
 
   private:
+    struct link_entry_t
+    {
+        bpf_link* link;
+        fd_t program_fd;
+        std::vector<uint8_t> params;
+    };
+
+    static std::vector<uint8_t>
+    _copy_params(_In_reads_bytes_opt_(size) const void* params, size_t size)
+    {
+        if (params == nullptr || size == 0) {
+            return {};
+        }
+        auto* bytes = static_cast<const uint8_t*>(params);
+        return std::vector<uint8_t>(bytes, bytes + size);
+    }
+
+    ebpf_attach_type_t _attach_type;
+    std::vector<link_entry_t> _entries;
+} hook_helper_t;
+
+/**
+ * @brief Mock NMR hook provider for user-mode testing.
+ *        Supports multiple clients, each identified by unique attach parameters (client_data).
+ *        Clients are stored in a vector of shared_ptr for safe concurrent fire/detach.
+ *
+ *        Typical usage:
+ *          single_instance_hook_t hook(prog_type, attach_type);
+ *          hook.initialize();
+ *          hook.attach(fd);                          // single client
+ *          hook.attach(fd, &params, sizeof(params)); // additional clients
+ *          hook.fire(ctx, &result);                  // invoke client[0]
+ *          hook.fire(attach_data, ctx, &result);     // invoke by matching client_data
+ */
+typedef class _single_instance_hook
+{
+  public:
+    _single_instance_hook(
+        ebpf_program_type_t program_type,
+        ebpf_attach_type_t attach_type,
+        bpf_link_type link_type = BPF_LINK_TYPE_UNSPEC);
+
+    ~_single_instance_hook();
+
+    // NMR provider registration.
+    ebpf_result_t
+    initialize();
+
+    // Delegated to hook_helper (backward compat — caller manages link lifetime).
+    _Must_inspect_result_ ebpf_result_t
+    attach_link(
+        fd_t program_fd,
+        _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+        size_t attach_parameters_size,
+        _Out_ bpf_link_ptr* unique_link)
+    {
+        return _helper.attach_link(program_fd, attach_parameters, attach_parameters_size, unique_link);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    attach_link(
+        fd_t program_fd,
+        _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+        size_t attach_parameters_size,
+        _Outptr_ bpf_link** link)
+    {
+        return _helper.attach_link(program_fd, attach_parameters, attach_parameters_size, link);
+    }
+
+    void
+    detach_link(_Inout_ bpf_link* link)
+    {
+        _helper.detach_link(link);
+    }
+
+    void
+    close_link(_Frees_ptr_ bpf_link* link)
+    {
+        _helper.close_link(link);
+    }
+
+    void
+    detach_and_close_link(_Inout_ bpf_link_ptr* unique_link)
+    {
+        _helper.detach_and_close_link(unique_link);
+    }
+
+    // Attach — hook_helper owns the link, NMR callback tracks the client.
+    _Must_inspect_result_ ebpf_result_t
+    attach(_In_ const bpf_program* program);
+
+    _Must_inspect_result_ ebpf_result_t
+    attach(_In_ const bpf_program* program, _In_reads_bytes_(params_size) void* params, size_t params_size);
+
+    // Detach — single client (client[0]).
+    void
+    detach();
+
+    // Detach — by attach parameters (finds matching client_data, first match wins).
+    _Must_inspect_result_ ebpf_result_t
+    detach(fd_t program_fd, _In_reads_bytes_(params_size) void* params, size_t params_size);
+
+    // Fire client[0].
+    _Must_inspect_result_ ebpf_result_t
+    fire(_Inout_ void* context, _Out_ uint32_t* result);
+
+    // Fire client matching attach parameters in client_data.
+    _Must_inspect_result_ ebpf_result_t
+    fire(
+        _In_reads_bytes_(params_size) const void* params,
+        size_t params_size,
+        _Inout_ void* context,
+        _Out_ uint32_t* result);
+
+    // Batch operations — param-less targets client[0].
+    _Must_inspect_result_ ebpf_result_t
+    batch_begin(size_t state_size, _Out_writes_(state_size) void* state);
+
+    _Must_inspect_result_ ebpf_result_t
+    batch_invoke(_Inout_ void* program_context, _Out_ uint32_t* result, _In_ const void* state);
+
+    _Must_inspect_result_ ebpf_result_t
+    batch_end(_In_ void* state);
+
+    // Client data — param-less returns client[0].
+    _Ret_maybenull_ const ebpf_extension_data_t*
+    get_client_data() const;
+
+    _Ret_maybenull_ const ebpf_extension_data_t*
+    get_client_data(_In_reads_bytes_(params_size) const void* params, size_t params_size) const;
+
+    // Allow implicit conversion to hook_helper_t& for backward compatibility
+    // (e.g., _program_load_attach_helper::initialize takes hook_helper_t&).
+    operator hook_helper_t&() { return _helper; }
+
+  private:
+    struct client_entry_t
+    {
+        _single_instance_hook* owner = nullptr;
+        PNPI_REGISTRATION_INSTANCE registration_instance = nullptr;
+        const void* binding_context = nullptr;
+        const ebpf_extension_data_t* data = nullptr;
+        const ebpf_extension_dispatch_table_t* dispatch_table = nullptr;
+        HANDLE nmr_binding_handle = nullptr;
+        std::atomic<int32_t> invoke_count{0};
+        std::atomic<bool> detached{false};
+    };
+
+    // Find client whose client_data matches the given params (raw byte comparison).
+    std::shared_ptr<client_entry_t>
+    find_client_by_params(_In_reads_bytes_(params_size) const void* params, size_t params_size) const;
+
+    // Find client[0] — returns shared_ptr copy for refcount safety.
+    std::shared_ptr<client_entry_t>
+    first_client() const;
+
+    // Invoke a client's dispatch function with rundown protection.
+    _Must_inspect_result_ ebpf_result_t
+    invoke_client(_In_ std::shared_ptr<client_entry_t> client, _Inout_ void* context, _Out_ uint32_t* result);
+
+    // NMR callbacks.
     static NTSTATUS
     provider_attach_client_callback(
         HANDLE nmr_binding_handle,
@@ -236,66 +353,21 @@ typedef class _single_instance_hook : public _hook_helper
         _In_ const void* client_binding_context,
         _In_ const void* client_dispatch,
         _Out_ void** provider_binding_context,
-        _Outptr_result_maybenull_ const void** provider_dispatch)
-    {
-        auto hook = reinterpret_cast<_single_instance_hook*>(provider_context);
-
-        if (hook->client_binding_context != nullptr) {
-            // Can't attach a single-instance provider to a second client.
-            return STATUS_NOINTERFACE;
-        }
-        UNREFERENCED_PARAMETER(nmr_binding_handle);
-        hook->client_registration_instance = client_registration_instance;
-        hook->client_binding_context = client_binding_context;
-        hook->nmr_binding_handle = nmr_binding_handle;
-        hook->client_dispatch_table = (ebpf_extension_dispatch_table_t*)client_dispatch;
-        hook->client_data =
-            reinterpret_cast<const ebpf_extension_data_t*>(client_registration_instance->NpiSpecificCharacteristics);
-        *provider_binding_context = provider_context;
-        *provider_dispatch = NULL;
-        return STATUS_SUCCESS;
-    };
+        _Outptr_result_maybenull_ const void** provider_dispatch);
 
     static NTSTATUS
-    provider_detach_client_callback(_Inout_ void* provider_binding_context)
-    {
-        auto hook = reinterpret_cast<_single_instance_hook*>(provider_binding_context);
-        hook->client_binding_context = nullptr;
-        hook->client_data = nullptr;
-        hook->client_dispatch_table = nullptr;
+    provider_detach_client_callback(_Inout_ void* provider_binding_context);
 
-        // There should be no in-progress calls to any client functions,
-        // we we can return success rather than pending.
-        return EBPF_SUCCESS;
-    };
-    ebpf_attach_type_t attach_type;
-    ebpf_attach_provider_data_t attach_provider_data;
+    _hook_helper _helper;
+    std::vector<std::shared_ptr<client_entry_t>> _clients;
+    mutable std::mutex _mutex;
 
-    NPI_MODULEID module_id = {
-        sizeof(NPI_MODULEID),
-        MIT_GUID,
-    };
-    const NPI_PROVIDER_CHARACTERISTICS provider_characteristics = {
-        0,
-        sizeof(provider_characteristics),
-        (NPI_PROVIDER_ATTACH_CLIENT_FN*)provider_attach_client_callback,
-        (NPI_PROVIDER_DETACH_CLIENT_FN*)provider_detach_client_callback,
-        NULL,
-        {
-            0,
-            sizeof(NPI_REGISTRATION_INSTANCE),
-            &EBPF_HOOK_EXTENSION_IID,
-            &module_id,
-            0,
-            &attach_provider_data,
-        },
-    };
-    HANDLE nmr_provider_handle;
-
-    PNPI_REGISTRATION_INSTANCE client_registration_instance = nullptr;
-    const void* client_binding_context = nullptr;
-    const ebpf_extension_data_t* client_data = nullptr;
-    const ebpf_extension_dispatch_table_t* client_dispatch_table = nullptr;
-    HANDLE nmr_binding_handle = nullptr;
-    bpf_link* link_object = nullptr;
+    // NMR provider data.
+    ebpf_attach_provider_data_t _attach_provider_data = {};
+    NPI_MODULEID _module_id = {sizeof(NPI_MODULEID), MIT_GUID};
+    NPI_PROVIDER_CHARACTERISTICS _provider_characteristics = {};
+    HANDLE _nmr_provider_handle = nullptr;
 } single_instance_hook_t;
+
+// Alias for multi-client usage (same class, just a name).
+typedef _single_instance_hook multi_instance_hook_t;

--- a/tests/libs/util/hook_provider.cpp
+++ b/tests/libs/util/hook_provider.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+#include "hook_helper.h"
+
+_single_instance_hook::_single_instance_hook(
+    ebpf_program_type_t program_type, ebpf_attach_type_t attach_type, bpf_link_type link_type)
+    : _helper(attach_type)
+{
+    _attach_provider_data.header = EBPF_ATTACH_PROVIDER_DATA_HEADER;
+    _attach_provider_data.supported_program_type = program_type;
+    _attach_provider_data.bpf_attach_type = ebpf_get_bpf_attach_type(&attach_type);
+    _attach_provider_data.link_type = link_type;
+    _module_id.Guid = attach_type;
+
+    _provider_characteristics.Length = sizeof(_provider_characteristics);
+    _provider_characteristics.ProviderAttachClient = (NPI_PROVIDER_ATTACH_CLIENT_FN*)provider_attach_client_callback;
+    _provider_characteristics.ProviderDetachClient = (NPI_PROVIDER_DETACH_CLIENT_FN*)provider_detach_client_callback;
+    _provider_characteristics.ProviderCleanupBindingContext = NULL;
+    _provider_characteristics.ProviderRegistrationInstance.Size = sizeof(NPI_REGISTRATION_INSTANCE);
+    _provider_characteristics.ProviderRegistrationInstance.NpiId = &EBPF_HOOK_EXTENSION_IID;
+    _provider_characteristics.ProviderRegistrationInstance.ModuleId = &_module_id;
+    _provider_characteristics.ProviderRegistrationInstance.NpiSpecificCharacteristics = &_attach_provider_data;
+}
+
+_single_instance_hook::~_single_instance_hook()
+{
+    if (_nmr_provider_handle != NULL) {
+        NTSTATUS status = NmrDeregisterProvider(_nmr_provider_handle);
+        if (status == STATUS_PENDING) {
+            NmrWaitForProviderDeregisterComplete(_nmr_provider_handle);
+        } else {
+            ebpf_assert(status == STATUS_SUCCESS);
+        }
+    }
+    // _helper destructor detaches all owned links.
+}
+
+ebpf_result_t
+_single_instance_hook::initialize()
+{
+    NTSTATUS status = NmrRegisterProvider(&_provider_characteristics, this, &_nmr_provider_handle);
+    return (status == STATUS_SUCCESS) ? EBPF_SUCCESS : EBPF_FAILED;
+}
+
+// Attach — param-less (single client).
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::attach(_In_ const bpf_program* program)
+{
+    fd_t fd = bpf_program__fd(program);
+    bpf_link* link = _helper.attach(fd, nullptr, 0);
+    return (link != nullptr) ? EBPF_SUCCESS : EBPF_EXTENSION_FAILED_TO_LOAD;
+}
+
+// Attach — with params.
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::attach(
+    _In_ const bpf_program* program, _In_reads_bytes_(params_size) void* params, size_t params_size)
+{
+    fd_t fd = bpf_program__fd(program);
+    bpf_link* link = _helper.attach(fd, params, params_size);
+    return (link != nullptr) ? EBPF_SUCCESS : EBPF_EXTENSION_FAILED_TO_LOAD;
+}
+
+// Detach — single client (client[0]).
+
+void
+_single_instance_hook::detach()
+{
+    // Detach the first link — NMR detach callback removes the client from _clients.
+    _helper.detach_first();
+}
+
+// Detach — by attach parameters.
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::detach(fd_t program_fd, _In_reads_bytes_(params_size) void* params, size_t params_size)
+{
+    return _helper.detach(program_fd, params, params_size);
+}
+
+// Invoke a client's dispatch function with rundown protection.
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::invoke_client(
+    _In_ std::shared_ptr<client_entry_t> client, _Inout_ void* context, _Out_ uint32_t* result)
+{
+    client->invoke_count++;
+    if (client->detached) {
+        client->invoke_count--;
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
+    }
+    auto invoke_program = reinterpret_cast<ebpf_result_t (*)(_In_ const void*, _Inout_ void*, _Out_ uint32_t*)>(
+        client->dispatch_table->function[0]);
+    ebpf_result_t status = invoke_program(client->binding_context, context, result);
+    client->invoke_count--;
+    return status;
+}
+
+// Fire client[0].
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::fire(_Inout_ void* context, _Out_ uint32_t* result)
+{
+    std::shared_ptr<client_entry_t> client = first_client();
+    if (!client) {
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
+    }
+    return invoke_client(client, context, result);
+}
+
+// Fire by attach params.
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::fire(
+    _In_reads_bytes_(params_size) const void* params, size_t params_size, _Inout_ void* context, _Out_ uint32_t* result)
+{
+    std::shared_ptr<client_entry_t> client = find_client_by_params(params, params_size);
+    if (!client) {
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
+    }
+    return invoke_client(client, context, result);
+}
+
+// Batch — param-less targets client[0].
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::batch_begin(size_t state_size, _Out_writes_(state_size) void* state)
+{
+    std::shared_ptr<client_entry_t> client = first_client();
+    if (!client) {
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
+    }
+    auto batch_begin_function =
+        reinterpret_cast<ebpf_program_batch_begin_invoke_function_t>(client->dispatch_table->function[1]);
+    return batch_begin_function(state_size, state);
+}
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::batch_invoke(_Inout_ void* program_context, _Out_ uint32_t* result, _In_ const void* state)
+{
+    std::shared_ptr<client_entry_t> client = first_client();
+    if (!client) {
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
+    }
+    auto batch_invoke_function =
+        reinterpret_cast<ebpf_program_batch_invoke_function_t>(client->dispatch_table->function[2]);
+    return batch_invoke_function(client->binding_context, program_context, result, state);
+}
+
+_Must_inspect_result_ ebpf_result_t
+_single_instance_hook::batch_end(_In_ void* state)
+{
+    std::shared_ptr<client_entry_t> client = first_client();
+    if (!client) {
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
+    }
+    auto batch_end_function =
+        reinterpret_cast<ebpf_program_batch_end_invoke_function_t>(client->dispatch_table->function[3]);
+    return batch_end_function(state);
+}
+
+// Client data.
+
+_Ret_maybenull_ const ebpf_extension_data_t*
+_single_instance_hook::get_client_data() const
+{
+    std::shared_ptr<client_entry_t> client = first_client();
+    return client ? client->data : nullptr;
+}
+
+_Ret_maybenull_ const ebpf_extension_data_t*
+_single_instance_hook::get_client_data(_In_reads_bytes_(params_size) const void* params, size_t params_size) const
+{
+    std::shared_ptr<client_entry_t> client = find_client_by_params(params, params_size);
+    return client ? client->data : nullptr;
+}
+
+// Private helpers.
+
+std::shared_ptr<_single_instance_hook::client_entry_t>
+_single_instance_hook::first_client() const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_clients.empty()) {
+        return nullptr;
+    }
+    return _clients.front();
+}
+
+std::shared_ptr<_single_instance_hook::client_entry_t>
+_single_instance_hook::find_client_by_params(_In_reads_bytes_(params_size) const void* params, size_t params_size) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    for (const auto& client : _clients) {
+        if (client->data != nullptr && client->data->data != nullptr && client->data->data_size >= params_size &&
+            memcmp(client->data->data, params, params_size) == 0) {
+            return client;
+        }
+    }
+    return nullptr;
+}
+
+// NMR callbacks.
+
+NTSTATUS
+_single_instance_hook::provider_attach_client_callback(
+    HANDLE nmr_binding_handle,
+    _Inout_ void* provider_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
+    _In_ const void* client_binding_context,
+    _In_ const void* client_dispatch,
+    _Out_ void** provider_binding_context,
+    _Outptr_result_maybenull_ const void** provider_dispatch)
+{
+    auto hook = reinterpret_cast<_single_instance_hook*>(provider_context);
+    std::lock_guard<std::mutex> lock(hook->_mutex);
+
+    auto client_data =
+        reinterpret_cast<const ebpf_extension_data_t*>(client_registration_instance->NpiSpecificCharacteristics);
+
+    // Reject if a client with identical client_data already exists.
+    // Two clients match if both have no data (null/empty) or both have the same byte content.
+    auto has_data = [](const ebpf_extension_data_t* d) -> bool {
+        return d != nullptr && d->data != nullptr && d->data_size > 0;
+    };
+    bool incoming_has_data = has_data(client_data);
+    for (const auto& existing : hook->_clients) {
+        bool existing_has_data = has_data(existing->data);
+        if (!incoming_has_data && !existing_has_data) {
+            // Both have no attach params — duplicate.
+            return STATUS_NOINTERFACE;
+        }
+        if (incoming_has_data && existing_has_data && existing->data->data_size == client_data->data_size &&
+            memcmp(existing->data->data, client_data->data, client_data->data_size) == 0) {
+            return STATUS_NOINTERFACE;
+        }
+    }
+
+    auto entry = std::make_shared<client_entry_t>();
+    entry->owner = hook;
+    entry->registration_instance = client_registration_instance;
+    entry->binding_context = client_binding_context;
+    entry->nmr_binding_handle = nmr_binding_handle;
+    entry->dispatch_table = (const ebpf_extension_dispatch_table_t*)client_dispatch;
+    entry->data = client_data;
+
+    *provider_binding_context = entry.get();
+    *provider_dispatch = NULL;
+
+    hook->_clients.push_back(std::move(entry));
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+_single_instance_hook::provider_detach_client_callback(_Inout_ void* provider_binding_context)
+{
+    auto* raw_entry = reinterpret_cast<client_entry_t*>(provider_binding_context);
+    auto* hook = raw_entry->owner;
+
+    // Mark as detached so new fire() calls bail out.
+    raw_entry->detached = true;
+
+    // Wait for in-flight invocations to drain.
+    while (raw_entry->invoke_count > 0) {
+        SwitchToThread();
+    }
+
+    std::lock_guard<std::mutex> lock(hook->_mutex);
+    auto it = std::find_if(
+        hook->_clients.begin(), hook->_clients.end(), [raw_entry](const std::shared_ptr<client_entry_t>& sp) {
+            return sp.get() == raw_entry;
+        });
+    if (it != hook->_clients.end()) {
+        hook->_clients.erase(it);
+    }
+
+    return EBPF_SUCCESS;
+}

--- a/tests/libs/util/hook_provider.cpp
+++ b/tests/libs/util/hook_provider.cpp
@@ -16,7 +16,7 @@ _single_instance_hook::_single_instance_hook(
     _provider_characteristics.Length = sizeof(_provider_characteristics);
     _provider_characteristics.ProviderAttachClient = (NPI_PROVIDER_ATTACH_CLIENT_FN*)provider_attach_client_callback;
     _provider_characteristics.ProviderDetachClient = (NPI_PROVIDER_DETACH_CLIENT_FN*)provider_detach_client_callback;
-    _provider_characteristics.ProviderCleanupBindingContext = NULL;
+    _provider_characteristics.ProviderCleanupBindingContext = nullptr;
     _provider_characteristics.ProviderRegistrationInstance.Size = sizeof(NPI_REGISTRATION_INSTANCE);
     _provider_characteristics.ProviderRegistrationInstance.NpiId = &EBPF_HOOK_EXTENSION_IID;
     _provider_characteristics.ProviderRegistrationInstance.ModuleId = &_module_id;

--- a/tests/libs/util/test_util.vcxproj
+++ b/tests/libs/util/test_util.vcxproj
@@ -8,6 +8,7 @@
     <ClCompile Include="capture_helper.cpp" />
     <ClCompile Include="..\..\..\libs\shared\hash.cpp" />
     <ClCompile Include="filter_helper.cpp" />
+    <ClCompile Include="hook_provider.cpp" />
     <ClCompile Include="ioctl_helper.cpp" />
     <ClCompile Include="native_helper.cpp" />
     <ClCompile Include="netsh_helper.cpp" />


### PR DESCRIPTION
## Description

This is the first PR towards addressing #5387. This enhances the `single_instance_hook` class to allow multiple programs to attach with unique attach parameters. Unit test variations are added to test attaching multiple programs to the UM sample extension and also race between invoke/detach.

The `hook_helper` class is a wrapper over libbpf APIs to attach/detach programs to hook. The `single_instance_hook` class is a user-mode mock implementation of the hook NPI provider, that can invoke the attached programs in a thread safe manner. Instead of inheriting from the `hook_helper, the `single_instance_hook` class now contains a `hook_helper` member to which the attach/detach operations are delegated.

## Testing

A unit test variation is added to validate the test helper class.

_If new tests were added:_
- [x] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.