### PR TITLE
Fix default verdict of `ebpf_extension_sock_addr_authorize_connection_classify()` when no BPF program is attached

### DIFF
--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -2491,6 +2491,7 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
             EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "net_ebpf_extension_sock_addr_authorize_connection_classify - Client detach detected.",
             STATUS_INVALID_PARAMETER);
+        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED_SOFT;
         goto Exit;
     }
 


### PR DESCRIPTION
Backport of #5467 to release/1.4.

## Summary
- set the default verdict to \\BPF_SOCK_ADDR_VERDICT_PROCEED_SOFT\\ when client detach is detected in `ebpf_extension_sock_addr_authorize_connection_classify()`
- preserve the no-program-attached behavior on the release branch