### PR TITLE
netebpfext: permit traffic when WFP callout is unregistered

### DIFF
--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -516,6 +516,7 @@ net_ebpf_extension_add_wfp_filters(
         filter.displayData.name = (wchar_t*)filter_parameter->name;
         filter.displayData.description = (wchar_t*)filter_parameter->description;
         filter.providerKey = (GUID*)&EBPF_WFP_PROVIDER;
+        filter.flags = FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED;
         filter.action.type =
             filter_parameter->action_type ? filter_parameter->action_type : FWP_ACTION_CALLOUT_TERMINATING;
         filter.action.calloutKey = *filter_parameter->callout_guid;

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -516,9 +516,11 @@ net_ebpf_extension_add_wfp_filters(
         filter.displayData.name = (wchar_t*)filter_parameter->name;
         filter.displayData.description = (wchar_t*)filter_parameter->description;
         filter.providerKey = (GUID*)&EBPF_WFP_PROVIDER;
-        filter.flags = FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED;
         filter.action.type =
             filter_parameter->action_type ? filter_parameter->action_type : FWP_ACTION_CALLOUT_TERMINATING;
+        if (filter.action.type == FWP_ACTION_CALLOUT_TERMINATING || filter.action.type == FWP_ACTION_CALLOUT_UNKNOWN) {
+            filter.flags = FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED;
+        }
         filter.action.calloutKey = *filter_parameter->callout_guid;
         filter.filterCondition = (FWPM_FILTER_CONDITION*)conditions;
         filter.numFilterConditions = condition_count;


### PR DESCRIPTION
## Summary

Set `FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED` on all WFP filters added
by `net_ebpf_extension_add_wfp_filters()`. This is a one-line defense-in-depth
change that prevents connectivity loss when a netebpfext callout is unregistered
while WFP filters referencing it are still installed.

## Motivation

All netebpfext WFP filters use `FWP_ACTION_CALLOUT_TERMINATING` or
`FWP_ACTION_CALLOUT_UNKNOWN`. Per WFP semantics, if the associated callout is
unregistered while these filters remain installed, WFP **blocks** all matching
traffic (fails closed). This can happen during driver unload (callouts are
unregistered before filters are cleaned up), or when a transient
`FwpmFilterDeleteById` failure leaves an orphaned filter (#5486).

With `FWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED`, WFP **permits** traffic
instead of blocking it when the callout is unavailable. This has zero effect
during normal eBPF program operation (callouts are registered and the classify
function runs normally).

## Testing

- Verified the flag has no effect on normal eBPF program attach/detach/classify
  (the callout is registered, so the flag is not consulted by WFP).
- Stranded a `TERMINATING` filter on `ALE_AUTH_CONNECT_V4` via the
  `FwpmFilterDeleteById` failure repro, confirmed that new TCP connections to
  unique ports are blocked (`WSAEACCES` / "access forbidden") during the
  callout-unregistered window. This is the connectivity loss this change
  mitigates.

## Related

- #5486 -- the underlying filter delete failure hang (fix in #5472)
- #5467 -- `PROCEED_SOFT` for detaching contexts in `authorize_connection_classify`