### PR TITLE
Update version to 1.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup Label="Version">
     <EbpfVersion_Major>1</EbpfVersion_Major>
-    <EbpfVersion_Minor>4</EbpfVersion_Minor>
+    <EbpfVersion_Minor>5</EbpfVersion_Minor>
     <EbpfVersion_Revision>0</EbpfVersion_Revision>
     <EbpfVersion_Modifier/>
     <EbpfVersionNoModifier>$(EbpfVersion_Major).$(EbpfVersion_Minor).$(EbpfVersion_Revision)</EbpfVersionNoModifier>

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_dll.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_dll.c
@@ -236,7 +236,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_raw.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_raw.c
@@ -206,7 +206,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_sys.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_sys.c
@@ -361,7 +361,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -207,7 +207,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -177,7 +177,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -332,7 +332,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -199,7 +199,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -169,7 +169,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -324,7 +324,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bind_policy_dll.c
+++ b/tests/bpf2c_tests/expected/bind_policy_dll.c
@@ -572,7 +572,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bind_policy_raw.c
+++ b/tests/bpf2c_tests/expected/bind_policy_raw.c
@@ -542,7 +542,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bind_policy_sys.c
+++ b/tests/bpf2c_tests/expected/bind_policy_sys.c
@@ -697,7 +697,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
@@ -523,7 +523,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
@@ -493,7 +493,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
@@ -648,7 +648,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -602,7 +602,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -6251,7 +6251,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -6221,7 +6221,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -6376,7 +6376,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_dll.c
@@ -214,7 +214,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_raw.c
@@ -184,7 +184,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_sys.c
@@ -339,7 +339,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -572,7 +572,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -205,7 +205,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -175,7 +175,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -330,7 +330,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -727,7 +727,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -858,7 +858,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -828,7 +828,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -983,7 +983,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
@@ -282,7 +282,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
@@ -252,7 +252,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
@@ -407,7 +407,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -197,7 +197,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -167,7 +167,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -322,7 +322,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -126,7 +126,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -96,7 +96,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -251,7 +251,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
@@ -802,7 +802,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
@@ -772,7 +772,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
@@ -927,7 +927,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_dll.c
@@ -276,7 +276,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_raw.c
@@ -246,7 +246,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_sys.c
@@ -401,7 +401,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_dll.c
@@ -261,7 +261,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_raw.c
@@ -231,7 +231,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_sys.c
@@ -386,7 +386,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -264,7 +264,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
@@ -234,7 +234,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
@@ -389,7 +389,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -264,7 +264,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
@@ -234,7 +234,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
@@ -389,7 +389,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -201,7 +201,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
@@ -171,7 +171,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
@@ -326,7 +326,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -201,7 +201,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
@@ -171,7 +171,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
@@ -326,7 +326,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -1308,7 +1308,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -1278,7 +1278,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -1433,7 +1433,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_dll.c
@@ -328,7 +328,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_raw.c
@@ -298,7 +298,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_sys.c
@@ -453,7 +453,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -1582,7 +1582,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_dll.c
@@ -2447,7 +2447,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_raw.c
@@ -2417,7 +2417,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_sys.c
@@ -2572,7 +2572,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -1552,7 +1552,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -1707,7 +1707,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_basic_dll.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_dll.c
@@ -2265,7 +2265,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_basic_raw.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_raw.c
@@ -2235,7 +2235,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_basic_sys.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_sys.c
@@ -2390,7 +2390,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_invalid_dll.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_dll.c
@@ -204,7 +204,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_invalid_raw.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_raw.c
@@ -174,7 +174,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_invalid_sys.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_sys.c
@@ -329,7 +329,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -214,7 +214,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -184,7 +184,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -339,7 +339,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -379,7 +379,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -349,7 +349,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -504,7 +504,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
@@ -253,7 +253,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
@@ -223,7 +223,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
@@ -378,7 +378,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_dll.c
@@ -260,7 +260,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_raw.c
@@ -230,7 +230,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_sys.c
@@ -385,7 +385,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -350,7 +350,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_raw.c
+++ b/tests/bpf2c_tests/expected/inner_map_raw.c
@@ -320,7 +320,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_sys.c
+++ b/tests/bpf2c_tests/expected/inner_map_sys.c
@@ -475,7 +475,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/lru_map_test_dll.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_dll.c
@@ -263,7 +263,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/lru_map_test_raw.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_raw.c
@@ -233,7 +233,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/lru_map_test_sys.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_sys.c
@@ -388,7 +388,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
@@ -293,7 +293,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
@@ -263,7 +263,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
@@ -418,7 +418,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -5109,7 +5109,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -5079,7 +5079,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -301,7 +301,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -271,7 +271,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -426,7 +426,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -301,7 +301,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -271,7 +271,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -426,7 +426,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_dll.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_dll.c
@@ -262,7 +262,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_raw.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_raw.c
@@ -232,7 +232,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_sys.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_sys.c
@@ -387,7 +387,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_synchronized_update_dll.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_dll.c
@@ -328,7 +328,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_synchronized_update_raw.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_raw.c
@@ -298,7 +298,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_synchronized_update_sys.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_sys.c
@@ -453,7 +453,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -5234,7 +5234,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_dll.c
@@ -177,7 +177,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_raw.c
@@ -147,7 +147,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_sys.c
@@ -302,7 +302,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multiple_programs_dll.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_dll.c
@@ -279,7 +279,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multiple_programs_raw.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_raw.c
@@ -249,7 +249,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multiple_programs_sys.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_sys.c
@@ -404,7 +404,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_burst_dll.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_dll.c
@@ -320,7 +320,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_burst_raw.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_raw.c
@@ -290,7 +290,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_burst_sys.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_sys.c
@@ -445,7 +445,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_dll.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_dll.c
@@ -216,7 +216,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_raw.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_raw.c
@@ -186,7 +186,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_sys.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_sys.c
@@ -341,7 +341,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -279,7 +279,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -249,7 +249,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -404,7 +404,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -627,7 +627,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -526,7 +526,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -496,7 +496,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -651,7 +651,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -597,7 +597,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -752,7 +752,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/process_start_key_dll.c
+++ b/tests/bpf2c_tests/expected/process_start_key_dll.c
@@ -368,7 +368,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/process_start_key_raw.c
+++ b/tests/bpf2c_tests/expected/process_start_key_raw.c
@@ -338,7 +338,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/process_start_key_sys.c
+++ b/tests/bpf2c_tests/expected/process_start_key_sys.c
@@ -493,7 +493,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -746,7 +746,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_flow_id_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_dll.c
@@ -879,7 +879,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_flow_id_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_raw.c
@@ -849,7 +849,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_flow_id_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_sys.c
@@ -1004,7 +1004,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -716,7 +716,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -871,7 +871,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/strings_dll.c
+++ b/tests/bpf2c_tests/expected/strings_dll.c
@@ -482,7 +482,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/strings_raw.c
+++ b/tests/bpf2c_tests/expected/strings_raw.c
@@ -452,7 +452,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/strings_sys.c
+++ b/tests/bpf2c_tests/expected/strings_sys.c
@@ -607,7 +607,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -310,7 +310,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -280,7 +280,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -435,7 +435,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -305,7 +305,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -282,7 +282,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -252,7 +252,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -407,7 +407,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -7834,7 +7834,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
@@ -7804,7 +7804,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
@@ -7959,7 +7959,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -317,7 +317,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -287,7 +287,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -442,7 +442,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -275,7 +275,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -311,7 +311,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
@@ -281,7 +281,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
@@ -436,7 +436,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
@@ -363,7 +363,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
@@ -333,7 +333,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
@@ -488,7 +488,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -7486,7 +7486,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
@@ -7456,7 +7456,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
@@ -7611,7 +7611,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -430,7 +430,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -347,7 +347,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -317,7 +317,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -472,7 +472,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
@@ -419,7 +419,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
@@ -389,7 +389,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
@@ -544,7 +544,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_dll.c
@@ -189,7 +189,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_raw.c
@@ -159,7 +159,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_sys.c
@@ -314,7 +314,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_dll.c
@@ -204,7 +204,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_raw.c
@@ -174,7 +174,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_sys.c
@@ -329,7 +329,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -351,7 +351,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -321,7 +321,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -476,7 +476,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/thread_start_time_dll.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_dll.c
@@ -362,7 +362,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/thread_start_time_raw.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_raw.c
@@ -332,7 +332,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/thread_start_time_sys.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_sys.c
@@ -487,7 +487,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -554,7 +554,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_raw.c
+++ b/tests/bpf2c_tests/expected/utility_raw.c
@@ -524,7 +524,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_sys.c
+++ b/tests/bpf2c_tests/expected/utility_sys.c
@@ -679,7 +679,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 4;
+    version->minor = 5;
     version->revision = 0;
 }
 

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 1, "minor": 4, "patch": 0 }
+{ "major": 1, "minor": 5, "patch": 0 }


### PR DESCRIPTION
## Description

Updates eBPF version to 1.5 in preparation for #5406 .

## Testing

_Do any existing tests cover this change? Are new tests needed?_

N/A

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

_Is there any documentation impact for this change?_
N/A

## Installation

_Is there any installer impact for this change?_
N/A