### PR TITLE
Release v1.4.1 version bump

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   <PropertyGroup Label="Version">
     <EbpfVersion_Major>1</EbpfVersion_Major>
     <EbpfVersion_Minor>4</EbpfVersion_Minor>
-    <EbpfVersion_Revision>0</EbpfVersion_Revision>
+    <EbpfVersion_Revision>1</EbpfVersion_Revision>
     <EbpfVersion_Modifier/>
     <EbpfVersionNoModifier>$(EbpfVersion_Major).$(EbpfVersion_Minor).$(EbpfVersion_Revision)</EbpfVersionNoModifier>
     <EbpfVersion Condition="'$(EbpfVersion_Modifier)' == ''">$(EbpfVersion_Major).$(EbpfVersion_Minor).$(EbpfVersion_Revision)</EbpfVersion>

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_dll.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_dll.c
@@ -237,7 +237,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_raw.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_raw.c
@@ -207,7 +207,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_sys.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_sys.c
@@ -362,7 +362,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -208,7 +208,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -178,7 +178,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -333,7 +333,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -200,7 +200,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -170,7 +170,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -325,7 +325,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bind_policy_dll.c
+++ b/tests/bpf2c_tests/expected/bind_policy_dll.c
@@ -573,7 +573,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bind_policy_raw.c
+++ b/tests/bpf2c_tests/expected/bind_policy_raw.c
@@ -543,7 +543,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bind_policy_sys.c
+++ b/tests/bpf2c_tests/expected/bind_policy_sys.c
@@ -698,7 +698,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
@@ -524,7 +524,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
@@ -494,7 +494,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
@@ -649,7 +649,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -603,7 +603,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -6252,7 +6252,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -6222,7 +6222,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -6377,7 +6377,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_dll.c
@@ -215,7 +215,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_raw.c
@@ -185,7 +185,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_sys.c
@@ -340,7 +340,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -573,7 +573,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -206,7 +206,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -176,7 +176,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -331,7 +331,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -728,7 +728,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -859,7 +859,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -829,7 +829,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -984,7 +984,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
@@ -283,7 +283,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
@@ -253,7 +253,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
@@ -408,7 +408,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -198,7 +198,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -168,7 +168,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -323,7 +323,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -127,7 +127,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -97,7 +97,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -252,7 +252,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
@@ -803,7 +803,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
@@ -773,7 +773,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
@@ -928,7 +928,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_dll.c
@@ -277,7 +277,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_raw.c
@@ -247,7 +247,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_sys.c
@@ -402,7 +402,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_dll.c
@@ -262,7 +262,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_raw.c
@@ -232,7 +232,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_sys.c
@@ -387,7 +387,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -265,7 +265,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
@@ -235,7 +235,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
@@ -390,7 +390,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -265,7 +265,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
@@ -235,7 +235,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
@@ -390,7 +390,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -202,7 +202,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
@@ -172,7 +172,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
@@ -327,7 +327,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -202,7 +202,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
@@ -172,7 +172,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
@@ -327,7 +327,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -1309,7 +1309,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -1279,7 +1279,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -1434,7 +1434,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_dll.c
@@ -329,7 +329,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_raw.c
@@ -299,7 +299,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_sys.c
@@ -454,7 +454,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -1583,7 +1583,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_dll.c
@@ -2448,7 +2448,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_raw.c
@@ -2418,7 +2418,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_sys.c
@@ -2573,7 +2573,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -1553,7 +1553,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -1708,7 +1708,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/custom_map_basic_dll.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_dll.c
@@ -2266,7 +2266,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/custom_map_basic_raw.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_raw.c
@@ -2236,7 +2236,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/custom_map_basic_sys.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_sys.c
@@ -2391,7 +2391,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/custom_map_invalid_dll.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_dll.c
@@ -205,7 +205,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/custom_map_invalid_raw.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_raw.c
@@ -175,7 +175,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/custom_map_invalid_sys.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_sys.c
@@ -330,7 +330,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -215,7 +215,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -185,7 +185,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -340,7 +340,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -380,7 +380,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -350,7 +350,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -505,7 +505,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
@@ -254,7 +254,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
@@ -224,7 +224,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
@@ -379,7 +379,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/global_vars_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_dll.c
@@ -261,7 +261,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/global_vars_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_raw.c
@@ -231,7 +231,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/global_vars_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_sys.c
@@ -386,7 +386,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -243,7 +243,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/hash_of_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_raw.c
@@ -213,7 +213,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/hash_of_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_sys.c
@@ -368,7 +368,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -351,7 +351,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/inner_map_raw.c
+++ b/tests/bpf2c_tests/expected/inner_map_raw.c
@@ -321,7 +321,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/inner_map_sys.c
+++ b/tests/bpf2c_tests/expected/inner_map_sys.c
@@ -476,7 +476,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/lru_map_test_dll.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_dll.c
@@ -264,7 +264,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/lru_map_test_raw.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_raw.c
@@ -234,7 +234,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/lru_map_test_sys.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_sys.c
@@ -389,7 +389,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
@@ -294,7 +294,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
@@ -264,7 +264,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
@@ -419,7 +419,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -5110,7 +5110,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -243,7 +243,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
@@ -213,7 +213,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
@@ -368,7 +368,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -243,7 +243,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
@@ -213,7 +213,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
@@ -368,7 +368,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -243,7 +243,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
@@ -213,7 +213,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
@@ -368,7 +368,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -5080,7 +5080,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -302,7 +302,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -272,7 +272,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -427,7 +427,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -302,7 +302,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -272,7 +272,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -427,7 +427,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_dll.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_dll.c
@@ -263,7 +263,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_raw.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_raw.c
@@ -233,7 +233,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_sys.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_sys.c
@@ -388,7 +388,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_synchronized_update_dll.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_dll.c
@@ -329,7 +329,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_synchronized_update_raw.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_raw.c
@@ -299,7 +299,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_synchronized_update_sys.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_sys.c
@@ -454,7 +454,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -5235,7 +5235,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_dll.c
@@ -178,7 +178,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_raw.c
@@ -148,7 +148,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_sys.c
@@ -303,7 +303,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/multiple_programs_dll.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_dll.c
@@ -280,7 +280,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/multiple_programs_raw.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_raw.c
@@ -250,7 +250,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/multiple_programs_sys.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_sys.c
@@ -405,7 +405,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/perf_event_burst_dll.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_dll.c
@@ -321,7 +321,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/perf_event_burst_raw.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_raw.c
@@ -291,7 +291,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/perf_event_burst_sys.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_sys.c
@@ -446,7 +446,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_dll.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_dll.c
@@ -217,7 +217,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_raw.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_raw.c
@@ -187,7 +187,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_sys.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_sys.c
@@ -342,7 +342,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -280,7 +280,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -250,7 +250,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -405,7 +405,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -628,7 +628,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -527,7 +527,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -497,7 +497,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -652,7 +652,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -598,7 +598,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -753,7 +753,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/process_start_key_dll.c
+++ b/tests/bpf2c_tests/expected/process_start_key_dll.c
@@ -369,7 +369,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/process_start_key_raw.c
+++ b/tests/bpf2c_tests/expected/process_start_key_raw.c
@@ -339,7 +339,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/process_start_key_sys.c
+++ b/tests/bpf2c_tests/expected/process_start_key_sys.c
@@ -494,7 +494,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -747,7 +747,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_flow_id_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_dll.c
@@ -880,7 +880,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_flow_id_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_raw.c
@@ -850,7 +850,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_flow_id_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_sys.c
@@ -1005,7 +1005,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -717,7 +717,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -872,7 +872,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/strings_dll.c
+++ b/tests/bpf2c_tests/expected/strings_dll.c
@@ -483,7 +483,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/strings_raw.c
+++ b/tests/bpf2c_tests/expected/strings_raw.c
@@ -453,7 +453,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/strings_sys.c
+++ b/tests/bpf2c_tests/expected/strings_sys.c
@@ -608,7 +608,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -311,7 +311,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -281,7 +281,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -436,7 +436,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -306,7 +306,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -283,7 +283,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -253,7 +253,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -408,7 +408,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -7835,7 +7835,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
@@ -7805,7 +7805,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
@@ -7960,7 +7960,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -318,7 +318,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -288,7 +288,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -443,7 +443,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -276,7 +276,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -312,7 +312,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
@@ -282,7 +282,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
@@ -437,7 +437,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
@@ -364,7 +364,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
@@ -334,7 +334,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
@@ -489,7 +489,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -7487,7 +7487,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
@@ -7457,7 +7457,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
@@ -7612,7 +7612,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 #pragma data_seg(push, "map_initial_values")

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -431,7 +431,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -348,7 +348,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -318,7 +318,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -473,7 +473,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
@@ -420,7 +420,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
@@ -390,7 +390,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
@@ -545,7 +545,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_dll.c
@@ -190,7 +190,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_raw.c
@@ -160,7 +160,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_sys.c
@@ -315,7 +315,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_dll.c
@@ -205,7 +205,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_raw.c
@@ -175,7 +175,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_sys.c
@@ -330,7 +330,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -352,7 +352,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -322,7 +322,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -477,7 +477,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/thread_start_time_dll.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_dll.c
@@ -363,7 +363,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/thread_start_time_raw.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_raw.c
@@ -333,7 +333,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/thread_start_time_sys.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_sys.c
@@ -488,7 +488,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -555,7 +555,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/utility_raw.c
+++ b/tests/bpf2c_tests/expected/utility_raw.c
@@ -525,7 +525,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/utility_sys.c
+++ b/tests/bpf2c_tests/expected/utility_sys.c
@@ -680,7 +680,7 @@ _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
     version->minor = 4;
-    version->revision = 0;
+    version->revision = 1;
 }
 
 static void

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 1, "minor": 4, "patch": 0 }
+{ "major": 1, "minor": 4, "patch": 1 }


### PR DESCRIPTION
## Release v1.4.1

Bump version number for v1.4.1 patch release.

### Changes
- **Update version to 1.4.1** — bumped `version.json` and `Directory.Build.props`; regenerated bpf2c expected output (version revision only).
