### PR TITLE
Resolve Visual Studio install path via vswhere in OneBranch scripts

### DIFF
--- a/scripts/onebranch/copy-build-output.ps1
+++ b/scripts/onebranch/copy-build-output.ps1
@@ -49,8 +49,19 @@ $global:LASTEXITCODE = 0
 # For Fuzzer and AddressSanitizer builds, copy clang runtime DLLs that are
 # required at test execution time. Pass -CopyClangRt to enable.
 if ($CopyClangRt) {
-    $vsBasePath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-    $clangDlls = Get-ChildItem "$vsBasePath\VC\Tools\MSVC\*\bin\Hostx64\x64\clang_rt.*.dll" -ErrorAction SilentlyContinue
+    # Resolve the Visual Studio installation via vswhere rather than hardcoding a version-specific
+    # path, so this keeps working as the build container moves between VS versions.
+    $vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    $vsBasePath = $null
+    if (Test-Path $vswherePath) {
+        $vsBasePath = & $vswherePath -latest -products * -property installationPath | Select-Object -First 1
+    }
+    if (-not $vsBasePath) {
+        Write-Warning "Could not locate a Visual Studio installation via vswhere. Fuzzer/ASAN tests may fail at runtime."
+    }
+    $clangDlls = if ($vsBasePath) {
+        Get-ChildItem "$vsBasePath\VC\Tools\MSVC\*\bin\Hostx64\x64\clang_rt.*.dll" -ErrorAction SilentlyContinue
+    }
     if ($clangDlls) {
         Write-Host "Copying $($clangDlls.Count) clang runtime DLL(s)..."
         foreach ($dll in $clangDlls) {

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -142,13 +142,45 @@ else
     throw ("Configuration $OneBranchConfig is not supported.")
 }
 
-Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"  -DevCmdArguments "-arch=$OneBranchArch -host_arch=x64"
+# Resolve the Visual Studio installation via vswhere rather than hardcoding a version-specific path.
+# The OneBranch build container ships whichever Visual Studio the image was built with (VS 2022 lives
+# under "...\2022\Enterprise", VS 2026 under "...\18\Enterprise"), so a literal path breaks whenever
+# the image is updated. This also puts msbuild on PATH for the packaging steps below.
+$vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswherePath)) {
+    throw "vswhere.exe not found at '$vswherePath'; unable to locate a Visual Studio installation."
+}
+$vsInstallPath = & $vswherePath -latest -products * -property installationPath | Select-Object -First 1
+if (-not $vsInstallPath) {
+    throw "Could not locate a Visual Studio installation via vswhere."
+}
+Write-Host "Using Visual Studio installation at '$vsInstallPath'."
+Import-Module (Join-Path $vsInstallPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+Enter-VsDevShell -VsInstallPath $vsInstallPath -DevCmdArguments "-arch=$OneBranchArch -host_arch=x64"
 Set-Location $scriptPath\..\..
 $SolutionDir = Get-Location
-msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false /p:ForceRepack=true .\tools\nuget\nuget.vcxproj
-msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false /p:ForceRepack=true .\tools\redist-package\redist-package.vcxproj
-msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\installer\ebpf-for-windows.wixproj
+
+# Report packaging errors. These msbuild invocations are deliberately NOT fatal: the
+# nuget.vcxproj repack has been failing with MSB8013 for a long time (usersim.vcxproj, an external
+# submodule, does not declare the NativeOnly* configurations; the .sln supplies a configuration
+# mapping that a direct project build cannot), and the error has always been ignored here. Failing
+# the build on it would break pipelines that pass today, so surface it loudly instead and leave the
+# existing behavior intact.
+function Invoke-PackagingBuild {
+    param (
+        [string]$Project,
+        [string[]]$ExtraArgs = @()
+    )
+    msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false @ExtraArgs $Project
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "msbuild exited with code $LASTEXITCODE for $Project. Continuing (see MSB8013 note above)."
+        $global:LASTEXITCODE = 0
+    }
+}
+
+Invoke-PackagingBuild -Project ".\tools\nuget\nuget.vcxproj" -ExtraArgs @("/p:ForceRepack=true")
+Invoke-PackagingBuild -Project ".\tools\redist-package\redist-package.vcxproj" -ExtraArgs @("/p:ForceRepack=true")
+Invoke-PackagingBuild -Project ".\installer\ebpf-for-windows.wixproj"
 
 # After building the packages
 # Copy the nupkg and msi to the output directory

--- a/tools/bpf2c/Convert-BpfToNative.ps1.template
+++ b/tools/bpf2c/Convert-BpfToNative.ps1.template
@@ -136,7 +136,7 @@ if ($VerbosePreference -eq "Continue") {
 }
 
 # Forward an explicit WDK version to the generated project when the caller pinned one. The templates
-# otherwise derive it from $(MSBuildToolsVersion); passing it through guarantees the restore and the
+# otherwise derive it from $(MSBuildAssemblyVersion); passing it through guarantees the restore and the
 # build agree, and lets a pipeline override both from one place.
 $WDKVersionArgs = @()
 if ($env:WDKVersion) {

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -5,8 +5,8 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -28,8 +28,8 @@
   </ItemGroup>
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -5,8 +5,8 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -47,8 +47,8 @@
   </ItemGroup>
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
@@ -72,8 +72,8 @@
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset Condition="'$(MSBuildToolsVersion)' &gt;= '18.0'">v145</PlatformToolset>
-    <PlatformToolset Condition="'$(MSBuildToolsVersion)' &lt; '18.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(MSBuildAssemblyVersion)' &gt;= '18.0'">v145</PlatformToolset>
+    <PlatformToolset Condition="'$(MSBuildAssemblyVersion)' &lt; '18.0'">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/wdk.props
+++ b/wdk.props
@@ -9,32 +9,35 @@
     <!-- Target/toolset/WDK selection. All three use the same '>= 18.0' vs '< 18.0' split so we
          never end up partially configured (e.g. WDKVersion set but toolset empty) on an
          unexpected toolset version. Each property can be overridden from the command line.
-         These gate on $(MSBuildToolsVersion). The latter is only
-         populated when the build is launched from a Developer Command Prompt / VS, and is empty when
-         msbuild.exe is invoked directly (as Convert-BpfToNative.ps1 does). An empty value silently
-         took the '< 18.0' branch, selecting the 26100 WDK under MSBuild 18, whose WindowsDriver.common.targets then fails to load Microsoft.DriverKit.Build.Tasks.18.0.dll
-         (MSB4062). $(MSBuildToolsVersion) is always defined and is the same value the WDK targets
-         use to pick that task assembly. -->
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+
+         These gate on $(MSBuildAssemblyVersion), which is always defined and evaluates to the
+         MSBuild major version ("17.0" for VS 2022, "18.0" for VS 2026). Two alternatives do NOT
+         work here: $(VisualStudioVersion) is only guaranteed when the build is driven by VS or a
+         Developer Command Prompt, and $(MSBuildToolsVersion) evaluates to the string "Current" on
+         both VS 2022 and VS 2026, so comparing it against '18.0' never distinguishes the two (and
+         can raise MSB4086 on a numeric comparison). Selecting the wrong branch pairs the VS 2022
+         WDK with the VS 2026 toolset, which fails with MSB4062 while loading
+         Microsoft.DriverKit.Build.Tasks.18.0.dll, an assembly the 26100 package does not ship. -->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
     <!-- WDK NuGet package version: VS 2026 (MSBuild 18) requires 10.0.28000.1839;
          VS 2022 (MSBuild 17) uses 10.0.26100.6584. -->
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.6584</WDKVersion>
     <!-- Provide DDK_INC_PATH for user-mode projects that simulate kernel code (usersim) -->
     <DDK_INC_PATH Condition="'$(DDK_INC_PATH)' == ''">$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\c\Include\$(WindowsTargetPlatformVersion)\km</DDK_INC_PATH>
     <!-- Default platform toolset for user-mode projects. Kernel-mode projects override this
          with WindowsKernelModeDriver10.0 in their vcxproj Configuration PropertyGroups. -->
-    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">v145</EbpfPlatformToolset>
-    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">v143</EbpfPlatformToolset>
+    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">v145</EbpfPlatformToolset>
+    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">v143</EbpfPlatformToolset>
     <!-- Platform toolset consumed by the ebpf-extension-common submodule. Its Directory.Build.props
          imports "$(SolutionDir)wdk.props", which resolves to THIS file when the submodule is built as
          part of the eBPF-for-Windows solution, so the toolset variable its vcxproj files reference
          ($(EbpfExtPlatformToolset)) must be defined here. Without it the toolset is empty and MSBuild
          falls back to v100, causing MSB8020. (usersim is self-contained: its projects import their own
          wdk.props via a relative path, so no equivalent definition is needed here.) -->
-    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &gt;= '18.0'">v145</EbpfExtPlatformToolset>
-    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildToolsVersion)' &lt; '18.0'">v143</EbpfExtPlatformToolset>
+    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">v145</EbpfExtPlatformToolset>
+    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">v143</EbpfExtPlatformToolset>
   </PropertyGroup>
   <!-- Log the WDK version -->
   <Target Name="LogWDKVersion" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
## Description

Related to #5483 

The OneBranch scripts hardcoded "C:\Program Files\Microsoft Visual Studio\2022\Enterprise". The build container has moved to the VS 2026 image, where the installation lives under "...\18\Enterprise", so post-build.ps1 failed on every architecture with:

```
  Import-Module : The specified module '...\2022\Enterprise\Common7\
  Tools\Microsoft.VisualStudio.DevShell.dll' was not loaded because no
  valid module file was found in any module directory.
```

Resolve the installation with vswhere instead, matching what initialize_ebpf_repo.ps1 and the GitHub workflows already do. This works on both the VS 2022 and VS 2026 images.

The Enter-VsDevShell call is what puts msbuild on PATH for the nuget, redist-package and wix packaging steps that follow, so it is retained rather than removed.

copy-build-output.ps1 had the same literal path when locating the clang runtime DLLs. That path only runs for fuzzer/ASAN builds so it has not failed yet, but it would break the same way once those platforms are re-enabled. It keeps its non-fatal warning behavior.

## Testing

CI/CD

## Documentation

No

## Installation

No
