### PR TITLE
Update regression test version to 1.3

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -320,7 +320,7 @@ jobs:
     if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -TestMode "Regression" -RegressionArtifactsVersion "1.0.0-rc1" -GranularTracing
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -TestMode "Regression" -RegressionArtifactsVersion "1.3.0" -GranularTracing
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Regression" -GranularTracing
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       name: regression_driver_ws2022

--- a/scripts/common.psm1
+++ b/scripts/common.psm1
@@ -999,7 +999,7 @@ function Get-RegressionTestArtifacts
 
     # Download regression test artifacts for each version.
     $DownloadPath = "$RegressionTestArtifactsPath"
-    $ArtifactName = "Release-v$ArtifactVersion/Build.$Configuration.x64.zip"
+    $ArtifactName = "v$ArtifactVersion/Build.$Configuration.x64.zip"
     $ArtifactUrl = "https://github.com/microsoft/ebpf-for-windows/releases/download/" + $ArtifactName
 
     if (Test-Path -Path $DownloadPath\Build-x64.$Configuration) {


### PR DESCRIPTION
Fixes #5396

## Description

This PR updates the regression test version to `1.3.0`

## Testing

This PR updates the regression tests

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

No

## Installation

No
