### PR TITLE
Update remaining files to use vs2026 and windows-2025

### DIFF
--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -38,7 +38,12 @@ variables:
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
 
-  WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2022:latest'  # Docker image which is used to build the project
+  # Docker image which is used to build the project.
+  # NOTE: no job in this pipeline sets `container:`, so this is currently unused boilerplate -
+  # the builds run directly on the hosted VM image selected in reusable-build.yml. If a
+  # container-based job is ever added, this image must be updated to a Visual Studio 2026
+  # equivalent to match the toolset the rest of the pipeline builds with.
+  WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2022:latest'
 
 resources:
   repositories:
@@ -83,7 +88,7 @@ jobs:
           test_command: '.\unit_tests.exe -d yes ~[processes]'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: true
           gather_dumps: true
           capture_etw: true
@@ -99,7 +104,7 @@ jobs:
           test_command: '.\netebpfext_unit.exe -d yes'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: true
           gather_dumps: true
           capture_etw: true
@@ -114,7 +119,7 @@ jobs:
   #         test_command: '.\bpf2c_tests.exe -d yes'
   #         dependency: regular
   #         build_artifact: Build
-  #         environment: windows-2022
+  #         environment: windows-2025-vs2026
   #         vs_dev: true
   #         code_coverage: true
   #         gather_dumps: true
@@ -130,7 +135,7 @@ jobs:
           test_command: '.\bpf_conformance_runner.exe --test_file_directory $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v3 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include $(Build.SourcesDirectory)\$(PROJECT_NAME)\include"'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           vs_dev: true
           code_coverage: true
           gather_dumps: true
@@ -145,7 +150,7 @@ jobs:
           test_command: '.\unit_tests.exe'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: true
           gather_dumps: true
           fault_injection: true
@@ -160,7 +165,7 @@ jobs:
           test_command: '.\netebpfext_unit.exe'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: true
           gather_dumps: true
           fault_injection: true
@@ -196,7 +201,7 @@ jobs:
           test_command: '.\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -210,7 +215,7 @@ jobs:
           test_command: '.\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -224,7 +229,7 @@ jobs:
           test_command: '.\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -238,7 +243,7 @@ jobs:
           test_command: '.\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -252,7 +257,7 @@ jobs:
           test_command: '.\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -266,7 +271,7 @@ jobs:
           test_command: '.\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -280,7 +285,7 @@ jobs:
           test_command: '.\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
           configurations: ["FuzzerDebug"]
@@ -295,7 +300,7 @@ jobs:
           test_command: '.\cilium_tests.exe -d yes'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
 
@@ -308,7 +313,7 @@ jobs:
           test_command: '.\ebpf_performance.exe'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           code_coverage: false
           gather_dumps: true
 
@@ -324,7 +329,7 @@ jobs:
           test_command: '.\unit_tests.exe -d yes ~[processes] ~printk ~recursive_tail_call ~sequential_tail_call'
           dependency: sanitize
           build_artifact: Build-Sanitize
-          environment: windows-2022
+          environment: windows-2025-vs2026
           gather_dumps: true
           capture_etw: true
 
@@ -337,7 +342,7 @@ jobs:
           test_command: '.\unit_tests.exe -d yes'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           gather_dumps: true
           fault_injection: true
           leak_detection: true
@@ -351,7 +356,7 @@ jobs:
           test_command: '.\netebpfext_unit.exe -d yes'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           gather_dumps: true
           fault_injection: true
           leak_detection: true
@@ -365,7 +370,7 @@ jobs:
           test_command: '.\ebpf_stress_tests_um -tt=32 -td=10'
           dependency: regular
           build_artifact: Build
-          environment: windows-2022
+          environment: windows-2025-vs2026
           gather_dumps: true
           leak_detection: false
           capture_etw: true

--- a/.azure/reusable-build.yml
+++ b/.azure/reusable-build.yml
@@ -95,7 +95,11 @@ jobs:
       # is exported for the build steps below.
       - script: |
           set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-          for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -version "%VS_VERSION_RANGE%" -property installationPath`) do set "VSINSTALLPATH=%%i"
+          rem Write vswhere's output to a file rather than using a for/f loop: the ')' in
+          rem %VS_VERSION_RANGE% would otherwise be parsed as the closing paren of the for/f
+          rem 'in (...)' clause, which breaks the quoting around the vswhere path.
+          "%VSWHERE%" -latest -version "%VS_VERSION_RANGE%" -property installationPath > "%TEMP%\vsinstallpath.txt"
+          set /p VSINSTALLPATH=<"%TEMP%\vsinstallpath.txt"
           if not defined VSINSTALLPATH (
             echo Could not locate a Visual Studio %VS_VERSION% installation via vswhere.
             exit /b 1

--- a/.azure/reusable-build.yml
+++ b/.azure/reusable-build.yml
@@ -38,6 +38,19 @@ parameters:
   - name: platform
     type: object
     default: ["x64"]
+  # Visual Studio major version to build with: '18' for VS 2026 (toolset v145,
+  # WDK 10.0.28000) or '17' for VS 2022 (toolset v143, WDK 10.0.26100). This selects both the
+  # hosted image and the MSBuild/MSVC toolset that wdk.props keys off of.
+  # Note: on Azure DevOps, unlike GitHub Actions, the 'windows-2025' image still ships
+  # Visual Studio 2022. VS 2026 is only available via the dedicated 'windows-2025-vs2026'
+  # image, which is in public preview until VS 2026 is folded into 'windows-2025'.
+  # See https://learn.microsoft.com/azure/devops/pipelines/agents/hosted
+  - name: vs_version
+    type: string
+    default: '18'
+    values:
+      - '18'
+      - '17'
 
 jobs:
   - job: '${{parameters.name}}'
@@ -52,7 +65,10 @@ jobs:
               buildConfiguration: ${{ configuration }}
 
     pool:
-      vmImage: 'windows-2022'
+      ${{ if eq(parameters.vs_version, '17') }}:
+        vmImage: 'windows-2022'
+      ${{ else }}:
+        vmImage: 'windows-2025-vs2026'
       type: windows
 
     variables:
@@ -64,15 +80,31 @@ jobs:
       BUILD_OPTIONS: ${{parameters.build_options}}
       CXX_FLAGS: ${{parameters.cxx_flags}}
       LD_FLAGS: ${{parameters.ld_flags}}
-      MSBUILD_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64'
-      VSVARS64_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build'
+      # vswhere-style version range used to pin every Visual Studio lookup to the requested
+      # major version, instead of taking whatever '-latest' happens to resolve to.
+      VS_VERSION: ${{parameters.vs_version}}
+      ${{ if eq(parameters.vs_version, '17') }}:
+        VS_VERSION_RANGE: '[17.0,18.0)'
+      ${{ else }}:
+        VS_VERSION_RANGE: '[18.0,19.0)'
       GDN_CODESIGN_TARGETDIRECTORY: '$(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)'
 
     steps:
+      # Resolve the Visual Studio install with vswhere rather than hardcoding an edition-specific
+      # path, so this works on any hosted image and for either Visual Studio version. MSBUILD_PATH
+      # is exported for the build steps below.
       - script: |
-          call "$(VSVARS64_PATH)\vcvars64.bat"
+          set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+          for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -version "%VS_VERSION_RANGE%" -property installationPath`) do set "VSINSTALLPATH=%%i"
+          if not defined VSINSTALLPATH (
+            echo Could not locate a Visual Studio %VS_VERSION% installation via vswhere.
+            exit /b 1
+          )
+          echo Visual Studio install path: %VSINSTALLPATH%
+          call "%VSINSTALLPATH%\VC\Auxiliary\Build\vcvars64.bat"
           echo "##vso[task.setvariable variable=msvc_tools_path;isOutput=true]%VCToolsInstallDir%"
           echo "##vso[task.setvariable variable=msvc_tools_version;isOutput=true]%VCToolsVersion%"
+          echo "##vso[task.setvariable variable=MSBUILD_PATH]%VSINSTALLPATH%\MSBuild\Current\Bin\amd64"
         name: msvc_variables
         displayName: 'Set MSVC Environment Variables'
 

--- a/.azure/reusable-test.yml
+++ b/.azure/reusable-test.yml
@@ -209,7 +209,13 @@ jobs:
         displayName: Run pre test command
 
       - script: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+          set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+          for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -property installationPath`) do set "VSINSTALLPATH=%%i"
+          if not defined VSINSTALLPATH (
+            echo Could not locate a Visual Studio installation via vswhere.
+            exit /b 1
+          )
+          call "%VSINSTALLPATH%\Common7\Tools\VsDevCmd.bat"
           set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe -q --cover_children --sources $(Build.SourcesDirectory)\$(PROJECT_NAME) --excluded_sources $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -- $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\$(TEST_COMMAND)
         workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)

--- a/.github/workflows/check_wdk.yml
+++ b/.github/workflows/check_wdk.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: Windows-latest
+    runs-on: windows-2025
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
@@ -38,7 +38,15 @@ jobs:
       - name: Check the version of the WDK in the repo
         id: check_repo_wdk
         run: |
-          $wdkVersion = (Get-Content -Path .\wdk.props | Select-String -Pattern "<WDKVersion>" | ForEach-Object { $_ -replace "<WDKVersion>", "" -replace "</WDKVersion>", "" }).trim()
+          # wdk.props declares one <WDKVersion> per supported Visual Studio version. Read the
+          # one selected for VS 2026 (MSBuildToolsVersion >= 18.0), which is the version the
+          # repo builds and ships with by default.
+          $props = Get-Content -Raw -Path .\wdk.props
+          $match = [regex]::Match($props, "<WDKVersion[^>]*&gt;=\s*'18\.0'[^>]*>([^<]+)</WDKVersion>")
+          if (-not $match.Success) {
+            throw "Could not determine the VS 2026 WDK version from wdk.props."
+          }
+          $wdkVersion = $match.Groups[1].Value.Trim()
           "wdk_version=$wdkVersion" >> $env:GITHUB_OUTPUT
 
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,6 +57,21 @@ jobs:
       build_nuget: true
       configurations: '["Debug", "FuzzerDebug", "Release"]'
 
+  # Keep a single build lane on Visual Studio 2022 (toolset v143, WDK 10.0.26100) while the
+  # community completes the move to Visual Studio 2026. This keeps the '< 18.0' branch of
+  # wdk.props covered. Remove this job once VS 2022 support is dropped.
+  regular_vs2022:
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+      build_artifact: Build-x64-vs2022
+      vs_version: '17'
+      configurations: '["Debug"]'
+      download_demo_repository: false
+
   onebranch:
     strategy:
       matrix:
@@ -75,6 +90,9 @@ jobs:
       build_options: /p:BuildOneBranch='True' /t:tools\onebranch /t:installer\ebpf-for-windows
       solution_file: "ebpf-for-windows.sln"
       architecture: ${{ matrix.Architecture }}
+      # ARM64 stays on VS 2022 until the Windows 11 ARM64 image with VS 2026
+      # (windows-11-vs2026-arm) leaves public preview.
+      vs_version: ${{ matrix.Architecture == 'x64' && '18' || '17' }}
       download_demo_repository: false
 
   # Perform the native-only build.
@@ -93,6 +111,9 @@ jobs:
       build_nuget: true
       download_demo_repository: false
       architecture: ${{ matrix.Architecture }}
+      # ARM64 stays on VS 2022 until the Windows 11 ARM64 image with VS 2026
+      # (windows-11-vs2026-arm) leaves public preview.
+      vs_version: ${{ matrix.Architecture == 'x64' && '18' || '17' }}
       configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
   everparse_validation:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -57,6 +57,10 @@ on:
         required: false
         type: string
         default: 'x64'
+      vs_version:
+        required: false
+        type: string
+        default: '18'
       download_demo_repository:
         required: false
         type: boolean
@@ -84,9 +88,12 @@ jobs:
       matrix:
         configurations: ${{ fromJSON(inputs.configurations) }}
 
-    # Make runs-on conditionally based on the architecture input.
-    # This is needed to support both x64 and ARM64 builds.
-    runs-on: ${{ inputs.architecture == 'x64' && 'windows-2025' || 'windows-11-arm' }}
+    # Make runs-on conditional on both the architecture and the requested Visual Studio
+    # version. This is needed to support x64 and ARM64 builds on VS 2022 and VS 2026.
+    # windows-2025 / windows-11-vs2026-arm ship VS 2026; windows-2022 / windows-11-arm
+    # ship VS 2022. Note that windows-latest now resolves to VS 2026, so images are pinned
+    # explicitly here rather than relying on the default label.
+    runs-on: ${{ inputs.architecture == 'x64' && (inputs.vs_version == '17' && 'windows-2022' || 'windows-2025') || (inputs.vs_version == '17' && 'windows-11-arm' || 'windows-11-vs2026-arm') }}
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: ${{inputs.solution_file}}
@@ -96,6 +103,10 @@ jobs:
       BUILD_OPTIONS: ${{inputs.build_options}}
       CXX_FLAGS: ${{inputs.cxx_flags}}
       LD_FLAGS: ${{inputs.ld_flags}}
+      VS_VERSION: ${{inputs.vs_version}}
+      # vswhere-style version range used to pin every Visual Studio lookup to the requested
+      # major version, instead of silently taking whatever '-latest' happens to resolve to.
+      VS_VERSION_RANGE: '[${{inputs.vs_version}}.0,${{ fromJSON(inputs.vs_version) + 1 }}.0)'
 
     steps:
       - name: Harden Runner
@@ -114,8 +125,8 @@ jobs:
         shell: cmd
         run: |
           set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-          for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -property installationPath`) do set "VSINSTALLPATH=%%i"
-          if not defined VSINSTALLPATH ( echo Could not locate a Visual Studio installation via vswhere. & exit /b 1 )
+          for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -version "%VS_VERSION_RANGE%" -property installationPath`) do set "VSINSTALLPATH=%%i"
+          if not defined VSINSTALLPATH ( echo Could not locate a Visual Studio %VS_VERSION% installation ^(%VS_VERSION_RANGE%^) via vswhere. & exit /b 1 )
           call "%VSINSTALLPATH%\VC\Auxiliary\Build\vcvars64.bat"
           powershell.exe "echo 'msvc_tools_path=%VCToolsInstallDir%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
           powershell.exe "echo 'msvc_tools_version=%VCToolsVersion%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
@@ -148,6 +159,23 @@ jobs:
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
         with:
           msbuild-architecture: x64
+          vs-version: ${{ env.VS_VERSION_RANGE }}
+
+      # Fail fast and loudly if the runner image resolved to a different Visual Studio than
+      # the one requested. wdk.props selects the platform toolset (v145 vs v143) and WDK
+      # version from $(MSBuildToolsVersion), so a silent toolchain change here would
+      # silently change what is built and shipped.
+      - name: Verify Visual Studio toolchain version
+        if: steps.skip_check.outputs.should_skip != 'true'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $msbuildVersion = (& msbuild -version -nologo | Select-Object -Last 1).Trim()
+          Write-Host "MSBuild version: $msbuildVersion"
+          Write-Host "MSVC toolset: ${{env.msvc_tools_version}} ($env:VCINSTALLDIR)"
+          $major = $msbuildVersion.Split('.')[0]
+          if ($major -ne '${{inputs.vs_version}}') {
+            throw "Expected MSBuild major version ${{inputs.vs_version}} (Visual Studio ${{inputs.vs_version}}.0) but found $msbuildVersion."
+          }
 
       # The hosted runner images do not always ship the Spectre-mitigated VC
       # runtime libraries for the installed MSVC toolset, which causes MSB8040
@@ -176,8 +204,8 @@ jobs:
           }
 
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $installPath = & $vswhere -latest -property installationPath
-          if (-not $installPath) { throw "Could not locate a Visual Studio installation via vswhere." }
+          $installPath = & $vswhere -latest -version $env:VS_VERSION_RANGE -property installationPath
+          if (-not $installPath) { throw "Could not locate a Visual Studio $env:VS_VERSION installation ($env:VS_VERSION_RANGE) via vswhere." }
           Write-Host "Visual Studio install path: $installPath"
 
           $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
@@ -339,6 +367,8 @@ jobs:
         run: Invoke-WebRequest https://github.com/microsoft/ebpf-for-windows-demo/releases/download/v0.0.2/${{env.BUILD_PLATFORM}}-Release-cilium-xdp.zip -OutFile x64-${{env.BUILD_CONFIGURATION}}-cilium-xdp.zip
 
       # Download the bpf_performance repository artifacts.
+      # Note: 'windows-2022' here is the name of an upstream prebuilt release asset, not a
+      # runner image or toolchain selection for this repo.
       - name: Download bpf_performance repository artifacts
         if: steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -106,7 +106,7 @@ jobs:
       VS_VERSION: ${{inputs.vs_version}}
       # vswhere-style version range used to pin every Visual Studio lookup to the requested
       # major version, instead of silently taking whatever '-latest' happens to resolve to.
-      VS_VERSION_RANGE: '[${{inputs.vs_version}}.0,${{ fromJSON(inputs.vs_version) + 1 }}.0)'
+      VS_VERSION_RANGE: ${{ inputs.vs_version == '17' && '[17.0,18.0)' || '[18.0,19.0)' }}
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -125,8 +125,17 @@ jobs:
         shell: cmd
         run: |
           set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-          for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -version "%VS_VERSION_RANGE%" -property installationPath`) do set "VSINSTALLPATH=%%i"
-          if not defined VSINSTALLPATH ( echo Could not locate a Visual Studio %VS_VERSION% installation ^(%VS_VERSION_RANGE%^) via vswhere. & exit /b 1 )
+          rem Write vswhere's output to a file rather than using a for/f loop, and keep
+          rem %VS_VERSION_RANGE% out of any parenthesized block: the ')' in the version range is
+          rem otherwise parsed as the closing paren of the for/f 'in (...)' clause or the if
+          rem block, which breaks the quoting around the vswhere path.
+          "%VSWHERE%" -latest -version "%VS_VERSION_RANGE%" -property installationPath > "%TEMP%\vsinstallpath.txt"
+          set /p VSINSTALLPATH=<"%TEMP%\vsinstallpath.txt"
+          if not defined VSINSTALLPATH (
+            echo Could not locate a Visual Studio %VS_VERSION% installation via vswhere.
+            exit /b 1
+          )
+          echo Visual Studio install path: %VSINSTALLPATH%
           call "%VSINSTALLPATH%\VC\Auxiliary\Build\vcvars64.bat"
           powershell.exe "echo 'msvc_tools_path=%VCToolsInstallDir%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
           powershell.exe "echo 'msvc_tools_version=%VCToolsVersion%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"

--- a/.github/workflows/reusable-everparse-validation.yml
+++ b/.github/workflows/reusable-everparse-validation.yml
@@ -39,6 +39,8 @@ jobs:
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
         with:
           msbuild-architecture: x64
+          # Pin to Visual Studio 2026 to match the default build toolset.
+          vs-version: '[18.0,19.0)'
 
       - name: Cache nuget packages
         continue-on-error: true

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -13,15 +13,22 @@ jump down to [Using eBPF in development](#using-ebpf-in-development).
 The following must be installed in order to build this project:
 
 1. Git (e.g., [Git for Windows 64-bit](https://git-scm.com/download/win))
-1. **Visual Studio 2022** - one of the following editions should be installed (once installed, upgrade to **v17.4.2 or later**):
+1. **Visual Studio 2026** - one of the following editions should be installed:
 
-   - [Download Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=17) (free)
-   - [Download Visual Studio Professional 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Professional&rel=17)
-   - [Download Visual Studio Enterprise 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Enterprise&rel=17)
-   
+   - [Download Visual Studio Community 2026](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=18) (free)
+   - [Download Visual Studio Professional 2026](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Professional&rel=18)
+   - [Download Visual Studio Enterprise 2026](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Enterprise&rel=18)
+
+   >**Note**: **Visual Studio 2022** (v17.4.2 or later) is also still supported, and is validated by a
+    dedicated CI build. The project selects the platform toolset and Windows Driver Kit version from the
+    Visual Studio version you build with: VS 2026 uses toolset `v145` with WDK `10.0.28000`, and VS 2022
+    uses toolset `v143` with WDK `10.0.26100`. See [wdk.props](../wdk.props). Support for VS 2022 will be
+    removed in a future release.
+
 Visual Studio will [prompt you to install](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2019#use-a-configuration-file-to-automatically-install-missing-components) the necessary dependencies when opening the main solution file for the
 first time.
 1. Install [Clang for Windows 64-bit](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe) (version **18.1.8**). The latest version of clang that ships with the Visual Studio installer does not support `bpf` as a target.
+1. CMake **4.2 or later** is required when building with Visual Studio 2026, as earlier versions do not support the `Visual Studio 18 2026` generator.
 
 You should add the paths to `git.exe`, `cmake.exe` and `nuget.exe` to the Windows PATH environment variable after the software packages
  above have been installed.
@@ -39,8 +46,19 @@ You should add the paths to `git.exe`, `cmake.exe` and `nuget.exe` to the Window
 
    ```ps
    Invoke-WebRequest 'https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Setup-DevEnv.ps1' -OutFile $env:TEMP\Setup-DeveEnv.ps1
-   if ((get-filehash -Algorithm SHA256 $env:TEMP\Setup-DeveEnv.ps1).Hash -eq 'B12416D3C84660BE33C88772B3E7D3571A10899A57BC9DDFE218DB751483FD71') { &"$env:TEMP\Setup-DeveEnv.ps1" }
+   if ((get-filehash -Algorithm SHA256 $env:TEMP\Setup-DeveEnv.ps1).Hash -eq '6384A8BA507B8C1FB48AAE8BA298C7A79E3927BC92B3BFAB47552371208D8AEB') { &"$env:TEMP\Setup-DeveEnv.ps1" }
    ```
+
+   This installs Visual Studio 2026 by default. To set up a Visual Studio 2022 environment instead, pass
+   `-VisualStudioVersion 2022`:
+
+   ```ps
+   &"$env:TEMP\Setup-DeveEnv.ps1" -VisualStudioVersion 2022
+   ```
+
+   >**Note**: the hash above must match the current contents of
+    [`scripts/Setup-DevEnv.ps1`](../scripts/Setup-DevEnv.ps1); if the script is changed, update this hash in
+    the same pull request, otherwise the snippet silently does nothing.
 
    >**Note**: the WDK for Windows 11 is [not currently available on Chocolatey](https://community.chocolatey.org/packages?q=windowsdriverkit),
     please install manually with the link in the [Prerequisites](#prerequisites) section above.
@@ -71,7 +89,7 @@ PE parse directory includes some malformed PE images as a part of the test suite
 
 The following steps need to be executed *once* before the first build on a new clone:
 
-1. Launch a `Developer PowerShell for VS 2022` session.
+1. Launch a `Developer PowerShell for VS 2026` session (or `Developer PowerShell for VS 2022` if building with Visual Studio 2022).
 1. Change directory to where the project is cloned (e.g. "`cd ebpf-for-windows`").
 1. Run the following script:
 
@@ -87,9 +105,9 @@ The following steps need to be executed *once* before the first build on a new c
 
 > TIP: In case you need to "reset" the repo, without re-cloning it, you can just delete all the folders under the `\external` directory (but keep the files), and then re-run the above script.
 
-#### Building using Developer Command Prompt for VS 2022
+#### Building using Developer Command Prompt for VS
 
-1. Launch `Developer Command Prompt for VS 2022`.
+1. Launch `Developer Command Prompt for VS 2026` (or `Developer Command Prompt for VS 2022` if building with Visual Studio 2022).
 1. Change directory to where the project is cloned (e.g. `cd ebpf-for-windows`), and run the following command:
 
    ```cmd

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -75,7 +75,7 @@ C:\Windows\system32\msiexec.exe /i eBPF-for-Windows.x.x.x.msi <other options> /l
 This method uses a machine that
 has already built the binaries for `x64/Debug` or `x64/Release`.
 
-1. Deploy the binaries to `C:\Temp` in your VM, as follows (from within a "*Developer PowerShell for VS 2022*"):
+1. Deploy the binaries to `C:\Temp` in your VM, as follows (from within a "*Developer PowerShell for VS*"):
 
     * If you **built the binaries from inside the VM**, then from your `ebpf-for-windows` directory in the VM, skip to step 2 (i.e., for running the MSI installer).
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -101,7 +101,7 @@ version.
 
 ## Updating the Product Version
 
-1. Run `.\scripts\update-product-version.ps1` from the root directory of the repository, from a "*Developer Powershell for VS 2022"* terminal.
+1. Run `.\scripts\update-product-version.ps1` from the root directory of the repository, from a "*Developer Powershell for VS"* terminal.
    The script takes as input parameters the major, minor, patch versions and *optionally* the version modifier.
 
    Examples:

--- a/scripts/Setup-DevEnv.ps1
+++ b/scripts/Setup-DevEnv.ps1
@@ -1,17 +1,35 @@
 # Copyright (c) eBPF for Windows contributors
 # SPDX-License-Identifier: MIT
 
+param (
+    [parameter(Mandatory = $false)][ValidateSet("2026", "2022")][string] $VisualStudioVersion = "2026"
+)
+
+$ErrorActionPreference = "Stop"
+
 Invoke-WebRequest 'https://community.chocolatey.org/install.ps1' -OutFile $env:TEMP\install_choco.ps1
 if ((get-filehash -Algorithm SHA256 $env:TEMP\install_choco.ps1).Hash -ne '44E045ED5350758616D664C5AF631E7F2CD10165F5BF2BD82CBF3A0BB8F63462') { throw "Wrong file hash for Chocolatey installer"}
 &"$env:TEMP\install_choco.ps1"
 
 choco install git -y --params "'/GitAndUnixToolsOnPath /WindowsTerminal /NoAutoCrlf'"
-choco install visualstudio2022community --version 117.4.2.0 -y
+
+if ($VisualStudioVersion -eq "2026") {
+    choco install visualstudio2026community --version 118.8.2 -y
+} else {
+    choco install visualstudio2022community --version 117.4.2.0 -y
+}
 
 echo "Adding required components to Visual Studio"
 Invoke-WebRequest 'https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/.vsconfig' -OutFile $env:TEMP\ebpf-for-windows.vsconfig
-& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" modify --installpath "$env:ProgramFiles\Microsoft Visual Studio\2022\Community" --config "$env:TEMP\ebpf-for-windows.vsconfig" --passive
+
+$vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$vsRange = if ($VisualStudioVersion -eq "2026") { "[18.0,19.0)" } else { "[17.0,18.0)" }
+$vsInstallPath = & $vsWhere -latest -version $vsRange -products '*' -property installationPath | Select-Object -First 1
+if (-not $vsInstallPath) { throw "Could not locate a Visual Studio $VisualStudioVersion installation ($vsRange) via vswhere." }
+echo "Visual Studio install path: $vsInstallPath"
+& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" modify --installpath "$vsInstallPath" --config "$env:TEMP\ebpf-for-windows.vsconfig" --passive
 
 choco install llvm --version=18.1.8 -y
 choco install nuget.commandline --version 6.4.0 -y
-choco install cmake.portable --version 3.25.1 -y
+# CMake 4.2 or later is required for the "Visual Studio 18 2026" generator.
+choco install cmake.portable --version 4.4.2 -y

--- a/scripts/Update-WdkVersion.ps1
+++ b/scripts/Update-WdkVersion.ps1
@@ -93,9 +93,12 @@ Updates the WDK version in a Visual Studio file.
 
 .DESCRIPTION
 Updates the WDK version in a Visual Studio file by replacing the existing version number with the specified version
-number. Only the first <WDKVersion> and <WindowsTargetPlatformVersion> elements are updated (the canonical "latest"
-values used for x64); platform-specific overrides such as <WDKVersionArm64> / <WindowsTargetPlatformVersionArm64> are
-intentionally left untouched so they can stay pinned independently.
+number. While Visual Studio 2022 and 2026 are both supported, the version is expressed as a pair of conditional
+elements (one per toolset); only the Visual Studio 2026 entry (the "'$(MSBuildToolsVersion)' &gt;= '18.0'" branch) is
+updated, so the Visual Studio 2022 entry stays pinned to the last VS 2022-compatible WDK. If no conditional entry is
+present, the first unconditional <WDKVersion> / <WindowsTargetPlatformVersion> element is updated instead.
+Platform-specific overrides such as <WDKVersionArm64> / <WindowsTargetPlatformVersionArm64> are intentionally left
+untouched so they can stay pinned independently.
 
 .PARAMETER vs_file_path
 The path to the Visual Studio file to update.
@@ -120,36 +123,45 @@ back the changes.
     # (e.g. WDK 10.0.28000.1839 -> target platform 10.0.28000.0).
     $target_platform_version = $version_number -replace '\.\d+$', '.0'
     try {
-        # Read the contents of the file
-        $vs_file_content = Get-Content $vs_file_path
-
-        # Transition guard: while VS 2022 and VS 2026 are both supported, the WDK version is expressed
-        # with conditional "<WDKVersion Condition=...>...</WDKVersion>" entries (one per toolset) that this
-        # simple replacement cannot safely update. If there is no unconditional "<WDKVersion>" element,
-        # skip and warn instead of silently leaving the version stale. This guard becomes inert once VS 2022
-        # support is removed and the files return to a single unconditional "<WDKVersion>" element.
-        if (-not ($vs_file_content -match "<WDKVersion>[^<]*</WDKVersion>")) {
-            Write-Warning "No unconditional <WDKVersion> element found in $vs_file_path (VS 2022 + VS 2026 transition state); skipping automatic update. Update the WDK version manually until VS 2022 support is removed."
-            return
-        }
-
         # Create backup
         $backup_path = "$vs_file_path.bak"
         Copy-Item $vs_file_path $backup_path -Force
         # Read the contents of the file
         $vs_file_content = @(Get-Content $vs_file_path)
-        # Replace only the first occurrence of each tag so that platform-specific overrides
-        # (e.g. <WDKVersionArm64>) are preserved.
-        $wdk_version_updated = $false
-        $target_version_updated = $false
-        for ($i = 0; $i -lt $vs_file_content.Length; $i++) {
-            if (-not $wdk_version_updated -and $vs_file_content[$i] -match "<WDKVersion>.*</WDKVersion>") {
-                $vs_file_content[$i] = $vs_file_content[$i] -replace "<WDKVersion>.*</WDKVersion>", "<WDKVersion>$version_number</WDKVersion>"
-                $wdk_version_updated = $true
+        # While VS 2022 and VS 2026 are both supported, the WDK version is expressed as a pair of
+        # conditional elements, one per toolset:
+        #   <WDKVersion Condition="... '$(MSBuildToolsVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+        #   <WDKVersion Condition="... '$(MSBuildToolsVersion)' &lt;  '18.0'">10.0.26100.6584</WDKVersion>
+        # Only the VS 2026 ('&gt;= 18.0') entry tracks the latest WDK; the VS 2022 entry stays pinned to
+        # the last VS 2022-compatible WDK and must not be moved. Once VS 2022 support is removed and the
+        # files return to a single unconditional element, the unconditional patterns below take over.
+        $patterns = @(
+            @{ Tag = 'WDKVersion'; Value = $version_number },
+            @{ Tag = 'WindowsTargetPlatformVersion'; Value = $target_platform_version }
+        )
+        foreach ($pattern in $patterns) {
+            $tag = $pattern.Tag
+            $value = $pattern.Value
+            # Prefer the VS 2026 conditional element; fall back to an unconditional element.
+            $conditional_regex = "(<$tag\b[^>]*&gt;=\s*'18\.0'[^>]*>)[^<]*(</$tag>)"
+            $unconditional_regex = "(<$tag>)[^<]*(</$tag>)"
+            $updated = $false
+            foreach ($regex in @($conditional_regex, $unconditional_regex)) {
+                for ($i = 0; $i -lt $vs_file_content.Length; $i++) {
+                    if ($vs_file_content[$i] -match $regex) {
+                        # Replace only the first match so platform-specific overrides
+                        # (e.g. <WDKVersionArm64>) and the pinned VS 2022 entry are preserved.
+                        $vs_file_content[$i] = [regex]::Replace($vs_file_content[$i], $regex, "`${1}$value`${2}", 1)
+                        $updated = $true
+                        break
+                    }
+                }
+                if ($updated) {
+                    break
+                }
             }
-            if (-not $target_version_updated -and $vs_file_content[$i] -match "<WindowsTargetPlatformVersion>.*</WindowsTargetPlatformVersion>") {
-                $vs_file_content[$i] = $vs_file_content[$i] -replace "<WindowsTargetPlatformVersion>.*</WindowsTargetPlatformVersion>", "<WindowsTargetPlatformVersion>$target_platform_version</WindowsTargetPlatformVersion>"
-                $target_version_updated = $true
+            if (-not $updated) {
+                throw "No <$tag> element found in $vs_file_path"
             }
         }
         # Write the updated contents back to the file
@@ -254,26 +266,12 @@ try {
         $files_updated += $vs_file
     }
 
-    # Generate the new packages.config file.
-    # Transition guard: while VS 2022 and VS 2026 are both supported, packages.config intentionally pins
-    # two WDK versions (one per toolset). The single-version template cannot represent that, so regenerating
-    # it here would silently drop the second toolset's packages and break that build. If the existing file
-    # already pins more than one distinct version, skip regeneration and warn. This guard becomes inert once
-    # VS 2022 support is removed and packages.config returns to a single WDK version.
+    # Generate the new packages.config file. The template pins two WDK versions: the $(WDKVersion)
+    # placeholder for the Visual Studio 2026 toolset, and a hardcoded entry for the last
+    # VS 2022-compatible WDK. Regenerating from the template therefore preserves both.
     $packages_config_path = "$PSScriptRoot\..\scripts\setup_build\packages.config"
-    $distinct_versions = @()
-    if (Test-Path $packages_config_path) {
-        $distinct_versions = @(Select-String -Path $packages_config_path -Pattern '<package\b[^>]*\bversion="([0-9.]+)"' -AllMatches |
-            ForEach-Object { $_.Matches } |
-            ForEach-Object { $_.Groups[1].Value } |
-            Sort-Object -Unique)
-    }
-    if ($distinct_versions.Count -gt 1) {
-        Write-Warning "packages.config pins multiple WDK versions ($($distinct_versions -join ', ')); skipping auto-regeneration to preserve the VS 2022 + VS 2026 multi-toolset configuration. Update packages.config manually until VS 2022 support is removed."
-    } else {
-        Update-TemplateFile -template_file_path "$PSScriptRoot\..\scripts\setup_build\packages.config.template" -output_file_path $packages_config_path -version_number $wdk_version_number
-        $files_updated += $packages_config_path
-    }
+    Update-TemplateFile -template_file_path "$PSScriptRoot\..\scripts\setup_build\packages.config.template" -output_file_path $packages_config_path -version_number $wdk_version_number
+    $files_updated += $packages_config_path
 
     # Print success message
     Write-Output "Updated WDK version in all files"


### PR DESCRIPTION
### Description

Moves the build workflows to Visual Studio 2026 (MSBuild 18, toolset `v145`, WDK `10.0.28000`), on both GitHub Actions and OneBranch/Azure DevOps.

Fixes #5483. The build system already supported VS 2026 (#5375); this makes CI actually select it, deliberately and verifiably, rather than by accident.

### Changes

- `reusable-build.yml`: new `vs_version` input (`'18'` default, `'17'` supported) selecting both the runner image and the toolchain. Every Visual Studio lookup — the MSVC env setup, the Spectre-library install, and `setup-msbuild` — is now pinned to that version instead of `-latest`.
- `reusable-build.yml`: new **Verify Visual Studio toolchain version** step that fails the build if the resolved MSBuild major version doesn't match the requested one, so an image swap can't silently change what ships.
- `cicd.yml`: new `regular_vs2022` job (x64, Debug) keeping VS 2022 covered.
- `cicd.yml`: ARM64 lanes pinned to VS 2022, because the Windows 11 ARM64 image with VS 2026 (`windows-11-vs2026-arm`) is still in public preview.
- `reusable-everparse-validation.yml`, `check_wdk.yml`: pinned to VS 2026 / `windows-2025`.
- `reusable-build.yml`: matching `vs_version` parameter. Note that on Azure DevOps, unlike GitHub Actions, `windows-2025` still ships **VS 2022** — VS 2026 is only available via the dedicated `windows-2025-vs2026` image ([docs](https://learn.microsoft.com/azure/devops/pipelines/agents/hosted)), so that label is used.
- `reusable-build.yml`: replaced the hardcoded `MSBUILD_PATH` / `VSVARS64_PATH` (`...\Visual Studio\2022\Enterprise\...`) with a `vswhere` lookup. The old paths were both version- and edition-specific. Follows the same approach as #5492.
- `reusable-test.yml`: `VsDevCmd.bat` resolved via `vswhere` instead of a hardcoded VS 2022 Enterprise path.
- `OneBranch.PullRequest.yml`: test jobs moved to `windows-2025-vs2026`.
- **`check_wdk.yml` was silently broken.** Its `<WDKVersion>` parse stopped matching when #5375 added `Condition` attributes, so the weekly job compared the latest NuGet version against an empty string and would file a spurious "Update the WDK" issue every Sunday. Now extracts the VS 2026 value explicitly.
- **`Update-WdkVersion.ps1` was a no-op.** Both of its transition guards fired unconditionally, so the script the above issue tells you to run refused to change anything. It now updates the VS 2026 entries while leaving the VS 2022 pin and any platform-specific overrides untouched.
- **`Setup-DevEnv.ps1` installed CMake 3.25.1**, which cannot use the `Visual Studio 18 2026` generator that `initialize_ebpf_repo.ps1` selects (requires CMake ≥ 4.2), so the documented setup path couldn't configure the repo for VS 2026. Also adds a `-VisualStudioVersion` parameter and resolves the install path via `vswhere` instead of a hardcoded `...\2022\Community` path.

## Testing

Covered by existing CI/CD

## Documentation

- `docs/GettingStarted.md`: prerequisites now lead with Visual Studio 2026 (with `rel=18` download links), note that VS 2022 remains supported and CI-validated, and explain the toolset/WDK pairing each version selects. Adds CMake ≥ 4.2 as an explicit prerequisite. Also refreshes the `Setup-DevEnv.ps1` SHA256 in the Chocolatey snippet — it no longer matched, so that snippet silently did nothing — and documents the new `-VisualStudioVersion` switch.
- `docs/InstallEbpf.md`, `docs/ReleaseProcess.md`: "Developer PowerShell for VS 2022" references made version-neutral.

## Installation

No