### PR TITLE
Remove license from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "license": ["Copyright (c) eBPF for Windows contributors", "SPDX-License-Identifier: MIT"],
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -24,6 +24,7 @@ Doxyfile
 \.clang-format
 \.gitattributes
 \.github/CODEOWNERS
+\.github/renovate.json
 \.github/workflows/build.yml
 \.gitignore
 \.gitmodules


### PR DESCRIPTION
## Description

While OSS Renovate supports the license field,
Mend Renovate (which github uses) does not.

Fixes #5392

## Testing

No new tests needed, github renovate will test it.

## Documentation

No impact.

## Installation

No impact.
