### PR TITLE
Gate EverParse generation behind opt-in build property

### DIFF
--- a/libs/elf_spec/elf_spec.vcxproj
+++ b/libs/elf_spec/elf_spec.vcxproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <CustomBuild Include="Elf.3d">
       <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(RunEverParseGeneration)' != 'true'">true</ExcludedFromBuild>
       <Command>
        if not exist "$(ProjectDir)generated" mkdir "$(ProjectDir)generated"
        pushd "$(ProjectDir)generated"

--- a/libs/ioctl_spec/ioctl_spec.vcxproj
+++ b/libs/ioctl_spec/ioctl_spec.vcxproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <CustomBuild Include="EbpfProtocol.3d">
       <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(RunEverParseGeneration)' != 'true'">true</ExcludedFromBuild>
       <Command>
          if not exist "$(ProjectDir)generated" mkdir "$(ProjectDir)generated"
          pushd "$(ProjectDir)generated"

--- a/scripts/validate_everparse_generation.ps1
+++ b/scripts/validate_everparse_generation.ps1
@@ -196,6 +196,7 @@ try {
                 "/p:Configuration=$Configuration",
                 "/p:Platform=$Platform",
                 "/p:HostPlatform=$Platform",
+                "/p:RunEverParseGeneration=true",
                 "/p:SolutionDir=$solution_dir",
                 $unit.project
             )


### PR DESCRIPTION
## Description

Gate EverParse generation behind an opt-in MSBuild property so normal solution builds continue to consume the committed generated files by default.

This change:
- adds `ExcludedFromBuild` to the EverParse custom build items in `libs\elf_spec\elf_spec.vcxproj` and `libs\ioctl_spec\ioctl_spec.vcxproj`, controlled by `/p:RunEverParseGeneration=true`
- updates `scripts\validate_everparse_generation.ps1` to pass `/p:RunEverParseGeneration=true` when it needs authoritative regeneration

Resolves #5461

## Testing

Validated both intended behaviors:
- a normal `Debug|x64` build does not regenerate EverParse outputs even when the `.3d` inputs are newer
- `scripts\validate_everparse_generation.ps1` does regenerate the EverParse outputs when invoked with the opt-in property

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

No documentation impact.

## Installation

No installer impact.
