### PR TITLE
ci: fallback to GITHUB_TOKEN in scorecard analysis when SCORECARD_READ_TOKEN is unavailable

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -61,7 +61,7 @@ jobs:
           results_format: sarif
           # Read-only PAT token. To create it,
           # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN || secrets.GITHUB_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`,


### PR DESCRIPTION
## Description
Resolves a CI failure where the Scorecards analysis workflow fails with `401 Bad credentials` on push/forks if `SCORECARD_READ_TOKEN` is expired or unavailable:
```text
scorecard had an error: repo unreachable: GET https://api.github.com/repos/microsoft/ebpf-for-windows: 401 Bad credentials []

This change updates the repo_token to fall back to ${{ secrets.SCORECARD_READ_TOKEN || secrets.GITHUB_TOKEN }}, ensuring that the workflow can always authenticate with the GitHub Actions default token while maintaining support for dedicated tokens when available.
Testing

    Verified syntax against .github/workflows/scorecards-analysis.yml.

    Verified required job permissions (security-events: write, id-token: write, contents: read) are already present for GITHUB_TOKEN.