### PR TITLE
Fix default verdict of `net_ebpf_extension_sock_addr_authorize_connection_classify()` when no BPF program is attached

### DIFF
--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -2491,6 +2491,7 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
             EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "net_ebpf_extension_sock_addr_authorize_connection_classify - Client detach detected.",
             STATUS_INVALID_PARAMETER);
+        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED_SOFT;
         goto Exit;
     }
 


### PR DESCRIPTION
## Description

When sock_addr BPF program has detached, but the WFP filter is still not deleted, `net_ebpf_extension_sock_addr_authorize_connection_classify()` can still be invoked. In such a case, since the BPF program is no longer attached, netebpfext should not block the connection. 

**Fix**
This PR changes the default verdict to `BPF_SOCK_ADDR_VERDICT_PROCEED_SOFT` when the BPF program is detaching.

## Testing
Existing CICD

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

No

## Installation

No
