### PR TITLE
docs: add release regression test reminder

### DIFF
--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -36,6 +36,7 @@ jobs:
 
             - [ ] Ensure SPGO data is regenerated and added to the repo using performance test suite.
             - [ ] Follow instructions in [ReleaseProcess.md](https://github.com/microsoft/ebpf-for-windows/blob/main/docs/ReleaseProcess.md).
+            - [ ] After publishing the release, update the regression tests to point to the release that is now N-1.
             - [ ] Sync the internal `undock` and follow the internal release instructions in `\.internal\docs\ReleaseEbpfRedistProcess.md`.
 
         with:

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -64,6 +64,8 @@ The release manager must download the relevant artifacts from the build pipeline
 
 1.  Check the "`Set as a pre-release`" checkbox, unless the release is production-signed.
 1.  Once the uploads are complete, click "`Publish release`". Github will automatically upload the zipped up source code file.
+1.  Update any regression test release references so tests that validate backward compatibility now use the release that just became N-1.
+    This keeps the regression tests pointed at the previous release after the new release is published.
 
 ## Publishing the Release to NuGet.org
 


### PR DESCRIPTION
## Summary

Add a release-process reminder to update regression test release references after publishing a new release, so the tests continue pointing at the prior release (N-1).

## Related Issue

Fixes #5397

## Changes

- Added the reminder to the release scheduler issue body.
- Documented the same step in the release process guide.

## Testing

- [x] YAML parse check for `.github/workflows/release-scheduler.yml`
- [x] `git diff --check`

## Notes

This is a docs/process-only change; it does not alter release automation behavior.
