### PR TITLE
Fix netebpfext fault-injection null dereference 

### DIFF
--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1369,6 +1369,7 @@ TEST_CASE("sock_addr_listen_invoke", "[netebpfext]")
         &npi_specific_characteristics,
         (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
         (netebpfext_helper_base_client_context_t*)client_context);
+    REQUIRE(helper.get_program_info_provider_data(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR) != nullptr);
 
     netebpfext_initialize_fwp_classify_parameters(&parameters);
 


### PR DESCRIPTION
## Description

Handle missing sock-address program information in the netebpfext unit-test callback.

Fault injection can prevent the program-info provider from attaching while the hook client remains active. In that case, `get_program_info_provider_data()` returns `nullptr`, which was dereferenced by `netebpfext_unit_invoke_sock_addr_program`.

Use a Catch2 `REQUIRE` to terminate the affected test cleanly instead.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

NA

## Installation

NA
