### PR TITLE
Interim hot-add-CPU workaround for epoch initialization

### DIFF
--- a/docs/EpochBasedMemoryManagement.md
+++ b/docs/EpochBasedMemoryManagement.md
@@ -103,6 +103,31 @@ using the globally published epoch value (so retirements are never stamped with 
 concurrent reader may have observed), and it becomes eligible for reclamation when `freed_epoch <= released_epoch`,
 where `released_epoch` is computed via the propose/commit epoch computation described below.
 
+### Active vs. potential (hot-add) CPUs
+
+The per-CPU table is sized for the system's *maximum* processor count. On systems where the maximum
+processor count exceeds the set of processors that are actually schedulable at boot (hot-add-capable
+firmware, BIOS-disabled cores, partial processor groups), a per-CPU work queue cannot be created for
+the non-schedulable indices.
+
+As an **interim stopgap** (full hot-add support is tracked separately), `ebpf_epoch_initiate()` no
+longer fails the whole load in this situation. Instead, each per-CPU entry carries an `admitted` flag:
+a CPU is *admitted* only if its work queue was successfully created (i.e., the processor is
+schedulable). CPU 0 is required — if it cannot be admitted, initialization still fails.
+
+Non-admitted CPUs are handled as follows:
+
+- The inter-CPU propose/commit/rundown ring walk skips non-admitted CPUs (it steps to the next
+    admitted CPU, always terminating because CPU 0 is admitted).
+- Any code path that touches a non-admitted CPU's per-CPU state (`ebpf_epoch_enter`,
+    `ebpf_epoch_exit`, free-list insertion, free-list queries) **fails fast** rather than corrupting
+    state.
+
+Because the current CPU of a running thread is always a schedulable (admitted) CPU, this is safe as
+long as the non-admitted (inactive/hot-add) CPUs are never brought online and used. If such a CPU is
+ever used before full hot-add support lands, the fail-fast guards trip instead of silently corrupting
+epoch state.
+
 ## Epoch computation (propose/commit)
 
 Reclamation is driven by an epoch computation cycle that is initiated when there are items

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -66,6 +66,7 @@ typedef __declspec(align(EBPF_CACHE_LINE_SIZE)) struct _ebpf_epoch_cpu_entry
     int timer_armed : 1;                   ///< Set if the flush timer is armed.
     int rundown_in_progress : 1;           ///< Set if rundown is in progress.
     int epoch_computation_in_progress : 1; ///< Set if epoch computation is in progress.
+    int admitted : 1;                      ///< Set if this CPU's message queue was successfully created (schedulable).
     ebpf_timed_work_queue_t* work_queue;   ///< Work queue used to schedule work items.
 } ebpf_epoch_cpu_entry_t;
 
@@ -243,6 +244,49 @@ static _IRQL_requires_(DISPATCH_LEVEL) void _ebpf_epoch_arm_timer_if_needed(ebpf
 static void
 _ebpf_epoch_work_item_callback(_In_ cxplat_preemptible_work_item_t* preemptible_work_item, void* context);
 
+/**
+ * @brief Return the next admitted CPU after cpu_id in the per-CPU ring, wrapping around.
+ * Non-admitted CPUs (whose message queue could not be created at initialization time) are
+ * skipped. Because CPU 0 is always admitted (ebpf_epoch_initiate() fails otherwise), the walk
+ * always terminates. A return value of 0 signals that the ring has been fully traversed.
+ *
+ * @param[in] cpu_id CPU to start the search from.
+ * @return The next admitted CPU index, or 0 if the ring wraps back to the start.
+ */
+static uint32_t
+_ebpf_epoch_get_next_active_cpu(uint32_t cpu_id);
+
+/**
+ * @brief Fail fast if the supplied CPU is out of range or was not admitted at initialization time.
+ * A non-admitted CPU corresponds to a processor that could not be scheduled when the epoch module
+ * was initialized (e.g. an inactive/hot-add-capable slot). Touching its per-CPU state is a bug.
+ *
+ * @param[in] cpu_id CPU to validate.
+ */
+static void
+_ebpf_epoch_fail_fast_if_unadmitted_cpu(uint32_t cpu_id);
+
+static uint32_t
+_ebpf_epoch_get_next_active_cpu(uint32_t cpu_id)
+{
+    uint32_t next = (cpu_id + 1) % _ebpf_epoch_cpu_count;
+    while (next != 0) {
+        if (_ebpf_epoch_cpu_table[next].admitted) {
+            return next;
+        }
+        next = (next + 1) % _ebpf_epoch_cpu_count;
+    }
+    // The ring wrapped back to CPU 0 (which is always admitted). Signal ring completion.
+    return 0;
+}
+
+static void
+_ebpf_epoch_fail_fast_if_unadmitted_cpu(uint32_t cpu_id)
+{
+    EBPF_EPOCH_FAIL_FAST(
+        FAST_FAIL_INVALID_ARG, cpu_id < _ebpf_epoch_cpu_count && _ebpf_epoch_cpu_table[cpu_id].admitted);
+}
+
 _Must_inspect_result_ ebpf_result_t
 ebpf_epoch_initiate()
 {
@@ -277,7 +321,14 @@ ebpf_epoch_initiate()
 
     _ebpf_epoch_published_current_epoch = 1;
 
-    // Initialize the message queue.
+    // Initialize the message queue for each CPU. On systems where the maximum processor count
+    // exceeds the set of processors that are actually schedulable (hot-add-capable firmware,
+    // BIOS-disabled cores, partial processor groups), ebpf_timed_work_queue_create() fails for
+    // the non-schedulable indices. Rather than failing the whole load, admit only the CPUs whose
+    // work queue could be created and mark the rest as not admitted. Non-admitted CPUs are skipped
+    // by the per-CPU ring walk and their per-CPU state must never be touched (fail fast otherwise).
+    // CPU 0 is required: if its work queue cannot be created, initialization fails.
+    uint32_t admitted_count = 0;
     for (uint32_t cpu_id = 0; cpu_id < _ebpf_epoch_cpu_count; cpu_id++) {
         ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
         LARGE_INTEGER interval;
@@ -285,10 +336,44 @@ ebpf_epoch_initiate()
 
         ebpf_result_t result = ebpf_timed_work_queue_create(
             &cpu_entry->work_queue, cpu_id, &interval, _ebpf_epoch_messenger_worker, cpu_entry);
-        if (result != EBPF_SUCCESS) {
+        if (result == EBPF_SUCCESS) {
+            cpu_entry->admitted = true;
+            admitted_count++;
+        } else if (result != EBPF_INVALID_ARGUMENT || cpu_id == 0) {
+            // Only a non-schedulable processor index is tolerated (ebpf_timed_work_queue_create
+            // returns EBPF_INVALID_ARGUMENT when KeGetProcessorNumberFromIndex or
+            // KeSetTargetProcessorDpcEx fails). Any other failure (e.g. EBPF_NO_MEMORY) is a real
+            // error, and CPU 0 is required regardless, so fail initialization.
             return_value = result;
             goto Error;
+        } else {
+            // This CPU is not schedulable. Leave work_queue == NULL and admitted == false, and
+            // continue. As long as this CPU is never brought online and used, everything works;
+            // if it is ever used, the fail-fast guards will trip instead of corrupting state.
+            cpu_entry->admitted = false;
+            EBPF_LOG_MESSAGE_UINT64(
+                EBPF_TRACELOG_LEVEL_WARNING,
+                EBPF_TRACELOG_KEYWORD_EPOCH,
+                "ebpf_epoch_initiate: skipping CPU that could not be admitted",
+                cpu_id);
         }
+    }
+
+    // Emit a summary only when some CPU was not admitted. KeQueryActiveProcessorCountEx is included
+    // for diagnostics only; it is NOT used to gate admission, since the systemwide processor index
+    // space is maximum-based with per-group gaps (schedulable CPUs are sparse in [0, max)).
+    if (admitted_count < _ebpf_epoch_cpu_count) {
+        EBPF_LOG_MESSAGE_UINT64_UINT64(
+            EBPF_TRACELOG_LEVEL_WARNING,
+            EBPF_TRACELOG_KEYWORD_EPOCH,
+            "ebpf_epoch_initiate initialized with a reduced set of admitted CPUs (admitted, max)",
+            admitted_count,
+            _ebpf_epoch_cpu_count);
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_WARNING,
+            EBPF_TRACELOG_KEYWORD_EPOCH,
+            "ebpf_epoch_initiate active processor count (informational)",
+            (uint64_t)KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS));
     }
 
     KeInitializeDpc(&_ebpf_epoch_timer_dpc, _ebpf_epoch_timer_worker, NULL);
@@ -333,9 +418,13 @@ ebpf_epoch_terminate()
 
     for (cpu_id = 0; cpu_id < _ebpf_epoch_cpu_count; cpu_id++) {
         ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
-        // Release all memory that is still in the free list.
-        _ebpf_epoch_release_free_list(cpu_entry, MAXINT64);
-        ebpf_assert(ebpf_list_is_empty(&cpu_entry->free_list));
+        // Non-admitted CPUs never had their free list used (the fail-fast guards prevent it), so
+        // skip releasing it for them. ebpf_timed_work_queue_destroy(NULL) is safe.
+        if (cpu_entry->admitted) {
+            // Release all memory that is still in the free list.
+            _ebpf_epoch_release_free_list(cpu_entry, MAXINT64);
+            ebpf_assert(ebpf_list_is_empty(&cpu_entry->free_list));
+        }
         ebpf_timed_work_queue_destroy(cpu_entry->work_queue);
     }
 
@@ -360,6 +449,8 @@ ebpf_epoch_enter(_Out_ ebpf_epoch_state_t* epoch_state)
     epoch_state->irql_at_enter = ebpf_raise_irql_to_dispatch_if_needed();
     epoch_state->cpu_id = ebpf_get_current_cpu();
 
+    _ebpf_epoch_fail_fast_if_unadmitted_cpu(epoch_state->cpu_id);
+
     ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[epoch_state->cpu_id];
     epoch_state->epoch = _ebpf_epoch_get_published_epoch();
     ebpf_list_insert_tail(&cpu_entry->epoch_state_list, &epoch_state->epoch_list_entry);
@@ -381,6 +472,8 @@ ebpf_epoch_exit(_In_ ebpf_epoch_state_t* epoch_state)
     ebpf_assert(old_irql == epoch_state->irql_at_enter);
 
     uint32_t cpu_id = ebpf_get_current_cpu();
+
+    _ebpf_epoch_fail_fast_if_unadmitted_cpu(cpu_id);
 
     // Special case: Thread has moved to a different CPU since entering the epoch.
     if (cpu_id != epoch_state->cpu_id) {
@@ -577,6 +670,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL) void ebpf_epoch_synchronize()
 bool
 ebpf_epoch_is_free_list_empty(uint32_t cpu_id)
 {
+    _ebpf_epoch_fail_fast_if_unadmitted_cpu(cpu_id);
+
     ebpf_epoch_cpu_message_t message = {0};
 
     message.message_type = EBPF_EPOCH_CPU_MESSAGE_TYPE_IS_FREE_LIST_EMPTY;
@@ -680,6 +775,7 @@ _ebpf_epoch_insert_in_free_list(_In_ ebpf_epoch_allocation_header_t* header)
 {
     KIRQL old_irql = ebpf_raise_irql_to_dispatch_if_needed();
     uint32_t cpu_id = ebpf_get_current_cpu();
+    _ebpf_epoch_fail_fast_if_unadmitted_cpu(cpu_id);
     ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
 
     if (cpu_entry->rundown_in_progress) {
@@ -815,14 +911,12 @@ _ebpf_epoch_messenger_propose_release_epoch(
     // Set the proposed release epoch to the minimum epoch seen so far.
     message->message.propose_epoch.proposed_release_epoch = minimum_epoch;
 
-    // If this is the last CPU, then send a message to the first CPU to commit the release epoch.
-    if (current_cpu == _ebpf_epoch_cpu_count - 1) {
+    // If this is the last admitted CPU (the ring wraps back to CPU 0), send a message to the first
+    // CPU to commit the release epoch. Otherwise forward to the next admitted CPU.
+    next_cpu = _ebpf_epoch_get_next_active_cpu(current_cpu);
+    if (next_cpu == 0) {
         message->message.commit_epoch.released_epoch = minimum_epoch;
         message->message_type = EBPF_EPOCH_CPU_MESSAGE_TYPE_COMMIT_RELEASE_EPOCH;
-        next_cpu = 0;
-    } else {
-        // Send the message to the next CPU.
-        next_cpu = current_cpu + 1;
     }
 
     _ebpf_epoch_send_message_async(message, next_cpu);
@@ -854,13 +948,11 @@ _ebpf_epoch_messenger_commit_release_epoch(
     // Set the released_epoch to the value computed by the EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_RELEASE_EPOCH message.
     cpu_entry->released_epoch = message->message.commit_epoch.released_epoch - 1;
 
-    // If this is the last CPU, send the message to the first CPU to complete the cycle.
-    if (current_cpu != _ebpf_epoch_cpu_count - 1) {
-        // Send the message to the next CPU.
-        next_cpu = current_cpu + 1;
-    } else {
+    // If this is the last admitted CPU (the ring wraps back to CPU 0), send the message to the
+    // first CPU to complete the cycle. Otherwise forward to the next admitted CPU.
+    next_cpu = _ebpf_epoch_get_next_active_cpu(current_cpu);
+    if (next_cpu == 0) {
         message->message_type = EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_EPOCH_COMPLETE;
-        next_cpu = 0;
     }
 
     _ebpf_epoch_send_message_async(message, next_cpu);
@@ -931,15 +1023,12 @@ _ebpf_epoch_messenger_rundown_in_progress(
 {
     uint32_t next_cpu;
     cpu_entry->rundown_in_progress = true;
-    // If this is the last CPU, then stop.
-    if (current_cpu != _ebpf_epoch_cpu_count - 1) {
-        // Send the message to the next CPU.
-        next_cpu = current_cpu + 1;
-    } else {
+    // If this is the last admitted CPU (the ring wraps back to CPU 0), then stop. Otherwise forward
+    // to the next admitted CPU.
+    next_cpu = _ebpf_epoch_get_next_active_cpu(current_cpu);
+    if (next_cpu == 0) {
         // Signal the caller that rundown is complete.
         KeSetEvent(&message->completion_event, 0, FALSE);
-        // Set next_cpu to UINT32_MAX to make code analysis happy.
-        next_cpu = UINT32_MAX;
         return;
     }
 
@@ -1042,6 +1131,10 @@ _IRQL_requires_max_(APC_LEVEL) static void _ebpf_epoch_send_message_and_wait(
 static void
 _ebpf_epoch_send_message_async(_In_ ebpf_epoch_cpu_message_t* message, uint32_t cpu_id)
 {
+    // Async messages are only ever routed through the admitted-CPU ring, so the target is always
+    // admitted (and therefore has a valid work queue). Assert this defensively.
+    ebpf_assert(_ebpf_epoch_cpu_table[cpu_id].admitted);
+
     // Queue the message to the specified CPU.
     ebpf_timed_work_queue_insert(
         _ebpf_epoch_cpu_table[cpu_id].work_queue, &message->list_entry, message->wake_behavior);

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -54,8 +54,16 @@ _ebpf_epoch_get_published_epoch()
 #pragma warning(disable : 4324) // Structure was padded due to alignment specifier.
 /**
  * @brief Per-CPU state.
- * Each entry is only accessed by the CPU that owns it and only at IRQL >= DISPATCH_LEVEL.
- * This ensures that no locks are required to access the per CPU state.
+ * During steady-state operation, each entry's mutable state (epoch state list, free list, epoch
+ * counters, and the timer_armed / rundown_in_progress / epoch_computation_in_progress flags) is
+ * accessed only by the owning CPU at IRQL >= DISPATCH_LEVEL, so no locks are required for it.
+ * The admitted and work_queue fields are the exception: they are set once during
+ * ebpf_epoch_initiate() and never modified afterward, and are read by other CPUs while routing
+ * inter-CPU messages (admitted while walking the active-CPU ring; work_queue when queuing to the
+ * target CPU). Because both are established before any CPU processes an epoch message and are
+ * immutable thereafter, those cross-CPU reads observe a stable value without locking.
+ * Initialization and rundown/teardown also touch entries across all CPUs while no owner CPU is
+ * concurrently running.
  */
 typedef __declspec(align(EBPF_CACHE_LINE_SIZE)) struct _ebpf_epoch_cpu_entry
 {
@@ -315,6 +323,8 @@ ebpf_epoch_initiate()
     for (uint32_t cpu_id = 0; cpu_id < _ebpf_epoch_cpu_count; cpu_id++) {
         ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
         cpu_entry->current_epoch = 1;
+        cpu_entry->work_queue = NULL; // Unadmitted CPUs must have a NULL work queue.
+        cpu_entry->admitted = false;  // Explicit default; set true on successful admission below.
         ebpf_list_initialize(&cpu_entry->epoch_state_list);
         ebpf_list_initialize(&cpu_entry->free_list);
     }


### PR DESCRIPTION
## Description

On systems where `KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS)` exceeds the set of
processors that are actually schedulable at boot (hot-add-capable firmware, BIOS-disabled cores,
partial processor groups), `ebpf_epoch_initiate()` sizes its per-CPU table to the maximum and
creates a per-CPU message queue for every index. Work-queue creation fails at
`KeGetProcessorNumberFromIndex` / `KeSetTargetProcessorDpcEx` for the non-schedulable indices,
which previously aborted driver load entirely (status 87).

This is an **interim workaround** (full hot-add support is a separate follow-up) so that driver
load no longer fails when some CPUs cannot be set up:

- Add an `admitted` flag to each per-CPU epoch entry. A CPU is admitted only if its work queue was
  created (i.e. it is schedulable).
- `ebpf_epoch_initiate()` now continues past a CPU whose work queue cannot be created, leaving it
  unadmitted with a `NULL` work queue. Only a non-schedulable-index failure
  (`EBPF_INVALID_ARGUMENT`) is tolerated; any other failure (e.g. `EBPF_NO_MEMORY`) still fails
  initialization. **CPU 0 is still required**: if it cannot be admitted, initiation fails.
- The inter-CPU propose/commit/rundown ring walk skips unadmitted CPUs via
  `_ebpf_epoch_get_next_active_cpu()`, which terminates because CPU 0 is always admitted.
- Code that touches per-CPU epoch state fails fast if the CPU is not admitted (`ebpf_epoch_enter`,
  `ebpf_epoch_exit`, `_ebpf_epoch_insert_in_free_list`, `ebpf_epoch_is_free_list_empty`), and
  `ebpf_epoch_terminate` skips releasing the free list for unadmitted entries.
- Emit a diagnostic WARNING (silent on normal boots) when some CPU is not admitted.

As long as the unadmitted (inactive/hot-add) CPUs are never brought online and used, everything
works; if such a CPU is ever used, the code fails fast instead of corrupting state. The safety
invariant is that a running thread''s current CPU (`KeGetCurrentProcessorIndex`, same systemwide
index domain as the table) is always an admitted/schedulable CPU, so unadmitted CPUs'' per-CPU
lists stay empty.

Fixes #3768

## Testing

Existing epoch platform tests cover non-regression for the all-admitted configuration:
`unit_tests.exe "[platform]"` -> 30 test cases / 5530 assertions pass. Builds clean for both the
kernel driver (ebpfcore) and the user-mode unit tests.

No new tests are added in this change. Exercising the reduced/gap admission path requires a usersim
seam that fails index-resolution / DPC-targeting for inactive indices, which is not yet available on
usersim `main`; unit tests for that path are a deferred follow-up.

- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

`docs/EpochBasedMemoryManagement.md` gains an "Active vs. potential (hot-add) CPU" note describing
the interim behavior and fail-fast, marked as a stopgap pending full hot-add support.

## Installation

No installer impact.
