### PR TITLE
fix: honor gather_dumps=false in "Mark run as failed" step

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -506,7 +506,7 @@ jobs:
           retention-days: 10
 
       - name: Mark run as failed if crash dumps are found
-        if: (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true')
+        if: (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true') && (inputs.gather_dumps == true)
         run: exit 1
 
   create_or_update_issue:


### PR DESCRIPTION
## Problem

The `km_mt_stress_tests` job sets `gather_dumps: false` because it only cares about kernel mode dumps. However, the **Mark run as failed if crash dumps are found** step in `reusable-test.yml` was not checking this flag -- it would fail the run whenever any dump existed in the dump path, regardless of the setting.

This caused a false failure in [run #30435555664](https://github.com/microsoft/ebpf-for-windows/actions/runs/30435555664/job/90528755822?pr=5430) where an unrelated `svchost.exe.dmp` (a user-mode process dump) caused the kernel stress test to be marked as failed.

## Fix

Added `(inputs.gather_dumps == true)` to the failing step's condition, matching what the **Upload any crash dumps** step already does. When `gather_dumps: false`, dumps are now silently ignored -- neither uploaded nor used to fail the run.