### PR TITLE
Revert rename of `ebpf_context_descriptor_t` to `ebpf_ctx_descriptor_t`

### DIFF
--- a/docs/PerfEventArray.md
+++ b/docs/PerfEventArray.md
@@ -55,7 +55,7 @@ The perf buffers are implemented using the ring buffer map support in ebpf-for-w
    - Specify current CPU in flags using `BPF_F_INDEX_MASK` or pass `BPF_F_CURRENT_CPU`.
 2. **BPF_F_CTXLEN_MASK support** for any eBPF program types with a data pointer in the context
    - The global helper copies the memory from the program-type specific context data pointer, so no extension-specific helpers are needed.
-   - The extension-provided `ebpf_ctx_descriptor_t` includes the offset of the data pointer.
+   - The extension-provided `ebpf_context_descriptor_t` includes the offset of the data pointer.
    - Passing a non-zero value in `BPF_F_CTXLEN_MASK` returns an operation not supported error for program types without a data pointer in the context.
 
 ### libbpf Support

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -235,13 +235,13 @@ The various fields of this structure should be set as follows:
 The various fields of this structure should be set as follows:
 * `header`: Version and size.
 * `name`: Friendly name of the program type.
-* `context_descriptor`: Pointer of type `ebpf_ctx_descriptor_t`.
+* `context_descriptor`: Pointer of type `ebpf_context_descriptor_t`.
 * `program_type`: GUID for the program type. This should be the same as the `NpiId` in `NPI_REGISTRATION_INSTANCE` as
 noted above.
 * `bpf_prog_type`: Set to the equivalent bpf program type integer. If there is no equivalent bpf program type, either add a value to the `bpf_prog_type` enum and assign it here or this field should be set to `0 (BPF_PROG_TYPE_UNSPEC)`.
 * `is_privileged`: Set to `FALSE`.
 
-#### `ebpf_ctx_descriptor_t` Struct
+#### `ebpf_context_descriptor_t` Struct
 This structure (as the name signifies) provides a description of the context parameter that a hook passes when
 invoking an eBPF program. The various fields of this struct are as follows.
 * `header`: Version and size.
@@ -265,7 +265,7 @@ typedef struct _sample_program_context
 ```
 The corresponding context descriptor looks like:
 ```c
-const ebpf_ctx_descriptor_t g_sample_program_context_descriptor = {sizeof(sample_program_context_t),
+const ebpf_context_descriptor_t g_sample_program_context_descriptor = {sizeof(sample_program_context_t),
                                                             EBPF_OFFSET_OF(sample_program_context_t, data_start),
                                                             EBPF_OFFSET_OF(sample_program_context_t, data_end),
                                                             -1};
@@ -565,7 +565,7 @@ When an extension invokes this function pointer, then the call flows through the
 invokes the eBPF program.  When invoking an eBPF program, the extension must supply the client binding context it
 obtained from the Hook NPI client as the `client_binding_context` parameter. For the second parameter `context`, it
 must pass the program type specific context data structure. Note that the Program Information NPI provider supplies
-the context descriptor (using the `ebpf_ctx_descriptor_t` type) to the eBPF verifier and JIT-compiler via the NPI
+the context descriptor (using the `ebpf_context_descriptor_t` type) to the eBPF verifier and JIT-compiler via the NPI
 client hosted by the execution context. The `result` output parameter holds the return value from the eBPF program
 post execution.
 

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -6,6 +6,11 @@
 #include "ebpf_result.h"
 #include "ebpf_windows.h"
 
+// Backward-compatible typedef: the verifier submodule renamed
+// ebpf_context_descriptor_t to ebpf_ctx_descriptor_t.  Keep the old
+// name available so that extensions and consumers are not broken.
+typedef ebpf_ctx_descriptor_t ebpf_context_descriptor_t;
+
 #define EBPF_MAX_PROGRAM_DESCRIPTOR_NAME_LENGTH 256
 #define EBPF_MAX_HELPER_FUNCTION_NAME_LENGTH 256
 
@@ -15,7 +20,7 @@ typedef struct _ebpf_program_type_descriptor
 {
     ebpf_extension_header_t header;
     const char* name;
-    const ebpf_ctx_descriptor_t* context_descriptor;
+    const ebpf_context_descriptor_t* context_descriptor;
     GUID program_type;
     uint32_t bpf_prog_type;
     char is_privileged;

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -143,7 +143,7 @@ _ebpf_store_load_program_type_descriptor(
     ebpf_result_t result = EBPF_SUCCESS;
     HKEY program_type_descriptor_key = nullptr;
     wchar_t* program_type_name = nullptr;
-    ebpf_ctx_descriptor_t* context_descriptor = nullptr;
+    ebpf_context_descriptor_t* context_descriptor = nullptr;
     uint32_t is_privileged = false;
     uint32_t bpf_program_type = 0;
     ebpf_program_type_descriptor_t* local_program_type_descriptor = nullptr;
@@ -198,7 +198,7 @@ _ebpf_store_load_program_type_descriptor(
 
     // Allocate and read context descriptor.
     context_descriptor =
-        (ebpf_ctx_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ctx_descriptor_t), EBPF_POOL_TAG_DEFAULT);
+        (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (context_descriptor == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -207,7 +207,7 @@ _ebpf_store_load_program_type_descriptor(
         program_type_descriptor_key,
         EBPF_PROGRAM_DATA_CONTEXT_DESCRIPTOR,
         (uint8_t*)context_descriptor,
-        sizeof(ebpf_ctx_descriptor_t));
+        sizeof(ebpf_context_descriptor_t));
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -158,8 +158,8 @@ _get_program_descriptor_from_info(
             goto Exit;
         }
         type->name = std::string(name);
-        type->ctx_descriptor =
-            (ebpf_ctx_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ctx_descriptor_t), EBPF_POOL_TAG_DEFAULT);
+        type->ctx_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(
+            sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
         if (type->ctx_descriptor == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -167,7 +167,7 @@ _get_program_descriptor_from_info(
         memcpy(
             (void*)type->ctx_descriptor,
             info->program_type_descriptor->context_descriptor,
-            sizeof(ebpf_ctx_descriptor_t));
+            sizeof(ebpf_context_descriptor_t));
         ebpf_program_type_t* program_type =
             (ebpf_program_type_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_type_t), EBPF_POOL_TAG_DEFAULT);
         if (program_type == nullptr) {

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -155,7 +155,7 @@ static const NPI_CLIENT_CHARACTERISTICS _ebpf_program_type_specific_program_info
  */
 void
 ebpf_program_set_header_context_descriptor(
-    _In_ const ebpf_ctx_descriptor_t* context_descriptor, _Inout_ void* program_context)
+    _In_ const ebpf_context_descriptor_t* context_descriptor, _Inout_ void* program_context)
 {
     // slot [1] contains the context_descriptor for the program.
     ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
@@ -175,10 +175,10 @@ ebpf_program_set_header_context_descriptor(
  */
 void
 ebpf_program_get_header_context_descriptor(
-    _In_ const void* program_context, _Outptr_ const ebpf_ctx_descriptor_t** context_descriptor)
+    _In_ const void* program_context, _Outptr_ const ebpf_context_descriptor_t** context_descriptor)
 {
     ebpf_context_header_t* header = CONTAINING_RECORD(program_context, ebpf_context_header_t, context);
-    *context_descriptor = (ebpf_ctx_descriptor_t*)header->context_header[1];
+    *context_descriptor = (ebpf_context_descriptor_t*)header->context_header[1];
 }
 
 _Requires_lock_held_(program->lock) static ebpf_result_t _ebpf_program_update_helpers(_Inout_ ebpf_program_t* program);
@@ -1643,7 +1643,7 @@ ebpf_program_invoke(
     // Set runtime state in context header.
     ebpf_program_set_runtime_state(execution_state, context);
     // Set context descriptor pointer in context header.
-    const ebpf_ctx_descriptor_t* context_descriptor =
+    const ebpf_context_descriptor_t* context_descriptor =
         program->extension_program_data->program_info->program_type_descriptor->context_descriptor;
     ebpf_program_set_header_context_descriptor(context_descriptor, context);
 
@@ -2564,7 +2564,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     // Set runtime state in context header.
     ebpf_program_set_runtime_state(&execution_context_state, program_context);
     // Set context descriptor pointer in context header.
-    const ebpf_ctx_descriptor_t* context_descriptor =
+    const ebpf_context_descriptor_t* context_descriptor =
         context->program_data->program_info->program_type_descriptor->context_descriptor;
     ebpf_program_set_header_context_descriptor(context_descriptor, program_context);
 
@@ -2823,7 +2823,7 @@ void
 ebpf_program_get_context_data(
     _In_ const void* program_context, _Out_ const uint8_t** data_start, _Out_ const uint8_t** data_end)
 {
-    ebpf_ctx_descriptor_t* context_descriptor;
+    ebpf_context_descriptor_t* context_descriptor;
     ebpf_program_get_header_context_descriptor(program_context, &context_descriptor);
     if (context_descriptor->data < 0 || context_descriptor->end < 0) {
         *data_start = NULL;

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -24,10 +24,10 @@ extern "C"
     // - Defined in ebpf_program.c, declared here for unit testing.
     void
     ebpf_program_set_header_context_descriptor(
-        _In_ const ebpf_ctx_descriptor_t* context_descriptor, _Inout_ void* program_context);
+        _In_ const ebpf_context_descriptor_t* context_descriptor, _Inout_ void* program_context);
     void
     ebpf_program_get_header_context_descriptor(
-        _In_ const void* program_context, _Outptr_ const ebpf_ctx_descriptor_t** context_descriptor);
+        _In_ const void* program_context, _Outptr_ const ebpf_context_descriptor_t** context_descriptor);
 
     bool
     ebpf_program_is_valid_general_helper_provider_data(
@@ -1727,7 +1727,7 @@ TEST_CASE("perf_event_array_output_capture", "[execution_context][perf_event_arr
     context.data_end = test_context_data.data() + test_context_data.size();
 
     void* ctx = &context.data;
-    ebpf_ctx_descriptor_t context_descriptor = {0};
+    ebpf_context_descriptor_t context_descriptor = {0};
     context_descriptor.size = sizeof(context);
     context_descriptor.data = 0;
     context_descriptor.end = EBPF_OFFSET_OF(decltype(context), data_end) - EBPF_OFFSET_OF(decltype(context), data);
@@ -1819,11 +1819,11 @@ TEST_CASE("context_descriptor_header", "[platform][perf_event_array]")
     void* ctx = &context.ctx;
 
     // The context descriptor tells the platform where to find the data pointers.
-    ebpf_ctx_descriptor_t context_descriptor = {
+    ebpf_context_descriptor_t context_descriptor = {
         sizeof(context_t), EBPF_OFFSET_OF(context_t, data), EBPF_OFFSET_OF(context_t, data_end), -1};
     ebpf_program_set_header_context_descriptor(&context_descriptor, ctx);
 
-    const ebpf_ctx_descriptor_t* test_ctx_descriptor;
+    const ebpf_context_descriptor_t* test_ctx_descriptor;
     ebpf_program_get_header_context_descriptor(ctx, &test_ctx_descriptor);
     REQUIRE(test_ctx_descriptor == &context_descriptor);
 
@@ -2569,7 +2569,7 @@ TEST_CASE("INVALID_PROGRAM_DATA", "[execution_context][negative]")
     _ebpf_core_initializer core;
     core.initialize();
 
-    ebpf_ctx_descriptor_t _test_context_descriptor = {sizeof(ebpf_ctx_descriptor_t), -1, -1, -1};
+    ebpf_context_descriptor_t _test_context_descriptor = {sizeof(ebpf_context_descriptor_t), -1, -1, -1};
 
     const uint32_t _test_prog_type = 1000;
     ebpf_program_type_descriptor_t _test_program_type_descriptor = {
@@ -2684,7 +2684,7 @@ TEST_CASE("INVALID_PROGRAM_DATA", "[execution_context][negative]")
     _test_context_descriptor.size = 0;
     test_register_provider(&provider_characteristics);
     // Fix up the context descriptor.
-    _test_context_descriptor.size = sizeof(ebpf_ctx_descriptor_t);
+    _test_context_descriptor.size = sizeof(ebpf_context_descriptor_t);
 
     // Remove the helper function prototype from the program info.
     _test_program_info.program_type_specific_helper_prototype = nullptr;

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1449,7 +1449,7 @@ TEST_CASE("serialize_program_info_test", "[platform]")
          {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}}};
     // The values of the fields in the context_descriptor variable are completely arbitrary
     // and have no effect on the test.
-    ebpf_ctx_descriptor_t context_descriptor = {32, 0, 8, -1};
+    ebpf_context_descriptor_t context_descriptor = {32, 0, 8, -1};
     GUID program_type_test = {0x7ebe418c, 0x76dd, 0x4c2c, {0x99, 0xbc, 0x5c, 0x48, 0xa2, 0x30, 0x4b, 0x90}};
     ebpf_program_type_descriptor_t program_type = {
         EBPF_PROGRAM_TYPE_DESCRIPTOR_HEADER, "unit_test_program", &context_descriptor, program_type_test};
@@ -1497,7 +1497,7 @@ TEST_CASE("serialize_program_info_test", "[platform]")
         memcmp(
             in_program_info.program_type_descriptor->context_descriptor,
             out_program_info->program_type_descriptor->context_descriptor,
-            sizeof(ebpf_ctx_descriptor_t)) == 0);
+            sizeof(ebpf_context_descriptor_t)) == 0);
     REQUIRE(
         strncmp(
             in_program_info.program_type_descriptor->name,

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -15,7 +15,7 @@ typedef struct _ebpf_serialized_program_type_descriptor
 {
     size_t size;
     ebpf_extension_header_t header;
-    ebpf_ctx_descriptor_t context_descriptor;
+    ebpf_context_descriptor_t context_descriptor;
     GUID program_type;
     uint32_t bpf_prog_type;
     unsigned char is_privileged;
@@ -474,7 +474,7 @@ ebpf_deserialize_program_info(
     ebpf_program_info_t* local_program_info;
     const uint8_t* current;
     size_t buffer_left;
-    ebpf_ctx_descriptor_t* local_context_descriptor;
+    ebpf_context_descriptor_t* local_context_descriptor;
     ebpf_program_type_descriptor_t* local_program_type_descriptor;
     const ebpf_serialized_program_type_descriptor_t* serialized_program_type_descriptor;
     char* local_program_type_descriptor_name;
@@ -518,8 +518,8 @@ ebpf_deserialize_program_info(
 
     // Allocate and deserialize context_descriptor, if present.
     if (serialized_program_type_descriptor->context_descriptor.size != 0) {
-        local_context_descriptor =
-            (ebpf_ctx_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ctx_descriptor_t), EBPF_POOL_TAG_DEFAULT);
+        local_context_descriptor = (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(
+            sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
         if (local_context_descriptor == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -246,9 +246,9 @@ ebpf_validate_helper_function_prototype_array(
 }
 
 static bool
-_ebpf_validate_context_descriptor(_In_ const ebpf_ctx_descriptor_t* context_descriptor)
+_ebpf_validate_context_descriptor(_In_ const ebpf_context_descriptor_t* context_descriptor)
 {
-    return ((context_descriptor != NULL) && (context_descriptor->size >= sizeof(ebpf_ctx_descriptor_t)));
+    return ((context_descriptor != NULL) && (context_descriptor->size >= sizeof(ebpf_context_descriptor_t)));
 }
 
 static bool
@@ -381,7 +381,7 @@ _duplicate_program_descriptor(
 {
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_program_type_descriptor_t* program_type_descriptor_copy = NULL;
-    ebpf_ctx_descriptor_t* context_descriptor_copy = NULL;
+    ebpf_context_descriptor_t* context_descriptor_copy = NULL;
 
     program_type_descriptor_copy = (ebpf_program_type_descriptor_t*)ebpf_allocate_with_tag(
         sizeof(ebpf_program_type_descriptor_t), EBPF_POOL_TAG_DEFAULT);
@@ -405,13 +405,13 @@ _duplicate_program_descriptor(
     }
 
     context_descriptor_copy =
-        (ebpf_ctx_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_ctx_descriptor_t), EBPF_POOL_TAG_DEFAULT);
+        (ebpf_context_descriptor_t*)ebpf_allocate_with_tag(sizeof(ebpf_context_descriptor_t), EBPF_POOL_TAG_DEFAULT);
     if (context_descriptor_copy == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
     }
 
-    memcpy(context_descriptor_copy, program_type_descriptor->context_descriptor, sizeof(ebpf_ctx_descriptor_t));
+    memcpy(context_descriptor_copy, program_type_descriptor->context_descriptor, sizeof(ebpf_context_descriptor_t));
     program_type_descriptor_copy->context_descriptor = context_descriptor_copy;
     context_descriptor_copy = NULL;
 

--- a/libs/store_helper/ebpf_store_helper.c
+++ b/libs/store_helper/ebpf_store_helper.c
@@ -316,7 +316,7 @@ _ebpf_store_update_program_descriptor(
         descriptor_key,
         EBPF_PROGRAM_DATA_CONTEXT_DESCRIPTOR,
         (uint8_t*)program_type_descriptor->context_descriptor,
-        sizeof(ebpf_ctx_descriptor_t));
+        sizeof(ebpf_context_descriptor_t));
     if (!IS_SUCCESS(result)) {
         return result;
     }

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -8,7 +8,7 @@
 #include "ebpf_shared_framework.h"
 
 // Bind program information.
-static const ebpf_ctx_descriptor_t _ebpf_bind_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
 
 static const ebpf_program_type_descriptor_t _ebpf_bind_program_type_descriptor = {
@@ -81,7 +81,7 @@ static const ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_func
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}};
 
 // CGROUP_SOCK_ADDR program information.
-static const ebpf_ctx_descriptor_t _ebpf_sock_addr_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_sock_addr_context_descriptor = {
     sizeof(bpf_sock_addr_t),
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
@@ -166,7 +166,7 @@ static const ebpf_program_section_info_t _ebpf_sock_addr_section_info[] = {
      BPF_CGROUP_INET6_LISTEN}};
 
 // SOCK_OPS program information.
-static const ebpf_ctx_descriptor_t _ebpf_sock_ops_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_sock_ops_context_descriptor = {
     sizeof(bpf_sock_ops_t),
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to data, or -1 if none.

--- a/tests/cilium/cilium_tests.cpp
+++ b/tests/cilium/cilium_tests.cpp
@@ -29,7 +29,7 @@ static const ebpf_helper_function_prototype_t _xdp_test_ebpf_extension_helper_fu
      {HELPER_FUNCTION_REALLOCATE_PACKET}}};
 
 // XDP program context descriptor
-static const ebpf_ctx_descriptor_t _ebpf_xdp_test_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_xdp_test_context_descriptor = {
     sizeof(xdp_md_t),
     EBPF_OFFSET_OF(xdp_md_t, data),
     EBPF_OFFSET_OF(xdp_md_t, data_end),

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -507,7 +507,7 @@ _test_sample_hash_map_preprocess_delete_entry(
 #pragma warning(pop)
 
 // XDP program information.
-static const ebpf_ctx_descriptor_t _ebpf_xdp_test_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_xdp_test_context_descriptor = {
     sizeof(xdp_md_t),
     EBPF_OFFSET_OF(xdp_md_t, data),
     EBPF_OFFSET_OF(xdp_md_t, data_end),

--- a/tests/export_program_info_test/export_program_info_test.cpp
+++ b/tests/export_program_info_test/export_program_info_test.cpp
@@ -26,7 +26,7 @@ typedef struct _ebpf_program_section_info_with_count
 } ebpf_program_section_info_with_count_t;
 
 // XDP Test program information
-static const ebpf_ctx_descriptor_t _ebpf_xdp_test_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_xdp_test_context_descriptor = {
     sizeof(xdp_md_t),
     EBPF_OFFSET_OF(xdp_md_t, data),
     EBPF_OFFSET_OF(xdp_md_t, data_end),

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -20,7 +20,7 @@ typedef struct
 typedef struct _test_client_context
 {
     netebpfext_helper_base_client_context_t base;
-    const ebpf_ctx_descriptor_t* ctx_descriptor;
+    const ebpf_context_descriptor_t* ctx_descriptor;
     netebpfext_fuzzer_metadata_t metadata;
 } test_client_context_t;
 

--- a/undocked/tests/sample/ext/inc/sample_ext_program_info.h
+++ b/undocked/tests/sample/ext/inc/sample_ext_program_info.h
@@ -15,7 +15,7 @@
 
 #define EBPF_COUNT_OF(arr) (sizeof(arr) / sizeof(arr[0]))
 
-static const ebpf_ctx_descriptor_t _sample_ebpf_context_descriptor = {
+static const ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
     sizeof(sample_program_context_t),
     EBPF_OFFSET_OF(sample_program_context_t, data_start),
     EBPF_OFFSET_OF(sample_program_context_t, data_end),


### PR DESCRIPTION
## Description

Revert the rename of `ebpf_context_descriptor_t` to `ebpf_ctx_descriptor_t` that was introduced in #5216 as part of the verifier submodule update. The type `ebpf_context_descriptor_t` is part of the public API surface used by extensions (e.g., in `ebpf_program_type_descriptor_t`), so renaming it is a breaking change for downstream consumers.

This PR adds a backward-compatible typedef (`typedef ebpf_ctx_descriptor_t ebpf_context_descriptor_t`) in `ebpf_program_types.h` and reverts all non-external usages back to `ebpf_context_descriptor_t`. The verifier submodule internally uses `ebpf_ctx_descriptor_t` and its struct field names remain unchanged.

## Testing

Existing tests cover this change — the typedef makes the two names interchangeable, so all existing unit tests, driver tests, and fuzz tests remain valid without modification.

- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

Yes — `docs/eBpfExtensions.md` and `docs/PerfEventArray.md` were reverted to reference `ebpf_context_descriptor_t`.

## Installation

No installer impact.