### PR TITLE
netebpfext: recover leaked WFP filter references on delete failure and fix unload hang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 	fetchRecurseSubmodules = no
 [submodule "external/usersim"]
 	path = external/usersim
-	url = https://github.com/microsoft/usersim.git
+	url = https://github.com/mikeagun/usersim.git
 [submodule "external/ebpf-extension-common"]
 	path = external/ebpf-extension-common
 	url =  https://github.com/microsoft/ebpf-extension-common.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 	fetchRecurseSubmodules = no
 [submodule "external/usersim"]
 	path = external/usersim
-	url = https://github.com/mikeagun/usersim.git
+	url = https://github.com/microsoft/usersim.git
 [submodule "external/ebpf-extension-common"]
 	path = external/ebpf-extension-common
 	url =  https://github.com/microsoft/ebpf-extension-common.git

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -49,7 +49,7 @@ static net_ebpf_ext_sublayer_info_t _net_ebpf_ext_sublayers[] = {
      SUBLAYER_WEIGHT_MAXIMUM}};
 
 // Global object used to store state for cleanup.
-static net_ebpf_extension_wfp_cleanup_state_t _net_ebpf_ext_wfp_cleanup_state = {0};
+static net_ebpf_extension_cleanup_state_t _net_ebpf_ext_cleanup_state = {0};
 
 // Bounded inline retry for a transient FwpmFilterDeleteById failure: up to this many attempts (initial + retries).
 #define NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS 3
@@ -58,8 +58,8 @@ static net_ebpf_extension_wfp_cleanup_state_t _net_ebpf_ext_wfp_cleanup_state = 
 static void
 _net_ebpf_ext_flow_delete(uint16_t layer_id, uint32_t callout_id, uint64_t flow_context);
 
-_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filter(
-    _In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts, _Out_opt_ NTSTATUS* last_failed_status);
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS
+    _net_ebpf_ext_try_delete_wfp_filter(_In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts);
 
 NTSTATUS
 net_ebpf_ext_filter_change_notify(
@@ -456,9 +456,8 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
         // A successful delete synchronously invokes net_ebpf_ext_filter_change_notify, which transitions the
         // filter to DELETED and releases the per-filter reference. FWP_E_FILTER_NOT_FOUND is treated as success
         // by the helper (the filter is already gone; its notification either already fired or will not fire).
-        NTSTATUS last_failed_status = STATUS_SUCCESS;
         status = _net_ebpf_ext_try_delete_wfp_filter(
-            wfp_engine_handle, filter_ids[index].id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS, &last_failed_status);
+            wfp_engine_handle, filter_ids[index].id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS);
         filter_ids[index].error_code = status;
         if (!NT_SUCCESS(status)) {
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
@@ -474,15 +473,6 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
                 filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETE_FAILED;
             }
             ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
-        } else if (last_failed_status != STATUS_SUCCESS) {
-            // Delete succeeded after an earlier attempt failed (a transient BFE outage the inline retry recovered).
-            // Log once per filter with the last failed status.
-            EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
-                EBPF_EXT_TRACELOG_LEVEL_INFO,
-                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "FwpmFilterDeleteById recovered after one or more transient failures.",
-                (uint64_t)last_failed_status,
-                filter_ids[index].id);
         } else {
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                 EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
@@ -496,11 +486,13 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
     EBPF_EXT_LOG_EXIT();
 }
 
-_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filter(
-    _In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts, _Out_opt_ NTSTATUS* last_failed_status)
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS
+    _net_ebpf_ext_try_delete_wfp_filter(_In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts)
 {
     NTSTATUS status = STATUS_UNSUCCESSFUL;
     NTSTATUS most_recent_failed_status = STATUS_SUCCESS;
+
+    EBPF_EXT_LOG_ENTRY();
 
     for (uint32_t attempt = 1; attempt <= max_attempts; attempt++) {
         status = FwpmFilterDeleteById(wfp_engine_handle, filter_id);
@@ -511,7 +503,7 @@ _IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filt
             break;
         }
 
-        // Remember the last failing status for the caller's one-per-filter recovered-delete log.
+        // Remember the last failing status for the one-per-filter recovered-delete log below.
         most_recent_failed_status = status;
 
         if (attempt < max_attempts) {
@@ -525,10 +517,18 @@ _IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filt
         }
     }
 
-    if (last_failed_status != NULL) {
-        *last_failed_status = most_recent_failed_status;
+    if (NT_SUCCESS(status) && most_recent_failed_status != STATUS_SUCCESS) {
+        // Delete succeeded after an earlier attempt failed (a transient BFE outage the inline retry recovered).
+        // Log once per filter with the last failed status.
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
+            EBPF_EXT_TRACELOG_LEVEL_INFO,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "FwpmFilterDeleteById recovered after one or more transient failures.",
+            (uint64_t)most_recent_failed_status,
+            filter_id);
     }
-    return status;
+
+    EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
 #pragma warning(suppress : 6386) // filter_ids receives a separately allocated buffer sized for filter_count entries.
@@ -808,9 +808,9 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
         goto Exit;
     }
 
-    InitializeListHead(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list);
-    InitializeListHead(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list);
-    KeInitializeEvent(&_net_ebpf_ext_wfp_cleanup_state.wfp_filter_cleanup_event, NotificationEvent, FALSE);
+    InitializeListHead(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list);
+    InitializeListHead(&_net_ebpf_ext_cleanup_state.filter_cleanup_list);
+    KeInitializeEvent(&_net_ebpf_ext_cleanup_state.wfp_filter_cleanup_event, NotificationEvent, FALSE);
 
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &_fwp_engine_handle);
     EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineOpen", status);
@@ -886,29 +886,32 @@ Exit:
 //
 // Runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
 // deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling rawContext across a reload). Unregistering
-// the callouts first normally keeps a classify/notify from racing this sweep; if a callout could not be
-// unregistered, a successful delete here can still fire the notify, so each context is pinned across its per-filter
-// processing to stay safe.
+// the callouts first normally keeps a classify/notify from racing this sweep; if FwpsCalloutUnregisterById failed
+// for a callout (e.g. STATUS_DEVICE_BUSY while a classify/notify is still in flight), a successful delete here can
+// still fire the notify, so each context is pinned across its per-filter processing to stay safe.
 static void
 _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
 {
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+    EBPF_EXT_LOG_ENTRY();
 
-    while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+
+    while (!IsListEmpty(&_net_ebpf_ext_cleanup_state.filter_cleanup_list)) {
         uint32_t release_count = 0;
-        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list);
+        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_cleanup_state.filter_cleanup_list);
         net_ebpf_extension_wfp_filter_context_t* filter_context =
             CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
         InitializeListHead(&filter_context->link);
 
-        // Pin the context for the duration of this sweep entry. If a callout could not be unregistered, a
-        // successful FwpmFilterDeleteById below can synchronously fire the delete notification, which releases the
-        // per-filter reference; the pin guarantees the context is not freed out from under the rest of this loop.
+        // Pin the context for the duration of this sweep entry. If FwpsCalloutUnregisterById failed for a callout
+        // (e.g. STATUS_DEVICE_BUSY while a classify/notify is still in flight), a successful FwpmFilterDeleteById
+        // below can synchronously fire the delete notification, which releases the per-filter reference; the pin
+        // guarantees the context is not freed out from under the rest of this loop.
         REFERENCE_FILTER_CONTEXT(filter_context);
 
         // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
         // DEREFERENCE_FILTER_CONTEXT re-acquires this lock.
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+        ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 
 #pragma warning(push)
 #pragma warning(disable : 6001) // Using uninitialized memory 'filter_id'. filter_ids is initialized by add_wfp_filters.
@@ -928,7 +931,7 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
             // Best-effort removal of the (possibly still live) WFP filter so it cannot outlive the filter context
             // it points at. A DELETING filter is already gone (returns FWP_E_FILTER_NOT_FOUND, treated as success).
             (void)_net_ebpf_ext_try_delete_wfp_filter(
-                filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS, NULL);
+                filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS);
 
             // Claim any non-DELETED reference under the lock (an ADDED filter whose external notification never
             // fired still holds it). If a notification races, whichever path reaches DELETED first releases once.
@@ -946,8 +949,8 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
         }
 #pragma warning(pop)
 
-        // If a callout could not be unregistered, release the references anyway so provider rundown does not hang,
-        // but flag it loudly.
+        // If FwpsCalloutUnregisterById failed for a callout, release the references anyway so provider rundown does
+        // not hang, but flag it loudly.
         if (!all_callouts_unregistered && release_count > 0) {
             EBPF_EXT_LOG_MESSAGE(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
@@ -967,10 +970,12 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
 #pragma warning(suppress : 6001) // filter_context is a live list entry pinned above; the loop cannot free it.
         DEREFERENCE_FILTER_CONTEXT(filter_context);
 
-        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
     }
 
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
+
+    EBPF_EXT_LOG_EXIT();
 }
 
 void
@@ -1080,23 +1085,31 @@ net_ebpf_extension_uninitialize_wfp_components(void)
         }
     }
 
+    EBPF_EXT_LOG_EXIT();
+}
+
+void
+net_ebpf_ext_wait_for_provider_context_rundown(void)
+{
+    EBPF_EXT_LOG_ENTRY();
+
     // Iterate through the provider list and handle cleanup.
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-    while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list)) {
-        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list);
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+    while (!IsListEmpty(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list)) {
+        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list);
         net_ebpf_extension_hook_provider_t* provider_context =
             CONTAINING_RECORD(entry, net_ebpf_extension_hook_provider_t, cleanup_list_entry);
 
         // Release the lock as waiting for rundown can take time.
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+        ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
         ebpf_ext_wait_for_rundown(&provider_context->rundown);
         ExFreePool(provider_context);
 
         // Re-acquire the lock.
-        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
     }
 
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 
     EBPF_EXT_LOG_EXIT();
 }
@@ -1305,31 +1318,30 @@ Exit:
 void
 net_ebpf_ext_add_provider_context_to_cleanup_list(_Inout_ net_ebpf_extension_hook_provider_t* provider_context)
 {
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-    InsertTailList(
-        &_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list, &provider_context->cleanup_list_entry);
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+    InsertTailList(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list, &provider_context->cleanup_list_entry);
+    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 }
 
 void
 net_ebpf_ext_add_filter_context_to_cleanup_list(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-    InsertTailList(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list, &filter_context->link);
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+    InsertTailList(&_net_ebpf_ext_cleanup_state.filter_cleanup_list, &filter_context->link);
+    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 }
 
 void
 net_ebpf_ext_remove_filter_context_from_cleanup_list(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     if (!IsListEmpty(&filter_context->link)) {
-        KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+        KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
         RemoveEntryList(&filter_context->link);
         InitializeListHead(&filter_context->link);
-        if (IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list) &&
-            _net_ebpf_ext_wfp_cleanup_state.signal_empty_filter_list) {
-            KeSetEvent(&_net_ebpf_ext_wfp_cleanup_state.wfp_filter_cleanup_event, 0, FALSE);
+        if (IsListEmpty(&_net_ebpf_ext_cleanup_state.filter_cleanup_list) &&
+            _net_ebpf_ext_cleanup_state.signal_empty_filter_list) {
+            KeSetEvent(&_net_ebpf_ext_cleanup_state.wfp_filter_cleanup_event, 0, FALSE);
         }
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+        ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
     }
 }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -312,6 +312,7 @@ net_ebpf_extension_wfp_filter_context_create(
     local_filter_context->client_context_count_max = client_context_count_max;
     local_filter_context->context_deleting = FALSE;
     InitializeListHead(&local_filter_context->link);
+    InitializeListHead(&local_filter_context->zombie_link);
     local_filter_context->reference_count = 1; // Initial reference.
 
     // Set the first client context.
@@ -345,15 +346,28 @@ Exit:
 }
 
 void
-net_ebpf_extension_wfp_filter_context_cleanup(_Frees_ptr_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+net_ebpf_extension_wfp_filter_context_detach(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     // Since the hook client is detaching, the eBPF program should not be invoked any further.
-    // The context_deleting field in filter_context is set to false for this reason. This way any
+    // The context_deleting field in filter_context is set to TRUE for this reason. This way any
     // lingering WFP classify callbacks will exit as it would not find any hook client associated
     // with the filter context. This is best effort & no locks are held.
     filter_context->context_deleting = TRUE;
-    net_ebpf_ext_add_filter_context_to_cleanup_list(filter_context);
-    DEREFERENCE_FILTER_CONTEXT(filter_context);
+}
+
+bool
+net_ebpf_ext_filter_context_all_deleted(_In_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+{
+    bool all_deleted = true;
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+    for (uint32_t i = 0; i < filter_context->filter_ids_count; i++) {
+        if (filter_context->filter_ids[i].state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
+            all_deleted = false;
+            break;
+        }
+    }
+    ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+    return all_deleted;
 }
 
 net_ebpf_extension_hook_id_t
@@ -809,7 +823,6 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
     }
 
     InitializeListHead(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list);
-    InitializeListHead(&_net_ebpf_ext_cleanup_state.filter_cleanup_list);
 
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &_fwp_engine_handle);
     EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineOpen", status);
@@ -880,98 +893,93 @@ Exit:
     EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
-// Reclaims references for non-DELETED filters at driver unload: DELETE_FAILED zombies and filters whose delete
-// notification never arrived. Best-effort deletes the (possibly live) WFP filter and releases the reference once.
+// Reclaims the filter contexts on a provider's zombie list at driver unload. A context becomes a zombie when at
+// least one of its WFP filters could not be deleted at detach: it keeps its initial reference plus a reference for
+// every filter whose delete failed, and because a filter WFP did not delete never produces a delete notification,
+// nothing can ever release those references. Left alone, the context blocks the provider rundown forever, which
+// hangs driver unload and with it the service stop.
 //
-// Runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
+// This runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
 // deleted, which avoids FWP_E_IN_USE and keeps a filter from surviving with a dangling rawContext across a reload.
-// With the callout functions unregistered, WFP no longer delivers a delete notification when a filter is removed, so
-// this sweep releases each reference itself instead of relying on net_ebpf_ext_filter_change_notify. A callout that
-// could not be unregistered is the exception: deleting one of its filters can still fire the notification
-// synchronously and drop the last reference, so each context is pinned across its per-filter processing.
-_IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
+// Once every callout is unregistered WFP can no longer invoke classify, notify or flow-delete for these filters, so
+// no other code can hold or acquire a reference and this sweep is the context's sole owner. That is what makes the
+// forced cleanup below sound: the reference count carries no information, and the context is freed unconditionally.
+//
+// Unconditional is deliberate. A filter whose delete never succeeds is left installed in WFP; it is marked
+// FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED, so with its callout gone it permits rather than blocks traffic.
+// Retaining the context's references instead would hang the provider rundown, which is a strictly worse outcome
+// than a leaked WFP filter.
+_IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_zombie_filters(
+    _In_ net_ebpf_extension_hook_provider_t* provider_context, bool all_callouts_unregistered)
 {
     EBPF_EXT_LOG_ENTRY();
 
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+    if (!all_callouts_unregistered) {
+        // The sole-ownership guarantee above does not hold: WFP can still reach a filter context that is about to
+        // be freed. Unload cannot be abandoned at this point, so proceed and record why the state is unsafe.
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "Reclaiming zombie WFP filter contexts while a callout is still registered.");
+    }
 
-    while (!IsListEmpty(&_net_ebpf_ext_cleanup_state.filter_cleanup_list)) {
-        uint32_t release_count = 0;
-        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_cleanup_state.filter_cleanup_list);
+    ACQUIRE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
+
+    while (!IsListEmpty(&provider_context->zombie_filter_context_list)) {
+        PLIST_ENTRY entry = RemoveHeadList(&provider_context->zombie_filter_context_list);
         net_ebpf_extension_wfp_filter_context_t* filter_context =
-            CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
-        InitializeListHead(&filter_context->link);
+            CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, zombie_link);
+        InitializeListHead(&filter_context->zombie_link);
 
-        // Pin the context across this sweep entry. If a callout could not be unregistered, a successful
-        // FwpmFilterDeleteById below can synchronously fire net_ebpf_ext_filter_change_notify, which releases the
-        // per-filter reference and may drop the last one; the pin keeps the context alive for the rest of this loop.
-        REFERENCE_FILTER_CONTEXT(filter_context);
-
-        // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
-        // DEREFERENCE_FILTER_CONTEXT re-acquires this lock.
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
+        // Release the provider lock while processing: FwpmFilterDeleteById requires PASSIVE_LEVEL.
+        RELEASE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
 
 #pragma warning(push)
 #pragma warning(disable : 6001) // Using uninitialized memory 'filter_id'. filter_ids is initialized by add_wfp_filters.
-        for (size_t index = 0; index < filter_context->filter_ids_count; index++) {
+        for (uint32_t index = 0; index < filter_context->filter_ids_count; index++) {
             net_ebpf_ext_wfp_filter_id_t* filter_id = &filter_context->filter_ids[index];
-            net_ebpf_ext_wfp_filter_state_t state;
+            NTSTATUS delete_status;
+            bool already_deleted;
             KIRQL filter_irql;
 
+            // Claim the filter before attempting the delete. net_ebpf_ext_filter_change_notify only releases a
+            // reference for a filter it finds in a non-DELETED state, so from here on the notification is inert and
+            // cannot drop the last reference and free the context while this loop is still walking filter_ids. Only
+            // a callout that could not be unregistered can deliver such a notification at all.
             filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
-            state = filter_id->state;
+            already_deleted = (filter_id->state == NET_EBPF_EXT_WFP_FILTER_DELETED);
+            filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
             ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
 
-            if (state == NET_EBPF_EXT_WFP_FILTER_DELETED) {
+            if (already_deleted) {
                 continue;
             }
 
-            // Best-effort removal of the (possibly still live) WFP filter so it cannot outlive the filter context
-            // it points at. A DELETING filter is already gone (returns FWP_E_FILTER_NOT_FOUND, treated as success).
-            (void)_net_ebpf_ext_try_delete_wfp_filter(
+            // Best-effort removal of the still-live WFP filter so it cannot outlive the filter context.
+            delete_status = _net_ebpf_ext_try_delete_wfp_filter(
                 filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS);
-
-            // Claim any non-DELETED reference under the lock (a filter whose delete notification never fired still
-            // holds it). If a callout could not be unregistered, a racing notification may reach DELETED first; the
-            // claim-under-lock ensures the reference is released exactly once.
-            filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
-            if (filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
-                filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
-                release_count++;
-                EBPF_EXT_LOG_MESSAGE_UINT64(
-                    EBPF_EXT_TRACELOG_LEVEL_WARNING,
+            filter_id->error_code = delete_status;
+            if (!NT_SUCCESS(delete_status)) {
+                EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
+                    EBPF_EXT_TRACELOG_LEVEL_ERROR,
                     EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                    "Releasing reference for leaked WFP filter during driver unload.",
+                    "Zombie WFP filter could not be deleted at unload; it is left installed.",
+                    delete_status,
                     filter_id->id);
             }
-            ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
         }
 #pragma warning(pop)
 
-        // A callout could not be unregistered, so a filter it backs may still be installed. Release the references
-        // anyway so provider rundown cannot hang, and log the condition.
-        if (!all_callouts_unregistered && release_count > 0) {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "Releasing WFP filter references while a callout is still registered.");
-        }
-
-        // Besides the pin taken above, only the per-filter references this sweep just claimed should remain (the
-        // add-time reference was released on the detach path).
-        ASSERT(filter_context->reference_count == (long)release_count + 1);
-        for (uint32_t i = 0; i < release_count; i++) {
-            DEREFERENCE_FILTER_CONTEXT(filter_context);
-        }
-
-        // Release the pin. This may free the context if the releases above dropped its last reference.
-#pragma warning(suppress : 6001) // filter_context is a live list entry pinned above; the loop cannot free it.
+        // Forced cleanup. Whatever references remain are unreachable now that the filters are claimed and the
+        // callouts are gone, so drop the count to one and release it: this leaves the provider rundown and frees
+        // the context, guaranteeing unload completes even when a filter could not be deleted.
+        InterlockedExchange(&filter_context->reference_count, 1);
         DEREFERENCE_FILTER_CONTEXT(filter_context);
 
-        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+        ACQUIRE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
     }
 
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
+    RELEASE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
 
     EBPF_EXT_LOG_EXIT();
 }
@@ -1012,9 +1020,23 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
             }
         }
 
-        // Step 2: Reclaim leaked filter references before removing the callout objects, sub-layers and provider
-        // they reference.
-        _net_ebpf_ext_cleanup_leaked_filters(all_callouts_unregistered);
+        // Step 2: Reclaim zombie filter contexts on each provider before removing the callout objects, sub-layers
+        // and provider they reference.
+        {
+            KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+            PLIST_ENTRY entry = _net_ebpf_ext_cleanup_state.provider_context_cleanup_list.Flink;
+            while (entry != &_net_ebpf_ext_cleanup_state.provider_context_cleanup_list) {
+                net_ebpf_extension_hook_provider_t* provider_context =
+                    CONTAINING_RECORD(entry, net_ebpf_extension_hook_provider_t, cleanup_list_entry);
+                entry = entry->Flink;
+                ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
+
+                _net_ebpf_ext_cleanup_zombie_filters(provider_context, all_callouts_unregistered);
+
+                old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+            }
+            ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
+        }
 
         // Step 3: Delete the callout objects; the filters referencing them are gone, so this should not fail with
         // FWP_E_IN_USE.
@@ -1067,10 +1089,6 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
             EBPF_EXT_LOG_NTSTATUS_API_FAILURE(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineClose", status);
         }
         _fwp_engine_handle = NULL;
-    } else {
-        // No global engine handle (e.g., a failed initialization). Still sweep the (expected-empty) cleanup list so
-        // provider rundown cannot hang.
-        _net_ebpf_ext_cleanup_leaked_filters(all_callouts_unregistered);
     }
 
     // FwpsInjectionHandleCreate can fail. So, check for NULL.
@@ -1148,7 +1166,7 @@ net_ebpf_ext_filter_change_notify(
         }
         ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
 
-        // Dereference outside the filter lock: it can free the context and re-acquires the cleanup-list lock.
+        // Dereference outside the filter lock: it can free the context.
         if (release_reference) {
             DEREFERENCE_FILTER_CONTEXT((filter_context));
         }
@@ -1317,23 +1335,4 @@ net_ebpf_ext_add_provider_context_to_cleanup_list(_Inout_ net_ebpf_extension_hoo
     KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
     InsertTailList(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list, &provider_context->cleanup_list_entry);
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
-}
-
-void
-net_ebpf_ext_add_filter_context_to_cleanup_list(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
-{
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
-    InsertTailList(&_net_ebpf_ext_cleanup_state.filter_cleanup_list, &filter_context->link);
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
-}
-
-void
-net_ebpf_ext_remove_filter_context_from_cleanup_list(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
-{
-    if (!IsListEmpty(&filter_context->link)) {
-        KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
-        RemoveEntryList(&filter_context->link);
-        InitializeListHead(&filter_context->link);
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
-    }
 }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -331,10 +331,6 @@ net_ebpf_extension_wfp_filter_context_create(
     }
     local_filter_context->provider_context = provider_context;
 
-    // Cache the provider's verdict callback. The dispatch table is fixed when the provider is registered, and the
-    // cached copy is what the WFP classify path uses, so it never has to follow provider_context.
-    local_filter_context->process_verdict = provider_context->dispatch.process_verdict;
-
     // Open the WFP engine handle.
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &local_filter_context->wfp_engine_handle);
     if (!NT_SUCCESS(status)) {
@@ -901,8 +897,8 @@ Exit:
 // The caller must have unregistered every callout function first. That is what makes the forced cleanup below
 // sound: WFP can no longer invoke classify, notify or flow-delete for these filters, so this sweep is the context's
 // sole owner, the reference count carries no information, and the context can be freed outright. It also runs
-// before the callout objects, sub-layers and provider are deleted, which avoids FWP_E_IN_USE and keeps a filter
-// from surviving with a dangling rawContext across a reload.
+// before the callout objects, sub-layers and provider are deleted, which avoids FWP_E_IN_USE for every filter it
+// does delete, and keeps a filter from surviving with a dangling rawContext across a reload.
 //
 // A filter whose delete never succeeds is left installed in WFP; it is marked
 // FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED, so with its callout gone it permits rather than blocks traffic.
@@ -965,49 +961,6 @@ _IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_zombie_filters(
     EBPF_EXT_LOG_EXIT();
 }
 
-// Abandons the filter contexts on a provider's zombie list when one or more callout functions could not be
-// unregistered. WFP can still invoke classify, notify and flow-delete against these contexts, so freeing them would
-// be a use-after-free. Instead each context is pinned with a reference count that can never reach zero and is
-// deliberately leaked, while the provider rundown reference it owns is released here so that driver unload, and the
-// service stop behind it, can still complete.
-_IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_abandon_zombie_filters(
-    _In_ net_ebpf_extension_hook_provider_t* provider_context)
-{
-    EBPF_EXT_LOG_ENTRY();
-
-    ACQUIRE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
-
-    while (!IsListEmpty(&provider_context->zombie_filter_context_list)) {
-        PLIST_ENTRY entry = RemoveHeadList(&provider_context->zombie_filter_context_list);
-        net_ebpf_extension_wfp_filter_context_t* filter_context =
-            CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, zombie_link);
-        InitializeListHead(&filter_context->zombie_link);
-
-        // The context keeps the initial reference taken when it was created: _net_ebpf_ext_dispose_filter_context
-        // only releases that reference for a context whose filters were all deleted, and every other reference has
-        // exactly one owner that releases it at most once. The count can therefore never reach zero, so a late
-        // dereference from WFP cannot free the context. The allocation is deliberately leaked.
-        ASSERT(filter_context->reference_count >= 1);
-
-        // WFP can still reach this context, and the provider is freed once the rundown reference below is released,
-        // so the context must not be left pointing at it. Nothing on a WFP callback path reads provider_context.
-        ASSERT(filter_context->context_deleting);
-        filter_context->provider_context = NULL;
-
-        EBPF_EXT_LOG_MESSAGE_UINT64(
-            EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-            "Leaking a zombie WFP filter context because a callout could not be unregistered.",
-            filter_context->filter_ids_count);
-
-        net_ebpf_extension_hook_provider_leave_rundown(provider_context);
-    }
-
-    RELEASE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
-
-    EBPF_EXT_LOG_EXIT();
-}
-
 _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_components(void)
 {
     size_t index;
@@ -1045,16 +998,9 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
         }
 
         // Step 2: Reclaim zombie filter contexts on each provider before removing the callout objects, sub-layers
-        // and provider they reference. Reclaiming is only safe once every callout function is unregistered; if any
-        // could not be, the contexts are abandoned instead so WFP cannot reach freed memory.
-        if (!all_callouts_unregistered) {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "One or more WFP callouts could not be unregistered; zombie filter contexts will be leaked rather "
-                "than freed.");
-        }
-        {
+        // and provider they reference. Reclaiming frees a context whose WFP filters may still be installed, so it is
+        // only safe once every callout function is unregistered and WFP can no longer reach the context.
+        if (all_callouts_unregistered) {
             KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
             PLIST_ENTRY entry = _net_ebpf_ext_cleanup_state.provider_context_cleanup_list.Flink;
             while (entry != &_net_ebpf_ext_cleanup_state.provider_context_cleanup_list) {
@@ -1063,19 +1009,25 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
                 entry = entry->Flink;
                 ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 
-                if (all_callouts_unregistered) {
-                    _net_ebpf_ext_cleanup_zombie_filters(provider_context);
-                } else {
-                    _net_ebpf_ext_abandon_zombie_filters(provider_context);
-                }
+                _net_ebpf_ext_cleanup_zombie_filters(provider_context);
 
                 old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
             }
             ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
+        } else {
+            // WFP can still invoke this driver, so freeing a zombie context here would be a use-after-free. The
+            // contexts and the provider rundown references they hold are deliberately retained: a callout driver
+            // must not return from its unload function until every callout it registered has been unregistered.
+            EBPF_EXT_LOG_MESSAGE(
+                EBPF_EXT_TRACELOG_LEVEL_ERROR,
+                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                "One or more WFP callouts could not be unregistered; zombie filter contexts cannot be reclaimed.");
+            ASSERT(FALSE);
         }
 
-        // Step 3: Delete the callout objects; the filters referencing them are gone, so this should not fail with
-        // FWP_E_IN_USE.
+        // Step 3: Delete the callout objects. A callout object cannot be deleted while a filter still specifies it
+        // for its action, so this fails with FWP_E_IN_USE for a callout referenced by a filter that step 2 could not
+        // delete; that callout object is then left installed alongside the filter.
         for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
             for (int i = 1; i <= max_retries; i++) {
                 status =

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -459,10 +459,10 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
 
     for (uint32_t index = 0; index < filter_count; index++) {
         // State transitions are serialized under the context lock, but the lock is dropped across
-        // FwpmFilterDeleteById because a successful delete re-enters the notification callback, which also takes it.
+        // FwpmFilterDeleteById because the delete notification callback also acquires it.
         old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
-        // A filter already in the terminal DELETED state has released its per-filter reference; leave it there
-        // instead of resurrecting it to DELETING, which would make the unload sweep over-release the context.
+        // A filter already in the terminal DELETED state no longer owns its per-filter reference; leave it there.
+        // Resurrecting it to DELETING would stop net_ebpf_ext_filter_context_all_deleted from ever succeeding.
         bool already_deleted = (filter_ids[index].state == NET_EBPF_EXT_WFP_FILTER_DELETED);
         if (!already_deleted) {
             filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETING;
@@ -472,9 +472,8 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
             continue;
         }
 
-        // A successful delete synchronously invokes net_ebpf_ext_filter_change_notify, which transitions the
-        // filter to DELETED and releases the per-filter reference. FWP_E_FILTER_NOT_FOUND is treated as success
-        // by the helper (the filter is already gone; its notification either already fired or will not fire).
+        // FWP_E_FILTER_NOT_FOUND is treated as success by the helper; the per-filter reference is released by
+        // net_ebpf_ext_filter_change_notify when WFP delivers the delete notification, not here.
         status = _net_ebpf_ext_try_delete_wfp_filter(
             wfp_engine_handle, filter_ids[index].id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS);
         filter_ids[index].error_code = status;
@@ -1120,20 +1119,22 @@ net_ebpf_ext_filter_change_notify(
         net_ebpf_extension_wfp_filter_context_t* filter_context =
             (net_ebpf_extension_wfp_filter_context_t*)(uintptr_t)filter->context;
         bool release_reference = false;
+        bool filter_id_found = false;
         KIRQL old_irql;
 
-        // Exactly one path (this notification or the unload cleanup sweep) releases the per-filter reference; the
-        // idempotent transition to DELETED is the claim.
+        // This notification transitions the filter to DELETED and releases the per-filter reference taken in
+        // net_ebpf_extension_add_wfp_filters. A filter WFP never deletes is never notified and keeps its reference.
         old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
         for (uint32_t index = 0; index < filter_context->filter_ids_count; index++) {
             net_ebpf_ext_wfp_filter_id_t* cur_filter_id = &filter_context->filter_ids[index];
             if (cur_filter_id->id == filter->filterId) {
-                // Any non-DELETED state still owns the reference (including an external delete or a BFE teardown of
-                // an ADDED filter); claim it by transitioning to DELETED.
-                if (cur_filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
-                    cur_filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
-                    release_reference = true;
-                }
+                filter_id_found = true;
+                // Every state a notified filter can be in (ADDED, DELETING or DELETE_FAILED) still owns the
+                // per-filter reference; claim it by transitioning to DELETED. WFP deletes a filter once, so it
+                // cannot notify a delete for a filter already in the terminal DELETED state.
+                ASSERT(cur_filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED);
+                cur_filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                release_reference = true;
                 EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                     EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
                     EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
@@ -1145,6 +1146,9 @@ net_ebpf_ext_filter_change_notify(
             }
         }
         ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+
+        // net_ebpf_extension_add_wfp_filters records every filter that carries this context.
+        ASSERT(filter_id_found);
 
         // Dereference outside the filter lock: it can free the context.
         if (release_reference) {

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -1001,19 +1001,17 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
         // and provider they reference. Reclaiming frees a context whose WFP filters may still be installed, so it is
         // only safe once every callout function is unregistered and WFP can no longer reach the context.
         if (all_callouts_unregistered) {
-            KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+            // No lock is needed: the cleanup list is only appended to by
+            // net_ebpf_extension_hook_provider_unregister, which net_ebpf_ext_unregister_providers has already run
+            // to completion for every provider before this function is called, so the list can no longer change.
             PLIST_ENTRY entry = _net_ebpf_ext_cleanup_state.provider_context_cleanup_list.Flink;
             while (entry != &_net_ebpf_ext_cleanup_state.provider_context_cleanup_list) {
                 net_ebpf_extension_hook_provider_t* provider_context =
                     CONTAINING_RECORD(entry, net_ebpf_extension_hook_provider_t, cleanup_list_entry);
                 entry = entry->Flink;
-                ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 
                 _net_ebpf_ext_cleanup_zombie_filters(provider_context);
-
-                old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
             }
-            ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
         } else {
             // WFP can still invoke this driver, so freeing a zombie context here would be a use-after-free. The
             // contexts and the provider rundown references they hold are deliberately retained: a callout driver
@@ -1095,23 +1093,17 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_ext_wait_for_provider_context_rundo
 {
     EBPF_EXT_LOG_ENTRY();
 
-    // Iterate through the provider list and handle cleanup.
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
+    // Iterate through the provider list and handle cleanup. No lock is needed: the cleanup list is only appended to
+    // by net_ebpf_extension_hook_provider_unregister, which net_ebpf_ext_unregister_providers has already run to
+    // completion for every provider before this function is called, so the list can no longer change.
     while (!IsListEmpty(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list)) {
         PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list);
         net_ebpf_extension_hook_provider_t* provider_context =
             CONTAINING_RECORD(entry, net_ebpf_extension_hook_provider_t, cleanup_list_entry);
 
-        // Release the lock as waiting for rundown can take time.
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
         ebpf_ext_wait_for_rundown(&provider_context->rundown);
         ExFreePool(provider_context);
-
-        // Re-acquire the lock.
-        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
     }
-
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 
     EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -51,8 +51,15 @@ static net_ebpf_ext_sublayer_info_t _net_ebpf_ext_sublayers[] = {
 // Global object used to store state for cleanup.
 static net_ebpf_extension_wfp_cleanup_state_t _net_ebpf_ext_wfp_cleanup_state = {0};
 
+// Bounded inline retry for a transient FwpmFilterDeleteById failure: up to this many attempts (initial + retries).
+#define NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS 3
+#define NET_EBPF_EXT_DELETE_RETRY_DELAY_100NS (-(SECONDSTO100NS(1) / 20)) // 50 ms, expressed as a relative timeout.
+
 static void
 _net_ebpf_ext_flow_delete(uint16_t layer_id, uint32_t callout_id, uint64_t flow_context);
+
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filter(
+    _In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts, _Out_opt_ NTSTATUS* last_failed_status);
 
 NTSTATUS
 net_ebpf_ext_filter_change_notify(
@@ -419,44 +426,113 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
     return callout_id;
 }
 
-void
-net_ebpf_extension_delete_wfp_filters(
-    _In_ HANDLE wfp_engine_handle,
-    uint32_t filter_count,
-    _Frees_ptr_ _In_count_(filter_count) net_ebpf_ext_wfp_filter_id_t* filter_ids)
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
+    _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     EBPF_EXT_LOG_ENTRY();
     NTSTATUS status = STATUS_SUCCESS;
+    HANDLE wfp_engine_handle = filter_context->wfp_engine_handle;
+    net_ebpf_ext_wfp_filter_id_t* filter_ids = filter_context->filter_ids;
+    uint32_t filter_count = filter_context->filter_ids_count;
+    KIRQL old_irql;
 
     ASSERT(wfp_engine_handle != NULL);
 
     for (uint32_t index = 0; index < filter_count; index++) {
-        filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETING;
-        status = FwpmFilterDeleteById(wfp_engine_handle, filter_ids[index].id);
+        // State transitions are serialized under the context lock, but the lock is dropped across
+        // FwpmFilterDeleteById because a successful delete re-enters the notification callback, which also takes it.
+        old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+        // A filter already in the terminal DELETED state has released its per-filter reference; leave it there
+        // instead of resurrecting it to DELETING, which would make the unload sweep over-release the context.
+        bool already_deleted = (filter_ids[index].state == NET_EBPF_EXT_WFP_FILTER_DELETED);
+        if (!already_deleted) {
+            filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETING;
+        }
+        ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+        if (already_deleted) {
+            continue;
+        }
+
+        // A successful delete synchronously invokes net_ebpf_ext_filter_change_notify, which transitions the
+        // filter to DELETED and releases the per-filter reference. FWP_E_FILTER_NOT_FOUND is treated as success
+        // by the helper (the filter is already gone; its notification either already fired or will not fire).
+        NTSTATUS last_failed_status = STATUS_SUCCESS;
+        status = _net_ebpf_ext_try_delete_wfp_filter(
+            wfp_engine_handle, filter_ids[index].id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS, &last_failed_status);
         filter_ids[index].error_code = status;
         if (!NT_SUCCESS(status)) {
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
                 EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "FwpmFilterDeleteById failed to mark WFP filter for deletion.",
+                "FwpmFilterDeleteById failed to delete WFP filter; leaving as zombie for later recovery.",
                 status,
                 filter_ids[index].id);
-            filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETE_FAILED;
+            // The failed delete issues no notification, so the reference is still held. Mark it DELETE_FAILED for
+            // recovery by the unload sweep, unless a notification already moved it to DELETED.
+            old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+            if (filter_ids[index].state == NET_EBPF_EXT_WFP_FILTER_DELETING) {
+                filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETE_FAILED;
+            }
+            ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+        } else if (last_failed_status != STATUS_SUCCESS) {
+            // Delete succeeded after an earlier attempt failed (a transient BFE outage the inline retry recovered).
+            // Log once per filter with the last failed status.
+            EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
+                EBPF_EXT_TRACELOG_LEVEL_INFO,
+                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                "FwpmFilterDeleteById recovered after one or more transient failures.",
+                (uint64_t)last_failed_status,
+                filter_ids[index].id);
         } else {
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                 EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
                 EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "FwpmFilterDeleteById successfully marked WFP filter for deletion",
+                "FwpmFilterDeleteById successfully deleted WFP filter",
                 index,
                 filter_ids[index].id);
         }
     }
+
     EBPF_EXT_LOG_EXIT();
 }
 
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filter(
+    _In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts, _Out_opt_ NTSTATUS* last_failed_status)
+{
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+    NTSTATUS most_recent_failed_status = STATUS_SUCCESS;
+
+    for (uint32_t attempt = 1; attempt <= max_attempts; attempt++) {
+        status = FwpmFilterDeleteById(wfp_engine_handle, filter_id);
+        if (NT_SUCCESS(status) || WFP_ERROR(status, FILTER_NOT_FOUND)) {
+            // FWP_E_FILTER_NOT_FOUND: the filter is already gone (the original delete may have completed but its
+            // RPC reply was lost). Treat as success so the reference is not released twice.
+            status = STATUS_SUCCESS;
+            break;
+        }
+
+        // Remember the last failing status for the caller's one-per-filter recovered-delete log.
+        most_recent_failed_status = status;
+
+        if (attempt < max_attempts) {
+            // Back off before retrying. Waiting on an unsignaled event with a relative timeout is a portable
+            // PASSIVE_LEVEL delay that is available in both the kernel driver and the user-mode test builds.
+            KEVENT delay_event;
+            LARGE_INTEGER delay = {0};
+            KeInitializeEvent(&delay_event, NotificationEvent, FALSE);
+            delay.QuadPart = NET_EBPF_EXT_DELETE_RETRY_DELAY_100NS;
+            KeWaitForSingleObject(&delay_event, Executive, KernelMode, FALSE, &delay);
+        }
+    }
+
+    if (last_failed_status != NULL) {
+        *last_failed_status = most_recent_failed_status;
+    }
+    return status;
+}
+
 #pragma warning(suppress : 6386) // filter_ids receives a separately allocated buffer sized for filter_count entries.
-_Must_inspect_result_ ebpf_result_t
-net_ebpf_extension_add_wfp_filters(
+_IRQL_requires_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t net_ebpf_extension_add_wfp_filters(
     _In_ HANDLE wfp_engine_handle,
     uint32_t filter_count,
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
@@ -805,29 +881,111 @@ Exit:
     EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
+// Reclaims references for non-DELETED filters at driver unload: DELETE_FAILED zombies and filters whose delete
+// notification never arrived. Best-effort deletes the (possibly live) WFP filter and releases the reference once.
+//
+// MUST run after the callout functions are unregistered (so no classify/notify can race) and before the callout
+// objects, sub-layers and provider are deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling
+// rawContext across a reload).
+static void
+_net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
+{
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+
+    while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
+        uint32_t release_count = 0;
+        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list);
+        net_ebpf_extension_wfp_filter_context_t* filter_context =
+            CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
+        InitializeListHead(&filter_context->link);
+
+        // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
+        // DEREFERENCE_FILTER_CONTEXT re-acquires this lock.
+        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+
+#pragma warning(push)
+#pragma warning(disable : 6001) // Using uninitialized memory 'filter_id'. filter_ids is initialized by add_wfp_filters.
+        for (size_t index = 0; index < filter_context->filter_ids_count; index++) {
+            net_ebpf_ext_wfp_filter_id_t* filter_id = &filter_context->filter_ids[index];
+            net_ebpf_ext_wfp_filter_state_t state;
+            KIRQL filter_irql;
+
+            filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+            state = filter_id->state;
+            ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
+
+            if (state == NET_EBPF_EXT_WFP_FILTER_DELETED) {
+                continue;
+            }
+
+            // Best-effort removal of the (possibly still live) WFP filter so it cannot outlive the filter context
+            // it points at. A DELETING filter is already gone (returns FWP_E_FILTER_NOT_FOUND, treated as success).
+            (void)_net_ebpf_ext_try_delete_wfp_filter(
+                filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS, NULL);
+
+            // Claim any non-DELETED reference under the lock (an ADDED filter whose external notification never
+            // fired still holds it). If a notification races, whichever path reaches DELETED first releases once.
+            filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+            if (filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
+                filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                release_count++;
+                EBPF_EXT_LOG_MESSAGE_UINT64(
+                    EBPF_EXT_TRACELOG_LEVEL_WARNING,
+                    EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                    "Releasing reference for leaked WFP filter during driver unload.",
+                    filter_id->id);
+            }
+            ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
+        }
+#pragma warning(pop)
+
+        // If a callout could not be unregistered, release the references anyway so provider rundown does not hang,
+        // but flag it loudly.
+        if (!all_callouts_unregistered && release_count > 0) {
+            EBPF_EXT_LOG_MESSAGE(
+                EBPF_EXT_TRACELOG_LEVEL_ERROR,
+                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                "Releasing WFP filter references while a callout is still registered.");
+            ASSERT(FALSE);
+        }
+
+        // Only the per-filter references this sweep just claimed should remain (the add-time reference was
+        // released on the detach path).
+        ASSERT(filter_context->reference_count == (long)release_count);
+        for (uint32_t i = 0; i < release_count; i++) {
+            DEREFERENCE_FILTER_CONTEXT(filter_context);
+        }
+
+        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+    }
+
+    ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+}
+
 void
 net_ebpf_extension_uninitialize_wfp_components(void)
 {
     size_t index;
     NTSTATUS status;
     const int max_retries = 10;
-    LARGE_INTEGER timeout = {0};
-    timeout.QuadPart = -SECONDSTO100NS(10);
+    bool all_callouts_unregistered = true;
 
     EBPF_EXT_LOG_ENTRY();
 
     if (_fwp_engine_handle != NULL) {
-        // WFP operations may fail if connections are in the middle of being classified and our WFP filters or callouts
-        // are in use. Prior to this function execution, it is expected that the WFP filter objects were removed,
-        // reducing the risk of this failure to occur. However, the following cleanup functions have retry logic built
-        // in to help ensure that the WFP objects are cleaned up properly.
+        // WFP operations may fail if connections are in the middle of being classified and our WFP filters or
+        // callouts are in use. The cleanup functions below have retry logic to help ensure the WFP objects are
+        // cleaned up properly.
 
-        // Clean up the callouts.
+        // Step 1: Unregister the callout functions. Once this succeeds, WFP can no longer invoke classify/notify,
+        // which makes releasing still-live filters' references safe in step 2. The callout objects are deleted in
+        // step 3, after the filters referencing them are gone.
         for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
-
+            bool callout_unregistered = false;
             for (int i = 1; i <= max_retries; i++) {
                 status = FwpsCalloutUnregisterById(_net_ebpf_ext_wfp_callout_states[index].assigned_callout_id);
                 if (NT_SUCCESS(status) || WFP_ERROR(status, CALLOUT_NOT_FOUND)) {
+                    callout_unregistered = true;
                     break;
                 }
 
@@ -836,7 +994,18 @@ net_ebpf_extension_uninitialize_wfp_components(void)
                         EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpsCalloutUnregisterById", status);
                 }
             }
+            if (!callout_unregistered) {
+                all_callouts_unregistered = false;
+            }
+        }
 
+        // Step 2: Reclaim leaked filter references before removing the callout objects, sub-layers and provider
+        // they reference.
+        _net_ebpf_ext_cleanup_leaked_filters(all_callouts_unregistered);
+
+        // Step 3: Delete the callout objects; the filters referencing them are gone, so this should not fail with
+        // FWP_E_IN_USE.
+        for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
             for (int i = 1; i <= max_retries; i++) {
                 status =
                     FwpmCalloutDeleteByKey(_fwp_engine_handle, _net_ebpf_ext_wfp_callout_states[index].callout_guid);
@@ -885,6 +1054,10 @@ net_ebpf_extension_uninitialize_wfp_components(void)
             EBPF_EXT_LOG_NTSTATUS_API_FAILURE(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineClose", status);
         }
         _fwp_engine_handle = NULL;
+    } else {
+        // No global engine handle (e.g., a failed initialization). Still sweep the (expected-empty) cleanup list so
+        // provider rundown cannot hang.
+        _net_ebpf_ext_cleanup_leaked_filters(all_callouts_unregistered);
     }
 
     // FwpsInjectionHandleCreate can fail. So, check for NULL.
@@ -896,63 +1069,8 @@ net_ebpf_extension_uninitialize_wfp_components(void)
         }
     }
 
-    // If there are cleanup filters, sleep to give WFP time to issue callbacks. Once this timeout completes,
-    // we assume that any remaining notifications will not be issued, and proceed with cleanup.
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-    if (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
-        EBPF_EXT_LOG_MESSAGE(
-            EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-            "Leaked WFP Filters found. Processing cleanup.");
-        _net_ebpf_ext_wfp_cleanup_state.signal_empty_filter_list = TRUE;
-
-        // Allow some time for WFP to signal deletion for the filters. KeWaitForSingleObject also requires dropping the
-        // IRQL level and therefore the lock.
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
-        status = KeWaitForSingleObject(
-            &_net_ebpf_ext_wfp_cleanup_state.wfp_filter_cleanup_event, Executive, KernelMode, FALSE, &timeout);
-        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-
-#pragma warning(push)
-#pragma warning(disable : 6001) // Using uninitialized memory 'filter_context' and 'filter_id'.
-        // Proceed with cleanup - assume that any remaining notifications will never be issued by WFP,
-        // and continue with cleaning up our internal state.
-        while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
-            uint32_t leaked_filter_count = 0;
-            PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list);
-            net_ebpf_extension_wfp_filter_context_t* filter_context =
-                CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
-            InitializeListHead(&filter_context->link);
-
-            // Release lock as we process the entry. DEREFERENCE_FILTER_CONTEXT also acquires the lock.
-            ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
-
-            // Anything left in the NET_EBPF_EXT_WFP_FILTER_DELETING is considered leaked. Remove the references
-            // to allow for cleanup.
-            for (index = 0; index < filter_context->filter_ids_count; index++) {
-                net_ebpf_ext_wfp_filter_id_t* filter_id = &filter_context->filter_ids[index];
-                if (filter_id->state == NET_EBPF_EXT_WFP_FILTER_DELETING) {
-                    leaked_filter_count++;
-                    EBPF_EXT_LOG_MESSAGE_UINT64(
-                        EBPF_EXT_TRACELOG_LEVEL_WARNING,
-                        EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                        "Releasing reference for leaked WFP filter.",
-                        filter_id->id);
-                }
-            }
-
-            // Remove remaining references.
-            ASSERT(filter_context->reference_count == (long)leaked_filter_count);
-            for (index = 0; index < leaked_filter_count; index++) {
-                DEREFERENCE_FILTER_CONTEXT(filter_context);
-            }
-
-            old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-        }
-#pragma warning(pop)
-    }
-
     // Iterate through the provider list and handle cleanup.
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
     while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list)) {
         PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list);
         net_ebpf_extension_hook_provider_t* provider_context =
@@ -983,11 +1101,21 @@ net_ebpf_ext_filter_change_notify(
     if (callout_notification_type == FWPS_CALLOUT_NOTIFY_DELETE_FILTER) {
         net_ebpf_extension_wfp_filter_context_t* filter_context =
             (net_ebpf_extension_wfp_filter_context_t*)(uintptr_t)filter->context;
+        bool release_reference = false;
+        KIRQL old_irql;
 
+        // Exactly one path (this notification or the unload cleanup sweep) releases the per-filter reference; the
+        // idempotent transition to DELETED is the claim.
+        old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
         for (uint32_t index = 0; index < filter_context->filter_ids_count; index++) {
             net_ebpf_ext_wfp_filter_id_t* cur_filter_id = &filter_context->filter_ids[index];
             if (cur_filter_id->id == filter->filterId) {
-                cur_filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                // Any non-DELETED state still owns the reference (including an external delete or a BFE teardown of
+                // an ADDED filter); claim it by transitioning to DELETED.
+                if (cur_filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
+                    cur_filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                    release_reference = true;
+                }
                 EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                     EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
                     EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
@@ -998,7 +1126,12 @@ net_ebpf_ext_filter_change_notify(
                 break;
             }
         }
-        DEREFERENCE_FILTER_CONTEXT((filter_context));
+        ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+
+        // Dereference outside the filter lock: it can free the context and re-acquires the cleanup-list lock.
+        if (release_reference) {
+            DEREFERENCE_FILTER_CONTEXT((filter_context));
+        }
     }
 
     EBPF_EXT_RETURN_NTSTATUS(STATUS_SUCCESS);

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -53,7 +53,6 @@ static net_ebpf_extension_cleanup_state_t _net_ebpf_ext_cleanup_state = {0};
 
 // Bounded inline retry for a transient FwpmFilterDeleteById failure: up to this many attempts (initial + retries).
 #define NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS 3
-#define NET_EBPF_EXT_DELETE_RETRY_DELAY_100NS (-(SECONDSTO100NS(1) / 20)) // 50 ms, expressed as a relative timeout.
 
 static void
 _net_ebpf_ext_flow_delete(uint16_t layer_id, uint32_t callout_id, uint64_t flow_context);
@@ -319,12 +318,22 @@ net_ebpf_extension_wfp_filter_context_create(
     local_filter_context->client_contexts[0] = (net_ebpf_extension_hook_client_t*)client_context;
     local_filter_context->client_context_count = 1;
 
-    // Set filter context as provider data in the hook client.
-    net_ebpf_extension_hook_client_set_provider_data(
-        (net_ebpf_extension_hook_client_t*)client_context, local_filter_context);
-
-    // Set the provider context.
+    // Acquire a rundown reference on the provider context. The filter context owns it from here on:
+    // CLEAN_UP_FILTER_CONTEXT releases it when the context is freed. provider_context is set only after the
+    // reference has been acquired, so a non-NULL provider_context means the context holds one.
+    if (!net_ebpf_extension_hook_provider_enter_rundown((net_ebpf_extension_hook_provider_t*)provider_context)) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "ExAcquireRundownProtection failed. Filter context creation rejected.");
+        result = EBPF_FAILED;
+        goto Exit;
+    }
     local_filter_context->provider_context = provider_context;
+
+    // Cache the provider's verdict callback. The dispatch table is fixed when the provider is registered, and the
+    // cached copy is what the WFP classify path uses, so it never has to follow provider_context.
+    local_filter_context->process_verdict = provider_context->dispatch.process_verdict;
 
     // Open the WFP engine handle.
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &local_filter_context->wfp_engine_handle);
@@ -519,16 +528,6 @@ _IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS
 
         // Remember the last failing status for the one-per-filter recovered-delete log below.
         most_recent_failed_status = status;
-
-        if (attempt < max_attempts) {
-            // Back off before retrying. Waiting on an unsignaled event with a relative timeout is a portable
-            // PASSIVE_LEVEL delay that is available in both the kernel driver and the user-mode test builds.
-            KEVENT delay_event;
-            LARGE_INTEGER delay = {0};
-            KeInitializeEvent(&delay_event, NotificationEvent, FALSE);
-            delay.QuadPart = NET_EBPF_EXT_DELETE_RETRY_DELAY_100NS;
-            KeWaitForSingleObject(&delay_event, Executive, KernelMode, FALSE, &delay);
-        }
     }
 
     if (NT_SUCCESS(status) && most_recent_failed_status != STATUS_SUCCESS) {
@@ -899,29 +898,19 @@ Exit:
 // nothing can ever release those references. Left alone, the context blocks the provider rundown forever, which
 // hangs driver unload and with it the service stop.
 //
-// This runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
-// deleted, which avoids FWP_E_IN_USE and keeps a filter from surviving with a dangling rawContext across a reload.
-// Once every callout is unregistered WFP can no longer invoke classify, notify or flow-delete for these filters, so
-// no other code can hold or acquire a reference and this sweep is the context's sole owner. That is what makes the
-// forced cleanup below sound: the reference count carries no information, and the context is freed unconditionally.
+// The caller must have unregistered every callout function first. That is what makes the forced cleanup below
+// sound: WFP can no longer invoke classify, notify or flow-delete for these filters, so this sweep is the context's
+// sole owner, the reference count carries no information, and the context can be freed outright. It also runs
+// before the callout objects, sub-layers and provider are deleted, which avoids FWP_E_IN_USE and keeps a filter
+// from surviving with a dangling rawContext across a reload.
 //
-// Unconditional is deliberate. A filter whose delete never succeeds is left installed in WFP; it is marked
+// A filter whose delete never succeeds is left installed in WFP; it is marked
 // FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED, so with its callout gone it permits rather than blocks traffic.
-// Retaining the context's references instead would hang the provider rundown, which is a strictly worse outcome
-// than a leaked WFP filter.
+// Leaking a WFP filter is a strictly better outcome than hanging the provider rundown.
 _IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_zombie_filters(
-    _In_ net_ebpf_extension_hook_provider_t* provider_context, bool all_callouts_unregistered)
+    _In_ net_ebpf_extension_hook_provider_t* provider_context)
 {
     EBPF_EXT_LOG_ENTRY();
-
-    if (!all_callouts_unregistered) {
-        // The sole-ownership guarantee above does not hold: WFP can still reach a filter context that is about to
-        // be freed. Unload cannot be abandoned at this point, so proceed and record why the state is unsafe.
-        EBPF_EXT_LOG_MESSAGE(
-            EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-            "Reclaiming zombie WFP filter contexts while a callout is still registered.");
-    }
 
     ACQUIRE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
 
@@ -939,27 +928,21 @@ _IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_zombie_filters(
         for (uint32_t index = 0; index < filter_context->filter_ids_count; index++) {
             net_ebpf_ext_wfp_filter_id_t* filter_id = &filter_context->filter_ids[index];
             NTSTATUS delete_status;
-            bool already_deleted;
-            KIRQL filter_irql;
 
-            // Claim the filter before attempting the delete. net_ebpf_ext_filter_change_notify only releases a
-            // reference for a filter it finds in a non-DELETED state, so from here on the notification is inert and
-            // cannot drop the last reference and free the context while this loop is still walking filter_ids. Only
-            // a callout that could not be unregistered can deliver such a notification at all.
-            filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
-            already_deleted = (filter_id->state == NET_EBPF_EXT_WFP_FILTER_DELETED);
-            filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
-            ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
-
-            if (already_deleted) {
+            // No lock is needed: the clients have detached and no callout is registered, so nothing else can
+            // observe or modify this state.
+            if (filter_id->state == NET_EBPF_EXT_WFP_FILTER_DELETED) {
                 continue;
             }
 
-            // Best-effort removal of the still-live WFP filter so it cannot outlive the filter context.
+            // Best-effort removal of the still-live WFP filter so it cannot outlive the filter context. The delete
+            // is retried because BFE may have recovered since the attempt at detach failed.
             delete_status = _net_ebpf_ext_try_delete_wfp_filter(
                 filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS);
             filter_id->error_code = delete_status;
-            if (!NT_SUCCESS(delete_status)) {
+            if (NT_SUCCESS(delete_status)) {
+                filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+            } else {
                 EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                     EBPF_EXT_TRACELOG_LEVEL_ERROR,
                     EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
@@ -970,13 +953,54 @@ _IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_zombie_filters(
         }
 #pragma warning(pop)
 
-        // Forced cleanup. Whatever references remain are unreachable now that the filters are claimed and the
-        // callouts are gone, so drop the count to one and release it: this leaves the provider rundown and frees
-        // the context, guaranteeing unload completes even when a filter could not be deleted.
-        InterlockedExchange(&filter_context->reference_count, 1);
-        DEREFERENCE_FILTER_CONTEXT(filter_context);
+        // Free the context outright. Its reference count is meaningless here: the references it still holds belong
+        // to filters WFP never deleted, and nothing can release them. This also leaves the provider rundown.
+        CLEAN_UP_FILTER_CONTEXT(filter_context);
 
         ACQUIRE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
+    }
+
+    RELEASE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
+
+    EBPF_EXT_LOG_EXIT();
+}
+
+// Abandons the filter contexts on a provider's zombie list when one or more callout functions could not be
+// unregistered. WFP can still invoke classify, notify and flow-delete against these contexts, so freeing them would
+// be a use-after-free. Instead each context is pinned with a reference count that can never reach zero and is
+// deliberately leaked, while the provider rundown reference it owns is released here so that driver unload, and the
+// service stop behind it, can still complete.
+_IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_abandon_zombie_filters(
+    _In_ net_ebpf_extension_hook_provider_t* provider_context)
+{
+    EBPF_EXT_LOG_ENTRY();
+
+    ACQUIRE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
+
+    while (!IsListEmpty(&provider_context->zombie_filter_context_list)) {
+        PLIST_ENTRY entry = RemoveHeadList(&provider_context->zombie_filter_context_list);
+        net_ebpf_extension_wfp_filter_context_t* filter_context =
+            CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, zombie_link);
+        InitializeListHead(&filter_context->zombie_link);
+
+        // The context keeps the initial reference taken when it was created: _net_ebpf_ext_dispose_filter_context
+        // only releases that reference for a context whose filters were all deleted, and every other reference has
+        // exactly one owner that releases it at most once. The count can therefore never reach zero, so a late
+        // dereference from WFP cannot free the context. The allocation is deliberately leaked.
+        ASSERT(filter_context->reference_count >= 1);
+
+        // WFP can still reach this context, and the provider is freed once the rundown reference below is released,
+        // so the context must not be left pointing at it. Nothing on a WFP callback path reads provider_context.
+        ASSERT(filter_context->context_deleting);
+        filter_context->provider_context = NULL;
+
+        EBPF_EXT_LOG_MESSAGE_UINT64(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+            "Leaking a zombie WFP filter context because a callout could not be unregistered.",
+            filter_context->filter_ids_count);
+
+        net_ebpf_extension_hook_provider_leave_rundown(provider_context);
     }
 
     RELEASE_PUSH_LOCK_EXCLUSIVE(&provider_context->lock);
@@ -1021,7 +1045,15 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
         }
 
         // Step 2: Reclaim zombie filter contexts on each provider before removing the callout objects, sub-layers
-        // and provider they reference.
+        // and provider they reference. Reclaiming is only safe once every callout function is unregistered; if any
+        // could not be, the contexts are abandoned instead so WFP cannot reach freed memory.
+        if (!all_callouts_unregistered) {
+            EBPF_EXT_LOG_MESSAGE(
+                EBPF_EXT_TRACELOG_LEVEL_ERROR,
+                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                "One or more WFP callouts could not be unregistered; zombie filter contexts will be leaked rather "
+                "than freed.");
+        }
         {
             KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
             PLIST_ENTRY entry = _net_ebpf_ext_cleanup_state.provider_context_cleanup_list.Flink;
@@ -1031,7 +1063,11 @@ _IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_componen
                 entry = entry->Flink;
                 ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
 
-                _net_ebpf_ext_cleanup_zombie_filters(provider_context, all_callouts_unregistered);
+                if (all_callouts_unregistered) {
+                    _net_ebpf_ext_cleanup_zombie_filters(provider_context);
+                } else {
+                    _net_ebpf_ext_abandon_zombie_filters(provider_context);
+                }
 
                 old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
             }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -810,7 +810,6 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
 
     InitializeListHead(&_net_ebpf_ext_cleanup_state.provider_context_cleanup_list);
     InitializeListHead(&_net_ebpf_ext_cleanup_state.filter_cleanup_list);
-    KeInitializeEvent(&_net_ebpf_ext_cleanup_state.wfp_filter_cleanup_event, NotificationEvent, FALSE);
 
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &_fwp_engine_handle);
     EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineOpen", status);
@@ -885,12 +884,12 @@ Exit:
 // notification never arrived. Best-effort deletes the (possibly live) WFP filter and releases the reference once.
 //
 // Runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
-// deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling rawContext across a reload). Unregistering
-// the callouts first normally keeps a classify/notify from racing this sweep; if FwpsCalloutUnregisterById failed
-// for a callout (e.g. STATUS_DEVICE_BUSY while a classify/notify is still in flight), a successful delete here can
-// still fire the notify, so each context is pinned across its per-filter processing to stay safe.
-static void
-_net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
+// deleted, which avoids FWP_E_IN_USE and keeps a filter from surviving with a dangling rawContext across a reload.
+// With the callout functions unregistered, WFP no longer delivers a delete notification when a filter is removed, so
+// this sweep releases each reference itself instead of relying on net_ebpf_ext_filter_change_notify. A callout that
+// could not be unregistered is the exception: deleting one of its filters can still fire the notification
+// synchronously and drop the last reference, so each context is pinned across its per-filter processing.
+_IRQL_requires_(PASSIVE_LEVEL) static void _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
 {
     EBPF_EXT_LOG_ENTRY();
 
@@ -903,10 +902,9 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
             CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
         InitializeListHead(&filter_context->link);
 
-        // Pin the context for the duration of this sweep entry. If FwpsCalloutUnregisterById failed for a callout
-        // (e.g. STATUS_DEVICE_BUSY while a classify/notify is still in flight), a successful FwpmFilterDeleteById
-        // below can synchronously fire the delete notification, which releases the per-filter reference; the pin
-        // guarantees the context is not freed out from under the rest of this loop.
+        // Pin the context across this sweep entry. If a callout could not be unregistered, a successful
+        // FwpmFilterDeleteById below can synchronously fire net_ebpf_ext_filter_change_notify, which releases the
+        // per-filter reference and may drop the last one; the pin keeps the context alive for the rest of this loop.
         REFERENCE_FILTER_CONTEXT(filter_context);
 
         // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
@@ -933,8 +931,9 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
             (void)_net_ebpf_ext_try_delete_wfp_filter(
                 filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS);
 
-            // Claim any non-DELETED reference under the lock (an ADDED filter whose external notification never
-            // fired still holds it). If a notification races, whichever path reaches DELETED first releases once.
+            // Claim any non-DELETED reference under the lock (a filter whose delete notification never fired still
+            // holds it). If a callout could not be unregistered, a racing notification may reach DELETED first; the
+            // claim-under-lock ensures the reference is released exactly once.
             filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
             if (filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
                 filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
@@ -949,14 +948,13 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
         }
 #pragma warning(pop)
 
-        // If FwpsCalloutUnregisterById failed for a callout, release the references anyway so provider rundown does
-        // not hang, but flag it loudly.
+        // A callout could not be unregistered, so a filter it backs may still be installed. Release the references
+        // anyway so provider rundown cannot hang, and log the condition.
         if (!all_callouts_unregistered && release_count > 0) {
             EBPF_EXT_LOG_MESSAGE(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
                 EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
                 "Releasing WFP filter references while a callout is still registered.");
-            ASSERT(FALSE);
         }
 
         // Besides the pin taken above, only the per-filter references this sweep just claimed should remain (the
@@ -978,8 +976,7 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
     EBPF_EXT_LOG_EXIT();
 }
 
-void
-net_ebpf_extension_uninitialize_wfp_components(void)
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_components(void)
 {
     size_t index;
     NTSTATUS status;
@@ -1088,8 +1085,7 @@ net_ebpf_extension_uninitialize_wfp_components(void)
     EBPF_EXT_LOG_EXIT();
 }
 
-void
-net_ebpf_ext_wait_for_provider_context_rundown(void)
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_ext_wait_for_provider_context_rundown(void)
 {
     EBPF_EXT_LOG_ENTRY();
 
@@ -1338,10 +1334,6 @@ net_ebpf_ext_remove_filter_context_from_cleanup_list(_Inout_ net_ebpf_extension_
         KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock);
         RemoveEntryList(&filter_context->link);
         InitializeListHead(&filter_context->link);
-        if (IsListEmpty(&_net_ebpf_ext_cleanup_state.filter_cleanup_list) &&
-            _net_ebpf_ext_cleanup_state.signal_empty_filter_list) {
-            KeSetEvent(&_net_ebpf_ext_cleanup_state.wfp_filter_cleanup_event, 0, FALSE);
-        }
         ExReleaseSpinLockExclusive(&_net_ebpf_ext_cleanup_state.lock, old_irql);
     }
 }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -884,9 +884,11 @@ Exit:
 // Reclaims references for non-DELETED filters at driver unload: DELETE_FAILED zombies and filters whose delete
 // notification never arrived. Best-effort deletes the (possibly live) WFP filter and releases the reference once.
 //
-// MUST run after the callout functions are unregistered (so no classify/notify can race) and before the callout
-// objects, sub-layers and provider are deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling
-// rawContext across a reload).
+// Runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
+// deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling rawContext across a reload). Unregistering
+// the callouts first normally keeps a classify/notify from racing this sweep; if a callout could not be
+// unregistered, a successful delete here can still fire the notify, so each context is pinned across its per-filter
+// processing to stay safe.
 static void
 _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
 {
@@ -898,6 +900,11 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
         net_ebpf_extension_wfp_filter_context_t* filter_context =
             CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
         InitializeListHead(&filter_context->link);
+
+        // Pin the context for the duration of this sweep entry. If a callout could not be unregistered, a
+        // successful FwpmFilterDeleteById below can synchronously fire the delete notification, which releases the
+        // per-filter reference; the pin guarantees the context is not freed out from under the rest of this loop.
+        REFERENCE_FILTER_CONTEXT(filter_context);
 
         // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
         // DEREFERENCE_FILTER_CONTEXT re-acquires this lock.
@@ -949,12 +956,16 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
             ASSERT(FALSE);
         }
 
-        // Only the per-filter references this sweep just claimed should remain (the add-time reference was
-        // released on the detach path).
-        ASSERT(filter_context->reference_count == (long)release_count);
+        // Besides the pin taken above, only the per-filter references this sweep just claimed should remain (the
+        // add-time reference was released on the detach path).
+        ASSERT(filter_context->reference_count == (long)release_count + 1);
         for (uint32_t i = 0; i < release_count; i++) {
             DEREFERENCE_FILTER_CONTEXT(filter_context);
         }
+
+        // Release the pin. This may free the context if the releases above dropped its last reference.
+#pragma warning(suppress : 6001) // filter_context is a live list entry pinned above; the loop cannot free it.
+        DEREFERENCE_FILTER_CONTEXT(filter_context);
 
         old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
     }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -881,9 +881,11 @@ Exit:
 // Reclaims references for non-DELETED filters at driver unload: DELETE_FAILED zombies and filters whose delete
 // notification never arrived. Best-effort deletes the (possibly live) WFP filter and releases the reference once.
 //
-// MUST run after the callout functions are unregistered (so no classify/notify can race) and before the callout
-// objects, sub-layers and provider are deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling
-// rawContext across a reload).
+// Runs after the callout functions are unregistered and before the callout objects, sub-layers and provider are
+// deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling rawContext across a reload). Unregistering
+// the callouts first normally keeps a classify/notify from racing this sweep; if a callout could not be
+// unregistered, a successful delete here can still fire the notify, so each context is pinned across its per-filter
+// processing to stay safe.
 static void
 _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
 {
@@ -895,6 +897,11 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
         net_ebpf_extension_wfp_filter_context_t* filter_context =
             CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
         InitializeListHead(&filter_context->link);
+
+        // Pin the context for the duration of this sweep entry. If a callout could not be unregistered, a
+        // successful FwpmFilterDeleteById below can synchronously fire the delete notification, which releases the
+        // per-filter reference; the pin guarantees the context is not freed out from under the rest of this loop.
+        REFERENCE_FILTER_CONTEXT(filter_context);
 
         // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
         // DEREFERENCE_FILTER_CONTEXT re-acquires this lock.
@@ -946,12 +953,16 @@ _net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
             ASSERT(FALSE);
         }
 
-        // Only the per-filter references this sweep just claimed should remain (the add-time reference was
-        // released on the detach path).
-        ASSERT(filter_context->reference_count == (long)release_count);
+        // Besides the pin taken above, only the per-filter references this sweep just claimed should remain (the
+        // add-time reference was released on the detach path).
+        ASSERT(filter_context->reference_count == (long)release_count + 1);
         for (uint32_t i = 0; i < release_count; i++) {
             DEREFERENCE_FILTER_CONTEXT(filter_context);
         }
+
+        // Release the pin. This may free the context if the releases above dropped its last reference.
+#pragma warning(suppress : 6001) // filter_context is a live list entry pinned above; the loop cannot free it.
+        DEREFERENCE_FILTER_CONTEXT(filter_context);
 
         old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
     }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -51,8 +51,15 @@ static net_ebpf_ext_sublayer_info_t _net_ebpf_ext_sublayers[] = {
 // Global object used to store state for cleanup.
 static net_ebpf_extension_wfp_cleanup_state_t _net_ebpf_ext_wfp_cleanup_state = {0};
 
+// Bounded inline retry for a transient FwpmFilterDeleteById failure: up to this many attempts (initial + retries).
+#define NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS 3
+#define NET_EBPF_EXT_DELETE_RETRY_DELAY_100NS (-(SECONDSTO100NS(1) / 20)) // 50 ms, expressed as a relative timeout.
+
 static void
 _net_ebpf_ext_flow_delete(uint16_t layer_id, uint32_t callout_id, uint64_t flow_context);
+
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filter(
+    _In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts, _Out_opt_ NTSTATUS* last_failed_status);
 
 NTSTATUS
 net_ebpf_ext_filter_change_notify(
@@ -419,44 +426,113 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
     return callout_id;
 }
 
-void
-net_ebpf_extension_delete_wfp_filters(
-    _In_ HANDLE wfp_engine_handle,
-    uint32_t filter_count,
-    _Frees_ptr_ _In_count_(filter_count) net_ebpf_ext_wfp_filter_id_t* filter_ids)
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
+    _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     EBPF_EXT_LOG_ENTRY();
     NTSTATUS status = STATUS_SUCCESS;
+    HANDLE wfp_engine_handle = filter_context->wfp_engine_handle;
+    net_ebpf_ext_wfp_filter_id_t* filter_ids = filter_context->filter_ids;
+    uint32_t filter_count = filter_context->filter_ids_count;
+    KIRQL old_irql;
 
     ASSERT(wfp_engine_handle != NULL);
 
     for (uint32_t index = 0; index < filter_count; index++) {
-        filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETING;
-        status = FwpmFilterDeleteById(wfp_engine_handle, filter_ids[index].id);
+        // State transitions are serialized under the context lock, but the lock is dropped across
+        // FwpmFilterDeleteById because a successful delete re-enters the notification callback, which also takes it.
+        old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+        // A filter already in the terminal DELETED state has released its per-filter reference; leave it there
+        // instead of resurrecting it to DELETING, which would make the unload sweep over-release the context.
+        bool already_deleted = (filter_ids[index].state == NET_EBPF_EXT_WFP_FILTER_DELETED);
+        if (!already_deleted) {
+            filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETING;
+        }
+        ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+        if (already_deleted) {
+            continue;
+        }
+
+        // A successful delete synchronously invokes net_ebpf_ext_filter_change_notify, which transitions the
+        // filter to DELETED and releases the per-filter reference. FWP_E_FILTER_NOT_FOUND is treated as success
+        // by the helper (the filter is already gone; its notification either already fired or will not fire).
+        NTSTATUS last_failed_status = STATUS_SUCCESS;
+        status = _net_ebpf_ext_try_delete_wfp_filter(
+            wfp_engine_handle, filter_ids[index].id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS, &last_failed_status);
         filter_ids[index].error_code = status;
         if (!NT_SUCCESS(status)) {
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
                 EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "FwpmFilterDeleteById failed to mark WFP filter for deletion.",
+                "FwpmFilterDeleteById failed to delete WFP filter; leaving as zombie for later recovery.",
                 status,
                 filter_ids[index].id);
-            filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETE_FAILED;
+            // The failed delete issues no notification, so the reference is still held. Mark it DELETE_FAILED for
+            // recovery by the unload sweep, unless a notification already moved it to DELETED.
+            old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+            if (filter_ids[index].state == NET_EBPF_EXT_WFP_FILTER_DELETING) {
+                filter_ids[index].state = NET_EBPF_EXT_WFP_FILTER_DELETE_FAILED;
+            }
+            ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+        } else if (last_failed_status != STATUS_SUCCESS) {
+            // Delete succeeded after an earlier attempt failed (a transient BFE outage the inline retry recovered).
+            // Log once per filter with the last failed status.
+            EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
+                EBPF_EXT_TRACELOG_LEVEL_INFO,
+                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                "FwpmFilterDeleteById recovered after one or more transient failures.",
+                (uint64_t)last_failed_status,
+                filter_ids[index].id);
         } else {
             EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                 EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
                 EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                "FwpmFilterDeleteById successfully marked WFP filter for deletion",
+                "FwpmFilterDeleteById successfully deleted WFP filter",
                 index,
                 filter_ids[index].id);
         }
     }
+
     EBPF_EXT_LOG_EXIT();
 }
 
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS _net_ebpf_ext_try_delete_wfp_filter(
+    _In_ HANDLE wfp_engine_handle, uint64_t filter_id, uint32_t max_attempts, _Out_opt_ NTSTATUS* last_failed_status)
+{
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+    NTSTATUS most_recent_failed_status = STATUS_SUCCESS;
+
+    for (uint32_t attempt = 1; attempt <= max_attempts; attempt++) {
+        status = FwpmFilterDeleteById(wfp_engine_handle, filter_id);
+        if (NT_SUCCESS(status) || WFP_ERROR(status, FILTER_NOT_FOUND)) {
+            // FWP_E_FILTER_NOT_FOUND: the filter is already gone (the original delete may have completed but its
+            // RPC reply was lost). Treat as success so the reference is not released twice.
+            status = STATUS_SUCCESS;
+            break;
+        }
+
+        // Remember the last failing status for the caller's one-per-filter recovered-delete log.
+        most_recent_failed_status = status;
+
+        if (attempt < max_attempts) {
+            // Back off before retrying. Waiting on an unsignaled event with a relative timeout is a portable
+            // PASSIVE_LEVEL delay that is available in both the kernel driver and the user-mode test builds.
+            KEVENT delay_event;
+            LARGE_INTEGER delay = {0};
+            KeInitializeEvent(&delay_event, NotificationEvent, FALSE);
+            delay.QuadPart = NET_EBPF_EXT_DELETE_RETRY_DELAY_100NS;
+            KeWaitForSingleObject(&delay_event, Executive, KernelMode, FALSE, &delay);
+        }
+    }
+
+    if (last_failed_status != NULL) {
+        *last_failed_status = most_recent_failed_status;
+    }
+    return status;
+}
+
 #pragma warning(suppress : 6386) // filter_ids receives a separately allocated buffer sized for filter_count entries.
-_Must_inspect_result_ ebpf_result_t
-net_ebpf_extension_add_wfp_filters(
+_IRQL_requires_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t net_ebpf_extension_add_wfp_filters(
     _In_ HANDLE wfp_engine_handle,
     uint32_t filter_count,
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
@@ -802,29 +878,111 @@ Exit:
     EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
+// Reclaims references for non-DELETED filters at driver unload: DELETE_FAILED zombies and filters whose delete
+// notification never arrived. Best-effort deletes the (possibly live) WFP filter and releases the reference once.
+//
+// MUST run after the callout functions are unregistered (so no classify/notify can race) and before the callout
+// objects, sub-layers and provider are deleted (avoids FWP_E_IN_USE and a filter surviving with a dangling
+// rawContext across a reload).
+static void
+_net_ebpf_ext_cleanup_leaked_filters(bool all_callouts_unregistered)
+{
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+
+    while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
+        uint32_t release_count = 0;
+        PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list);
+        net_ebpf_extension_wfp_filter_context_t* filter_context =
+            CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
+        InitializeListHead(&filter_context->link);
+
+        // Release the list lock while processing the entry: FwpmFilterDeleteById requires PASSIVE_LEVEL and
+        // DEREFERENCE_FILTER_CONTEXT re-acquires this lock.
+        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+
+#pragma warning(push)
+#pragma warning(disable : 6001) // Using uninitialized memory 'filter_id'. filter_ids is initialized by add_wfp_filters.
+        for (size_t index = 0; index < filter_context->filter_ids_count; index++) {
+            net_ebpf_ext_wfp_filter_id_t* filter_id = &filter_context->filter_ids[index];
+            net_ebpf_ext_wfp_filter_state_t state;
+            KIRQL filter_irql;
+
+            filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+            state = filter_id->state;
+            ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
+
+            if (state == NET_EBPF_EXT_WFP_FILTER_DELETED) {
+                continue;
+            }
+
+            // Best-effort removal of the (possibly still live) WFP filter so it cannot outlive the filter context
+            // it points at. A DELETING filter is already gone (returns FWP_E_FILTER_NOT_FOUND, treated as success).
+            (void)_net_ebpf_ext_try_delete_wfp_filter(
+                filter_context->wfp_engine_handle, filter_id->id, NET_EBPF_EXT_DELETE_RETRY_MAX_ATTEMPTS, NULL);
+
+            // Claim any non-DELETED reference under the lock (an ADDED filter whose external notification never
+            // fired still holds it). If a notification races, whichever path reaches DELETED first releases once.
+            filter_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
+            if (filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
+                filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                release_count++;
+                EBPF_EXT_LOG_MESSAGE_UINT64(
+                    EBPF_EXT_TRACELOG_LEVEL_WARNING,
+                    EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                    "Releasing reference for leaked WFP filter during driver unload.",
+                    filter_id->id);
+            }
+            ExReleaseSpinLockExclusive(&filter_context->lock, filter_irql);
+        }
+#pragma warning(pop)
+
+        // If a callout could not be unregistered, release the references anyway so provider rundown does not hang,
+        // but flag it loudly.
+        if (!all_callouts_unregistered && release_count > 0) {
+            EBPF_EXT_LOG_MESSAGE(
+                EBPF_EXT_TRACELOG_LEVEL_ERROR,
+                EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+                "Releasing WFP filter references while a callout is still registered.");
+            ASSERT(FALSE);
+        }
+
+        // Only the per-filter references this sweep just claimed should remain (the add-time reference was
+        // released on the detach path).
+        ASSERT(filter_context->reference_count == (long)release_count);
+        for (uint32_t i = 0; i < release_count; i++) {
+            DEREFERENCE_FILTER_CONTEXT(filter_context);
+        }
+
+        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
+    }
+
+    ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
+}
+
 void
 net_ebpf_extension_uninitialize_wfp_components(void)
 {
     size_t index;
     NTSTATUS status;
     const int max_retries = 10;
-    LARGE_INTEGER timeout = {0};
-    timeout.QuadPart = -SECONDSTO100NS(10);
+    bool all_callouts_unregistered = true;
 
     EBPF_EXT_LOG_ENTRY();
 
     if (_fwp_engine_handle != NULL) {
-        // WFP operations may fail if connections are in the middle of being classified and our WFP filters or callouts
-        // are in use. Prior to this function execution, it is expected that the WFP filter objects were removed,
-        // reducing the risk of this failure to occur. However, the following cleanup functions have retry logic built
-        // in to help ensure that the WFP objects are cleaned up properly.
+        // WFP operations may fail if connections are in the middle of being classified and our WFP filters or
+        // callouts are in use. The cleanup functions below have retry logic to help ensure the WFP objects are
+        // cleaned up properly.
 
-        // Clean up the callouts.
+        // Step 1: Unregister the callout functions. Once this succeeds, WFP can no longer invoke classify/notify,
+        // which makes releasing still-live filters' references safe in step 2. The callout objects are deleted in
+        // step 3, after the filters referencing them are gone.
         for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
-
+            bool callout_unregistered = false;
             for (int i = 1; i <= max_retries; i++) {
                 status = FwpsCalloutUnregisterById(_net_ebpf_ext_wfp_callout_states[index].assigned_callout_id);
                 if (NT_SUCCESS(status) || WFP_ERROR(status, CALLOUT_NOT_FOUND)) {
+                    callout_unregistered = true;
                     break;
                 }
 
@@ -833,7 +991,18 @@ net_ebpf_extension_uninitialize_wfp_components(void)
                         EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpsCalloutUnregisterById", status);
                 }
             }
+            if (!callout_unregistered) {
+                all_callouts_unregistered = false;
+            }
+        }
 
+        // Step 2: Reclaim leaked filter references before removing the callout objects, sub-layers and provider
+        // they reference.
+        _net_ebpf_ext_cleanup_leaked_filters(all_callouts_unregistered);
+
+        // Step 3: Delete the callout objects; the filters referencing them are gone, so this should not fail with
+        // FWP_E_IN_USE.
+        for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
             for (int i = 1; i <= max_retries; i++) {
                 status =
                     FwpmCalloutDeleteByKey(_fwp_engine_handle, _net_ebpf_ext_wfp_callout_states[index].callout_guid);
@@ -882,6 +1051,10 @@ net_ebpf_extension_uninitialize_wfp_components(void)
             EBPF_EXT_LOG_NTSTATUS_API_FAILURE(EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineClose", status);
         }
         _fwp_engine_handle = NULL;
+    } else {
+        // No global engine handle (e.g., a failed initialization). Still sweep the (expected-empty) cleanup list so
+        // provider rundown cannot hang.
+        _net_ebpf_ext_cleanup_leaked_filters(all_callouts_unregistered);
     }
 
     // FwpsInjectionHandleCreate can fail. So, check for NULL.
@@ -893,63 +1066,8 @@ net_ebpf_extension_uninitialize_wfp_components(void)
         }
     }
 
-    // If there are cleanup filters, sleep to give WFP time to issue callbacks. Once this timeout completes,
-    // we assume that any remaining notifications will not be issued, and proceed with cleanup.
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-    if (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
-        EBPF_EXT_LOG_MESSAGE(
-            EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-            "Leaked WFP Filters found. Processing cleanup.");
-        _net_ebpf_ext_wfp_cleanup_state.signal_empty_filter_list = TRUE;
-
-        // Allow some time for WFP to signal deletion for the filters. KeWaitForSingleObject also requires dropping the
-        // IRQL level and therefore the lock.
-        ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
-        status = KeWaitForSingleObject(
-            &_net_ebpf_ext_wfp_cleanup_state.wfp_filter_cleanup_event, Executive, KernelMode, FALSE, &timeout);
-        old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-
-#pragma warning(push)
-#pragma warning(disable : 6001) // Using uninitialized memory 'filter_context' and 'filter_id'.
-        // Proceed with cleanup - assume that any remaining notifications will never be issued by WFP,
-        // and continue with cleaning up our internal state.
-        while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list)) {
-            uint32_t leaked_filter_count = 0;
-            PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.filter_cleanup_list);
-            net_ebpf_extension_wfp_filter_context_t* filter_context =
-                CONTAINING_RECORD(entry, net_ebpf_extension_wfp_filter_context_t, link);
-            InitializeListHead(&filter_context->link);
-
-            // Release lock as we process the entry. DEREFERENCE_FILTER_CONTEXT also acquires the lock.
-            ExReleaseSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock, old_irql);
-
-            // Anything left in the NET_EBPF_EXT_WFP_FILTER_DELETING is considered leaked. Remove the references
-            // to allow for cleanup.
-            for (index = 0; index < filter_context->filter_ids_count; index++) {
-                net_ebpf_ext_wfp_filter_id_t* filter_id = &filter_context->filter_ids[index];
-                if (filter_id->state == NET_EBPF_EXT_WFP_FILTER_DELETING) {
-                    leaked_filter_count++;
-                    EBPF_EXT_LOG_MESSAGE_UINT64(
-                        EBPF_EXT_TRACELOG_LEVEL_WARNING,
-                        EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-                        "Releasing reference for leaked WFP filter.",
-                        filter_id->id);
-                }
-            }
-
-            // Remove remaining references.
-            ASSERT(filter_context->reference_count == (long)leaked_filter_count);
-            for (index = 0; index < leaked_filter_count; index++) {
-                DEREFERENCE_FILTER_CONTEXT(filter_context);
-            }
-
-            old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
-        }
-#pragma warning(pop)
-    }
-
     // Iterate through the provider list and handle cleanup.
+    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_wfp_cleanup_state.lock);
     while (!IsListEmpty(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list)) {
         PLIST_ENTRY entry = RemoveHeadList(&_net_ebpf_ext_wfp_cleanup_state.provider_context_cleanup_list);
         net_ebpf_extension_hook_provider_t* provider_context =
@@ -980,11 +1098,21 @@ net_ebpf_ext_filter_change_notify(
     if (callout_notification_type == FWPS_CALLOUT_NOTIFY_DELETE_FILTER) {
         net_ebpf_extension_wfp_filter_context_t* filter_context =
             (net_ebpf_extension_wfp_filter_context_t*)(uintptr_t)filter->context;
+        bool release_reference = false;
+        KIRQL old_irql;
 
+        // Exactly one path (this notification or the unload cleanup sweep) releases the per-filter reference; the
+        // idempotent transition to DELETED is the claim.
+        old_irql = ExAcquireSpinLockExclusive(&filter_context->lock);
         for (uint32_t index = 0; index < filter_context->filter_ids_count; index++) {
             net_ebpf_ext_wfp_filter_id_t* cur_filter_id = &filter_context->filter_ids[index];
             if (cur_filter_id->id == filter->filterId) {
-                cur_filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                // Any non-DELETED state still owns the reference (including an external delete or a BFE teardown of
+                // an ADDED filter); claim it by transitioning to DELETED.
+                if (cur_filter_id->state != NET_EBPF_EXT_WFP_FILTER_DELETED) {
+                    cur_filter_id->state = NET_EBPF_EXT_WFP_FILTER_DELETED;
+                    release_reference = true;
+                }
                 EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(
                     EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
                     EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
@@ -995,7 +1123,12 @@ net_ebpf_ext_filter_change_notify(
                 break;
             }
         }
-        DEREFERENCE_FILTER_CONTEXT((filter_context));
+        ExReleaseSpinLockExclusive(&filter_context->lock, old_irql);
+
+        // Dereference outside the filter lock: it can free the context and re-acquires the cleanup-list lock.
+        if (release_reference) {
+            DEREFERENCE_FILTER_CONTEXT((filter_context));
+        }
     }
 
     EBPF_EXT_RETURN_NTSTATUS(STATUS_SUCCESS);

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -290,8 +290,7 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
  * @retval EBPF_SUCCESS The operation completed successfully.
  * @retval EBPF_INVALID_ARGUMENT One or more arguments are invalid.
  */
-_Must_inspect_result_ ebpf_result_t
-net_ebpf_extension_add_wfp_filters(
+_IRQL_requires_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t net_ebpf_extension_add_wfp_filters(
     _In_ HANDLE wfp_engine_handle,
     uint32_t filter_count,
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
@@ -302,17 +301,16 @@ net_ebpf_extension_add_wfp_filters(
         net_ebpf_ext_wfp_filter_id_t** filter_ids);
 
 /**
- * @brief Deletes WFP filters with specified filter IDs.
+ * @brief Deletes the WFP filters associated with a filter context.
  *
- * @param[in] wfp_filter_handle The WFP filter handle used to delete the filters.
- * @param[in]  filter_count Count of filters to be added.
- * @param[in]  filter_ids ID of the filter being deleted.
+ * Marks each filter as deleting and calls @c FwpmFilterDeleteById; a successful delete releases the per-filter
+ * reference through the synchronous WFP delete notification. A filter whose delete fails is left in the
+ * @c NET_EBPF_EXT_WFP_FILTER_DELETE_FAILED state for the driver-unload sweep to recover.
+ *
+ * @param[in,out] filter_context The filter context whose WFP filters are being deleted.
  */
-void
-net_ebpf_extension_delete_wfp_filters(
-    _In_ HANDLE wfp_engine_handle,
-    uint32_t filter_count,
-    _Frees_ptr_ _In_count_(filter_count) net_ebpf_ext_wfp_filter_id_t* filter_ids);
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_delete_wfp_filters(
+    _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context);
 
 // eBPF WFP Provider GUID.
 // ddb851f5-841a-4b77-8a46-bb7063e9f162

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -140,6 +140,11 @@ typedef struct _net_ebpf_extension_wfp_filter_context
     _Guarded_by_(lock) uint32_t client_context_count;                   ///< Current number of hook NPI clients.
     const struct _net_ebpf_extension_hook_provider* provider_context;   ///< Pointer to provider binding context.
 
+    /// Cached copy of the provider's verdict callback, taken when the context is created. The WFP classify path uses
+    /// this copy so that it never has to follow provider_context, which is cleared when a context is abandoned at
+    /// unload and whose target is freed once the provider rundown is released.
+    net_ebpf_extension_hook_process_verdict process_verdict;
+
     net_ebpf_ext_wfp_filter_id_t* filter_ids; ///< Array of WFP filter Ids.
     uint32_t filter_ids_count;                ///< Number of WFP filter Ids.
 
@@ -165,20 +170,24 @@ typedef struct _net_ebpf_extension_cleanup_state
 #define PRAGMA_WARNING_SUPPRESS_26100 _Pragma("warning(suppress: 26100)")
 #define PRAGMA_WARNING_POP _Pragma("warning(pop)")
 
-#define CLEAN_UP_FILTER_CONTEXT(filter_context)               \
-    ASSERT((filter_context) != NULL);                         \
-    if ((filter_context)->filter_ids != NULL) {               \
-        ExFreePool((filter_context)->filter_ids);             \
-    }                                                         \
-    PRAGMA_WARNING_PUSH                                       \
-    PRAGMA_WARNING_SUPPRESS_26100                             \
-    if ((filter_context)->client_contexts != NULL) {          \
-        ExFreePool((filter_context)->client_contexts);        \
-    }                                                         \
-    PRAGMA_WARNING_POP                                        \
-    if ((filter_context)->wfp_engine_handle != NULL) {        \
-        FwpmEngineClose((filter_context)->wfp_engine_handle); \
-    }                                                         \
+#define CLEAN_UP_FILTER_CONTEXT(filter_context)                                       \
+    ASSERT((filter_context) != NULL);                                                 \
+    if ((filter_context)->filter_ids != NULL) {                                       \
+        ExFreePool((filter_context)->filter_ids);                                     \
+    }                                                                                 \
+    PRAGMA_WARNING_PUSH                                                               \
+    PRAGMA_WARNING_SUPPRESS_26100                                                     \
+    if ((filter_context)->client_contexts != NULL) {                                  \
+        ExFreePool((filter_context)->client_contexts);                                \
+    }                                                                                 \
+    PRAGMA_WARNING_POP                                                                \
+    if ((filter_context)->wfp_engine_handle != NULL) {                                \
+        FwpmEngineClose((filter_context)->wfp_engine_handle);                         \
+    }                                                                                 \
+    if ((filter_context)->provider_context != NULL) {                                 \
+        net_ebpf_extension_hook_provider_leave_rundown(                               \
+            (net_ebpf_extension_hook_provider_t*)(filter_context)->provider_context); \
+    }                                                                                 \
     ExFreePool((filter_context));
 
 #define REFERENCE_FILTER_CONTEXT(filter_context)                  \
@@ -186,13 +195,11 @@ typedef struct _net_ebpf_extension_cleanup_state
         InterlockedIncrement(&(filter_context)->reference_count); \
     }
 
-#define DEREFERENCE_FILTER_CONTEXT(filter_context)                                        \
-    if ((filter_context) != NULL) {                                                       \
-        if (InterlockedDecrement(&(filter_context)->reference_count) == 0) {              \
-            net_ebpf_extension_hook_provider_leave_rundown(                               \
-                (net_ebpf_extension_hook_provider_t*)(filter_context)->provider_context); \
-            CLEAN_UP_FILTER_CONTEXT((filter_context));                                    \
-        }                                                                                 \
+#define DEREFERENCE_FILTER_CONTEXT(filter_context)                           \
+    if ((filter_context) != NULL) {                                          \
+        if (InterlockedDecrement(&(filter_context)->reference_count) == 0) { \
+            CLEAN_UP_FILTER_CONTEXT((filter_context));                       \
+        }                                                                    \
     }
 
 /**

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -130,7 +130,8 @@ typedef struct _net_ebpf_ext_wfp_filter_id
 
 typedef struct _net_ebpf_extension_wfp_filter_context
 {
-    LIST_ENTRY link;                   ///< Entry in the list of filter contexts.
+    LIST_ENTRY link;                   ///< Entry in the provider's active filter context list.
+    LIST_ENTRY zombie_link;            ///< Entry in the provider's zombie filter context list.
     volatile long reference_count;     ///< Reference count.
     EX_SPIN_LOCK lock;                 ///< Lock to protect the client context array.
     uint32_t client_context_count_max; ///< Maximum number of hook NPI clients.
@@ -149,14 +150,12 @@ typedef struct _net_ebpf_extension_wfp_filter_context
 } net_ebpf_extension_wfp_filter_context_t;
 
 /**
- * @brief Structure that holds the provider-context and filter-context lists that require cleanup at driver unload.
+ * @brief Structure that holds the provider-context list that requires cleanup at driver unload.
  */
 typedef struct _net_ebpf_extension_cleanup_state
 {
     EX_SPIN_LOCK lock;
     _Guarded_by_(lock) LIST_ENTRY provider_context_cleanup_list; ///< List of provider contexts to cleanup.
-    _Guarded_by_(lock)
-        LIST_ENTRY filter_cleanup_list; ///< List of filter contexts that are awaiting a WFP filter deletion callback.
 } net_ebpf_extension_cleanup_state_t;
 
 // Macro definition of warning suppression for 26100. This is only used in the cleanup context, for which
@@ -166,21 +165,20 @@ typedef struct _net_ebpf_extension_cleanup_state
 #define PRAGMA_WARNING_SUPPRESS_26100 _Pragma("warning(suppress: 26100)")
 #define PRAGMA_WARNING_POP _Pragma("warning(pop)")
 
-#define CLEAN_UP_FILTER_CONTEXT(filter_context)                             \
-    ASSERT((filter_context) != NULL);                                       \
-    net_ebpf_ext_remove_filter_context_from_cleanup_list((filter_context)); \
-    if ((filter_context)->filter_ids != NULL) {                             \
-        ExFreePool((filter_context)->filter_ids);                           \
-    }                                                                       \
-    PRAGMA_WARNING_PUSH                                                     \
-    PRAGMA_WARNING_SUPPRESS_26100                                           \
-    if ((filter_context)->client_contexts != NULL) {                        \
-        ExFreePool((filter_context)->client_contexts);                      \
-    }                                                                       \
-    PRAGMA_WARNING_POP                                                      \
-    if ((filter_context)->wfp_engine_handle != NULL) {                      \
-        FwpmEngineClose((filter_context)->wfp_engine_handle);               \
-    }                                                                       \
+#define CLEAN_UP_FILTER_CONTEXT(filter_context)               \
+    ASSERT((filter_context) != NULL);                         \
+    if ((filter_context)->filter_ids != NULL) {               \
+        ExFreePool((filter_context)->filter_ids);             \
+    }                                                         \
+    PRAGMA_WARNING_PUSH                                       \
+    PRAGMA_WARNING_SUPPRESS_26100                             \
+    if ((filter_context)->client_contexts != NULL) {          \
+        ExFreePool((filter_context)->client_contexts);        \
+    }                                                         \
+    PRAGMA_WARNING_POP                                        \
+    if ((filter_context)->wfp_engine_handle != NULL) {        \
+        FwpmEngineClose((filter_context)->wfp_engine_handle); \
+    }                                                         \
     ExFreePool((filter_context));
 
 #define REFERENCE_FILTER_CONTEXT(filter_context)                  \
@@ -217,14 +215,26 @@ net_ebpf_extension_wfp_filter_context_create(
     _Outptr_ net_ebpf_extension_wfp_filter_context_t** filter_context);
 
 /**
- * @brief This function cleans up the input ebpf extension WFP filter context. This should be invoked when the hook
- * client is being detached.
+ * @brief This function marks a filter context as detaching. It sets context_deleting to TRUE so classify callbacks
+ * will not invoke programs. The caller is responsible for deciding whether to release the initial reference (if all
+ * WFP filters were successfully deleted) or transfer ownership to the provider's zombie list (if any filter delete
+ * failed).
  *
- * @param[out] filter_context Pointer to filter_context to clean up.
+ * @param[in,out] filter_context Pointer to filter_context to mark as detaching.
  *
  */
 void
-net_ebpf_extension_wfp_filter_context_cleanup(_Frees_ptr_ net_ebpf_extension_wfp_filter_context_t* filter_context);
+net_ebpf_extension_wfp_filter_context_detach(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context);
+
+/**
+ * @brief Checks whether all WFP filters in a filter context have been successfully deleted (all in DELETED state).
+ *
+ * @param[in] filter_context Pointer to filter_context to check.
+ * @retval TRUE All filters are in DELETED state.
+ * @retval FALSE At least one filter is not in DELETED state.
+ */
+bool
+net_ebpf_ext_filter_context_all_deleted(_In_ net_ebpf_extension_wfp_filter_context_t* filter_context);
 
 /**
  * @brief Structure for WFP flow Id parameters.
@@ -418,19 +428,3 @@ net_ebpf_ext_add_client_context(
  */
 void
 net_ebpf_ext_add_provider_context_to_cleanup_list(_Inout_ net_ebpf_extension_hook_provider_t* provider_context);
-
-/**
- * @brief Add a filter context to the cleanup list.
- *
- * @param filter_context Filter context to add.
- */
-void
-net_ebpf_ext_add_filter_context_to_cleanup_list(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context);
-
-/**
- * @brief Remove a filter context from the cleanup list.
- *
- * @param filter_context Filter context to remove.
- */
-void
-net_ebpf_ext_remove_filter_context_from_cleanup_list(_Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context);

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -157,8 +157,6 @@ typedef struct _net_ebpf_extension_cleanup_state
     _Guarded_by_(lock) LIST_ENTRY provider_context_cleanup_list; ///< List of provider contexts to cleanup.
     _Guarded_by_(lock)
         LIST_ENTRY filter_cleanup_list; ///< List of filter contexts that are awaiting a WFP filter deletion callback.
-    bool signal_empty_filter_list : 1;  ///< True if the WFP filter cleanup event should be signaled.
-    KEVENT wfp_filter_cleanup_event;    ///< Event to signal when no remaining WFP filters require a deletion callback.
 } net_ebpf_extension_cleanup_state_t;
 
 // Macro definition of warning suppression for 26100. This is only used in the cleanup context, for which
@@ -360,15 +358,13 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object);
  * @brief Unregister the WFP callouts.
  *
  */
-void
-net_ebpf_extension_uninitialize_wfp_components(void);
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_extension_uninitialize_wfp_components(void);
 
 /**
  * @brief Wait for the rundown of all provider contexts pending cleanup and free them.
  *
  */
-void
-net_ebpf_ext_wait_for_provider_context_rundown(void);
+_IRQL_requires_(PASSIVE_LEVEL) void net_ebpf_ext_wait_for_provider_context_rundown(void);
 
 /**
  * @brief Register network extension NPI providers with eBPF core.

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -140,11 +140,6 @@ typedef struct _net_ebpf_extension_wfp_filter_context
     _Guarded_by_(lock) uint32_t client_context_count;                   ///< Current number of hook NPI clients.
     const struct _net_ebpf_extension_hook_provider* provider_context;   ///< Pointer to provider binding context.
 
-    /// Cached copy of the provider's verdict callback, taken when the context is created. The WFP classify path uses
-    /// this copy so that it never has to follow provider_context, which is cleared when a context is abandoned at
-    /// unload and whose target is freed once the provider rundown is released.
-    net_ebpf_extension_hook_process_verdict process_verdict;
-
     net_ebpf_ext_wfp_filter_id_t* filter_ids; ///< Array of WFP filter Ids.
     uint32_t filter_ids_count;                ///< Number of WFP filter Ids.
 

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -149,9 +149,9 @@ typedef struct _net_ebpf_extension_wfp_filter_context
 } net_ebpf_extension_wfp_filter_context_t;
 
 /**
- * @brief Structure that holds objects related to WFP that require cleanup.
+ * @brief Structure that holds the provider-context and filter-context lists that require cleanup at driver unload.
  */
-typedef struct _net_ebpf_extension_wfp_cleanup_state
+typedef struct _net_ebpf_extension_cleanup_state
 {
     EX_SPIN_LOCK lock;
     _Guarded_by_(lock) LIST_ENTRY provider_context_cleanup_list; ///< List of provider contexts to cleanup.
@@ -159,7 +159,7 @@ typedef struct _net_ebpf_extension_wfp_cleanup_state
         LIST_ENTRY filter_cleanup_list; ///< List of filter contexts that are awaiting a WFP filter deletion callback.
     bool signal_empty_filter_list : 1;  ///< True if the WFP filter cleanup event should be signaled.
     KEVENT wfp_filter_cleanup_event;    ///< Event to signal when no remaining WFP filters require a deletion callback.
-} net_ebpf_extension_wfp_cleanup_state_t;
+} net_ebpf_extension_cleanup_state_t;
 
 // Macro definition of warning suppression for 26100. This is only used in the cleanup context, for which
 // we are the only reference of the memory
@@ -362,6 +362,13 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object);
  */
 void
 net_ebpf_extension_uninitialize_wfp_components(void);
+
+/**
+ * @brief Wait for the rundown of all provider contexts pending cleanup and free them.
+ *
+ */
+void
+net_ebpf_ext_wait_for_provider_context_rundown(void);
 
 /**
  * @brief Register network extension NPI providers with eBPF core.

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -144,8 +144,7 @@ Exit:
 }
 
 static void
-_net_ebpf_ext_bind_delete_filter_context(
-    _In_opt_ _Frees_ptr_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+_net_ebpf_ext_bind_delete_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     EBPF_EXT_LOG_ENTRY();
 
@@ -155,7 +154,7 @@ _net_ebpf_ext_bind_delete_filter_context(
 
     // Delete the WFP filters.
     net_ebpf_extension_delete_wfp_filters(filter_context);
-    net_ebpf_extension_wfp_filter_context_cleanup((net_ebpf_extension_wfp_filter_context_t*)filter_context);
+    net_ebpf_extension_wfp_filter_context_detach((net_ebpf_extension_wfp_filter_context_t*)filter_context);
 
 Exit:
     EBPF_EXT_LOG_EXIT();

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -161,7 +161,7 @@ net_ebpf_ext_bind_register_providers()
     const net_ebpf_extension_hook_provider_dispatch_table_t dispatch_table = {
         .create_filter_context = _net_ebpf_ext_bind_create_filter_context,
         // No hook-specific resources to release.
-        .release_hook_resources = NULL,
+        .cleanup_filter_context = NULL,
         .validate_client_data = _net_ebpf_ext_bind_validate_client_data};
 
     status = net_ebpf_extension_program_info_provider_register(

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -143,23 +143,6 @@ Exit:
     EBPF_EXT_RETURN_RESULT(result);
 }
 
-static void
-_net_ebpf_ext_bind_delete_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
-{
-    EBPF_EXT_LOG_ENTRY();
-
-    if (filter_context == NULL) {
-        goto Exit;
-    }
-
-    // Delete the WFP filters.
-    net_ebpf_extension_delete_wfp_filters(filter_context);
-    net_ebpf_extension_wfp_filter_context_detach((net_ebpf_extension_wfp_filter_context_t*)filter_context);
-
-Exit:
-    EBPF_EXT_LOG_EXIT();
-}
-
 //
 // NMR Registration Helper Routines.
 //
@@ -177,7 +160,8 @@ net_ebpf_ext_bind_register_providers()
         &_ebpf_bind_hook_provider_moduleid, &_net_ebpf_bind_hook_provider_data};
     const net_ebpf_extension_hook_provider_dispatch_table_t dispatch_table = {
         .create_filter_context = _net_ebpf_ext_bind_create_filter_context,
-        .delete_filter_context = _net_ebpf_ext_bind_delete_filter_context,
+        // No hook-specific resources to release.
+        .release_hook_resources = NULL,
         .validate_client_data = _net_ebpf_ext_bind_validate_client_data};
 
     status = net_ebpf_extension_program_info_provider_register(

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -154,8 +154,7 @@ _net_ebpf_ext_bind_delete_filter_context(
     }
 
     // Delete the WFP filters.
-    net_ebpf_extension_delete_wfp_filters(
-        filter_context->wfp_engine_handle, filter_context->filter_ids_count, filter_context->filter_ids);
+    net_ebpf_extension_delete_wfp_filters(filter_context);
     net_ebpf_extension_wfp_filter_context_cleanup((net_ebpf_extension_wfp_filter_context_t*)filter_context);
 
 Exit:

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -356,10 +356,10 @@ _net_ebpf_extension_hook_client_cleanup(_In_opt_ _Frees_ptr_opt_ net_ebpf_extens
 /**
  * @brief Tears down a filter context that is no longer referenced by any hook NPI client, and disposes of it.
  *
- * The context is marked as detaching, its WFP filters are deleted, and any hook-specific resources are released.
- * If every WFP filter was deleted the initial reference is released here and the context is freed. If any delete
- * failed the context is transferred to the provider's zombie list without releasing that reference, so it cannot
- * be freed while live WFP filters still point at it; the unload sweep reclaims it.
+ * Marks the context as detaching, deletes its WFP filters and releases any hook-specific resources. If every WFP
+ * filter was deleted, releases the initial reference and frees the context. If any delete failed, transfers the
+ * context to the provider's zombie list without releasing that reference, so it cannot be freed while live WFP
+ * filters still point at it; the unload sweep reclaims it.
  *
  * @param[in] provider_context Provider module's context.
  * @param[in] filter_context Filter context to dispose of. The caller must not use it on return: it is either
@@ -377,8 +377,8 @@ _IRQL_requires_(PASSIVE_LEVEL)
     net_ebpf_extension_delete_wfp_filters(filter_context);
 
     // Release hook-specific resources (redirect handle, flow contexts).
-    if (provider_context->dispatch.release_hook_resources != NULL) {
-        provider_context->dispatch.release_hook_resources(filter_context);
+    if (provider_context->dispatch.cleanup_filter_context != NULL) {
+        provider_context->dispatch.cleanup_filter_context(filter_context);
     }
 
     if (net_ebpf_ext_filter_context_all_deleted(filter_context)) {

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -180,7 +180,8 @@ net_ebpf_extension_hook_invoke_filtered_programs(
     bool lock_acquired = FALSE;
     uint32_t client_count = 0;
     net_ebpf_extension_hook_client_t* clients[NET_EBPF_EXT_MAX_CLIENTS_PER_HOOK_MULTI_ATTACH] = {0};
-    const net_ebpf_extension_hook_process_verdict process_verdict = filter_context->process_verdict;
+    const net_ebpf_extension_hook_process_verdict process_verdict =
+        filter_context->provider_context->dispatch.process_verdict;
 
     *result = 0;
 

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -562,7 +562,16 @@ Exit:
             RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
         }
 
-        local_provider_context->dispatch.delete_filter_context(new_filter_context);
+        if (new_filter_context != NULL) {
+            local_provider_context->dispatch.delete_filter_context(new_filter_context);
+            if (net_ebpf_ext_filter_context_all_deleted(new_filter_context)) {
+                DEREFERENCE_FILTER_CONTEXT(new_filter_context);
+            } else {
+                ACQUIRE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
+                InsertTailList(&local_provider_context->zombie_filter_context_list, &new_filter_context->zombie_link);
+                RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
+            }
+        }
     }
 
     _net_ebpf_extension_hook_client_cleanup(hook_client);
@@ -582,11 +591,22 @@ _Requires_exclusive_lock_held_(provider_context->lock) static void _net_ebpf_ext
 {
     EBPF_EXT_LOG_ENTRY();
 
-    // Remove the list entry from the provider's list of filter contexts.
+    // Remove the list entry from the provider's active list.
     RemoveEntryList(&filter_context->link);
+    InitializeListHead(&filter_context->link);
 
-    // Release the filter context.
+    // Delete WFP filters and mark the context as detaching.
     provider_context->dispatch.delete_filter_context(filter_context);
+
+    // If all WFP filters were successfully deleted, their per-filter references were released by notifications.
+    // Release the initial reference to free the context immediately.
+    // Otherwise, transfer to the zombie list without releasing the initial reference — the unload sweep will
+    // reclaim after callouts are unregistered.
+    if (net_ebpf_ext_filter_context_all_deleted(filter_context)) {
+        DEREFERENCE_FILTER_CONTEXT(filter_context);
+    } else {
+        InsertTailList(&provider_context->zombie_filter_context_list, &filter_context->zombie_link);
+    }
 
     EBPF_EXT_LOG_EXIT();
 }
@@ -708,6 +728,7 @@ net_ebpf_extension_hook_provider_register(
     memset(local_provider_context, 0, sizeof(net_ebpf_extension_hook_provider_t));
     ExInitializePushLock(&local_provider_context->lock);
     InitializeListHead(&local_provider_context->filter_context_list);
+    InitializeListHead(&local_provider_context->zombie_filter_context_list);
     ebpf_ext_init_rundown(&local_provider_context->rundown);
 
     characteristics = &local_provider_context->characteristics;

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -180,8 +180,7 @@ net_ebpf_extension_hook_invoke_filtered_programs(
     bool lock_acquired = FALSE;
     uint32_t client_count = 0;
     net_ebpf_extension_hook_client_t* clients[NET_EBPF_EXT_MAX_CLIENTS_PER_HOOK_MULTI_ATTACH] = {0};
-    const net_ebpf_extension_hook_process_verdict process_verdict =
-        filter_context->provider_context->dispatch.process_verdict;
+    const net_ebpf_extension_hook_process_verdict process_verdict = filter_context->process_verdict;
 
     *result = 0;
 
@@ -423,7 +422,6 @@ _net_ebpf_extension_hook_provider_attach_client(
     ebpf_extension_data_t* client_data = NULL;
     bool is_wild_card_attach_parameter = FALSE;
     net_ebpf_extension_wfp_filter_context_t* new_filter_context = NULL;
-    bool rundown_acquired = FALSE;
 
     EBPF_EXT_LOG_ENTRY();
 
@@ -550,18 +548,8 @@ _net_ebpf_extension_hook_provider_attach_client(
         }
     }
 
-    // No matching filter context found. Need to create a new filter context.
-    // Acquire rundown reference on provider context. This will be released when the filter context is deleted.
-    rundown_acquired = net_ebpf_extension_hook_provider_enter_rundown(local_provider_context);
-    if (!rundown_acquired) {
-        EBPF_EXT_LOG_MESSAGE(
-            EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
-            "ExAcquireRundownProtection failed. Attach attempt rejected.");
-        status = STATUS_ACCESS_DENIED;
-        goto Exit;
-    }
-
+    // No matching filter context found. Need to create a new filter context. It acquires its own rundown reference
+    // on the provider context, which it releases when it is freed.
     result = local_provider_context->dispatch.create_filter_context(
         hook_client, local_provider_context, &new_filter_context);
     if (result != EBPF_SUCCESS) {
@@ -574,9 +562,9 @@ _net_ebpf_extension_hook_provider_attach_client(
         goto Exit;
     }
 
-    // The filter context now owns the rundown reference: DEREFERENCE_FILTER_CONTEXT releases it via
-    // leave_rundown when the context's last reference is dropped, so this function must not release it.
-    rundown_acquired = FALSE;
+    // Set the filter context as the client's provider data. This is done only now that the context is guaranteed to
+    // outlive the call: every failure path inside create_filter_context frees it.
+    net_ebpf_extension_hook_client_set_provider_data(hook_client, new_filter_context);
 
     // If the attach parameter is a wildcard, set the wildcard flag in the filter context.
     if (is_wild_card_attach_parameter) {
@@ -608,12 +596,6 @@ Exit:
     }
 
     _net_ebpf_extension_hook_client_cleanup(hook_client);
-
-    if (status != STATUS_SUCCESS) {
-        if (rundown_acquired) {
-            net_ebpf_extension_hook_provider_leave_rundown(local_provider_context);
-        }
-    }
 
     EBPF_EXT_RETURN_NTSTATUS(status);
 }

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -599,8 +599,8 @@ _Requires_exclusive_lock_held_(provider_context->lock) static void _net_ebpf_ext
  * @retval STATUS_PENDING The operation is pending completion.
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
-static NTSTATUS
-_net_ebpf_extension_hook_provider_detach_client(_In_ const void* provider_binding_context)
+_IRQL_requires_(PASSIVE_LEVEL) static NTSTATUS
+    _net_ebpf_extension_hook_provider_detach_client(_In_ const void* provider_binding_context)
 {
     NTSTATUS status = STATUS_PENDING;
     net_ebpf_extension_hook_provider_t* local_provider_context = NULL;

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -361,12 +361,13 @@ _net_ebpf_extension_hook_client_cleanup(_In_opt_ _Frees_ptr_opt_ net_ebpf_extens
  * be freed while live WFP filters still point at it; the unload sweep reclaims it.
  *
  * @param[in] provider_context Provider module's context.
- * @param[in,out] filter_context Filter context to dispose of. May be freed on return.
+ * @param[in] filter_context Filter context to dispose of. The caller must not use it on return: it is either
+ * freed here or transferred to the provider's zombie list.
  */
 _IRQL_requires_(PASSIVE_LEVEL)
     _Requires_exclusive_lock_held_(provider_context->lock) static void _net_ebpf_ext_dispose_filter_context(
         _In_ net_ebpf_extension_hook_provider_t* provider_context,
-        _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+        _In_ _Post_ptr_invalid_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     EBPF_EXT_LOG_ENTRY();
 

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -354,7 +354,43 @@ _net_ebpf_extension_hook_client_cleanup(_In_opt_ _Frees_ptr_opt_ net_ebpf_extens
 }
 
 /**
- * @brief Callback invoked when an eBPF hook NPI client (a.k.a eBPF link object) attaches.
+ * @brief Tears down a filter context that is no longer referenced by any hook NPI client, and disposes of it.
+ *
+ * The context is marked as detaching, its WFP filters are deleted, and any hook-specific resources are released.
+ * If every WFP filter was deleted the initial reference is released here and the context is freed. If any delete
+ * failed the context is transferred to the provider's zombie list without releasing that reference, so it cannot
+ * be freed while live WFP filters still point at it; the unload sweep reclaims it.
+ *
+ * @param[in] provider_context Provider module's context.
+ * @param[in,out] filter_context Filter context to dispose of. May be freed on return.
+ */
+_IRQL_requires_(PASSIVE_LEVEL)
+    _Requires_exclusive_lock_held_(provider_context->lock) static void _net_ebpf_ext_dispose_filter_context(
+        _In_ net_ebpf_extension_hook_provider_t* provider_context,
+        _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+{
+    EBPF_EXT_LOG_ENTRY();
+
+    // Stop invoking eBPF programs before removing the filters that reference this context.
+    net_ebpf_extension_wfp_filter_context_detach(filter_context);
+    net_ebpf_extension_delete_wfp_filters(filter_context);
+
+    // Release hook-specific resources (redirect handle, flow contexts).
+    if (provider_context->dispatch.release_hook_resources != NULL) {
+        provider_context->dispatch.release_hook_resources(filter_context);
+    }
+
+    if (net_ebpf_ext_filter_context_all_deleted(filter_context)) {
+        DEREFERENCE_FILTER_CONTEXT(filter_context);
+    } else {
+        InsertTailList(&provider_context->zombie_filter_context_list, &filter_context->zombie_link);
+    }
+
+    EBPF_EXT_LOG_EXIT();
+}
+
+/**
+ * @brief Callback invoked when a hook NPI client (a.k.a. eBPF link object) attaches.
  *
  * @param[in] nmr_binding_handle NMR binding between the client module and the provider module.
  * @param[in] provider_context Provider module's context.
@@ -538,6 +574,10 @@ _net_ebpf_extension_hook_provider_attach_client(
         goto Exit;
     }
 
+    // The filter context now owns the rundown reference: DEREFERENCE_FILTER_CONTEXT releases it via
+    // leave_rundown when the context's last reference is dropped, so this function must not release it.
+    rundown_acquired = FALSE;
+
     // If the attach parameter is a wildcard, set the wildcard flag in the filter context.
     if (is_wild_card_attach_parameter) {
         new_filter_context->wildcard = TRUE;
@@ -559,18 +599,11 @@ _net_ebpf_extension_hook_provider_attach_client(
 Exit:
     if (local_provider_context) {
         if (provider_lock_acquired) {
-            RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
-        }
-
-        if (new_filter_context != NULL) {
-            local_provider_context->dispatch.delete_filter_context(new_filter_context);
-            if (net_ebpf_ext_filter_context_all_deleted(new_filter_context)) {
-                DEREFERENCE_FILTER_CONTEXT(new_filter_context);
-            } else {
-                ACQUIRE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
-                InsertTailList(&local_provider_context->zombie_filter_context_list, &new_filter_context->zombie_link);
-                RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
+            // new_filter_context is only non-NULL while the lock is held.
+            if (new_filter_context != NULL) {
+                _net_ebpf_ext_dispose_filter_context(local_provider_context, new_filter_context);
             }
+            RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
         }
     }
 
@@ -595,18 +628,7 @@ _Requires_exclusive_lock_held_(provider_context->lock) static void _net_ebpf_ext
     RemoveEntryList(&filter_context->link);
     InitializeListHead(&filter_context->link);
 
-    // Delete WFP filters and mark the context as detaching.
-    provider_context->dispatch.delete_filter_context(filter_context);
-
-    // If all WFP filters were successfully deleted, their per-filter references were released by notifications.
-    // Release the initial reference to free the context immediately.
-    // Otherwise, transfer to the zombie list without releasing the initial reference — the unload sweep will
-    // reclaim after callouts are unregistered.
-    if (net_ebpf_ext_filter_context_all_deleted(filter_context)) {
-        DEREFERENCE_FILTER_CONTEXT(filter_context);
-    } else {
-        InsertTailList(&provider_context->zombie_filter_context_list, &filter_context->zombie_link);
-    }
+    _net_ebpf_ext_dispose_filter_context(provider_context, filter_context);
 
     EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -11,6 +11,9 @@
 void
 net_ebpf_extension_hook_provider_leave_rundown(_Inout_ net_ebpf_extension_hook_provider_t* provider_context);
 
+_Must_inspect_result_ bool
+net_ebpf_extension_hook_provider_enter_rundown(_Inout_ net_ebpf_extension_hook_provider_t* provider_context);
+
 /**
  * @brief Get the attach parameters for the input client.
  *

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -925,8 +925,7 @@ _net_ebpf_extension_sock_addr_delete_filter_context(
     }
     sock_addr_filter_context = (net_ebpf_extension_sock_addr_wfp_filter_context_t*)filter_context;
 
-    net_ebpf_extension_delete_wfp_filters(
-        filter_context->wfp_engine_handle, filter_context->filter_ids_count, filter_context->filter_ids);
+    net_ebpf_extension_delete_wfp_filters(filter_context);
     if (sock_addr_filter_context->redirect_handle != NULL) {
         FwpsRedirectHandleDestroy(sock_addr_filter_context->redirect_handle);
     }

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -913,14 +913,15 @@ Exit:
 }
 
 static void
-_net_ebpf_extension_sock_addr_delete_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+_net_ebpf_extension_sock_addr_release_hook_resources(
+    _Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     net_ebpf_extension_sock_addr_wfp_filter_context_t* sock_addr_filter_context = NULL;
 
     EBPF_EXT_LOG_ENTRY();
 
-    // net_ebpf_extension_delete_wfp_filters requires PASSIVE_LEVEL. This delete_filter_context callback has a fixed
-    // signature so the requirement cannot be expressed via SAL on it; assert it here instead.
+    // FwpsRedirectHandleDestroy requires PASSIVE_LEVEL. This release_hook_resources callback has a fixed signature so
+    // the requirement cannot be expressed via SAL on it; assert it here instead.
     ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
 
     if (filter_context == NULL) {
@@ -928,11 +929,9 @@ _net_ebpf_extension_sock_addr_delete_filter_context(_Inout_opt_ net_ebpf_extensi
     }
     sock_addr_filter_context = (net_ebpf_extension_sock_addr_wfp_filter_context_t*)filter_context;
 
-    net_ebpf_extension_delete_wfp_filters(filter_context);
     if (sock_addr_filter_context->redirect_handle != NULL) {
         FwpsRedirectHandleDestroy(sock_addr_filter_context->redirect_handle);
     }
-    net_ebpf_extension_wfp_filter_context_detach(filter_context);
 
 Exit:
     EBPF_EXT_LOG_EXIT();
@@ -1388,14 +1387,14 @@ net_ebpf_ext_sock_addr_register_providers()
 
     const net_ebpf_extension_hook_provider_dispatch_table_t connect_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .delete_filter_context = _net_ebpf_extension_sock_addr_delete_filter_context,
+        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
         .process_verdict = _net_ebpf_extension_sock_addr_process_verdict,
     };
 
     const net_ebpf_extension_hook_provider_dispatch_table_t recv_accept_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .delete_filter_context = _net_ebpf_extension_sock_addr_delete_filter_context,
+        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
     };
 
@@ -1404,14 +1403,14 @@ net_ebpf_ext_sock_addr_register_providers()
     // programs and short-circuits on REJECT.
     const net_ebpf_extension_hook_provider_dispatch_table_t bind_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .delete_filter_context = _net_ebpf_extension_sock_addr_delete_filter_context,
+        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
         .process_verdict = _net_ebpf_extension_sock_addr_bind_process_verdict,
     };
 
     const net_ebpf_extension_hook_provider_dispatch_table_t listen_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .delete_filter_context = _net_ebpf_extension_sock_addr_delete_filter_context,
+        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
     };
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -913,14 +913,14 @@ Exit:
 }
 
 static void
-_net_ebpf_extension_sock_addr_release_hook_resources(
+_net_ebpf_extension_sock_addr_cleanup_filter_context(
     _Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     net_ebpf_extension_sock_addr_wfp_filter_context_t* sock_addr_filter_context = NULL;
 
     EBPF_EXT_LOG_ENTRY();
 
-    // FwpsRedirectHandleDestroy requires PASSIVE_LEVEL. This release_hook_resources callback has a fixed signature so
+    // FwpsRedirectHandleDestroy requires PASSIVE_LEVEL. This cleanup_filter_context callback has a fixed signature so
     // the requirement cannot be expressed via SAL on it; assert it here instead.
     ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
 
@@ -1387,14 +1387,14 @@ net_ebpf_ext_sock_addr_register_providers()
 
     const net_ebpf_extension_hook_provider_dispatch_table_t connect_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
+        .cleanup_filter_context = _net_ebpf_extension_sock_addr_cleanup_filter_context,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
         .process_verdict = _net_ebpf_extension_sock_addr_process_verdict,
     };
 
     const net_ebpf_extension_hook_provider_dispatch_table_t recv_accept_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
+        .cleanup_filter_context = _net_ebpf_extension_sock_addr_cleanup_filter_context,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
     };
 
@@ -1403,14 +1403,14 @@ net_ebpf_ext_sock_addr_register_providers()
     // programs and short-circuits on REJECT.
     const net_ebpf_extension_hook_provider_dispatch_table_t bind_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
+        .cleanup_filter_context = _net_ebpf_extension_sock_addr_cleanup_filter_context,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
         .process_verdict = _net_ebpf_extension_sock_addr_bind_process_verdict,
     };
 
     const net_ebpf_extension_hook_provider_dispatch_table_t listen_dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_addr_create_filter_context,
-        .release_hook_resources = _net_ebpf_extension_sock_addr_release_hook_resources,
+        .cleanup_filter_context = _net_ebpf_extension_sock_addr_cleanup_filter_context,
         .validate_client_data = _net_ebpf_extension_sock_addr_validate_client_data,
     };
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -913,8 +913,7 @@ Exit:
 }
 
 static void
-_net_ebpf_extension_sock_addr_delete_filter_context(
-    _In_opt_ _Frees_ptr_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+_net_ebpf_extension_sock_addr_delete_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     net_ebpf_extension_sock_addr_wfp_filter_context_t* sock_addr_filter_context = NULL;
 
@@ -933,7 +932,7 @@ _net_ebpf_extension_sock_addr_delete_filter_context(
     if (sock_addr_filter_context->redirect_handle != NULL) {
         FwpsRedirectHandleDestroy(sock_addr_filter_context->redirect_handle);
     }
-    net_ebpf_extension_wfp_filter_context_cleanup(filter_context);
+    net_ebpf_extension_wfp_filter_context_detach(filter_context);
 
 Exit:
     EBPF_EXT_LOG_EXIT();

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -920,6 +920,10 @@ _net_ebpf_extension_sock_addr_delete_filter_context(
 
     EBPF_EXT_LOG_ENTRY();
 
+    // net_ebpf_extension_delete_wfp_filters requires PASSIVE_LEVEL. This delete_filter_context callback has a fixed
+    // signature so the requirement cannot be expressed via SAL on it; assert it here instead.
+    ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
     if (filter_context == NULL) {
         goto Exit;
     }

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -273,7 +273,7 @@ Exit:
 }
 
 static void
-_net_ebpf_extension_sock_ops_delete_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+_net_ebpf_extension_sock_ops_release_hook_resources(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     net_ebpf_extension_sock_ops_wfp_filter_context_t* local_filter_context = NULL;
     KIRQL irql;
@@ -288,7 +288,6 @@ _net_ebpf_extension_sock_ops_delete_filter_context(_Inout_opt_ net_ebpf_extensio
     local_filter_context = (net_ebpf_extension_sock_ops_wfp_filter_context_t*)filter_context;
 
     InitializeListHead(&local_list_head);
-    net_ebpf_extension_delete_wfp_filters(filter_context);
 
     KeAcquireSpinLock(&local_filter_context->lock, &irql);
     if (local_filter_context->flow_context_list.count > 0) {
@@ -321,8 +320,6 @@ _net_ebpf_extension_sock_ops_delete_filter_context(_Inout_opt_ net_ebpf_extensio
         ASSERT(status == STATUS_SUCCESS);
     }
 
-    net_ebpf_extension_wfp_filter_context_detach(filter_context);
-
 Exit:
     EBPF_EXT_LOG_EXIT();
 }
@@ -339,7 +336,7 @@ net_ebpf_ext_sock_ops_register_providers()
 
     const net_ebpf_extension_hook_provider_dispatch_table_t dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_ops_create_filter_context,
-        .delete_filter_context = _net_ebpf_extension_sock_ops_delete_filter_context,
+        .release_hook_resources = _net_ebpf_extension_sock_ops_release_hook_resources,
         .validate_client_data = _net_ebpf_extension_sock_ops_validate_client_data,
     };
 

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -289,10 +289,7 @@ _net_ebpf_extension_sock_ops_delete_filter_context(
     local_filter_context = (net_ebpf_extension_sock_ops_wfp_filter_context_t*)filter_context;
 
     InitializeListHead(&local_list_head);
-    net_ebpf_extension_delete_wfp_filters(
-        filter_context->wfp_engine_handle,
-        local_filter_context->base.filter_ids_count,
-        local_filter_context->base.filter_ids);
+    net_ebpf_extension_delete_wfp_filters(filter_context);
 
     KeAcquireSpinLock(&local_filter_context->lock, &irql);
     if (local_filter_context->flow_context_list.count > 0) {

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -273,8 +273,7 @@ Exit:
 }
 
 static void
-_net_ebpf_extension_sock_ops_delete_filter_context(
-    _In_opt_ _Frees_ptr_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+_net_ebpf_extension_sock_ops_delete_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     net_ebpf_extension_sock_ops_wfp_filter_context_t* local_filter_context = NULL;
     KIRQL irql;
@@ -322,7 +321,7 @@ _net_ebpf_extension_sock_ops_delete_filter_context(
         ASSERT(status == STATUS_SUCCESS);
     }
 
-    net_ebpf_extension_wfp_filter_context_cleanup(filter_context);
+    net_ebpf_extension_wfp_filter_context_detach(filter_context);
 
 Exit:
     EBPF_EXT_LOG_EXIT();

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -277,7 +277,6 @@ _net_ebpf_extension_sock_ops_release_hook_resources(_Inout_opt_ net_ebpf_extensi
 {
     net_ebpf_extension_sock_ops_wfp_filter_context_t* local_filter_context = NULL;
     KIRQL irql;
-    LIST_ENTRY local_list_head;
 
     EBPF_EXT_LOG_ENTRY();
 
@@ -287,37 +286,38 @@ _net_ebpf_extension_sock_ops_release_hook_resources(_Inout_opt_ net_ebpf_extensi
 
     local_filter_context = (net_ebpf_extension_sock_ops_wfp_filter_context_t*)filter_context;
 
-    InitializeListHead(&local_list_head);
+    // Pop one entry at a time under the lock: the flow delete callback runs asynchronously and would unlink and
+    // free entries from a detached list while it was being walked. Whichever of this loop and
+    // net_ebpf_extension_sock_ops_flow_delete reaches an entry first unlinks it, but only the latter frees it.
+    for (;;) {
+        LIST_ENTRY* entry;
+        net_ebpf_extension_flow_context_parameters_t flow_parameters;
+        NTSTATUS status;
 
-    KeAcquireSpinLock(&local_filter_context->lock, &irql);
-    if (local_filter_context->flow_context_list.count > 0) {
-
-        LIST_ENTRY* entry = local_filter_context->flow_context_list.list_head.Flink;
-        RemoveEntryList(&local_filter_context->flow_context_list.list_head);
-        InitializeListHead(&local_filter_context->flow_context_list.list_head);
-        AppendTailList(&local_list_head, entry);
-
-        local_filter_context->flow_context_list.count = 0;
-    }
-    KeReleaseSpinLock(&local_filter_context->lock, irql);
-
-    // Remove the flow context associated with the WFP flows.
-    while (!IsListEmpty(&local_list_head)) {
-        LIST_ENTRY* entry = RemoveHeadList(&local_list_head);
+        KeAcquireSpinLock(&local_filter_context->lock, &irql);
+        if (IsListEmpty(&local_filter_context->flow_context_list.list_head)) {
+            KeReleaseSpinLock(&local_filter_context->lock, irql);
+            break;
+        }
+        entry = RemoveHeadList(&local_filter_context->flow_context_list.list_head);
         InitializeListHead(entry);
-        net_ebpf_extension_sock_ops_wfp_flow_context_t* flow_context =
-            CONTAINING_RECORD(entry, net_ebpf_extension_sock_ops_wfp_flow_context_t, link);
+        local_filter_context->flow_context_list.count--;
 
-        net_ebpf_extension_flow_context_parameters_t* flow_parameters = &flow_context->parameters;
+        // Copy the parameters under the lock; the flow delete callback may free the flow context once it drops.
+        flow_parameters = CONTAINING_RECORD(entry, net_ebpf_extension_sock_ops_wfp_flow_context_t, link)->parameters;
+        KeReleaseSpinLock(&local_filter_context->lock, irql);
 
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsflowremovecontext0
-        // Calling FwpsFlowRemoveContext may cause the flowDeleteFn callback on the callout to be invoked synchronously.
-        // The net_ebpf_extension_sock_ops_flow_delete function frees the flow context memory and
-        // releases reference on the filter_context.
-        NTSTATUS status =
-            FwpsFlowRemoveContext(flow_parameters->flow_id, flow_parameters->layer_id, flow_parameters->callout_id);
-        EBPF_EXT_LOG_NTSTATUS_API_FAILURE(EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS, "FwpsFlowRemoveContext", status);
-        ASSERT(status == STATUS_SUCCESS);
+        // This invokes net_ebpf_extension_sock_ops_flow_delete, which frees the flow context and releases its
+        // reference on the filter context: synchronously on STATUS_SUCCESS, asynchronously on STATUS_PENDING while
+        // a classify callback is still active. STATUS_UNSUCCESSFUL means the flow no longer has a context.
+        status = FwpsFlowRemoveContext(flow_parameters.flow_id, flow_parameters.layer_id, flow_parameters.callout_id);
+        if (!NT_SUCCESS(status)) {
+            EBPF_EXT_LOG_NTSTATUS_API_FAILURE(EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS, "FwpsFlowRemoveContext", status);
+        }
+
+        // Any other status leaves the association outstanding with the entry already removed from the list.
+        ASSERT((status == STATUS_SUCCESS) || (status == STATUS_PENDING) || (status == STATUS_UNSUCCESSFUL));
     }
 
 Exit:
@@ -511,6 +511,7 @@ net_ebpf_extension_sock_ops_flow_established_classify(
     EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
         EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS, local_flow_context, "flow_context", result);
     memset(local_flow_context, 0, sizeof(net_ebpf_extension_sock_ops_wfp_flow_context_t));
+    InitializeListHead(&local_flow_context->link);
 
     // Associate the filter context with the local flow context.
     REFERENCE_FILTER_CONTEXT(&filter_context->base);
@@ -618,14 +619,20 @@ net_ebpf_extension_sock_ops_flow_delete(uint16_t layer_id, uint32_t callout_id, 
         goto Exit;
     }
 
+    // Unlink before the context_deleting check below: this function frees the flow context before it returns, so
+    // an early return would leave a freed entry linked into flow_context_list. The entry is already self-linked if
+    // the teardown drain removed it first.
+    KeAcquireSpinLock(&filter_context->lock, &irql);
+    if (!IsListEmpty(&local_flow_context->link)) {
+        RemoveEntryList(&local_flow_context->link);
+        InitializeListHead(&local_flow_context->link);
+        filter_context->flow_context_list.count--;
+    }
+    KeReleaseSpinLock(&filter_context->lock, irql);
+
     if (filter_context->base.context_deleting) {
         goto Exit;
     }
-
-    KeAcquireSpinLock(&filter_context->lock, &irql);
-    RemoveEntryList(&local_flow_context->link);
-    filter_context->flow_context_list.count--;
-    KeReleaseSpinLock(&filter_context->lock, irql);
 
     EBPF_EXT_LOG_MESSAGE_UINT64(
         EBPF_EXT_TRACELOG_LEVEL_VERBOSE,

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -273,7 +273,7 @@ Exit:
 }
 
 static void
-_net_ebpf_extension_sock_ops_release_hook_resources(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+_net_ebpf_extension_sock_ops_cleanup_filter_context(_Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context)
 {
     net_ebpf_extension_sock_ops_wfp_filter_context_t* local_filter_context = NULL;
     KIRQL irql;
@@ -336,7 +336,7 @@ net_ebpf_ext_sock_ops_register_providers()
 
     const net_ebpf_extension_hook_provider_dispatch_table_t dispatch_table = {
         .create_filter_context = _net_ebpf_extension_sock_ops_create_filter_context,
-        .release_hook_resources = _net_ebpf_extension_sock_ops_release_hook_resources,
+        .cleanup_filter_context = _net_ebpf_extension_sock_ops_cleanup_filter_context,
         .validate_client_data = _net_ebpf_extension_sock_ops_validate_client_data,
     };
 

--- a/netebpfext/net_ebpf_ext_structs.h
+++ b/netebpfext/net_ebpf_ext_structs.h
@@ -58,7 +58,7 @@ typedef ebpf_result_t (*net_ebpf_extension_create_filter_context)(
  *
  * @param[in,out] filter_context Pointer to the filter context whose hook-specific resources are being released.
  */
-typedef void (*net_ebpf_extension_release_hook_resources)(
+typedef void (*net_ebpf_extension_cleanup_filter_context)(
     _Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context);
 
 /**
@@ -88,7 +88,7 @@ typedef bool (*net_ebpf_extension_hook_process_verdict)(_Inout_ void* program_co
 typedef struct _net_ebpf_extension_hook_provider_dispatch_table
 {
     net_ebpf_extension_create_filter_context create_filter_context;
-    net_ebpf_extension_release_hook_resources release_hook_resources;
+    net_ebpf_extension_cleanup_filter_context cleanup_filter_context;
     net_ebpf_extension_validate_client_data validate_client_data;
     net_ebpf_extension_hook_process_verdict process_verdict;
 } net_ebpf_extension_hook_provider_dispatch_table_t;

--- a/netebpfext/net_ebpf_ext_structs.h
+++ b/netebpfext/net_ebpf_ext_structs.h
@@ -51,13 +51,15 @@ typedef ebpf_result_t (*net_ebpf_extension_create_filter_context)(
     _Outptr_ net_ebpf_extension_wfp_filter_context_t** filter_context);
 
 /**
- * @brief Callback function to delete hook specific filter context. This callback is invoked when a hook NPI client
-          is detaching from the hook NPI provider.
+ * @brief Callback function to tear down a hook specific filter context. This callback is invoked when a hook NPI
+          client is detaching from the hook NPI provider. It deletes the context's WFP filters and releases any hook
+          specific resources, then marks the context as detaching. It does NOT free the filter context: the caller
+          decides whether to release the initial reference or hand the context to the provider's zombie list.
  *
- * @param[in] filter_context Pointer to the filter context being deleted.
+ * @param[in,out] filter_context Pointer to the filter context being torn down.
  */
 typedef void (*net_ebpf_extension_delete_filter_context)(
-    _In_opt_ _Frees_ptr_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context);
+    _Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context);
 
 /**
  * @brief Callback function to validate if the attach parameters (i.e., client data) is valid, and to get information
@@ -130,8 +132,10 @@ typedef struct _net_ebpf_extension_hook_provider
     const void* custom_data; ///< Opaque pointer to hook specific data associated for this provider.
     _Guarded_by_(lock)
         LIST_ENTRY filter_context_list; ///< Linked list of filter contexts that are attached to this provider.
-    LIST_ENTRY cleanup_list_entry;      ///< List entry for cleanup.
-    ebpf_attach_type_t attach_type;     ///< Attach type of the eBPF program.
+    _Guarded_by_(lock)
+        LIST_ENTRY zombie_filter_context_list; ///< Filter contexts with leaked WFP filters awaiting unload cleanup.
+    LIST_ENTRY cleanup_list_entry;             ///< List entry for cleanup.
+    ebpf_attach_type_t attach_type;            ///< Attach type of the eBPF program.
 } net_ebpf_extension_hook_provider_t;
 
 typedef struct _net_ebpf_extension_invoke_programs_parameters

--- a/netebpfext/net_ebpf_ext_structs.h
+++ b/netebpfext/net_ebpf_ext_structs.h
@@ -51,14 +51,14 @@ typedef ebpf_result_t (*net_ebpf_extension_create_filter_context)(
     _Outptr_ net_ebpf_extension_wfp_filter_context_t** filter_context);
 
 /**
- * @brief Callback function to tear down a hook specific filter context. This callback is invoked when a hook NPI
-          client is detaching from the hook NPI provider. It deletes the context's WFP filters and releases any hook
-          specific resources, then marks the context as detaching. It does NOT free the filter context: the caller
-          decides whether to release the initial reference or hand the context to the provider's zombie list.
+ * @brief Optional callback to release hook-specific resources held by a filter context. Invoked by the hook provider
+          when the last NPI client detaches, after the context has been marked as detaching and its WFP filters have
+          been deleted. It must NOT free the filter context. May be NULL if the hook holds no hook-specific
+          resources.
  *
- * @param[in,out] filter_context Pointer to the filter context being torn down.
+ * @param[in,out] filter_context Pointer to the filter context whose hook-specific resources are being released.
  */
-typedef void (*net_ebpf_extension_delete_filter_context)(
+typedef void (*net_ebpf_extension_release_hook_resources)(
     _Inout_opt_ net_ebpf_extension_wfp_filter_context_t* filter_context);
 
 /**
@@ -88,7 +88,7 @@ typedef bool (*net_ebpf_extension_hook_process_verdict)(_Inout_ void* program_co
 typedef struct _net_ebpf_extension_hook_provider_dispatch_table
 {
     net_ebpf_extension_create_filter_context create_filter_context;
-    net_ebpf_extension_delete_filter_context delete_filter_context;
+    net_ebpf_extension_release_hook_resources release_hook_resources;
     net_ebpf_extension_validate_client_data validate_client_data;
     net_ebpf_extension_hook_process_verdict process_verdict;
 } net_ebpf_extension_hook_provider_dispatch_table_t;

--- a/netebpfext/sys/net_ebpf_ext_drv.c
+++ b/netebpfext/sys/net_ebpf_ext_drv.c
@@ -47,6 +47,8 @@ _net_ebpf_ext_driver_uninitialize_objects()
 
     net_ebpf_extension_uninitialize_wfp_components();
 
+    net_ebpf_ext_wait_for_provider_context_rundown();
+
     net_ebpf_ext_uninitialize_ndis_handles();
 
     ebpf_ext_trace_terminate();

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -114,6 +114,7 @@ _netebpf_ext_helper::~_netebpf_ext_helper()
 
     if (wfp_initialized) {
         net_ebpf_extension_uninitialize_wfp_components();
+        net_ebpf_ext_wait_for_provider_context_rundown();
     }
 
     if (ndis_handle_initialized) {

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -122,6 +122,16 @@ typedef class _netebpf_ext_helper
         return usersim_fwp_cgroup_inet6_listen(const_cast<fwp_classify_parameters_t*>(parameters));
     }
 
+    // Detach the hook client via NMR (deletes its WFP filters) while leaving WFP initialized, for filter-delete
+    // recovery tests.
+    void
+    detach_hook_client()
+    {
+        if (nmr_hook_client_handle) {
+            nmr_hook_client_handle.reset(nullptr);
+        }
+    }
+
   private:
     bool trace_initiated = false;
     bool ndis_handle_initialized = false;

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -10,6 +10,7 @@
 #include "netebpf_ext_helper.h"
 #include "watchdog.h"
 
+#include <chrono>
 #include <map>
 #include <stop_token>
 #include <thread>
@@ -905,6 +906,113 @@ TEST_CASE("sock_addr_connect_authorization_invoke", "[netebpfext]")
     // routes both CONNECT and CONNECT_AUTHORIZATION through the same WFP filter context, and the
     // _is_auth_connect_program filter finds no CONNECT_AUTHORIZATION clients. This is validated
     // by integration tests (socket_tests) instead.
+}
+
+// Verifies that the inline retry recovers a transient WFP filter delete failure before unload: a failed
+// FwpmFilterDeleteById is retried in the delete path, and the delete notification releases the reference.
+TEST_CASE("wfp_filter_delete_failure_runtime_retry", "[netebpfext][wfp_cleanup]")
+{
+    // This test drives a deterministic fault-injection sequence; skip it under the random fault-injection harness.
+    if (cxplat_fault_injection_is_enabled()) {
+        return;
+    }
+
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
+    test_sock_addr_client_context_header_t client_context_header = {0};
+    client_context_header.context.base.desired_attach_types = {BPF_CGROUP_INET4_CONNECT, BPF_CGROUP_INET6_CONNECT};
+    test_sock_addr_client_context_t* client_context = &client_context_header.context;
+
+    netebpf_ext_helper_t helper(
+        &npi_specific_characteristics,
+        (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
+        (netebpfext_helper_base_client_context_t*)client_context);
+
+    // Attaching the connect program creates WFP filters.
+    REQUIRE(usersim_fwp_get_fwpm_filter_count() > 0);
+
+    // Fail the first delete attempt so the inline retry path is exercised.
+    usersim_fwp_set_filter_delete_failure_count(1);
+
+    // Detach: the inline retry recovers the transient failure and removes the filter before returning.
+    helper.detach_hook_client();
+
+    REQUIRE(usersim_fwp_get_fwpm_filter_count() == 0);
+
+    usersim_fwp_set_filter_delete_failure_count(0);
+}
+
+// Verifies that driver unload reclaims a WFP filter's reference when its delete permanently fails: the unload
+// sweep releases the reference so unload completes even though the filter cannot be deleted.
+TEST_CASE("wfp_filter_delete_failure_unload_reclaim", "[netebpfext][wfp_cleanup]")
+{
+    if (cxplat_fault_injection_is_enabled()) {
+        return;
+    }
+
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
+    test_sock_addr_client_context_header_t client_context_header = {0};
+    client_context_header.context.base.desired_attach_types = {BPF_CGROUP_INET4_CONNECT, BPF_CGROUP_INET6_CONNECT};
+    test_sock_addr_client_context_t* client_context = &client_context_header.context;
+
+    {
+        netebpf_ext_helper_t helper(
+            &npi_specific_characteristics,
+            (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
+            (netebpfext_helper_base_client_context_t*)client_context);
+
+        REQUIRE(usersim_fwp_get_fwpm_filter_count() > 0);
+
+        // Fail every delete attempt so the filters remain DELETE_FAILED until the unload sweep.
+        usersim_fwp_set_filter_delete_failure_count(UINT32_MAX);
+
+        helper.detach_hook_client();
+
+        // End of scope runs unload cleanup, which must reclaim the references without asserting or hanging.
+    }
+
+    // Deletes still fail, so the filters remain in the mock engine; clear them for the next test.
+    REQUIRE(usersim_fwp_get_fwpm_filter_count() > 0);
+    usersim_fwp_set_filter_delete_failure_count(0);
+    usersim_fwp_clear_fwpm_filters();
+}
+
+// Verifies that unload deletes now-stale WFP filters (after callout unregister) and releases their references, so
+// no filter survives with a dangling context pointer across a driver reload.
+TEST_CASE("wfp_filter_delete_failure_unload_deletes_stale_filter", "[netebpfext][wfp_cleanup]")
+{
+    if (cxplat_fault_injection_is_enabled()) {
+        return;
+    }
+
+    ebpf_extension_data_t npi_specific_characteristics = {
+        .header = EBPF_ATTACH_CLIENT_DATA_HEADER_VERSION,
+    };
+    test_sock_addr_client_context_header_t client_context_header = {0};
+    client_context_header.context.base.desired_attach_types = {BPF_CGROUP_INET4_CONNECT, BPF_CGROUP_INET6_CONNECT};
+    test_sock_addr_client_context_t* client_context = &client_context_header.context;
+
+    {
+        netebpf_ext_helper_t helper(
+            &npi_specific_characteristics,
+            (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
+            (netebpfext_helper_base_client_context_t*)client_context);
+
+        REQUIRE(usersim_fwp_get_fwpm_filter_count() > 0);
+
+        // Fail every delete through detach so unload sees DELETE_FAILED filters.
+        usersim_fwp_set_filter_delete_failure_count(UINT32_MAX);
+        helper.detach_hook_client();
+
+        // Let deletes succeed: the unload sweep now deletes the stale filters after callout unregister and
+        // releases their references.
+        usersim_fwp_set_filter_delete_failure_count(0);
+    }
+
+    REQUIRE(usersim_fwp_get_fwpm_filter_count() == 0);
 }
 
 #pragma endregion cgroup_sock_addr


### PR DESCRIPTION
## Description
Fixes #5486

Fixes a reference leak and driver-unload hang in netebpfext's WFP filter teardown.

When a WFP filter delete fails during client detach -- e.g. `FwpmFilterDeleteById` transiently returns
`RPC_NT_CALL_FAILED` -- the filter is left in `DELETE_FAILED` and its reference on the filter context is
never released, because the only releaser is the WFP delete notification, which never fires for a filter
that wasn't deleted. That leaked reference tripped `ASSERT(reference_count == leaked_filter_count)` on
checked builds and, on free builds, kept the context alive so provider run-down never completed, hanging
the next `NetEbpfExt` service stop indefinitely.

## Solution
Filter contexts whose WFP filters could not all be deleted are tracked on a per-provider zombie list and
reclaimed at unload.

**Detach.** Delete the context's WFP filters, retrying `FwpmFilterDeleteById` up to three times;
`FWP_E_FILTER_NOT_FOUND` counts as success. If every filter was deleted, the initial reference is
released and the context freed. If any delete failed, the context moves to its provider's zombie list
**without** releasing that reference, so it cannot be freed while live WFP filters still point at it
through `rawContext`.

**Unload.** Callout functions are unregistered first, then each provider's zombie list is swept, then
the callout objects, sub-layers and provider are deleted. A zombie context can only be reclaimed once
every callout function is unregistered, since until then WFP can still invoke classify, notify or
flow-delete for its filters:
- If every callout unregistered, the sweep is the context's sole owner: no notification can fire, so it
  best-effort deletes any filter still installed and then frees the context outright. This is the case
  the original hang depends on -- a filter that could not be deleted does not stop its callout from
  unregistering -- so the run-down is released and unload completes.
- Otherwise the zombie contexts are left in place, still holding their run-down references, so the
  driver stays loaded rather than unloading while WFP can still call into it. Exhausting the unregister
  retries is not recoverable, so checked builds assert.

**Flow contexts.** Teardown now marks a filter context deleting before it deletes the WFP filters, and
removing the `FLOW_ESTABLISHED` filter triggers flow deletions inside that window.
`net_ebpf_extension_sock_ops_flow_delete` therefore unlinks its flow context before its early return for
a context being deleted rather than after: the exit path frees the flow context either way, so returning
early left a freed entry linked into the flow list. The teardown drain also pops one entry at a time
under the lock instead of detaching the list and walking it while the asynchronous flow-delete callback
frees entries from it.

Supporting changes:
- Filter-state transitions are serialized under the filter-context lock and `DELETED` is terminal, so each filter's reference is released exactly once.
- Teardown is unified in `_net_ebpf_ext_dispose_filter_context` for both the detach and attach-failure paths; the per-hook `delete_filter_context` dispatch entry becomes `cleanup_filter_context`, which only releases hook-specific resources.
- The unload sweep and the provider run-down wait walk the provider cleanup list without taking its lock: that list is only appended to during provider unregistration, which has already completed for every provider before either runs.
- The filter context acquires the provider's run-down reference when it is created and releases it when it is freed, so the provider always outlives every context that can reach it.
- Retried recoveries, undeletable filters and callouts that could not be unregistered are traced.

### Trade-off
A filter whose delete never succeeds is left installed. All netebpfext filters carry
`FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED` (#5496), so a stranded filter permits rather than
blocks traffic, and leaving it installed is both preferable to hanging the provider run-down and safer
than freeing memory WFP can still reach. A callout that cannot be unregistered is handled differently:
the driver must not return from its unload function in that state, so its contexts are retained rather
than freed.

### Known limitation (follow-up)
With unload now completing, the reload path becomes reachable. A leftover filter pins its provider,
sub-layer and callout objects, so on the next start `FwpmProviderAdd` returns `FWP_E_ALREADY_EXISTS` and
`net_ebpf_extension_initialize_wfp_components` fails -- but `sys/net_ebpf_ext_drv.c` discards that
result (`(void)`, #521), leaving the service reporting `RUNNING` with no WFP components registered. A
reboot clears the leftover filters. A follow-up will purge stale eBPF WFP objects at init and stop
ignoring the initialization failure.

## Testing
Adds three `netebpfext_unit` regression tests, driven by the WFP delete-failure fault injection from
microsoft/usersim#317:
- `wfp_filter_delete_failure_runtime_retry` -- a transient delete failure is recovered by the retry.
- `wfp_filter_delete_failure_unload_reclaim` -- with deletes failing permanently, detach leaves a zombie
  context and unload reclaims it and completes.
- `wfp_filter_delete_failure_unload_deletes_stale_filter` -- the unload sweep deletes a filter left
  installed by a failed detach.

The flow-list change is covered by the existing `socket_tests` driver tests.

## Dependency
Requires the usersim WFP mock changes in microsoft/usersim#317 (merged); the `external/usersim` submodule
is bumped accordingly.