### PR TITLE
add instrumentation to perf_event__new

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -6141,15 +6141,24 @@ ebpf_perf_buffer__new(
     _In_opt_ void* ctx,
     _In_opt_ const struct ebpf_perf_buffer_opts* opts) EBPF_NO_EXCEPT
 {
+    EBPF_LOG_ENTRY();
+
     ebpf_result_t result = EBPF_SUCCESS;
+    uint32_t win32_error = ERROR_SUCCESS;
     struct perf_buffer* local_perf_buffer = nullptr;
 
     if ((sample_cb == nullptr) || (lost_cb == nullptr)) {
+        EBPF_LOG_MESSAGE(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_API,
+            "perf_buffer__new requires both sample and lost callbacks");
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
 
     if (page_cnt != 0) {
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "perf_buffer__new page count must be zero", page_cnt);
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
@@ -6189,8 +6198,9 @@ ebpf_perf_buffer__new(
 
             HANDLE wait_handle = CreateEvent(nullptr, TRUE, FALSE, nullptr);
             if (wait_handle == nullptr) {
-                result = EBPF_NO_MEMORY;
-                goto Exit;
+                win32_error = GetLastError();
+                result = win32_error_code_to_ebpf_result(win32_error);
+                EBPF_BAIL_ON_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, CreateEvent, win32_error, Exit);
             }
             perf_buffer->wait_handle = reinterpret_cast<ebpf_handle_t>(wait_handle);
 

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -646,9 +646,12 @@ perf_buffer__new(
     void* ctx,
     const struct perf_buffer_opts* opts)
 {
+    EBPF_LOG_ENTRY();
+
     // Convert Linux opts to Windows opts with default synchronous behavior.
     auto ebpf_opts = _convert_to_ebpf_perf_opts(opts);
-    return ebpf_perf_buffer__new(map_fd, page_cnt, sample_cb, lost_cb, ctx, &ebpf_opts);
+    struct perf_buffer* perf_buffer = ebpf_perf_buffer__new(map_fd, page_cnt, sample_cb, lost_cb, ctx, &ebpf_opts);
+    EBPF_RETURN_POINTER(struct perf_buffer*, perf_buffer);
 }
 
 void

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -191,8 +191,6 @@ get_async_ioctl_operation_overlapped(_In_ const async_ioctl_completion_t* async_
 _Must_inspect_result_ ebpf_result_t
 get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion)
 {
-    EBPF_LOG_ENTRY();
-
     ebpf_result_t result = EBPF_SUCCESS;
     unsigned long dummy;
     if (!GetOverlappedResult(
@@ -212,8 +210,6 @@ initialize_async_ioctl_operation(
     _In_ const async_ioctl_completion_callback_t callback,
     _Outptr_ async_ioctl_completion_t** async_ioctl_completion)
 {
-    EBPF_LOG_ENTRY();
-
     ebpf_result_t result = EBPF_SUCCESS;
     uint32_t win32_error = ERROR_SUCCESS;
     *async_ioctl_completion = nullptr;

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -135,6 +135,7 @@ _Must_inspect_result_ ebpf_result_t
 register_wait_async_ioctl_operation(_Inout_ async_ioctl_completion_t* async_ioctl_completion)
 {
     ebpf_result_t result = EBPF_SUCCESS;
+    uint32_t win32_error = ERROR_SUCCESS;
 
     EBPF_LOG_ENTRY();
 
@@ -156,18 +157,18 @@ register_wait_async_ioctl_operation(_Inout_ async_ioctl_completion_t* async_ioct
             false,    // not signaled
             nullptr); // no name
         if (async_ioctl_completion->overlapped.hEvent == nullptr) {
-            result = win32_error_code_to_ebpf_result(GetLastError());
+            win32_error = GetLastError();
+            result = win32_error_code_to_ebpf_result(win32_error);
             _Analysis_assume_(result != EBPF_SUCCESS);
-            EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, CreateEvent);
-            goto Exit;
+            EBPF_BAIL_ON_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, CreateEvent, win32_error, Exit);
         }
     } else {
         // Reset the event.
         if (!ResetEvent(event)) {
-            result = win32_error_code_to_ebpf_result(GetLastError());
+            win32_error = GetLastError();
+            result = win32_error_code_to_ebpf_result(win32_error);
             _Analysis_assume_(result != EBPF_SUCCESS);
-            EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, ResetEvent);
-            goto Exit;
+            EBPF_BAIL_ON_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, ResetEvent, win32_error, Exit);
         }
         async_ioctl_completion->overlapped.hEvent = event;
     }
@@ -190,14 +191,19 @@ get_async_ioctl_operation_overlapped(_In_ const async_ioctl_completion_t* async_
 _Must_inspect_result_ ebpf_result_t
 get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion)
 {
+    EBPF_LOG_ENTRY();
+
+    ebpf_result_t result = EBPF_SUCCESS;
     unsigned long dummy;
     if (!GetOverlappedResult(
             reinterpret_cast<HANDLE>(get_async_device_handle()),
             get_async_ioctl_operation_overlapped(ioctl_completion),
             &dummy,
-            FALSE))
-        return win32_error_code_to_ebpf_result(GetLastError());
-    return EBPF_SUCCESS;
+            FALSE)) {
+        result = win32_error_code_to_ebpf_result(GetLastError());
+    }
+
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t
@@ -206,7 +212,10 @@ initialize_async_ioctl_operation(
     _In_ const async_ioctl_completion_callback_t callback,
     _Outptr_ async_ioctl_completion_t** async_ioctl_completion)
 {
+    EBPF_LOG_ENTRY();
+
     ebpf_result_t result = EBPF_SUCCESS;
+    uint32_t win32_error = ERROR_SUCCESS;
     *async_ioctl_completion = nullptr;
 
     async_ioctl_completion_context_t* local_async_ioctl_completion =
@@ -214,7 +223,7 @@ initialize_async_ioctl_operation(
             sizeof(async_ioctl_completion_context_t), EBPF_POOL_TAG_DEFAULT);
     if (local_async_ioctl_completion == nullptr) {
         result = EBPF_NO_MEMORY;
-        goto Exit;
+        EBPF_BAIL_ON_ALLOC_FAILURE(local_async_ioctl_completion, Exit);
     }
 
     local_async_ioctl_completion->callback_context = callback_context;
@@ -236,10 +245,10 @@ initialize_async_ioctl_operation(
         local_async_ioctl_completion,
         nullptr);
     if (local_async_ioctl_completion->wait == nullptr) {
-        result = win32_error_code_to_ebpf_result(GetLastError());
+        win32_error = GetLastError();
+        result = win32_error_code_to_ebpf_result(win32_error);
         _Analysis_assume_(result != EBPF_SUCCESS);
-        EBPF_LOG_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, CreateThreadpoolWait);
-        goto Exit;
+        EBPF_BAIL_ON_WIN32_API_FAILURE(EBPF_TRACELOG_KEYWORD_API, CreateThreadpoolWait, win32_error, Exit);
     }
 
     // Register for wait on the completion of the async IOCTL.

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1992,9 +1992,7 @@ _ebpf_core_protocol_map_set_wait_handle(_In_ const ebpf_operation_map_set_wait_h
 
     ebpf_result_t result =
         EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
-    if (result != EBPF_SUCCESS) {
-        goto Done;
-    }
+    EBPF_BAIL_ON_OBJECT_REF_ERROR(EBPF_TRACELOG_KEYWORD_BASE, result, request->map_handle, Done);
 
     result = ebpf_map_set_wait_handle_internal(map, request->index, request->wait_handle, request->flags);
 
@@ -2110,9 +2108,7 @@ _ebpf_core_protocol_map_query_buffer(
     ebpf_map_t* map = NULL;
     ebpf_result_t result =
         EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
-    if (result != EBPF_SUCCESS) {
-        goto Exit;
-    }
+    EBPF_BAIL_ON_OBJECT_REF_ERROR(EBPF_TRACELOG_KEYWORD_BASE, result, request->map_handle, Exit);
 
     result = ebpf_map_query_buffer(
         map, request->index, (uint8_t**)(uintptr_t*)&reply->buffer_address, &reply->consumer_offset);
@@ -2129,6 +2125,8 @@ _ebpf_core_protocol_map_async_query(
     uint16_t reply_length,
     _Inout_ void* async_context)
 {
+    EBPF_LOG_ENTRY();
+
     UNREFERENCED_PARAMETER(reply_length);
 
     ebpf_map_t* map = NULL;
@@ -2136,9 +2134,7 @@ _ebpf_core_protocol_map_async_query(
 
     ebpf_result_t result =
         EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
-    if (result != EBPF_SUCCESS) {
-        goto Exit;
-    }
+    EBPF_BAIL_ON_OBJECT_REF_ERROR(EBPF_TRACELOG_KEYWORD_BASE, result, request->map_handle, Exit);
 
     index = request->index;
 
@@ -2157,7 +2153,7 @@ _ebpf_core_protocol_map_async_query(
 
 Exit:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
-    return result;
+    EBPF_RETURN_RESULT(result);
 }
 
 static ebpf_result_t
@@ -2589,6 +2585,8 @@ _ebpf_core_protocol_ring_buffer_map_map_buffer(
     _In_ const ebpf_operation_ring_buffer_map_map_buffer_request_t* request,
     _Inout_ ebpf_operation_ring_buffer_map_map_buffer_reply_t* reply)
 {
+    EBPF_LOG_ENTRY();
+
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_map_t* map = NULL;
     void* consumer = NULL;
@@ -2597,15 +2595,12 @@ _ebpf_core_protocol_ring_buffer_map_map_buffer(
     size_t data_size = 0;
 
     result = EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
-    if (result != EBPF_SUCCESS) {
-        return result;
-    }
+    EBPF_BAIL_ON_OBJECT_REF_ERROR(EBPF_TRACELOG_KEYWORD_BASE, result, request->map_handle, Exit);
 
     // Get the consumer and producer pointers to the mapped ring buffer memory.
     result = ebpf_ring_buffer_map_map_user(map, request->index, &consumer, &producer, &data, &data_size);
     if (result != EBPF_SUCCESS) {
-        EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
-        return result;
+        goto Exit;
     }
 
     reply->consumer_address = (uint64_t)consumer;
@@ -2613,22 +2608,26 @@ _ebpf_core_protocol_ring_buffer_map_map_buffer(
     reply->data_address = (uint64_t)data;
     reply->data_size = data_size;
 
+Exit:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
-    return EBPF_SUCCESS;
+    EBPF_RETURN_RESULT(result);
 }
 
 static ebpf_result_t
 _ebpf_core_protocol_ring_buffer_map_unmap_buffer(
     _In_ const ebpf_operation_ring_buffer_map_unmap_buffer_request_t* request)
 {
+    EBPF_LOG_ENTRY();
+
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_map_t* map = NULL;
     result = EBPF_OBJECT_REFERENCE_BY_HANDLE(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
-    if (result != EBPF_SUCCESS)
-        return result;
+    EBPF_BAIL_ON_OBJECT_REF_ERROR(EBPF_TRACELOG_KEYWORD_BASE, result, request->map_handle, Exit);
     result = ebpf_ring_buffer_map_unmap_user(map, request->index);
+
+Exit:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
-    return result;
+    EBPF_RETURN_RESULT(result);
 }
 
 static int

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -3032,15 +3032,22 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_map_query_buffer(
     _In_ const ebpf_map_t* map, uint64_t index, _Outptr_ uint8_t** buffer, _Out_ size_t* consumer_offset)
 {
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+
     if ((map->properties == NULL) || (map->properties->query_buffer == NULL)) {
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_MAP,
             "ebpf_map_query_buffer not supported on map",
             map->ebpf_map_definition.type);
-        return EBPF_OPERATION_NOT_SUPPORTED;
+        result = EBPF_OPERATION_NOT_SUPPORTED;
+        goto Exit;
     }
-    return map->properties->query_buffer(map, index, buffer, consumer_offset);
+    result = map->properties->query_buffer(map, index, buffer, consumer_offset);
+
+Exit:
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t
@@ -3052,40 +3059,62 @@ ebpf_ring_buffer_map_map_user(
     _Outptr_result_buffer_(*data_size) const uint8_t** data,
     _Out_ size_t* data_size)
 {
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+
     if ((map->properties == NULL) || (map->properties->map_ring_buffer == NULL)) {
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_MAP,
             "ebpf_ring_buffer_map_map_user not supported on map",
             map->ebpf_map_definition.type);
-        return EBPF_OPERATION_NOT_SUPPORTED;
+        result = EBPF_OPERATION_NOT_SUPPORTED;
+        goto Exit;
     }
 
-    return map->properties->map_ring_buffer(map, index, consumer, producer, data, data_size);
+    result = map->properties->map_ring_buffer(map, index, consumer, producer, data, data_size);
+
+Exit:
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_unmap_user(_In_ const ebpf_map_t* map, uint64_t index)
 {
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+
     if ((map->properties == NULL) || (map->properties->unmap_ring_buffer == NULL)) {
-        return EBPF_INVALID_ARGUMENT;
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
     }
 
-    return map->properties->unmap_ring_buffer((const ebpf_core_map_t*)map, index);
+    result = map->properties->unmap_ring_buffer((const ebpf_core_map_t*)map, index);
+
+Exit:
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_map_set_wait_handle_internal(_In_ const ebpf_map_t* map, uint64_t index, ebpf_handle_t wait_handle, uint64_t flags)
 {
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+
     if ((map->properties == NULL) || (map->properties->set_wait_handle == NULL)) {
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_MAP,
             "ebpf_map_set_wait_handle_internal not supported on map",
             map->ebpf_map_definition.type);
-        return EBPF_OPERATION_NOT_SUPPORTED;
+        result = EBPF_OPERATION_NOT_SUPPORTED;
+        goto Exit;
     }
-    return map->properties->set_wait_handle(map, index, wait_handle, flags);
+
+    result = map->properties->set_wait_handle(map, index, wait_handle, flags);
+
+Exit:
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t
@@ -3095,15 +3124,23 @@ ebpf_map_async_query(
     _Inout_ ebpf_map_async_query_result_t* async_query_result,
     _Inout_ void* async_context)
 {
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+
     if ((map->properties == NULL) || (map->properties->async_query == NULL)) {
         EBPF_LOG_MESSAGE_UINT64(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_MAP,
             "ebpf_map_async_query not supported on map",
             map->ebpf_map_definition.type);
-        return EBPF_OPERATION_NOT_SUPPORTED;
+        result = EBPF_OPERATION_NOT_SUPPORTED;
+        goto Exit;
     }
-    return map->properties->async_query(map, index, async_query_result, async_context);
+
+    result = map->properties->async_query(map, index, async_query_result, async_context);
+
+Exit:
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -222,8 +222,14 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_ring_map_user(
     _In_ ebpf_ring_descriptor_t* ring, _Outptr_ void** consumer, _Outptr_ void** producer, _Outptr_ uint8_t** data)
 {
+    EBPF_LOG_ENTRY();
+    ebpf_result_t result = EBPF_SUCCESS;
+    NTSTATUS status = STATUS_SUCCESS;
+
     if (!ring || !consumer || !producer || !data) {
-        return EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Invalid ring map user arguments");
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
     }
 
     *consumer = NULL;
@@ -232,29 +238,42 @@ ebpf_ring_map_user(
 
     // Check if already mapped.
     if (ring->user_consumer_address != NULL) {
-        return EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Ring already mapped to user mode");
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
     }
 
     __try {
         *consumer =
             MmMapLockedPagesSpecifyCache(ring->user_mdl_consumer, UserMode, MmCached, NULL, FALSE, NormalPagePriority);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
+        status = GetExceptionCode();
         *consumer = NULL;
     }
     if (!*consumer) {
-        return EBPF_INVALID_ARGUMENT;
+        if (NT_SUCCESS(status)) {
+            status = STATUS_NO_MEMORY;
+        }
+        result = EBPF_INVALID_ARGUMENT;
+        EBPF_BAIL_ON_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, MmMapLockedPagesSpecifyCache, status, Exit);
     }
 
+    status = STATUS_SUCCESS;
     __try {
         *producer = MmMapLockedPagesSpecifyCache(
             ring->user_mdl_producer, UserMode, MmCached, NULL, FALSE, NormalPagePriority | MdlMappingNoWrite);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
+        status = GetExceptionCode();
         *producer = NULL;
     }
     if (!*producer) {
         MmUnmapLockedPages(*consumer, ring->user_mdl_consumer);
         *consumer = NULL;
-        return EBPF_INVALID_ARGUMENT;
+        if (NT_SUCCESS(status)) {
+            status = STATUS_NO_MEMORY;
+        }
+        result = EBPF_INVALID_ARGUMENT;
+        EBPF_BAIL_ON_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, MmMapLockedPagesSpecifyCache, status, Exit);
     }
 
     // Capture process reference and addresses for secure unmapping.
@@ -264,7 +283,10 @@ ebpf_ring_map_user(
     ring->user_producer_address = *producer;
 
     *data = (uint8_t*)*producer + PAGE_SIZE;
-    return EBPF_SUCCESS;
+    result = EBPF_SUCCESS;
+
+Exit:
+    EBPF_RETURN_RESULT(result);
 }
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/runtime/kernel/ebpf_platform_kernel.c
+++ b/libs/runtime/kernel/ebpf_platform_kernel.c
@@ -17,6 +17,7 @@ struct _ebpf_ring_descriptor
     void* base_address;
     // User-mode mapping state: captures the process and addresses returned from MmMapLockedPagesSpecifyCache.
     PEPROCESS user_process;
+    uint64_t user_pid;
     void* user_consumer_address;
     void* user_producer_address;
 };
@@ -238,7 +239,8 @@ ebpf_ring_map_user(
 
     // Check if already mapped.
     if (ring->user_consumer_address != NULL) {
-        EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Ring already mapped to user mode");
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Ring already mapped to user mode", ring->user_pid);
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
@@ -279,6 +281,7 @@ ebpf_ring_map_user(
     // Capture process reference and addresses for secure unmapping.
     ring->user_process = PsGetCurrentProcess();
     ObReferenceObject(ring->user_process);
+    ring->user_pid = (uint64_t)(uintptr_t)PsGetCurrentProcessId();
     ring->user_consumer_address = *consumer;
     ring->user_producer_address = *producer;
 

--- a/libs/shared/ebpf_tracelog.h
+++ b/libs/shared/ebpf_tracelog.h
@@ -456,6 +456,62 @@ extern "C"
             TraceLoggingWinError(last_error));                                                     \
     }
 
+#define EBPF_LOG_WIN32_API_FAILURE_WITH_ERROR(keyword, api, error)                                 \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, keyword)) { \
+        TraceLoggingWrite(                                                                         \
+            ebpf_tracelog_provider,                                                                \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                         \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                          \
+            TraceLoggingKeyword((keyword)),                                                        \
+            TraceLoggingString(#api " failed with error", "Message"),                              \
+            TraceLoggingWinError((unsigned long)(error)));                                         \
+    }
+
+#define EBPF_BAIL_ON_ALLOC_FAILURE(allocation, label)                                                     \
+    do {                                                                                                  \
+        if (!(allocation)) {                                                                              \
+            EBPF_LOG_MESSAGE_STRING(                                                                      \
+                EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Allocation failed", #allocation); \
+            goto label;                                                                                   \
+        }                                                                                                 \
+    } while (false)
+
+#define EBPF_BAIL_ON_NTSTATUS_API_FAILURE(keyword, api, status, label)                                 \
+    do {                                                                                               \
+        NTSTATUS local_status = (status);                                                              \
+        if (!NT_SUCCESS(local_status)) {                                                               \
+            if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, 0, (keyword))) {                   \
+                ebpf_log_ntstatus_api_failure((ebpf_tracelog_keyword_t)(keyword), #api, local_status); \
+            }                                                                                          \
+            goto label;                                                                                \
+        }                                                                                              \
+    } while (false)
+
+#define EBPF_BAIL_ON_WIN32_API_FAILURE(keyword, api, error, label)            \
+    do {                                                                      \
+        unsigned long local_error = (unsigned long)(error);                   \
+        if (local_error != 0) {                                               \
+            EBPF_LOG_WIN32_API_FAILURE_WITH_ERROR(keyword, api, local_error); \
+            goto label;                                                       \
+        }                                                                     \
+    } while (false)
+
+#define EBPF_BAIL_ON_OBJECT_REF_ERROR(keyword, result, handle, label)                                        \
+    do {                                                                                                     \
+        ebpf_result_t local_result = (result);                                                               \
+        if (local_result != EBPF_SUCCESS) {                                                                  \
+            if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, (keyword))) { \
+                ebpf_log_message_uint64_uint64(                                                              \
+                    (ebpf_tracelog_level_t)EBPF_TRACELOG_LEVEL_ERROR,                                        \
+                    (ebpf_tracelog_keyword_t)(keyword),                                                      \
+                    "Failed to reference object by handle",                                                  \
+                    (uint64_t)(handle),                                                                      \
+                    (uint64_t)local_result);                                                                 \
+            }                                                                                                \
+            goto label;                                                                                      \
+        }                                                                                                    \
+    } while (false)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description

This PR instruments the `perf_event__new` API, as part of #5437.
This PR adds a few macros in ebpf_tracelog.h that are used in the failure code paths of the above function.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

_If new tests were added:_
N/A

## Documentation

_Is there any documentation impact for this change?_
N/A

## Installation

_Is there any installer impact for this change?_
N/A