### PR TITLE
Update product version to 1.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup Label="Version">
     <EbpfVersion_Major>1</EbpfVersion_Major>
-    <EbpfVersion_Minor>5</EbpfVersion_Minor>
+    <EbpfVersion_Minor>6</EbpfVersion_Minor>
     <EbpfVersion_Revision>0</EbpfVersion_Revision>
     <EbpfVersion_Modifier/>
     <EbpfVersionNoModifier>$(EbpfVersion_Major).$(EbpfVersion_Minor).$(EbpfVersion_Revision)</EbpfVersionNoModifier>

--- a/scripts/update-product-version.ps1
+++ b/scripts/update-product-version.ps1
@@ -43,7 +43,7 @@ if ("$majorVersion.$minorVersion.$revisionNumber" -match '^\d+\.\d+\.\d+.*$') {
 
         # Rebuild the solution, so to regenerate the NuGet packages and the '.o' files with the new version number.
         Write-Host -ForegroundColor DarkGreen "Rebuilding the solution, please wait..."
-        $res = & msbuild /m /p:Configuration=Debug /p:Platform=x64 ebpf-for-windows.sln /t:Clean,Build
+        $res = & msbuild /m /p:Configuration=NativeOnlyDebug /p:Platform=x64 ebpf-for-windows.sln /t:Clean,Build
         if ($LASTEXITCODE -ne 0) {
             Write-Host -ForegroundColor Red "msbuild failed with exit code [$LASTEXITCODE] (res=$res). Aborting script."
             Write-Host -ForegroundColor DarkYellow "Please rebuild the solution in 'x64/Debug' with Visual Studio or MsBuild to debug the issue."
@@ -52,7 +52,7 @@ if ("$majorVersion.$minorVersion.$revisionNumber" -match '^\d+\.\d+\.\d+.*$') {
 
         # Regenerate the expected 'bpf2c' output (i.e. the corresponding '.c' files for all the solution's test/demo '.o' files).
         Write-Host -ForegroundColor DarkGreen "Regenerating the expected 'bpf2c' output..."
-        .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
+        .\scripts\generate_expected_bpf2c_output.ps1 .\x64\NativeOnlyDebug\
         Write-Host -ForegroundColor DarkGreen "Expected 'bpf2c' output regenerated."
     } else {
         Write-Host -ForegroundColor Red "'ebpf-for-windows.sln' not found in the current path."

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_dll.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_dll.c
@@ -236,7 +236,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_raw.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_raw.c
@@ -206,7 +206,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/ambiguous_array_map_sys.c
+++ b/tests/bpf2c_tests/expected/ambiguous_array_map_sys.c
@@ -361,7 +361,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -207,7 +207,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -177,7 +177,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -332,7 +332,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -199,7 +199,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -169,7 +169,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -324,7 +324,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bind_policy_dll.c
+++ b/tests/bpf2c_tests/expected/bind_policy_dll.c
@@ -572,7 +572,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bind_policy_raw.c
+++ b/tests/bpf2c_tests/expected/bind_policy_raw.c
@@ -542,7 +542,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bind_policy_sys.c
+++ b/tests/bpf2c_tests/expected/bind_policy_sys.c
@@ -697,7 +697,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
@@ -523,7 +523,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
@@ -493,7 +493,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
@@ -648,7 +648,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -602,7 +602,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -6251,7 +6251,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -6221,7 +6221,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -6376,7 +6376,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_dll.c
@@ -214,7 +214,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_raw.c
@@ -184,7 +184,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_perf_event_array_sys.c
@@ -339,7 +339,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -572,7 +572,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -205,7 +205,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -175,7 +175,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -330,7 +330,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -727,7 +727,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -858,7 +858,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -828,7 +828,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -983,7 +983,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
@@ -282,7 +282,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
@@ -252,7 +252,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
@@ -407,7 +407,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -197,7 +197,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -167,7 +167,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -322,7 +322,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -126,7 +126,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -96,7 +96,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -251,7 +251,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/btf_resolved_dll.c
+++ b/tests/bpf2c_tests/expected/btf_resolved_dll.c
@@ -185,7 +185,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/btf_resolved_raw.c
+++ b/tests/bpf2c_tests/expected/btf_resolved_raw.c
@@ -155,7 +155,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/btf_resolved_sys.c
+++ b/tests/bpf2c_tests/expected/btf_resolved_sys.c
@@ -310,7 +310,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
@@ -802,7 +802,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
@@ -772,7 +772,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
@@ -927,7 +927,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_dll.c
@@ -276,7 +276,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_raw.c
@@ -246,7 +246,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization6_sys.c
@@ -401,7 +401,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_dll.c
@@ -261,7 +261,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_raw.c
@@ -231,7 +231,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_connect_authorization_readonly_sys.c
@@ -386,7 +386,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_dll.c
@@ -264,7 +264,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_raw.c
@@ -234,7 +234,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect4_sys.c
@@ -389,7 +389,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_dll.c
@@ -264,7 +264,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_raw.c
@@ -234,7 +234,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_count_connect6_sys.c
@@ -389,7 +389,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_dll.c
@@ -201,7 +201,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_raw.c
@@ -171,7 +171,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect4_sys.c
@@ -326,7 +326,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_dll.c
@@ -201,7 +201,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_raw.c
@@ -171,7 +171,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_mt_connect6_sys.c
@@ -326,7 +326,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -1308,7 +1308,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -1278,7 +1278,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -1433,7 +1433,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_dll.c
@@ -328,7 +328,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_raw.c
@@ -298,7 +298,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_bind_sys.c
@@ -453,7 +453,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -1582,7 +1582,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_dll.c
@@ -2447,7 +2447,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_raw.c
@@ -2417,7 +2417,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_helpers_sys.c
@@ -2572,7 +2572,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -1552,7 +1552,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -1707,7 +1707,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_basic_dll.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_dll.c
@@ -2265,7 +2265,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_basic_raw.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_raw.c
@@ -2235,7 +2235,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_basic_sys.c
+++ b/tests/bpf2c_tests/expected/custom_map_basic_sys.c
@@ -2390,7 +2390,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_invalid_dll.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_dll.c
@@ -204,7 +204,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_invalid_raw.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_raw.c
@@ -174,7 +174,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/custom_map_invalid_sys.c
+++ b/tests/bpf2c_tests/expected/custom_map_invalid_sys.c
@@ -329,7 +329,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -214,7 +214,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -184,7 +184,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -339,7 +339,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -379,7 +379,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -349,7 +349,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -504,7 +504,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_dll.c
@@ -253,7 +253,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_raw.c
@@ -223,7 +223,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_and_map_sys.c
@@ -378,7 +378,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_dll.c
+++ b/tests/bpf2c_tests/expected/global_vars_dll.c
@@ -260,7 +260,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_raw.c
+++ b/tests/bpf2c_tests/expected/global_vars_raw.c
@@ -230,7 +230,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/global_vars_sys.c
+++ b/tests/bpf2c_tests/expected/global_vars_sys.c
@@ -385,7 +385,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_dll.c
+++ b/tests/bpf2c_tests/expected/inner_map_dll.c
@@ -350,7 +350,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_raw.c
+++ b/tests/bpf2c_tests/expected/inner_map_raw.c
@@ -320,7 +320,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/inner_map_sys.c
+++ b/tests/bpf2c_tests/expected/inner_map_sys.c
@@ -475,7 +475,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/lru_map_test_dll.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_dll.c
@@ -263,7 +263,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/lru_map_test_raw.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_raw.c
@@ -233,7 +233,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/lru_map_test_sys.c
+++ b/tests/bpf2c_tests/expected/lru_map_test_sys.c
@@ -388,7 +388,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
@@ -293,7 +293,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
@@ -263,7 +263,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
@@ -418,7 +418,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -5109,7 +5109,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_btf_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_id_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_dll.c
@@ -242,7 +242,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_raw.c
@@ -212,7 +212,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_legacy_idx_sys.c
@@ -367,7 +367,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -5079,7 +5079,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -301,7 +301,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -271,7 +271,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -426,7 +426,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -301,7 +301,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -271,7 +271,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -426,7 +426,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_dll.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_dll.c
@@ -262,7 +262,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_raw.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_raw.c
@@ -232,7 +232,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sequential_lookup_sys.c
+++ b/tests/bpf2c_tests/expected/map_sequential_lookup_sys.c
@@ -387,7 +387,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_synchronized_update_dll.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_dll.c
@@ -328,7 +328,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_synchronized_update_raw.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_raw.c
@@ -298,7 +298,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_synchronized_update_sys.c
+++ b/tests/bpf2c_tests/expected/map_synchronized_update_sys.c
@@ -453,7 +453,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -5234,7 +5234,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_dll.c
@@ -177,7 +177,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_raw.c
@@ -147,7 +147,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multi_prog_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/multi_prog_same_section_sys.c
@@ -302,7 +302,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multiple_programs_dll.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_dll.c
@@ -279,7 +279,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multiple_programs_raw.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_raw.c
@@ -249,7 +249,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/multiple_programs_sys.c
+++ b/tests/bpf2c_tests/expected/multiple_programs_sys.c
@@ -404,7 +404,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_burst_dll.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_dll.c
@@ -320,7 +320,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_burst_raw.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_raw.c
@@ -290,7 +290,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_burst_sys.c
+++ b/tests/bpf2c_tests/expected/perf_event_burst_sys.c
@@ -445,7 +445,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_dll.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_dll.c
@@ -216,7 +216,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_raw.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_raw.c
@@ -186,7 +186,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/perf_event_cpu_target_sys.c
+++ b/tests/bpf2c_tests/expected/perf_event_cpu_target_sys.c
@@ -341,7 +341,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -279,7 +279,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -249,7 +249,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -404,7 +404,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -627,7 +627,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -526,7 +526,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -496,7 +496,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -651,7 +651,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -597,7 +597,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -752,7 +752,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/process_start_key_dll.c
+++ b/tests/bpf2c_tests/expected/process_start_key_dll.c
@@ -111,104 +111,104 @@ static uint16_t function_v4_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 function_v4(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     // Prologue.
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r0 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r1 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r2 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r3 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r4 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r5 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r6 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r7 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=17 imm=48955
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
         goto label_1;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=33
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_RSH64_IMM pc=8 dst=r6 src=r0 offset=0 imm=32
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     r6 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=12 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=14 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=15 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/process_start_key.c"
+#line 41 "sample/process_start_key.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/process_start_key.c"
+#line 41 "sample/process_start_key.c"
     return r0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -242,104 +242,104 @@ static uint16_t function_v6_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 function_v6(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     // Prologue.
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r0 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r1 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r2 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r3 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r4 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r5 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r6 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r7 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=17 imm=48955
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
         goto label_1;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=33
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_RSH64_IMM pc=8 dst=r6 src=r0 offset=0 imm=32
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     r6 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=12 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=14 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=15 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/process_start_key.c"
+#line 48 "sample/process_start_key.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/process_start_key.c"
+#line 48 "sample/process_start_key.c"
     return r0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -390,7 +390,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/process_start_key_raw.c
+++ b/tests/bpf2c_tests/expected/process_start_key_raw.c
@@ -81,104 +81,104 @@ static uint16_t function_v4_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 function_v4(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     // Prologue.
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r0 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r1 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r2 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r3 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r4 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r5 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r6 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r7 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=17 imm=48955
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
         goto label_1;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=33
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_RSH64_IMM pc=8 dst=r6 src=r0 offset=0 imm=32
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     r6 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=12 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=14 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=15 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/process_start_key.c"
+#line 41 "sample/process_start_key.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/process_start_key.c"
+#line 41 "sample/process_start_key.c"
     return r0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -212,104 +212,104 @@ static uint16_t function_v6_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 function_v6(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     // Prologue.
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r0 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r1 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r2 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r3 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r4 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r5 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r6 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r7 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=17 imm=48955
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
         goto label_1;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=33
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_RSH64_IMM pc=8 dst=r6 src=r0 offset=0 imm=32
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     r6 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=12 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=14 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=15 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/process_start_key.c"
+#line 48 "sample/process_start_key.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/process_start_key.c"
+#line 48 "sample/process_start_key.c"
     return r0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -360,7 +360,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/process_start_key_sys.c
+++ b/tests/bpf2c_tests/expected/process_start_key_sys.c
@@ -236,104 +236,104 @@ static uint16_t function_v4_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 function_v4(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     // Prologue.
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r0 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r1 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r2 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r3 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r4 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r5 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r6 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r7 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=17 imm=48955
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
         goto label_1;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=33
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_RSH64_IMM pc=8 dst=r6 src=r0 offset=0 imm=32
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     r6 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=12 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=14 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=15 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/process_start_key.c"
+#line 41 "sample/process_start_key.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/process_start_key.c"
+#line 41 "sample/process_start_key.c"
     return r0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -367,104 +367,104 @@ static uint16_t function_v6_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 function_v6(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     // Prologue.
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r0 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r1 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r2 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r3 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r4 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r5 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r6 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r7 = 0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=17 imm=48955
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
         goto label_1;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 37 "sample/process_start_key.c"
+#line 28 "sample/process_start_key.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=33
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/process_start_key.c"
+#line 29 "sample/process_start_key.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_RSH64_IMM pc=8 dst=r6 src=r0 offset=0 imm=32
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     r6 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/process_start_key.c"
+#line 30 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=10 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=11 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/process_start_key.c"
+#line 31 "sample/process_start_key.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=12 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=14 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/process_start_key.c"
+#line 26 "sample/process_start_key.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=15 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/process_start_key.c"
+#line 32 "sample/process_start_key.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/process_start_key.c"
+#line 48 "sample/process_start_key.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/process_start_key.c"
+#line 48 "sample/process_start_key.c"
     return r0;
-#line 31 "sample/process_start_key.c"
+#line 22 "sample/process_start_key.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -515,7 +515,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -746,7 +746,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_flow_id_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_dll.c
@@ -879,7 +879,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_flow_id_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_raw.c
@@ -849,7 +849,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_flow_id_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_flow_id_sys.c
@@ -1004,7 +1004,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -716,7 +716,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -871,7 +871,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/strings_dll.c
+++ b/tests/bpf2c_tests/expected/strings_dll.c
@@ -482,7 +482,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/strings_raw.c
+++ b/tests/bpf2c_tests/expected/strings_raw.c
@@ -452,7 +452,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/strings_sys.c
+++ b/tests/bpf2c_tests/expected/strings_sys.c
@@ -607,7 +607,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -310,7 +310,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -280,7 +280,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -435,7 +435,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -305,7 +305,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -282,7 +282,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -252,7 +252,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -407,7 +407,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_dll.c
@@ -7834,7 +7834,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_raw.c
@@ -7804,7 +7804,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_max_exceed_sys.c
@@ -7959,7 +7959,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -317,7 +317,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -287,7 +287,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -442,7 +442,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -275,7 +275,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_dll.c
@@ -311,7 +311,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_raw.c
@@ -281,7 +281,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_recursive_sys.c
@@ -436,7 +436,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_dll.c
@@ -363,7 +363,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_raw.c
@@ -333,7 +333,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_same_section_sys.c
@@ -488,7 +488,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_dll.c
@@ -7486,7 +7486,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_raw.c
@@ -7456,7 +7456,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sequential_sys.c
@@ -7611,7 +7611,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -430,7 +430,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_invalid_redirect_map_dll.c
+++ b/tests/bpf2c_tests/expected/test_invalid_redirect_map_dll.c
@@ -233,7 +233,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_invalid_redirect_map_raw.c
+++ b/tests/bpf2c_tests/expected/test_invalid_redirect_map_raw.c
@@ -203,7 +203,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_invalid_redirect_map_sys.c
+++ b/tests/bpf2c_tests/expected/test_invalid_redirect_map_sys.c
@@ -358,7 +358,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -347,7 +347,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -317,7 +317,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -472,7 +472,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_dll.c
@@ -419,7 +419,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_raw.c
@@ -389,7 +389,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_implicit_helpers_sys.c
@@ -544,7 +544,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_dll.c
@@ -189,7 +189,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_raw.c
@@ -159,7 +159,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_invalid_socket_cookie_sys.c
@@ -314,7 +314,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_dll.c
@@ -204,7 +204,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_raw.c
@@ -174,7 +174,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_perf_event_array_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_perf_event_array_sys.c
@@ -329,7 +329,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_redirect_map_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_redirect_map_dll.c
@@ -233,7 +233,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_redirect_map_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_redirect_map_raw.c
@@ -203,7 +203,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_sample_redirect_map_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_redirect_map_sys.c
@@ -358,7 +358,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -351,7 +351,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -321,7 +321,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -476,7 +476,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/thread_start_time_dll.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_dll.c
@@ -111,101 +111,101 @@ static uint16_t function_v4_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 function_v4(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     // Prologue.
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r0 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r1 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r2 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r3 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r4 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r5 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r6 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r7 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=16 imm=48955
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
         goto label_1;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=34
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_STXW pc=8 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/thread_start_time.c"
+#line 30 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=9 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=13 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=14 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=16 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=17 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/thread_start_time.c"
+#line 41 "sample/thread_start_time.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=19 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/thread_start_time.c"
+#line 41 "sample/thread_start_time.c"
     return r0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -239,101 +239,101 @@ static uint16_t function_v6_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 function_v6(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     // Prologue.
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r0 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r1 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r2 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r3 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r4 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r5 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r6 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r7 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=16 imm=48955
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
         goto label_1;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=34
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_STXW pc=8 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/thread_start_time.c"
+#line 30 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=9 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=13 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=14 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=16 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=17 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/thread_start_time.c"
+#line 48 "sample/thread_start_time.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=19 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/thread_start_time.c"
+#line 48 "sample/thread_start_time.c"
     return r0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -384,7 +384,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/thread_start_time_raw.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_raw.c
@@ -81,101 +81,101 @@ static uint16_t function_v4_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 function_v4(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     // Prologue.
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r0 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r1 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r2 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r3 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r4 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r5 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r6 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r7 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=16 imm=48955
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
         goto label_1;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=34
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_STXW pc=8 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/thread_start_time.c"
+#line 30 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=9 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=13 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=14 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=16 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=17 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/thread_start_time.c"
+#line 41 "sample/thread_start_time.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=19 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/thread_start_time.c"
+#line 41 "sample/thread_start_time.c"
     return r0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -209,101 +209,101 @@ static uint16_t function_v6_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 function_v6(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     // Prologue.
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r0 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r1 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r2 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r3 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r4 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r5 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r6 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r7 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=16 imm=48955
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
         goto label_1;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=34
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_STXW pc=8 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/thread_start_time.c"
+#line 30 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=9 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=13 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=14 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=16 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=17 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/thread_start_time.c"
+#line 48 "sample/thread_start_time.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=19 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/thread_start_time.c"
+#line 48 "sample/thread_start_time.c"
     return r0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -354,7 +354,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/thread_start_time_sys.c
+++ b/tests/bpf2c_tests/expected/thread_start_time_sys.c
@@ -236,101 +236,101 @@ static uint16_t function_v4_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 function_v4(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     // Prologue.
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r0 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r1 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r2 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r3 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r4 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r5 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r6 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r7 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=16 imm=48955
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
         goto label_1;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=34
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_STXW pc=8 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/thread_start_time.c"
+#line 30 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=9 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=13 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=14 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=16 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=17 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/thread_start_time.c"
+#line 41 "sample/thread_start_time.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=19 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/thread_start_time.c"
+#line 41 "sample/thread_start_time.c"
     return r0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -364,101 +364,101 @@ static uint16_t function_v6_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 function_v6(void* context, const program_runtime_context_t* runtime_context)
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     // Prologue.
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r0 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r1 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r2 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r3 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r4 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r5 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r6 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r7 = 0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     register uint64_t r10 = 0;
 
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r1 = (uintptr_t)context;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXH pc=0 dst=r1 src=r1 offset=40 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     READ_ONCE_16(r1, r1, OFFSET(40));
     // EBPF_OP_JNE_IMM pc=1 dst=r1 src=r0 offset=16 imm=48955
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     if (r1 != IMMEDIATE(48955)) {
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
         goto label_1;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     }
     // EBPF_OP_MOV64_IMM pc=2 dst=r7 src=r0 offset=0 imm=0
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-16 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r7, OFFSET(-16));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=5 dst=r6 src=r0 offset=0 imm=0
-#line 36 "sample/thread_start_time.c"
+#line 27 "sample/thread_start_time.c"
     r6 = r0;
     // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=34
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, runtime_context->map_data[0].address);
     // EBPF_OP_STXDW pc=7 dst=r10 src=r0 offset=-8 imm=0
-#line 38 "sample/thread_start_time.c"
+#line 29 "sample/thread_start_time.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-8));
     // EBPF_OP_STXW pc=8 dst=r10 src=r6 offset=-16 imm=0
-#line 39 "sample/thread_start_time.c"
+#line 30 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-16));
     // EBPF_OP_STXW pc=9 dst=r10 src=r7 offset=-20 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     WRITE_ONCE_32(r10, (uint32_t)r7, OFFSET(-20));
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
-#line 40 "sample/thread_start_time.c"
+#line 31 "sample/thread_start_time.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-20
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=12 dst=r3 src=r10 offset=0 imm=0
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=13 dst=r3 src=r0 offset=0 imm=-16
-#line 35 "sample/thread_start_time.c"
+#line 26 "sample/thread_start_time.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=14 dst=r1 src=r1 offset=0 imm=1
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=16 dst=r4 src=r0 offset=0 imm=0
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=17 dst=r0 src=r0 offset=0 imm=2
-#line 41 "sample/thread_start_time.c"
+#line 32 "sample/thread_start_time.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
 label_1:
     // EBPF_OP_MOV64_IMM pc=18 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/thread_start_time.c"
+#line 48 "sample/thread_start_time.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=19 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/thread_start_time.c"
+#line 48 "sample/thread_start_time.c"
     return r0;
-#line 31 "sample/thread_start_time.c"
+#line 22 "sample/thread_start_time.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -509,7 +509,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_dll.c
+++ b/tests/bpf2c_tests/expected/utility_dll.c
@@ -554,7 +554,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_raw.c
+++ b/tests/bpf2c_tests/expected/utility_raw.c
@@ -524,7 +524,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/utility_sys.c
+++ b/tests/bpf2c_tests/expected/utility_sys.c
@@ -679,7 +679,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 1;
-    version->minor = 5;
+    version->minor = 6;
     version->revision = 0;
 }
 

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 1, "minor": 5, "patch": 0 }
+{ "major": 1, "minor": 6, "patch": 0 }


### PR DESCRIPTION
## Description
Update product version to 1.6.
This was performed as part of #5481 
The `scripts\update-product-version.ps1` file was updated to build targeting `NativeOnlyDebug`.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CI.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.