### PR TITLE
Fix HASH_OF_MAPS replacement object handling

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2010,8 +2010,8 @@ _update_hash_map_entry_with_handle(
         goto Done;
     }
 
-    // Store the old object.
-    ebpf_core_object_t* old_object = (ebpf_core_object_t*)old_value;
+    // The hash table stores the object pointer in the value bytes.
+    ebpf_core_object_t* old_object = old_value ? *(ebpf_core_object_t**)old_value : NULL;
 
     // Store the new entry.
     result =

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -2335,6 +2335,26 @@ TEST_CASE("EBPF_OPERATION_MAP_UPDATE_ELEMENT_WITH_HANDLE", "[execution_context][
     }
 }
 
+TEST_CASE("EBPF_OPERATION_MAP_UPDATE_ELEMENT_WITH_HANDLE hash map replacement", "[execution_context]")
+{
+    NEGATIVE_TEST_PROLOG();
+
+    std::vector<uint8_t> request(
+        EBPF_OFFSET_OF(ebpf_operation_map_update_element_with_handle_request_t, key) + sizeof(uint32_t));
+    auto map_update_element_with_handle_request =
+        reinterpret_cast<ebpf_operation_map_update_element_with_handle_request_t*>(request.data());
+
+    map_update_element_with_handle_request->map_handle = map_handles["BPF_MAP_TYPE_HASH_OF_MAPS"];
+    map_update_element_with_handle_request->value_handle = map_handles["BPF_MAP_TYPE_ARRAY"];
+    map_update_element_with_handle_request->option = EBPF_ANY;
+
+    uint32_t key = 0;
+    memcpy(map_update_element_with_handle_request->key, &key, sizeof(key));
+
+    REQUIRE(invoke_protocol(EBPF_OPERATION_MAP_UPDATE_ELEMENT_WITH_HANDLE, request) == EBPF_SUCCESS);
+    REQUIRE(invoke_protocol(EBPF_OPERATION_MAP_UPDATE_ELEMENT_WITH_HANDLE, request) == EBPF_SUCCESS);
+}
+
 TEST_CASE("EBPF_OPERATION_MAP_DELETE_ELEMENT", "[execution_context][negative]")
 {
     NEGATIVE_TEST_PROLOG();

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2527,6 +2527,14 @@ _ebpf_test_map_in_map(ebpf_map_type_t type)
     // Verify that we can read it back.
     REQUIRE(bpf_map_lookup_elem(outer_map_fd, &outer_key, &inner_map_id) == 0);
 
+    if (type == BPF_MAP_TYPE_HASH_OF_MAPS) {
+        // Replacing an existing hash-of-maps entry must release the stored object pointer.
+        REQUIRE(bpf_map_update_elem(outer_map_fd, &outer_key, &inner_map_fd, 0) == 0);
+        ebpf_id_t replaced_inner_map_id;
+        REQUIRE(bpf_map_lookup_elem(outer_map_fd, &outer_key, &replaced_inner_map_id) == 0);
+        REQUIRE(replaced_inner_map_id == inner_map_id);
+    }
+
     // Verify that we can convert the ID to a new fd, so we know it is actually
     // a valid map ID.
     int inner_map_fd2 = bpf_map_get_fd_by_id(inner_map_id);


### PR DESCRIPTION
## Summary
- Correctly dereference the stored object pointer when replacing a HASH_OF_MAPS entry.
- Add execution-context and libbpf regression tests for replacement.

## Reliability impact
Replacing an existing HASH_OF_MAPS entry could interpret hash-table value storage as an object during reference release and trigger a kernel fast-fail.

## Validation
The source changes compile through the available portions of the Debug build. Full solution validation is blocked in this environment by missing Windows SDK 10.0.28000.0 and stampinf.exe.