### PR TITLE
Fix api_test crash: don't call Catch2 REQUIRE from the consumer thread

### DIFF
--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -2595,6 +2595,12 @@ TEST_CASE("perf_buffer_sync_callback_block", "[perf_buffer]")
     // Local tracking variables for consumer thread.
     std::atomic<bool> terminate_flag{false};
     std::atomic<uint64_t> total_polled_events{0};
+    // Records the first negative perf_buffer__poll() result seen by the consumer thread (0 == no error).
+    // Catch2's REQUIRE must not be called from a worker thread: its assertion/output-redirect machinery is
+    // not thread-safe before v3.9.0 and concurrent use trips an internal "redirect is already active"
+    // assertion (see catchorg/Catch2#2935). So the consumer only records the value and the main thread
+    // asserts it after the thread is joined.
+    std::atomic<int> consumer_poll_result{0};
 
     // Spawn consumer thread to poll perf buffer.
     std::thread consumer_thread([&]() {
@@ -2602,7 +2608,11 @@ TEST_CASE("perf_buffer_sync_callback_block", "[perf_buffer]")
         while (!terminate_flag.load() && std::chrono::steady_clock::now() < timeout_time) {
             int poll_result = perf_buffer__poll(pb, 100);
             // Poll returns 0 on timeout or event count on data; exact value depends on timing.
-            REQUIRE(poll_result >= 0);
+            // Do not REQUIRE here (worker thread); record the failure and let the main thread assert it.
+            if (poll_result < 0) {
+                consumer_poll_result.store(poll_result);
+                break;
+            }
             total_polled_events.fetch_add(poll_result);
         }
     });
@@ -2712,6 +2722,11 @@ TEST_CASE("perf_buffer_sync_callback_block", "[perf_buffer]")
         REQUIRE(phase_events + phase_lost == phase_written);
         REQUIRE(phase_polled == phase_events);
     }
+
+    // Stop and join the consumer thread, then validate its poll results on the main thread (see the note on
+    // consumer_poll_result above for why the check cannot run inside the consumer thread).
+    thread_cleanup.reset();
+    REQUIRE(consumer_poll_result.load() >= 0);
 }
 
 // Test that BPF_F_INDEX_MASK (explicit CPU index in flags) works for perf_event_output.


### PR DESCRIPTION
## Description
This issue surfaced while switching CI to VS 2026 support. VS 2026's different codegen/thread-timing widened the race window enough to trip this race condition.

Fixes a crash in the `perf_buffer_sync_callback_block` api_test. The test spawns a consumer thread that calls `REQUIRE(poll_result >= 0)` in a loop while the main thread also calls `REQUIRE` concurrently. Catch2's output-redirect machinery is **not thread-safe** before v3.9.0, so concurrent `REQUIRE` from two threads trips an internal assertion and aborts the process:

```
Assertion failed: !m_redirectActive && "redirect is already active",
  external/Catch2/src/catch2/internal/catch_output_redirect.hpp, line 40
abort() has been called
api_test.exe failed with -1073740768   (0xC0000420 STATUS_ASSERTION_FAILURE)
```

This is the limitation documented in catchorg/Catch2#2935 ("do not touch Catch2 from multiple execution threads"). It is a latent race (introduced in #4966) and surfaces intermittently depending on thread timing.

## Fix

Record the first negative `perf_buffer__poll()` result in an atomic on the worker thread and assert it on the main thread after the consumer thread is joined. This matches the pattern already used by the other multithreaded tests in this file (atomic `failure_count` + main-thread `REQUIRE`).

## Testing

CI/CD. The change keeps the same validation (a negative poll result still fails the test) while removing the cross-thread Catch2 usage.

## Documentation

No.

## Installation

No.