### PR TITLE
Run-Test.ps1: fix ProcDump crash monitor to attach, and fail the run if it can't start

### DIFF
--- a/scripts/Run-Test.ps1
+++ b/scripts/Run-Test.ps1
@@ -6,6 +6,10 @@
 # is captured using the procdump tool from Sysinternals. The dump is saved to
 # the <output folder> with the name of the test executable and the current date
 # and time.
+#
+# While the test runs, a ProcDump monitor is attached to capture a dump if the
+# test process crashes. If that monitor cannot start, the run is failed so the
+# loss of crash coverage is not silently ignored.
 
 # Modifying $args directly can cause issues, so copy it to a new variable.
 $arguments = $args
@@ -46,6 +50,7 @@ $process.Start() | Out-Null
 # If ProcDump is available (installed by CI when dump collection is enabled), start it as a background
 # monitor so crashes that don't produce WER dumps still generate a dump file.
 $procdump_process = $null
+$procdump_monitor_failed = $false
 $procdump_command = Get-Command procdump.exe -ErrorAction SilentlyContinue
 if ($null -eq $procdump_command) {
     $procdump_command = Get-Command procdump -ErrorAction SilentlyContinue
@@ -64,7 +69,20 @@ if ($enable_procdump_monitor) {
     try {
         $procdump_process = Start-Process -NoNewWindow -PassThru -FilePath $procdump_command.Source -ArgumentList $procdump_args
     } catch {
-        Write-Output "Failed to start ProcDump monitor: $($_.Exception.Message)"
+        Write-Output "ERROR: Failed to start ProcDump monitor: $($_.Exception.Message)"
+        $procdump_monitor_failed = $true
+    }
+
+    # Confirm the monitor actually attached. ProcDump is expected to keep running
+    # for the lifetime of the test process. If it exits during a short startup
+    # window while the test process is still running, it failed to attach (for
+    # example due to a bad argument) and would silently provide no crash coverage.
+    if ($null -ne $procdump_process) {
+        $procdump_startup_window_ms = 3000
+        if ($procdump_process.WaitForExit($procdump_startup_window_ms) -and !$process.HasExited) {
+            Write-Output "ERROR: ProcDump monitor exited during startup while the test process (PID $($process.Id)) was still running; it failed to attach."
+            $procdump_monitor_failed = $true
+        }
     }
 }
 
@@ -116,6 +134,13 @@ if ($process.ExitCode -ne 0) {
         }
     } else {
         Write-Output "No dump files found in $OutputFolder"
+    }
+}
+
+if ($enable_procdump_monitor -and $procdump_monitor_failed) {
+    Write-Output "ERROR: The ProcDump crash-dump monitor failed to start; failing the test run so the regression is not silently ignored."
+    if ($process.ExitCode -eq 0) {
+        exit 1
     }
 }
 

--- a/scripts/Run-Test.ps1
+++ b/scripts/Run-Test.ps1
@@ -59,7 +59,7 @@ if ($enable_procdump_monitor) {
     } else {
         $procdump_args += @('-e')
     }
-    $procdump_args += @('-x', $OutputFolder, $process.Id)
+    $procdump_args += @($process.Id, ($OutputFolder -replace '/', '\'))
     Write-Output "Starting ProcDump monitor: $($procdump_command.Source) $($procdump_args -join ' ')"
     try {
         $procdump_process = Start-Process -NoNewWindow -PassThru -FilePath $procdump_command.Source -ArgumentList $procdump_args


### PR DESCRIPTION
## Description

Fixes #5465.

The ProcDump crash-dump monitor started by `scripts/Run-Test.ps1` was invoked with `-x <dump-folder> <pid>`. ProcDump's `-x` switch launches a new image, so ProcDump treated the PID as an image name, failed to find it, and exited immediately without attaching. The monitor therefore never ran, and its failure was never surfaced.

This PR:
- **Fixes the invocation** so ProcDump attaches to the already-running test process and writes any crash dump to the run's dump folder (`-ma -e <pid> <folder>`), matching the form already used by this script's timeout-capture path.
- **Surfaces a monitor start failure** so it can no longer go unnoticed: after starting ProcDump, the script confirms the monitor stays alive while the test process is running; if it exits during a short startup window while the test is still running, the run is failed (overriding an otherwise-passing exit code). ProcDump's exit code is not used for this, because it returns the same value for a healthy "no dump needed" run and a failed launch.

## Testing

No existing automated tests cover this helper script; it is exercised by the existing CI test jobs. Validated manually with ProcDump v12.01 (the version pinned by CI):
- The corrected invocation attaches to a live test process and keeps monitoring it; a clean run produces no dump and passes (exit 0).
- The previous `-x` form was confirmed to exit immediately without attaching.
- A run whose monitor fails to start now exits non-zero with a clear error message, even when the test itself passes.

- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

No new automated tests are added — the change is to a CI helper script covered by existing CI jobs.

## Documentation

None. (A short comment was added to the script describing the monitor and the fail-on-start-failure behavior.)

## Installation

None.
