### PR TITLE
Add arm64 28000 wdk and fix build tools version bug

### DIFF
--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -8,6 +8,10 @@
   <package id="Microsoft.Windows.SDK.CPP" version="10.0.28000.1839" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.28000.1839" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x64" version="10.0.28000.1839" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.28000.1839" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.28000.1839" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.28000.1839" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.28000.1839" targetFramework="native" />
   <!-- Last VS2022-compatible WDK: used for ARM64/x86 builds, and for x64 builds under Visual Studio 2022.
        The duplicate Microsoft.Windows.SDK.CPP / .x64 / WDK.x64 ids (also pinned at 28000 above) are
        intentional: NuGet restore keys on id+version and installs each into its own packages\ folder, and

--- a/scripts/setup_build/packages.config.template
+++ b/scripts/setup_build/packages.config.template
@@ -9,6 +9,10 @@
   <package id="Microsoft.Windows.SDK.CPP" version="$(WDKVersion)" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="$(WDKVersion)" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x64" version="$(WDKVersion)" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="$(WDKVersion)" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="$(WDKVersion)" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="$(WDKVersion)" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="$(WDKVersion)" targetFramework="native" />
   <!-- Last VS2022-compatible WDK: used for ARM64/x86 builds, and for x64 builds under Visual Studio 2022.
        The duplicate Microsoft.Windows.SDK.CPP / .x64 / WDK.x64 ids (also pinned above) are intentional:
        NuGet restore keys on id+version and installs each into its own packages\ folder, and wdk.props

--- a/tools/bpf2c/Convert-BpfToNative.ps1.template
+++ b/tools/bpf2c/Convert-BpfToNative.ps1.template
@@ -135,12 +135,20 @@ if ($VerbosePreference -eq "Continue") {
     $AdditionalOptions += " --verbose"
 }
 
+# Forward an explicit WDK version to the generated project when the caller pinned one. The templates
+# otherwise derive it from $(MSBuildToolsVersion); passing it through guarantees the restore and the
+# build agree, and lets a pipeline override both from one place.
+$WDKVersionArgs = @()
+if ($env:WDKVersion) {
+    $WDKVersionArgs += "/p:WDKVersion=$env:WDKVersion"
+}
+
 # Restore NuGet packages (Windows SDK / WDK) referenced by the generated project so that
 # $(WindowsSdkDir) is resolved from the package and the SDK does not need to be installed on the
 # machine. Both kernel-mode and user-mode templates reference SDK packages, so restore for both.
-msbuild /t:restore /p:Configuration="$Configuration" /p:Platform="$Platform" $ProjectFile
+msbuild /t:restore /p:Configuration="$Configuration" /p:Platform="$Platform" @WDKVersionArgs $ProjectFile
 
-msbuild /p:BinDir="$BinDir\" /p:OutDir="$OutDir\" /p:IncludeDir="$IncludeDir" /p:Configuration="$Configuration" /p:Platform="$Platform" /p:FileName="$FileName" /p:AdditionalOptions="$AdditionalOptions" /p:ResourceFile="$ResourceFile" /p:SpdFile="$SpdFile" $ProjectFile
+msbuild /p:BinDir="$BinDir\" /p:OutDir="$OutDir\" /p:IncludeDir="$IncludeDir" /p:Configuration="$Configuration" /p:Platform="$Platform" /p:FileName="$FileName" /p:AdditionalOptions="$AdditionalOptions" /p:ResourceFile="$ResourceFile" /p:SpdFile="$SpdFile" @WDKVersionArgs $ProjectFile
 
 if ($LASTEXITCODE -ne 0) {
     throw "Build failed for $FileName.o"

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -5,8 +5,8 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -28,8 +28,8 @@
   </ItemGroup>
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -5,8 +5,8 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -47,8 +47,8 @@
   </ItemGroup>
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
@@ -72,8 +72,8 @@
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' &gt;= '18.0'">v145</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' &lt; '18.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(MSBuildToolsVersion)' &gt;= '18.0'">v145</PlatformToolset>
+    <PlatformToolset Condition="'$(MSBuildToolsVersion)' &lt; '18.0'">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/wdk.props
+++ b/wdk.props
@@ -8,27 +8,33 @@
     <HostPlatform Condition="'$(HostPlatform)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <!-- Target/toolset/WDK selection. All three use the same '>= 18.0' vs '< 18.0' split so we
          never end up partially configured (e.g. WDKVersion set but toolset empty) on an
-         unexpected VisualStudioVersion. Each property can be overridden from the command line. -->
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+         unexpected toolset version. Each property can be overridden from the command line.
+         These gate on $(MSBuildToolsVersion). The latter is only
+         populated when the build is launched from a Developer Command Prompt / VS, and is empty when
+         msbuild.exe is invoked directly (as Convert-BpfToNative.ps1 does). An empty value silently
+         took the '< 18.0' branch, selecting the 26100 WDK under MSBuild 18, whose WindowsDriver.common.targets then fails to load Microsoft.DriverKit.Build.Tasks.18.0.dll
+         (MSB4062). $(MSBuildToolsVersion) is always defined and is the same value the WDK targets
+         use to pick that task assembly. -->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
     <!-- WDK NuGet package version: VS 2026 (MSBuild 18) requires 10.0.28000.1839;
          VS 2022 (MSBuild 17) uses 10.0.26100.6584. -->
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
     <!-- Provide DDK_INC_PATH for user-mode projects that simulate kernel code (usersim) -->
     <DDK_INC_PATH Condition="'$(DDK_INC_PATH)' == ''">$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\c\Include\$(WindowsTargetPlatformVersion)\km</DDK_INC_PATH>
     <!-- Default platform toolset for user-mode projects. Kernel-mode projects override this
          with WindowsKernelModeDriver10.0 in their vcxproj Configuration PropertyGroups. -->
-    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">v145</EbpfPlatformToolset>
-    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">v143</EbpfPlatformToolset>
+    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">v145</EbpfPlatformToolset>
+    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">v143</EbpfPlatformToolset>
     <!-- Platform toolset consumed by the ebpf-extension-common submodule. Its Directory.Build.props
          imports "$(SolutionDir)wdk.props", which resolves to THIS file when the submodule is built as
          part of the eBPF-for-Windows solution, so the toolset variable its vcxproj files reference
          ($(EbpfExtPlatformToolset)) must be defined here. Without it the toolset is empty and MSBuild
          falls back to v100, causing MSB8020. (usersim is self-contained: its projects import their own
          wdk.props via a relative path, so no equivalent definition is needed here.) -->
-    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">v145</EbpfExtPlatformToolset>
-    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(VisualStudioVersion)' &lt; '18.0'">v143</EbpfExtPlatformToolset>
+    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">v145</EbpfExtPlatformToolset>
+    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">v143</EbpfExtPlatformToolset>
   </PropertyGroup>
   <!-- Log the WDK version -->
   <Target Name="LogWDKVersion" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
## Description

In ADO, OneBranch has no ARM pool, the ES pipelines cross-compile arm64 inside the x64 ltsc2025/vse2026  container, so arm64 runs under MSBuild 18. The OSS split can't survive that: WDK 26100's  WindowsDriver.common.targets  loads  Microsoft.DriverKit.Build.Tasks. $(MSBuildToolsVersion).dll and the 26100 package ships only the 17.0 assembly → MSB4062.  In ADO, arm64 must move to 28000.1839 while in GitHub arm64 stays at 26000.

## Testing

CI/CD

## Documentation

No

## Installation

No
