### PR TITLE
Cherry-picking null deref fix in netebpf fault injection test (#5512)

### DIFF
--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -1369,6 +1369,7 @@ TEST_CASE("sock_addr_listen_invoke", "[netebpfext]")
         &npi_specific_characteristics,
         (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
         (netebpfext_helper_base_client_context_t*)client_context);
+    REQUIRE(helper.get_program_info_provider_data(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR) != nullptr);
 
     netebpfext_initialize_fwp_classify_parameters(&parameters);
 


### PR DESCRIPTION
## Description

Cherry-picking https://github.com/microsoft/ebpf-for-windows/pull/5512 into release branch.

## Testing

NA
_If new tests were added:_
- [ ] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation

NA
## Installation

NA
