### PR TITLE
Fix bpf2c subprogram stack frames

### DIFF
--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_dll.c
@@ -87,7 +87,7 @@ BindMonitor_Caller(void* context, const program_runtime_context_t* runtime_conte
 #line 45 "sample/bindmonitor_bpf2bpf.c"
     // Prologue.
 #line 45 "sample/bindmonitor_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 8) + 7) / 8];
 #line 45 "sample/bindmonitor_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 45 "sample/bindmonitor_bpf2bpf.c"
@@ -139,7 +139,7 @@ BindMonitor_Caller(void* context, const program_runtime_context_t* runtime_conte
     r1 += IMMEDIATE(16);
     // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=35
 #line 53 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee1(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=10 dst=r0 src=r0 offset=0 imm=32
 #line 53 "sample/bindmonitor_bpf2bpf.c"
     r0 <<= (IMMEDIATE(32) & 63);
@@ -295,7 +295,7 @@ BindMonitor_Callee1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -324,7 +324,7 @@ BindMonitor_Callee2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee3(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -353,7 +353,7 @@ BindMonitor_Callee3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee4(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -382,7 +382,7 @@ BindMonitor_Callee4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee5(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee5(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -411,7 +411,7 @@ BindMonitor_Callee5(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee6(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee6(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -440,7 +440,7 @@ BindMonitor_Callee6(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee7(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee7(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_raw.c
@@ -57,7 +57,7 @@ BindMonitor_Caller(void* context, const program_runtime_context_t* runtime_conte
 #line 45 "sample/bindmonitor_bpf2bpf.c"
     // Prologue.
 #line 45 "sample/bindmonitor_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 8) + 7) / 8];
 #line 45 "sample/bindmonitor_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 45 "sample/bindmonitor_bpf2bpf.c"
@@ -109,7 +109,7 @@ BindMonitor_Caller(void* context, const program_runtime_context_t* runtime_conte
     r1 += IMMEDIATE(16);
     // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=35
 #line 53 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee1(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=10 dst=r0 src=r0 offset=0 imm=32
 #line 53 "sample/bindmonitor_bpf2bpf.c"
     r0 <<= (IMMEDIATE(32) & 63);
@@ -265,7 +265,7 @@ BindMonitor_Callee1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -294,7 +294,7 @@ BindMonitor_Callee2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee3(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -323,7 +323,7 @@ BindMonitor_Callee3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee4(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -352,7 +352,7 @@ BindMonitor_Callee4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee5(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee5(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -381,7 +381,7 @@ BindMonitor_Callee5(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee6(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee6(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -410,7 +410,7 @@ BindMonitor_Callee6(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee7(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee7(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;

--- a/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_bpf2bpf_sys.c
@@ -212,7 +212,7 @@ BindMonitor_Caller(void* context, const program_runtime_context_t* runtime_conte
 #line 45 "sample/bindmonitor_bpf2bpf.c"
     // Prologue.
 #line 45 "sample/bindmonitor_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 8) + 7) / 8];
 #line 45 "sample/bindmonitor_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 45 "sample/bindmonitor_bpf2bpf.c"
@@ -264,7 +264,7 @@ BindMonitor_Caller(void* context, const program_runtime_context_t* runtime_conte
     r1 += IMMEDIATE(16);
     // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=35
 #line 53 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee1(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=10 dst=r0 src=r0 offset=0 imm=32
 #line 53 "sample/bindmonitor_bpf2bpf.c"
     r0 <<= (IMMEDIATE(32) & 63);
@@ -420,7 +420,7 @@ BindMonitor_Callee1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -449,7 +449,7 @@ BindMonitor_Callee2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee3(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -478,7 +478,7 @@ BindMonitor_Callee3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee4(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -507,7 +507,7 @@ BindMonitor_Callee4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee5(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee5(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -536,7 +536,7 @@ BindMonitor_Callee5(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee6(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee6(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;
@@ -565,7 +565,7 @@ BindMonitor_Callee6(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=1
 #line 77 "sample/bindmonitor_bpf2bpf.c"
-    r0 = BindMonitor_Callee7(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = BindMonitor_Callee7(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=6 dst=r0 src=r0 offset=0 imm=0
 #line 77 "sample/bindmonitor_bpf2bpf.c"
     return r0;

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
@@ -110,7 +110,7 @@ caller_with_loop(void* context, const program_runtime_context_t* runtime_context
 #line 28 "sample/undocked/bpf2bpf_loop.c"
     // Prologue.
 #line 28 "sample/undocked/bpf2bpf_loop.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 28 "sample/undocked/bpf2bpf_loop.c"
     register uint64_t r0 = 0;
 #line 28 "sample/undocked/bpf2bpf_loop.c"
@@ -167,7 +167,7 @@ label_1:
     r1 = r0;
     // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=18
 #line 34 "sample/undocked/bpf2bpf_loop.c"
-    r0 = increment(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = increment(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LDXW pc=10 dst=r1 src=r10 offset=-12 imm=0
 #line 33 "sample/undocked/bpf2bpf_loop.c"
     READ_ONCE_32(r1, r10, OFFSET(-12));

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_dll.c
@@ -93,6 +93,8 @@ static helper_function_entry_t caller_with_loop_helpers[] = {
 // Forward references for local functions.
 static uint64_t
 increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID caller_with_loop_program_type_guid = {
     0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
@@ -102,7 +104,7 @@ static uint16_t caller_with_loop_maps[] = {
     0,
 };
 
-#pragma code_seg(push, "sample~1")
+#pragma code_seg(push, "sample~2")
 static uint64_t
 caller_with_loop(void* context, const program_runtime_context_t* runtime_context)
 #line 28 "sample/undocked/bpf2bpf_loop.c"
@@ -251,13 +253,139 @@ increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint6
 #line 22 "sample/undocked/bpf2bpf_loop.c"
     return r0;
 }
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)r10;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r0 src=r1 offset=0 imm=0
+#line 20 "sample/undocked/bpf2bpf_loop.c"
+    r0 = r1;
+    // EBPF_OP_ADD64_IMM pc=1 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    r0 += IMMEDIATE(1);
+    // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+}
+static helper_function_entry_t stack_frame_test_entry_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID stack_frame_test_entry_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID stack_frame_test_entry_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+#pragma code_seg(push, "sample~1")
+static uint64_t
+stack_frame_test_entry(void* context, const program_runtime_context_t* runtime_context)
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+{
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    // Prologue.
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r0 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r1 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r2 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r3 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r4 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r5 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r10 = 0;
+
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (uintptr_t)context;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = IMMEDIATE(4660);
+    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
+#line 30 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
+    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r2 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r2 = IMMEDIATE(1);
+    // EBPF_OP_MOV64_IMM pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if (r1 != IMMEDIATE(4661)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_1;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if (r1 != IMMEDIATE(4660)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_2;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r2 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 |= r2;
+    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
 #pragma data_seg(push, "programs")
 static program_entry_t _programs[] = {
     {
         0,
         {1, 154, 160}, // Version header.
         caller_with_loop,
-        "sample~1",
+        "sample~2",
         "sample_ext",
         "caller_with_loop",
         caller_with_loop_maps,
@@ -268,6 +396,21 @@ static program_entry_t _programs[] = {
         &caller_with_loop_program_type_guid,
         &caller_with_loop_attach_type_guid,
     },
+    {
+        0,
+        {1, 154, 160}, // Version header.
+        stack_frame_test_entry,
+        "sample~1",
+        "sample_ext",
+        "stack_frame_test_entry",
+        NULL,
+        0,
+        stack_frame_test_entry_helpers,
+        1,
+        14,
+        &stack_frame_test_entry_program_type_guid,
+        &stack_frame_test_entry_attach_type_guid,
+    },
 };
 #pragma data_seg(pop)
 
@@ -275,7 +418,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 1;
+    *count = 2;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
@@ -63,6 +63,8 @@ static helper_function_entry_t caller_with_loop_helpers[] = {
 // Forward references for local functions.
 static uint64_t
 increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID caller_with_loop_program_type_guid = {
     0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
@@ -72,7 +74,7 @@ static uint16_t caller_with_loop_maps[] = {
     0,
 };
 
-#pragma code_seg(push, "sample~1")
+#pragma code_seg(push, "sample~2")
 static uint64_t
 caller_with_loop(void* context, const program_runtime_context_t* runtime_context)
 #line 28 "sample/undocked/bpf2bpf_loop.c"
@@ -221,13 +223,139 @@ increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint6
 #line 22 "sample/undocked/bpf2bpf_loop.c"
     return r0;
 }
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)r10;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r0 src=r1 offset=0 imm=0
+#line 20 "sample/undocked/bpf2bpf_loop.c"
+    r0 = r1;
+    // EBPF_OP_ADD64_IMM pc=1 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    r0 += IMMEDIATE(1);
+    // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+}
+static helper_function_entry_t stack_frame_test_entry_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID stack_frame_test_entry_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID stack_frame_test_entry_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+#pragma code_seg(push, "sample~1")
+static uint64_t
+stack_frame_test_entry(void* context, const program_runtime_context_t* runtime_context)
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+{
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    // Prologue.
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r0 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r1 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r2 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r3 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r4 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r5 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r10 = 0;
+
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (uintptr_t)context;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = IMMEDIATE(4660);
+    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
+#line 30 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
+    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r2 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r2 = IMMEDIATE(1);
+    // EBPF_OP_MOV64_IMM pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if (r1 != IMMEDIATE(4661)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_1;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if (r1 != IMMEDIATE(4660)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_2;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r2 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 |= r2;
+    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
 #pragma data_seg(push, "programs")
 static program_entry_t _programs[] = {
     {
         0,
         {1, 154, 160}, // Version header.
         caller_with_loop,
-        "sample~1",
+        "sample~2",
         "sample_ext",
         "caller_with_loop",
         caller_with_loop_maps,
@@ -238,6 +366,21 @@ static program_entry_t _programs[] = {
         &caller_with_loop_program_type_guid,
         &caller_with_loop_attach_type_guid,
     },
+    {
+        0,
+        {1, 154, 160}, // Version header.
+        stack_frame_test_entry,
+        "sample~1",
+        "sample_ext",
+        "stack_frame_test_entry",
+        NULL,
+        0,
+        stack_frame_test_entry_helpers,
+        1,
+        14,
+        &stack_frame_test_entry_program_type_guid,
+        &stack_frame_test_entry_attach_type_guid,
+    },
 };
 #pragma data_seg(pop)
 
@@ -245,7 +388,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 1;
+    *count = 2;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_raw.c
@@ -80,7 +80,7 @@ caller_with_loop(void* context, const program_runtime_context_t* runtime_context
 #line 28 "sample/undocked/bpf2bpf_loop.c"
     // Prologue.
 #line 28 "sample/undocked/bpf2bpf_loop.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 28 "sample/undocked/bpf2bpf_loop.c"
     register uint64_t r0 = 0;
 #line 28 "sample/undocked/bpf2bpf_loop.c"
@@ -137,7 +137,7 @@ label_1:
     r1 = r0;
     // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=18
 #line 34 "sample/undocked/bpf2bpf_loop.c"
-    r0 = increment(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = increment(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LDXW pc=10 dst=r1 src=r10 offset=-12 imm=0
 #line 33 "sample/undocked/bpf2bpf_loop.c"
     READ_ONCE_32(r1, r10, OFFSET(-12));

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
@@ -218,6 +218,8 @@ static helper_function_entry_t caller_with_loop_helpers[] = {
 // Forward references for local functions.
 static uint64_t
 increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID caller_with_loop_program_type_guid = {
     0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
@@ -227,7 +229,7 @@ static uint16_t caller_with_loop_maps[] = {
     0,
 };
 
-#pragma code_seg(push, "sample~1")
+#pragma code_seg(push, "sample~2")
 static uint64_t
 caller_with_loop(void* context, const program_runtime_context_t* runtime_context)
 #line 28 "sample/undocked/bpf2bpf_loop.c"
@@ -376,13 +378,139 @@ increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint6
 #line 22 "sample/undocked/bpf2bpf_loop.c"
     return r0;
 }
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)r10;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_MOV64_REG pc=0 dst=r0 src=r1 offset=0 imm=0
+#line 20 "sample/undocked/bpf2bpf_loop.c"
+    r0 = r1;
+    // EBPF_OP_ADD64_IMM pc=1 dst=r0 src=r0 offset=0 imm=1
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    r0 += IMMEDIATE(1);
+    // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
+#line 22 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+}
+static helper_function_entry_t stack_frame_test_entry_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+increment(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID stack_frame_test_entry_program_type_guid = {
+    0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+static GUID stack_frame_test_entry_attach_type_guid = {
+    0xf788ef4b, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+#pragma code_seg(push, "sample~1")
+static uint64_t
+stack_frame_test_entry(void* context, const program_runtime_context_t* runtime_context)
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+{
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    // Prologue.
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r0 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r1 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r2 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r3 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r4 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r5 = 0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    register uint64_t r10 = 0;
+
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = (uintptr_t)context;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+    r1 = IMMEDIATE(4660);
+    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
+#line 30 "sample/undocked/bpf2bpf_loop.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
+    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r2 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r2 = IMMEDIATE(1);
+    // EBPF_OP_MOV64_IMM pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if (r1 != IMMEDIATE(4661)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_1;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    r0 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
+#line 34 "sample/undocked/bpf2bpf_loop.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    if (r1 != IMMEDIATE(4660)) {
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+        goto label_2;
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r2 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    r0 |= r2;
+    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
+#line 33 "sample/undocked/bpf2bpf_loop.c"
+    return r0;
+#line 28 "sample/undocked/bpf2bpf_loop.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
 #pragma data_seg(push, "programs")
 static program_entry_t _programs[] = {
     {
         0,
         {1, 154, 160}, // Version header.
         caller_with_loop,
-        "sample~1",
+        "sample~2",
         "sample_ext",
         "caller_with_loop",
         caller_with_loop_maps,
@@ -393,6 +521,21 @@ static program_entry_t _programs[] = {
         &caller_with_loop_program_type_guid,
         &caller_with_loop_attach_type_guid,
     },
+    {
+        0,
+        {1, 154, 160}, // Version header.
+        stack_frame_test_entry,
+        "sample~1",
+        "sample_ext",
+        "stack_frame_test_entry",
+        NULL,
+        0,
+        stack_frame_test_entry_helpers,
+        1,
+        14,
+        &stack_frame_test_entry_program_type_guid,
+        &stack_frame_test_entry_attach_type_guid,
+    },
 };
 #pragma data_seg(pop)
 
@@ -400,7 +543,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 1;
+    *count = 2;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
+++ b/tests/bpf2c_tests/expected/bpf2bpf_loop_sys.c
@@ -235,7 +235,7 @@ caller_with_loop(void* context, const program_runtime_context_t* runtime_context
 #line 28 "sample/undocked/bpf2bpf_loop.c"
     // Prologue.
 #line 28 "sample/undocked/bpf2bpf_loop.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 28 "sample/undocked/bpf2bpf_loop.c"
     register uint64_t r0 = 0;
 #line 28 "sample/undocked/bpf2bpf_loop.c"
@@ -292,7 +292,7 @@ label_1:
     r1 = r0;
     // EBPF_OP_CALL pc=9 dst=r0 src=r1 offset=0 imm=18
 #line 34 "sample/undocked/bpf2bpf_loop.c"
-    r0 = increment(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = increment(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LDXW pc=10 dst=r1 src=r10 offset=-12 imm=0
 #line 33 "sample/undocked/bpf2bpf_loop.c"
     READ_ONCE_32(r1, r10, OFFSET(-12));

--- a/tests/bpf2c_tests/expected/btf_resolved_dll.c
+++ b/tests/bpf2c_tests/expected/btf_resolved_dll.c
@@ -81,7 +81,7 @@ func(void* context, const program_runtime_context_t* runtime_context)
 #line 18 "sample/undocked/btf_resolved.c"
     // Prologue.
 #line 18 "sample/undocked/btf_resolved.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 18 "sample/undocked/btf_resolved.c"
     register uint64_t r0 = 0;
 #line 18 "sample/undocked/btf_resolved.c"
@@ -107,7 +107,7 @@ func(void* context, const program_runtime_context_t* runtime_context)
     READ_ONCE_32(r1, r1, OFFSET(16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r1 offset=0 imm=1
 #line 18 "sample/undocked/btf_resolved.c"
-    r0 = btf_lookup(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = btf_lookup(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
 #line 18 "sample/undocked/btf_resolved.c"
     return r0;

--- a/tests/bpf2c_tests/expected/btf_resolved_raw.c
+++ b/tests/bpf2c_tests/expected/btf_resolved_raw.c
@@ -51,7 +51,7 @@ func(void* context, const program_runtime_context_t* runtime_context)
 #line 18 "sample/undocked/btf_resolved.c"
     // Prologue.
 #line 18 "sample/undocked/btf_resolved.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 18 "sample/undocked/btf_resolved.c"
     register uint64_t r0 = 0;
 #line 18 "sample/undocked/btf_resolved.c"
@@ -77,7 +77,7 @@ func(void* context, const program_runtime_context_t* runtime_context)
     READ_ONCE_32(r1, r1, OFFSET(16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r1 offset=0 imm=1
 #line 18 "sample/undocked/btf_resolved.c"
-    r0 = btf_lookup(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = btf_lookup(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
 #line 18 "sample/undocked/btf_resolved.c"
     return r0;

--- a/tests/bpf2c_tests/expected/btf_resolved_sys.c
+++ b/tests/bpf2c_tests/expected/btf_resolved_sys.c
@@ -206,7 +206,7 @@ func(void* context, const program_runtime_context_t* runtime_context)
 #line 18 "sample/undocked/btf_resolved.c"
     // Prologue.
 #line 18 "sample/undocked/btf_resolved.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 18 "sample/undocked/btf_resolved.c"
     register uint64_t r0 = 0;
 #line 18 "sample/undocked/btf_resolved.c"
@@ -232,7 +232,7 @@ func(void* context, const program_runtime_context_t* runtime_context)
     READ_ONCE_32(r1, r1, OFFSET(16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r1 offset=0 imm=1
 #line 18 "sample/undocked/btf_resolved.c"
-    r0 = btf_lookup(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = btf_lookup(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=2 dst=r0 src=r0 offset=0 imm=0
 #line 18 "sample/undocked/btf_resolved.c"
     return r0;

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
@@ -115,8 +115,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program1_program_type_guid = {
@@ -126,93 +124,93 @@ static GUID entry_program1_attach_type_guid = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 entry_program1(void* context, const program_runtime_context_t* runtime_context)
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
 {
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r6 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r7 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 141 "sample/callgraph_bpf2bpf.c"
+#line 129 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=9
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=4 dst=r6 src=r10 offset=0 imm=0
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r6 = r10;
     // EBPF_OP_ADD64_IMM pc=5 dst=r6 src=r0 offset=0 imm=-8
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r6 += IMMEDIATE(-8);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r6 offset=0 imm=0
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 133 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 133 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=12 dst=r7 src=r0 offset=0 imm=32
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=13 dst=r0 src=r0 offset=0 imm=2
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=14 dst=r7 src=r0 offset=1 imm=2
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     if (r7 == IMMEDIATE(2)) {
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=15 dst=r0 src=r0 offset=0 imm=1
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
 label_1:
     // EBPF_OP_EXIT pc=16 dst=r0 src=r0 offset=0 imm=0
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -223,19 +221,19 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -246,16 +244,16 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     UNREFERENCED_PARAMETER(runtime_context);
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -264,53 +262,53 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=3 dst=r1 src=r1 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=4 dst=r1 src=r0 offset=4 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=2
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-4 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=3 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_2:
     // EBPF_OP_MOV64_IMM pc=9 dst=r1 src=r0 offset=0 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=10 dst=r10 src=r1 offset=-4 imm=0
-#line 70 "sample/callgraph_bpf2bpf.c"
+#line 65 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 70 "sample/callgraph_bpf2bpf.c"
+#line 65 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXW pc=12 dst=r0 src=r10 offset=-4 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -319,46 +317,16 @@ ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=9
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_IMM pc=2 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    return r0;
-}
-static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
-{
-    register uint64_t r0 = 0;
-    (void)r2;
-    (void)r3;
-    (void)r4;
-    (void)r5;
-    (void)context;
-    UNREFERENCED_PARAMETER(runtime_context);
-
-    // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
-    // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_ADD64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
-    // EBPF_OP_LDXDW pc=4 dst=r0 src=r10 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r0, r10, OFFSET(-16));
-    // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -368,174 +336,174 @@ update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r6 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-16 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-24 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-24));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=5 dst=r10 src=r0 offset=-32 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-32));
     // EBPF_OP_LDXDW pc=6 dst=r1 src=r10 offset=-32 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-32));
     // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=7 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=0 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=-1
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     r1 = (uint64_t)4294967295;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-4 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-36 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=14 dst=r0 src=r0 offset=39 imm=0
-#line 74 "sample/callgraph_bpf2bpf.c"
+#line 69 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_2:
     // EBPF_OP_MOV64_REG pc=15 dst=r2 src=r10 offset=0 imm=0
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=16 dst=r2 src=r0 offset=0 imm=-24
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_LDDW pc=17 dst=r1 src=r1 offset=0 imm=1
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 84 "sample/callgraph_bpf2bpf.c"
+#line 79 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=20 dst=r10 src=r0 offset=-48 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-48));
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-48 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_JEQ_IMM pc=22 dst=r1 src=r0 offset=17 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
         goto label_4;
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 89 "sample/callgraph_bpf2bpf.c"
+#line 84 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXDW pc=24 dst=r1 src=r10 offset=-48 imm=0
-#line 94 "sample/callgraph_bpf2bpf.c"
+#line 89 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_LDXDW pc=25 dst=r1 src=r1 offset=0 imm=0
-#line 95 "sample/callgraph_bpf2bpf.c"
+#line 90 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=26 dst=r1 src=r0 offset=0 imm=1
-#line 95 "sample/callgraph_bpf2bpf.c"
+#line 90 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXDW pc=27 dst=r10 src=r1 offset=-56 imm=0
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 97 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-56));
     // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-24
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=30 dst=r3 src=r10 offset=0 imm=0
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=31 dst=r3 src=r0 offset=0 imm=-56
-#line 107 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-56);
     // EBPF_OP_LDDW pc=32 dst=r1 src=r1 offset=0 imm=1
-#line 107 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=34 dst=r4 src=r0 offset=0 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=2
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=36 dst=r10 src=r0 offset=-4 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=37 dst=r1 src=r0 offset=0 imm=1
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=38 dst=r10 src=r1 offset=-36 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=39 dst=r0 src=r0 offset=13 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_4:
     // EBPF_OP_MOV64_IMM pc=40 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=41 dst=r10 src=r6 offset=-64 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r6, OFFSET(-64));
     // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-24
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r10 offset=0 imm=0
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r3 src=r0 offset=0 imm=-64
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-64);
     // EBPF_OP_LDDW pc=46 dst=r1 src=r1 offset=0 imm=1
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=50 dst=r10 src=r0 offset=-4 imm=0
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_STXW pc=51 dst=r10 src=r6 offset=-36 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-36));
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_5:
     // EBPF_OP_JA pc=53 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_6:
     // EBPF_OP_LDXW pc=54 dst=r0 src=r10 offset=-4 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=55 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static helper_function_entry_t entry_program2_helpers[] = {
@@ -571,8 +539,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program2_program_type_guid = {
@@ -582,77 +548,77 @@ static GUID entry_program2_attach_type_guid = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 entry_program2(void* context, const program_runtime_context_t* runtime_context)
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
 {
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=3 dst=r1 src=r10 offset=0 imm=0
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r1 src=r0 offset=0 imm=-8
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=8 dst=r1 src=r0 offset=0 imm=32
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=1
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=2
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(2)) {
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
-#line 169 "sample/callgraph_bpf2bpf.c"
-    return r0;
 #line 157 "sample/callgraph_bpf2bpf.c"
+    return r0;
+#line 145 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -690,8 +656,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program3_program_type_guid = {
@@ -705,201 +669,74 @@ static uint16_t entry_program3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 entry_program3(void* context, const program_runtime_context_t* runtime_context)
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
 {
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_MOV64_REG pc=2 dst=r1 src=r10 offset=0 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=3 dst=r1 src=r0 offset=0 imm=-8
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=6 dst=r1 src=r0 offset=0 imm=32
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 185 "sample/callgraph_bpf2bpf.c"
+#line 173 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 175 "sample/callgraph_bpf2bpf.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static helper_function_entry_t entry_program4_helpers[] = {
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-};
-
-// Forward references for local functions.
-static uint64_t
-ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-
-static GUID entry_program4_program_type_guid = {
-    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
-static GUID entry_program4_attach_type_guid = {
-    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-#pragma code_seg(push, "bind/4")
-static uint64_t
-entry_program4(void* context, const program_runtime_context_t* runtime_context)
-#line 189 "sample/callgraph_bpf2bpf.c"
-{
-#line 189 "sample/callgraph_bpf2bpf.c"
-    // Prologue.
-#line 189 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r0 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r1 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r2 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r3 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r4 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r5 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r10 = 0;
-
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r1 = (uintptr_t)context;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r1 = IMMEDIATE(4660);
-    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 192 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
-    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
-    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r1 = r0;
-    // EBPF_OP_MOV64_IMM pc=5 dst=r0 src=r0 offset=0 imm=1
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r0 = IMMEDIATE(1);
-    // EBPF_OP_MOV64_IMM pc=6 dst=r2 src=r0 offset=0 imm=1
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r2 = IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
-#line 193 "sample/callgraph_bpf2bpf.c"
-    if (r1 != IMMEDIATE(4661)) {
-#line 193 "sample/callgraph_bpf2bpf.c"
-        goto label_1;
-#line 193 "sample/callgraph_bpf2bpf.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=8 dst=r2 src=r0 offset=0 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r2 = IMMEDIATE(0);
-label_1:
-    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
-#line 195 "sample/callgraph_bpf2bpf.c"
-    if (r1 != IMMEDIATE(4660)) {
-#line 195 "sample/callgraph_bpf2bpf.c"
-        goto label_2;
-#line 195 "sample/callgraph_bpf2bpf.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    r0 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    r0 |= r2;
-    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 200 "sample/callgraph_bpf2bpf.c"
-    return r0;
-#line 189 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -951,21 +788,6 @@ static program_entry_t _programs[] = {
         &entry_program3_program_type_guid,
         &entry_program3_attach_type_guid,
     },
-    {
-        0,
-        {1, 154, 160}, // Version header.
-        entry_program4,
-        "bind/4",
-        "bind/4",
-        "entry_program4",
-        NULL,
-        0,
-        entry_program4_helpers,
-        4,
-        14,
-        &entry_program4_program_type_guid,
-        &entry_program4_attach_type_guid,
-    },
 };
 #pragma data_seg(pop)
 
@@ -973,7 +795,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 4;
+    *count = 3;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
@@ -115,6 +115,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program1_program_type_guid = {
@@ -124,93 +126,93 @@ static GUID entry_program1_attach_type_guid = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 entry_program1(void* context, const program_runtime_context_t* runtime_context)
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
 {
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r6 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r7 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 129 "sample/callgraph_bpf2bpf.c"
+#line 141 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=9
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=4 dst=r6 src=r10 offset=0 imm=0
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r6 = r10;
     // EBPF_OP_ADD64_IMM pc=5 dst=r6 src=r0 offset=0 imm=-8
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r6 += IMMEDIATE(-8);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r6 offset=0 imm=0
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 133 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
-#line 133 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=12 dst=r7 src=r0 offset=0 imm=32
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=13 dst=r0 src=r0 offset=0 imm=2
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=14 dst=r7 src=r0 offset=1 imm=2
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     if (r7 == IMMEDIATE(2)) {
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=15 dst=r0 src=r0 offset=0 imm=1
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
 label_1:
     // EBPF_OP_EXIT pc=16 dst=r0 src=r0 offset=0 imm=0
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -221,19 +223,19 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -244,16 +246,16 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     UNREFERENCED_PARAMETER(runtime_context);
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -262,53 +264,53 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-16 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=3 dst=r1 src=r1 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=4 dst=r1 src=r0 offset=4 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=2
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-4 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=3 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_2:
     // EBPF_OP_MOV64_IMM pc=9 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=10 dst=r10 src=r1 offset=-4 imm=0
-#line 65 "sample/callgraph_bpf2bpf.c"
+#line 70 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 65 "sample/callgraph_bpf2bpf.c"
+#line 70 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXW pc=12 dst=r0 src=r10 offset=-4 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -317,16 +319,46 @@ ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=9
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_IMM pc=2 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
+    return r0;
+}
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
+#line 61 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
+#line 64 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_ADD64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
+#line 67 "sample/callgraph_bpf2bpf.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
+    // EBPF_OP_LDXDW pc=4 dst=r0 src=r10 offset=-16 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r0, r10, OFFSET(-16));
+    // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -336,174 +368,174 @@ update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r6 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-16 imm=0
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-24 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-24));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=5 dst=r10 src=r0 offset=-32 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-32));
     // EBPF_OP_LDXDW pc=6 dst=r1 src=r10 offset=-32 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-32));
     // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=7 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=0 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=-1
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     r1 = (uint64_t)4294967295;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-4 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-36 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=14 dst=r0 src=r0 offset=39 imm=0
-#line 69 "sample/callgraph_bpf2bpf.c"
+#line 74 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_2:
     // EBPF_OP_MOV64_REG pc=15 dst=r2 src=r10 offset=0 imm=0
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=16 dst=r2 src=r0 offset=0 imm=-24
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_LDDW pc=17 dst=r1 src=r1 offset=0 imm=1
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 79 "sample/callgraph_bpf2bpf.c"
+#line 84 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=20 dst=r10 src=r0 offset=-48 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-48));
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-48 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_JEQ_IMM pc=22 dst=r1 src=r0 offset=17 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
         goto label_4;
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 84 "sample/callgraph_bpf2bpf.c"
+#line 89 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXDW pc=24 dst=r1 src=r10 offset=-48 imm=0
-#line 89 "sample/callgraph_bpf2bpf.c"
+#line 94 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_LDXDW pc=25 dst=r1 src=r1 offset=0 imm=0
-#line 90 "sample/callgraph_bpf2bpf.c"
+#line 95 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=26 dst=r1 src=r0 offset=0 imm=1
-#line 90 "sample/callgraph_bpf2bpf.c"
+#line 95 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXDW pc=27 dst=r10 src=r1 offset=-56 imm=0
-#line 97 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-56));
     // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-24
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=30 dst=r3 src=r10 offset=0 imm=0
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=31 dst=r3 src=r0 offset=0 imm=-56
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 107 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-56);
     // EBPF_OP_LDDW pc=32 dst=r1 src=r1 offset=0 imm=1
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 107 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=34 dst=r4 src=r0 offset=0 imm=0
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=2
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=36 dst=r10 src=r0 offset=-4 imm=0
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=37 dst=r1 src=r0 offset=0 imm=1
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=38 dst=r10 src=r1 offset=-36 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=39 dst=r0 src=r0 offset=13 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_4:
     // EBPF_OP_MOV64_IMM pc=40 dst=r6 src=r0 offset=0 imm=1
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=41 dst=r10 src=r6 offset=-64 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r6, OFFSET(-64));
     // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-24
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r10 offset=0 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r3 src=r0 offset=0 imm=-64
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-64);
     // EBPF_OP_LDDW pc=46 dst=r1 src=r1 offset=0 imm=1
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=50 dst=r10 src=r0 offset=-4 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_STXW pc=51 dst=r10 src=r6 offset=-36 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-36));
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_5:
     // EBPF_OP_JA pc=53 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_6:
     // EBPF_OP_LDXW pc=54 dst=r0 src=r10 offset=-4 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=55 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static helper_function_entry_t entry_program2_helpers[] = {
@@ -539,6 +571,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program2_program_type_guid = {
@@ -548,77 +582,77 @@ static GUID entry_program2_attach_type_guid = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 entry_program2(void* context, const program_runtime_context_t* runtime_context)
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
 {
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=3 dst=r1 src=r10 offset=0 imm=0
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r1 src=r0 offset=0 imm=-8
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=8 dst=r1 src=r0 offset=0 imm=32
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=1
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=2
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(2)) {
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 169 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -656,6 +690,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program3_program_type_guid = {
@@ -669,74 +705,201 @@ static uint16_t entry_program3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 entry_program3(void* context, const program_runtime_context_t* runtime_context)
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
 {
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_MOV64_REG pc=2 dst=r1 src=r10 offset=0 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=3 dst=r1 src=r0 offset=0 imm=-8
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=6 dst=r1 src=r0 offset=0 imm=32
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 173 "sample/callgraph_bpf2bpf.c"
+#line 185 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+static helper_function_entry_t entry_program4_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID entry_program4_program_type_guid = {
+    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
+static GUID entry_program4_attach_type_guid = {
+    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
+#pragma code_seg(push, "bind/4")
+static uint64_t
+entry_program4(void* context, const program_runtime_context_t* runtime_context)
+#line 189 "sample/callgraph_bpf2bpf.c"
+{
+#line 189 "sample/callgraph_bpf2bpf.c"
+    // Prologue.
+#line 189 "sample/callgraph_bpf2bpf.c"
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r0 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r1 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r2 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r3 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r4 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r5 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r10 = 0;
+
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r1 = (uintptr_t)context;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r1 = IMMEDIATE(4660);
+    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
+#line 192 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
+    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r0 src=r0 offset=0 imm=1
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_MOV64_IMM pc=6 dst=r2 src=r0 offset=0 imm=1
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r2 = IMMEDIATE(1);
+    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
+#line 193 "sample/callgraph_bpf2bpf.c"
+    if (r1 != IMMEDIATE(4661)) {
+#line 193 "sample/callgraph_bpf2bpf.c"
+        goto label_1;
+#line 193 "sample/callgraph_bpf2bpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r2 src=r0 offset=0 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r2 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
+#line 195 "sample/callgraph_bpf2bpf.c"
+    if (r1 != IMMEDIATE(4660)) {
+#line 195 "sample/callgraph_bpf2bpf.c"
+        goto label_2;
+#line 195 "sample/callgraph_bpf2bpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    r0 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    r0 |= r2;
+    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
+#line 200 "sample/callgraph_bpf2bpf.c"
+    return r0;
+#line 189 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -788,6 +951,21 @@ static program_entry_t _programs[] = {
         &entry_program3_program_type_guid,
         &entry_program3_attach_type_guid,
     },
+    {
+        0,
+        {1, 154, 160}, // Version header.
+        entry_program4,
+        "bind/4",
+        "bind/4",
+        "entry_program4",
+        NULL,
+        0,
+        entry_program4_helpers,
+        4,
+        14,
+        &entry_program4_program_type_guid,
+        &entry_program4_attach_type_guid,
+    },
 };
 #pragma data_seg(pop)
 
@@ -795,7 +973,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 3;
+    *count = 4;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_dll.c
@@ -129,7 +129,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
 #line 124 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 124 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
 #line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 124 "sample/callgraph_bpf2bpf.c"
@@ -177,7 +177,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
 #line 132 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS1(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 132 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
@@ -186,7 +186,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
 #line 133 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS4(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
 #line 132 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
@@ -231,7 +231,7 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
 #line 62 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
 #line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
@@ -251,7 +251,7 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
 #line 62 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS3(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
 #line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
@@ -553,7 +553,7 @@ entry_program2(void* context, const program_runtime_context_t* runtime_context)
 #line 145 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 145 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
 #line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 145 "sample/callgraph_bpf2bpf.c"
@@ -591,7 +591,7 @@ entry_program2(void* context, const program_runtime_context_t* runtime_context)
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
 #line 151 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
 #line 151 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
@@ -674,7 +674,7 @@ entry_program3(void* context, const program_runtime_context_t* runtime_context)
 #line 163 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 163 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 163 "sample/callgraph_bpf2bpf.c"
@@ -709,7 +709,7 @@ entry_program3(void* context, const program_runtime_context_t* runtime_context)
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
 #line 166 "sample/callgraph_bpf2bpf.c"
-    r0 = update_map(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
 #line 166 "sample/callgraph_bpf2bpf.c"
     r1 = r0;

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
@@ -99,7 +99,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
 #line 124 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 124 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
 #line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 124 "sample/callgraph_bpf2bpf.c"
@@ -147,7 +147,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
 #line 132 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS1(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 132 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
@@ -156,7 +156,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
 #line 133 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS4(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
 #line 132 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
@@ -201,7 +201,7 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
 #line 62 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
 #line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
@@ -221,7 +221,7 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
 #line 62 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS3(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
 #line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
@@ -523,7 +523,7 @@ entry_program2(void* context, const program_runtime_context_t* runtime_context)
 #line 145 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 145 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
 #line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 145 "sample/callgraph_bpf2bpf.c"
@@ -561,7 +561,7 @@ entry_program2(void* context, const program_runtime_context_t* runtime_context)
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
 #line 151 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
 #line 151 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
@@ -644,7 +644,7 @@ entry_program3(void* context, const program_runtime_context_t* runtime_context)
 #line 163 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 163 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 163 "sample/callgraph_bpf2bpf.c"
@@ -679,7 +679,7 @@ entry_program3(void* context, const program_runtime_context_t* runtime_context)
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
 #line 166 "sample/callgraph_bpf2bpf.c"
-    r0 = update_map(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
 #line 166 "sample/callgraph_bpf2bpf.c"
     r1 = r0;

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
@@ -85,8 +85,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program1_program_type_guid = {
@@ -96,93 +94,93 @@ static GUID entry_program1_attach_type_guid = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 entry_program1(void* context, const program_runtime_context_t* runtime_context)
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
 {
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r6 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r7 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 141 "sample/callgraph_bpf2bpf.c"
+#line 129 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=9
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=4 dst=r6 src=r10 offset=0 imm=0
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r6 = r10;
     // EBPF_OP_ADD64_IMM pc=5 dst=r6 src=r0 offset=0 imm=-8
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r6 += IMMEDIATE(-8);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r6 offset=0 imm=0
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 133 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 133 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=12 dst=r7 src=r0 offset=0 imm=32
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=13 dst=r0 src=r0 offset=0 imm=2
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=14 dst=r7 src=r0 offset=1 imm=2
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     if (r7 == IMMEDIATE(2)) {
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=15 dst=r0 src=r0 offset=0 imm=1
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
 label_1:
     // EBPF_OP_EXIT pc=16 dst=r0 src=r0 offset=0 imm=0
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -193,19 +191,19 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -216,16 +214,16 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     UNREFERENCED_PARAMETER(runtime_context);
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -234,53 +232,53 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=3 dst=r1 src=r1 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=4 dst=r1 src=r0 offset=4 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=2
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-4 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=3 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_2:
     // EBPF_OP_MOV64_IMM pc=9 dst=r1 src=r0 offset=0 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=10 dst=r10 src=r1 offset=-4 imm=0
-#line 70 "sample/callgraph_bpf2bpf.c"
+#line 65 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 70 "sample/callgraph_bpf2bpf.c"
+#line 65 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXW pc=12 dst=r0 src=r10 offset=-4 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -289,46 +287,16 @@ ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=9
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_IMM pc=2 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    return r0;
-}
-static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
-{
-    register uint64_t r0 = 0;
-    (void)r2;
-    (void)r3;
-    (void)r4;
-    (void)r5;
-    (void)context;
-    UNREFERENCED_PARAMETER(runtime_context);
-
-    // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
-    // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_ADD64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
-    // EBPF_OP_LDXDW pc=4 dst=r0 src=r10 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r0, r10, OFFSET(-16));
-    // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -338,174 +306,174 @@ update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r6 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-16 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-24 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-24));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=5 dst=r10 src=r0 offset=-32 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-32));
     // EBPF_OP_LDXDW pc=6 dst=r1 src=r10 offset=-32 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-32));
     // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=7 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=0 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=-1
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     r1 = (uint64_t)4294967295;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-4 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-36 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=14 dst=r0 src=r0 offset=39 imm=0
-#line 74 "sample/callgraph_bpf2bpf.c"
+#line 69 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_2:
     // EBPF_OP_MOV64_REG pc=15 dst=r2 src=r10 offset=0 imm=0
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=16 dst=r2 src=r0 offset=0 imm=-24
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_LDDW pc=17 dst=r1 src=r1 offset=0 imm=1
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 84 "sample/callgraph_bpf2bpf.c"
+#line 79 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=20 dst=r10 src=r0 offset=-48 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-48));
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-48 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_JEQ_IMM pc=22 dst=r1 src=r0 offset=17 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
         goto label_4;
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 89 "sample/callgraph_bpf2bpf.c"
+#line 84 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXDW pc=24 dst=r1 src=r10 offset=-48 imm=0
-#line 94 "sample/callgraph_bpf2bpf.c"
+#line 89 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_LDXDW pc=25 dst=r1 src=r1 offset=0 imm=0
-#line 95 "sample/callgraph_bpf2bpf.c"
+#line 90 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=26 dst=r1 src=r0 offset=0 imm=1
-#line 95 "sample/callgraph_bpf2bpf.c"
+#line 90 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXDW pc=27 dst=r10 src=r1 offset=-56 imm=0
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 97 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-56));
     // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-24
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=30 dst=r3 src=r10 offset=0 imm=0
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=31 dst=r3 src=r0 offset=0 imm=-56
-#line 107 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-56);
     // EBPF_OP_LDDW pc=32 dst=r1 src=r1 offset=0 imm=1
-#line 107 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=34 dst=r4 src=r0 offset=0 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=2
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=36 dst=r10 src=r0 offset=-4 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=37 dst=r1 src=r0 offset=0 imm=1
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=38 dst=r10 src=r1 offset=-36 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=39 dst=r0 src=r0 offset=13 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_4:
     // EBPF_OP_MOV64_IMM pc=40 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=41 dst=r10 src=r6 offset=-64 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r6, OFFSET(-64));
     // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-24
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r10 offset=0 imm=0
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r3 src=r0 offset=0 imm=-64
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-64);
     // EBPF_OP_LDDW pc=46 dst=r1 src=r1 offset=0 imm=1
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=50 dst=r10 src=r0 offset=-4 imm=0
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_STXW pc=51 dst=r10 src=r6 offset=-36 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-36));
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_5:
     // EBPF_OP_JA pc=53 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_6:
     // EBPF_OP_LDXW pc=54 dst=r0 src=r10 offset=-4 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=55 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static helper_function_entry_t entry_program2_helpers[] = {
@@ -541,8 +509,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program2_program_type_guid = {
@@ -552,77 +518,77 @@ static GUID entry_program2_attach_type_guid = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 entry_program2(void* context, const program_runtime_context_t* runtime_context)
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
 {
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=3 dst=r1 src=r10 offset=0 imm=0
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r1 src=r0 offset=0 imm=-8
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=8 dst=r1 src=r0 offset=0 imm=32
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=1
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=2
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(2)) {
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
-#line 169 "sample/callgraph_bpf2bpf.c"
-    return r0;
 #line 157 "sample/callgraph_bpf2bpf.c"
+    return r0;
+#line 145 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -660,8 +626,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program3_program_type_guid = {
@@ -675,201 +639,74 @@ static uint16_t entry_program3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 entry_program3(void* context, const program_runtime_context_t* runtime_context)
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
 {
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_MOV64_REG pc=2 dst=r1 src=r10 offset=0 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=3 dst=r1 src=r0 offset=0 imm=-8
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=6 dst=r1 src=r0 offset=0 imm=32
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 185 "sample/callgraph_bpf2bpf.c"
+#line 173 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 175 "sample/callgraph_bpf2bpf.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static helper_function_entry_t entry_program4_helpers[] = {
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-};
-
-// Forward references for local functions.
-static uint64_t
-ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-
-static GUID entry_program4_program_type_guid = {
-    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
-static GUID entry_program4_attach_type_guid = {
-    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-#pragma code_seg(push, "bind/4")
-static uint64_t
-entry_program4(void* context, const program_runtime_context_t* runtime_context)
-#line 189 "sample/callgraph_bpf2bpf.c"
-{
-#line 189 "sample/callgraph_bpf2bpf.c"
-    // Prologue.
-#line 189 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r0 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r1 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r2 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r3 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r4 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r5 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r10 = 0;
-
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r1 = (uintptr_t)context;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r1 = IMMEDIATE(4660);
-    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 192 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
-    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
-    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r1 = r0;
-    // EBPF_OP_MOV64_IMM pc=5 dst=r0 src=r0 offset=0 imm=1
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r0 = IMMEDIATE(1);
-    // EBPF_OP_MOV64_IMM pc=6 dst=r2 src=r0 offset=0 imm=1
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r2 = IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
-#line 193 "sample/callgraph_bpf2bpf.c"
-    if (r1 != IMMEDIATE(4661)) {
-#line 193 "sample/callgraph_bpf2bpf.c"
-        goto label_1;
-#line 193 "sample/callgraph_bpf2bpf.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=8 dst=r2 src=r0 offset=0 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r2 = IMMEDIATE(0);
-label_1:
-    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
-#line 195 "sample/callgraph_bpf2bpf.c"
-    if (r1 != IMMEDIATE(4660)) {
-#line 195 "sample/callgraph_bpf2bpf.c"
-        goto label_2;
-#line 195 "sample/callgraph_bpf2bpf.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    r0 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    r0 |= r2;
-    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 200 "sample/callgraph_bpf2bpf.c"
-    return r0;
-#line 189 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -921,21 +758,6 @@ static program_entry_t _programs[] = {
         &entry_program3_program_type_guid,
         &entry_program3_attach_type_guid,
     },
-    {
-        0,
-        {1, 154, 160}, // Version header.
-        entry_program4,
-        "bind/4",
-        "bind/4",
-        "entry_program4",
-        NULL,
-        0,
-        entry_program4_helpers,
-        4,
-        14,
-        &entry_program4_program_type_guid,
-        &entry_program4_attach_type_guid,
-    },
 };
 #pragma data_seg(pop)
 
@@ -943,7 +765,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 4;
+    *count = 3;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_raw.c
@@ -85,6 +85,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program1_program_type_guid = {
@@ -94,93 +96,93 @@ static GUID entry_program1_attach_type_guid = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 entry_program1(void* context, const program_runtime_context_t* runtime_context)
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
 {
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r6 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r7 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 129 "sample/callgraph_bpf2bpf.c"
+#line 141 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=9
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=4 dst=r6 src=r10 offset=0 imm=0
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r6 = r10;
     // EBPF_OP_ADD64_IMM pc=5 dst=r6 src=r0 offset=0 imm=-8
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r6 += IMMEDIATE(-8);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r6 offset=0 imm=0
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 133 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
-#line 133 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=12 dst=r7 src=r0 offset=0 imm=32
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=13 dst=r0 src=r0 offset=0 imm=2
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=14 dst=r7 src=r0 offset=1 imm=2
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     if (r7 == IMMEDIATE(2)) {
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=15 dst=r0 src=r0 offset=0 imm=1
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
 label_1:
     // EBPF_OP_EXIT pc=16 dst=r0 src=r0 offset=0 imm=0
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -191,19 +193,19 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -214,16 +216,16 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     UNREFERENCED_PARAMETER(runtime_context);
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -232,53 +234,53 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-16 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=3 dst=r1 src=r1 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=4 dst=r1 src=r0 offset=4 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=2
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-4 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=3 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_2:
     // EBPF_OP_MOV64_IMM pc=9 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=10 dst=r10 src=r1 offset=-4 imm=0
-#line 65 "sample/callgraph_bpf2bpf.c"
+#line 70 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 65 "sample/callgraph_bpf2bpf.c"
+#line 70 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXW pc=12 dst=r0 src=r10 offset=-4 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -287,16 +289,46 @@ ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=9
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_IMM pc=2 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
+    return r0;
+}
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
+#line 61 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
+#line 64 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_ADD64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
+#line 67 "sample/callgraph_bpf2bpf.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
+    // EBPF_OP_LDXDW pc=4 dst=r0 src=r10 offset=-16 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r0, r10, OFFSET(-16));
+    // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -306,174 +338,174 @@ update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r6 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-16 imm=0
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-24 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-24));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=5 dst=r10 src=r0 offset=-32 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-32));
     // EBPF_OP_LDXDW pc=6 dst=r1 src=r10 offset=-32 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-32));
     // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=7 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=0 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=-1
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     r1 = (uint64_t)4294967295;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-4 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-36 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=14 dst=r0 src=r0 offset=39 imm=0
-#line 69 "sample/callgraph_bpf2bpf.c"
+#line 74 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_2:
     // EBPF_OP_MOV64_REG pc=15 dst=r2 src=r10 offset=0 imm=0
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=16 dst=r2 src=r0 offset=0 imm=-24
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_LDDW pc=17 dst=r1 src=r1 offset=0 imm=1
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 79 "sample/callgraph_bpf2bpf.c"
+#line 84 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=20 dst=r10 src=r0 offset=-48 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-48));
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-48 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_JEQ_IMM pc=22 dst=r1 src=r0 offset=17 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
         goto label_4;
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 84 "sample/callgraph_bpf2bpf.c"
+#line 89 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXDW pc=24 dst=r1 src=r10 offset=-48 imm=0
-#line 89 "sample/callgraph_bpf2bpf.c"
+#line 94 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_LDXDW pc=25 dst=r1 src=r1 offset=0 imm=0
-#line 90 "sample/callgraph_bpf2bpf.c"
+#line 95 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=26 dst=r1 src=r0 offset=0 imm=1
-#line 90 "sample/callgraph_bpf2bpf.c"
+#line 95 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXDW pc=27 dst=r10 src=r1 offset=-56 imm=0
-#line 97 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-56));
     // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-24
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=30 dst=r3 src=r10 offset=0 imm=0
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=31 dst=r3 src=r0 offset=0 imm=-56
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 107 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-56);
     // EBPF_OP_LDDW pc=32 dst=r1 src=r1 offset=0 imm=1
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 107 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=34 dst=r4 src=r0 offset=0 imm=0
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=2
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=36 dst=r10 src=r0 offset=-4 imm=0
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=37 dst=r1 src=r0 offset=0 imm=1
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=38 dst=r10 src=r1 offset=-36 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=39 dst=r0 src=r0 offset=13 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_4:
     // EBPF_OP_MOV64_IMM pc=40 dst=r6 src=r0 offset=0 imm=1
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=41 dst=r10 src=r6 offset=-64 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r6, OFFSET(-64));
     // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-24
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r10 offset=0 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r3 src=r0 offset=0 imm=-64
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-64);
     // EBPF_OP_LDDW pc=46 dst=r1 src=r1 offset=0 imm=1
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=50 dst=r10 src=r0 offset=-4 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_STXW pc=51 dst=r10 src=r6 offset=-36 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-36));
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_5:
     // EBPF_OP_JA pc=53 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_6:
     // EBPF_OP_LDXW pc=54 dst=r0 src=r10 offset=-4 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=55 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static helper_function_entry_t entry_program2_helpers[] = {
@@ -509,6 +541,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program2_program_type_guid = {
@@ -518,77 +552,77 @@ static GUID entry_program2_attach_type_guid = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 entry_program2(void* context, const program_runtime_context_t* runtime_context)
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
 {
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=3 dst=r1 src=r10 offset=0 imm=0
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r1 src=r0 offset=0 imm=-8
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=8 dst=r1 src=r0 offset=0 imm=32
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=1
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=2
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(2)) {
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 169 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -626,6 +660,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program3_program_type_guid = {
@@ -639,74 +675,201 @@ static uint16_t entry_program3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 entry_program3(void* context, const program_runtime_context_t* runtime_context)
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
 {
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_MOV64_REG pc=2 dst=r1 src=r10 offset=0 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=3 dst=r1 src=r0 offset=0 imm=-8
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=6 dst=r1 src=r0 offset=0 imm=32
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 173 "sample/callgraph_bpf2bpf.c"
+#line 185 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+static helper_function_entry_t entry_program4_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID entry_program4_program_type_guid = {
+    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
+static GUID entry_program4_attach_type_guid = {
+    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
+#pragma code_seg(push, "bind/4")
+static uint64_t
+entry_program4(void* context, const program_runtime_context_t* runtime_context)
+#line 189 "sample/callgraph_bpf2bpf.c"
+{
+#line 189 "sample/callgraph_bpf2bpf.c"
+    // Prologue.
+#line 189 "sample/callgraph_bpf2bpf.c"
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r0 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r1 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r2 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r3 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r4 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r5 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r10 = 0;
+
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r1 = (uintptr_t)context;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r1 = IMMEDIATE(4660);
+    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
+#line 192 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
+    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r0 src=r0 offset=0 imm=1
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_MOV64_IMM pc=6 dst=r2 src=r0 offset=0 imm=1
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r2 = IMMEDIATE(1);
+    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
+#line 193 "sample/callgraph_bpf2bpf.c"
+    if (r1 != IMMEDIATE(4661)) {
+#line 193 "sample/callgraph_bpf2bpf.c"
+        goto label_1;
+#line 193 "sample/callgraph_bpf2bpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r2 src=r0 offset=0 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r2 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
+#line 195 "sample/callgraph_bpf2bpf.c"
+    if (r1 != IMMEDIATE(4660)) {
+#line 195 "sample/callgraph_bpf2bpf.c"
+        goto label_2;
+#line 195 "sample/callgraph_bpf2bpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    r0 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    r0 |= r2;
+    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
+#line 200 "sample/callgraph_bpf2bpf.c"
+    return r0;
+#line 189 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -758,6 +921,21 @@ static program_entry_t _programs[] = {
         &entry_program3_program_type_guid,
         &entry_program3_attach_type_guid,
     },
+    {
+        0,
+        {1, 154, 160}, // Version header.
+        entry_program4,
+        "bind/4",
+        "bind/4",
+        "entry_program4",
+        NULL,
+        0,
+        entry_program4_helpers,
+        4,
+        14,
+        &entry_program4_program_type_guid,
+        &entry_program4_attach_type_guid,
+    },
 };
 #pragma data_seg(pop)
 
@@ -765,7 +943,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 3;
+    *count = 4;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
@@ -240,6 +240,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program1_program_type_guid = {
@@ -249,93 +251,93 @@ static GUID entry_program1_attach_type_guid = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 entry_program1(void* context, const program_runtime_context_t* runtime_context)
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
 {
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r6 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r7 = 0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 129 "sample/callgraph_bpf2bpf.c"
+#line 141 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=9
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=4 dst=r6 src=r10 offset=0 imm=0
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r6 = r10;
     // EBPF_OP_ADD64_IMM pc=5 dst=r6 src=r0 offset=0 imm=-8
-#line 130 "sample/callgraph_bpf2bpf.c"
+#line 142 "sample/callgraph_bpf2bpf.c"
     r6 += IMMEDIATE(-8);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r6 offset=0 imm=0
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 133 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
-#line 133 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=12 dst=r7 src=r0 offset=0 imm=32
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r7 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=13 dst=r0 src=r0 offset=0 imm=2
-#line 132 "sample/callgraph_bpf2bpf.c"
+#line 144 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=14 dst=r7 src=r0 offset=1 imm=2
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     if (r7 == IMMEDIATE(2)) {
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=15 dst=r0 src=r0 offset=0 imm=1
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
 label_1:
     // EBPF_OP_EXIT pc=16 dst=r0 src=r0 offset=0 imm=0
-#line 139 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 124 "sample/callgraph_bpf2bpf.c"
+#line 136 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -346,19 +348,19 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -369,16 +371,16 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     UNREFERENCED_PARAMETER(runtime_context);
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -387,53 +389,53 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-16 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=3 dst=r1 src=r1 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=4 dst=r1 src=r0 offset=4 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=2
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-4 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=3 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_2:
     // EBPF_OP_MOV64_IMM pc=9 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=10 dst=r10 src=r1 offset=-4 imm=0
-#line 65 "sample/callgraph_bpf2bpf.c"
+#line 70 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 65 "sample/callgraph_bpf2bpf.c"
+#line 70 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXW pc=12 dst=r0 src=r10 offset=-4 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -442,16 +444,46 @@ ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=9
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_IMM pc=2 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
+    return r0;
+}
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
+{
+    register uint64_t r0 = 0;
+    (void)r2;
+    (void)r3;
+    (void)r4;
+    (void)r5;
+    (void)context;
+    UNREFERENCED_PARAMETER(runtime_context);
+
+    // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
+#line 61 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
+#line 64 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_ADD64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
+#line 67 "sample/callgraph_bpf2bpf.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
+    // EBPF_OP_LDXDW pc=4 dst=r0 src=r10 offset=-16 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r0, r10, OFFSET(-16));
+    // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
+#line 67 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -461,174 +493,174 @@ update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r6 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/callgraph_bpf2bpf.c"
+#line 61 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-16 imm=0
-#line 59 "sample/callgraph_bpf2bpf.c"
+#line 64 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=0 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-24 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-24));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=5 dst=r10 src=r0 offset=-32 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-32));
     // EBPF_OP_LDXDW pc=6 dst=r1 src=r10 offset=-32 imm=0
-#line 62 "sample/callgraph_bpf2bpf.c"
+#line 67 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-32));
     // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=7 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=0 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=-1
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     r1 = (uint64_t)4294967295;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-4 imm=0
-#line 63 "sample/callgraph_bpf2bpf.c"
+#line 68 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-36 imm=0
-#line 66 "sample/callgraph_bpf2bpf.c"
+#line 71 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=14 dst=r0 src=r0 offset=39 imm=0
-#line 69 "sample/callgraph_bpf2bpf.c"
+#line 74 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_2:
     // EBPF_OP_MOV64_REG pc=15 dst=r2 src=r10 offset=0 imm=0
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=16 dst=r2 src=r0 offset=0 imm=-24
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_LDDW pc=17 dst=r1 src=r1 offset=0 imm=1
-#line 72 "sample/callgraph_bpf2bpf.c"
+#line 77 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 79 "sample/callgraph_bpf2bpf.c"
+#line 84 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=20 dst=r10 src=r0 offset=-48 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-48));
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-48 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_JEQ_IMM pc=22 dst=r1 src=r0 offset=17 imm=0
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
         goto label_4;
-#line 80 "sample/callgraph_bpf2bpf.c"
+#line 85 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 84 "sample/callgraph_bpf2bpf.c"
+#line 89 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXDW pc=24 dst=r1 src=r10 offset=-48 imm=0
-#line 89 "sample/callgraph_bpf2bpf.c"
+#line 94 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_LDXDW pc=25 dst=r1 src=r1 offset=0 imm=0
-#line 90 "sample/callgraph_bpf2bpf.c"
+#line 95 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=26 dst=r1 src=r0 offset=0 imm=1
-#line 90 "sample/callgraph_bpf2bpf.c"
+#line 95 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXDW pc=27 dst=r10 src=r1 offset=-56 imm=0
-#line 97 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-56));
     // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-24
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=30 dst=r3 src=r10 offset=0 imm=0
-#line 99 "sample/callgraph_bpf2bpf.c"
+#line 104 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=31 dst=r3 src=r0 offset=0 imm=-56
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 107 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-56);
     // EBPF_OP_LDDW pc=32 dst=r1 src=r1 offset=0 imm=1
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 107 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=34 dst=r4 src=r0 offset=0 imm=0
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=2
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=36 dst=r10 src=r0 offset=-4 imm=0
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=37 dst=r1 src=r0 offset=0 imm=1
-#line 105 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=38 dst=r10 src=r1 offset=-36 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=39 dst=r0 src=r0 offset=13 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_4:
     // EBPF_OP_MOV64_IMM pc=40 dst=r6 src=r0 offset=0 imm=1
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=41 dst=r10 src=r6 offset=-64 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r6, OFFSET(-64));
     // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
-#line 106 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-24
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r10 offset=0 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r3 src=r0 offset=0 imm=-64
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-64);
     // EBPF_OP_LDDW pc=46 dst=r1 src=r1 offset=0 imm=1
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 115 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=50 dst=r10 src=r0 offset=-4 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 116 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_STXW pc=51 dst=r10 src=r6 offset=-36 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-36));
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_5:
     // EBPF_OP_JA pc=53 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_6:
     // EBPF_OP_LDXW pc=54 dst=r0 src=r10 offset=-4 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=55 dst=r0 src=r0 offset=0 imm=0
-#line 112 "sample/callgraph_bpf2bpf.c"
+#line 117 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static helper_function_entry_t entry_program2_helpers[] = {
@@ -664,6 +696,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program2_program_type_guid = {
@@ -673,77 +707,77 @@ static GUID entry_program2_attach_type_guid = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 entry_program2(void* context, const program_runtime_context_t* runtime_context)
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
 {
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=3 dst=r1 src=r10 offset=0 imm=0
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r1 src=r0 offset=0 imm=-8
-#line 149 "sample/callgraph_bpf2bpf.c"
+#line 161 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=8 dst=r1 src=r0 offset=0 imm=32
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=1
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=2
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(2)) {
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 153 "sample/callgraph_bpf2bpf.c"
+#line 165 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 169 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 157 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -781,6 +815,8 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program3_program_type_guid = {
@@ -794,74 +830,201 @@ static uint16_t entry_program3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 entry_program3(void* context, const program_runtime_context_t* runtime_context)
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
 {
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_MOV64_REG pc=2 dst=r1 src=r10 offset=0 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=3 dst=r1 src=r0 offset=0 imm=-8
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=6 dst=r1 src=r0 offset=0 imm=32
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
-#line 166 "sample/callgraph_bpf2bpf.c"
+#line 178 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
-#line 168 "sample/callgraph_bpf2bpf.c"
+#line 180 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 173 "sample/callgraph_bpf2bpf.c"
+#line 185 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 175 "sample/callgraph_bpf2bpf.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+static helper_function_entry_t entry_program4_helpers[] = {
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+    {
+     {1, 40, 40}, // Version header.
+     0,
+     "",
+    },
+};
+
+// Forward references for local functions.
+static uint64_t
+ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+static uint64_t
+update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
+
+static GUID entry_program4_program_type_guid = {
+    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
+static GUID entry_program4_attach_type_guid = {
+    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
+#pragma code_seg(push, "bind/4")
+static uint64_t
+entry_program4(void* context, const program_runtime_context_t* runtime_context)
+#line 189 "sample/callgraph_bpf2bpf.c"
+{
+#line 189 "sample/callgraph_bpf2bpf.c"
+    // Prologue.
+#line 189 "sample/callgraph_bpf2bpf.c"
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r0 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r1 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r2 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r3 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r4 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r5 = 0;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    register uint64_t r10 = 0;
+
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r1 = (uintptr_t)context;
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
+#line 189 "sample/callgraph_bpf2bpf.c"
+    r1 = IMMEDIATE(4660);
+    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
+#line 192 "sample/callgraph_bpf2bpf.c"
+    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
+    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
+    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r0 src=r0 offset=0 imm=1
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_MOV64_IMM pc=6 dst=r2 src=r0 offset=0 imm=1
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r2 = IMMEDIATE(1);
+    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
+#line 193 "sample/callgraph_bpf2bpf.c"
+    if (r1 != IMMEDIATE(4661)) {
+#line 193 "sample/callgraph_bpf2bpf.c"
+        goto label_1;
+#line 193 "sample/callgraph_bpf2bpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=8 dst=r2 src=r0 offset=0 imm=0
+#line 193 "sample/callgraph_bpf2bpf.c"
+    r2 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    READ_ONCE_64(r1, r10, OFFSET(-8));
+    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
+#line 195 "sample/callgraph_bpf2bpf.c"
+    if (r1 != IMMEDIATE(4660)) {
+#line 195 "sample/callgraph_bpf2bpf.c"
+        goto label_2;
+#line 195 "sample/callgraph_bpf2bpf.c"
+    }
+    // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    r0 = IMMEDIATE(0);
+label_2:
+    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
+#line 195 "sample/callgraph_bpf2bpf.c"
+    r0 |= r2;
+    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
+#line 200 "sample/callgraph_bpf2bpf.c"
+    return r0;
+#line 189 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -913,6 +1076,21 @@ static program_entry_t _programs[] = {
         &entry_program3_program_type_guid,
         &entry_program3_attach_type_guid,
     },
+    {
+        0,
+        {1, 154, 160}, // Version header.
+        entry_program4,
+        "bind/4",
+        "bind/4",
+        "entry_program4",
+        NULL,
+        0,
+        entry_program4_helpers,
+        4,
+        14,
+        &entry_program4_program_type_guid,
+        &entry_program4_attach_type_guid,
+    },
 };
 #pragma data_seg(pop)
 
@@ -920,7 +1098,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 3;
+    *count = 4;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
@@ -240,8 +240,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program1_program_type_guid = {
@@ -251,93 +249,93 @@ static GUID entry_program1_attach_type_guid = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 entry_program1(void* context, const program_runtime_context_t* runtime_context)
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
 {
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r6 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r7 = 0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 141 "sample/callgraph_bpf2bpf.c"
+#line 129 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=9
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=4 dst=r6 src=r10 offset=0 imm=0
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r6 = r10;
     // EBPF_OP_ADD64_IMM pc=5 dst=r6 src=r0 offset=0 imm=-8
-#line 142 "sample/callgraph_bpf2bpf.c"
+#line 130 "sample/callgraph_bpf2bpf.c"
     r6 += IMMEDIATE(-8);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r6 offset=0 imm=0
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 133 "sample/callgraph_bpf2bpf.c"
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
-#line 145 "sample/callgraph_bpf2bpf.c"
+#line 133 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=12 dst=r7 src=r0 offset=0 imm=32
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r7 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=13 dst=r0 src=r0 offset=0 imm=2
-#line 144 "sample/callgraph_bpf2bpf.c"
+#line 132 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_JEQ_IMM pc=14 dst=r7 src=r0 offset=1 imm=2
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     if (r7 == IMMEDIATE(2)) {
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=15 dst=r0 src=r0 offset=0 imm=1
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
 label_1:
     // EBPF_OP_EXIT pc=16 dst=r0 src=r0 offset=0 imm=0
-#line 151 "sample/callgraph_bpf2bpf.c"
+#line 139 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 136 "sample/callgraph_bpf2bpf.c"
+#line 124 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -348,19 +346,19 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -371,16 +369,16 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     UNREFERENCED_PARAMETER(runtime_context);
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -389,53 +387,53 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=19
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=3 dst=r1 src=r1 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=4 dst=r1 src=r0 offset=4 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=2
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(2);
     // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-4 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=3 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_2:
     // EBPF_OP_MOV64_IMM pc=9 dst=r1 src=r0 offset=0 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=10 dst=r10 src=r1 offset=-4 imm=0
-#line 70 "sample/callgraph_bpf2bpf.c"
+#line 65 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_JA pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 70 "sample/callgraph_bpf2bpf.c"
+#line 65 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXW pc=12 dst=r0 src=r10 offset=-4 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -444,46 +442,16 @@ ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r0 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=1 dst=r0 src=r0 offset=0 imm=9
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[2].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_IMM pc=2 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    return r0;
-}
-static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context)
-{
-    register uint64_t r0 = 0;
-    (void)r2;
-    (void)r3;
-    (void)r4;
-    (void)r5;
-    (void)context;
-    UNREFERENCED_PARAMETER(runtime_context);
-
-    // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
-    // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-8 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_ADD64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
-#line 67 "sample/callgraph_bpf2bpf.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
-    // EBPF_OP_LDXDW pc=4 dst=r0 src=r10 offset=-16 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r0, r10, OFFSET(-16));
-    // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static uint64_t
@@ -493,174 +461,174 @@ update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     register uint64_t r6 = 0;
 
     // EBPF_OP_STXDW pc=0 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/callgraph_bpf2bpf.c"
+#line 56 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-16));
     // EBPF_OP_LDXDW pc=1 dst=r1 src=r10 offset=-16 imm=0
-#line 64 "sample/callgraph_bpf2bpf.c"
+#line 59 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-16));
     // EBPF_OP_LDXDW pc=2 dst=r1 src=r1 offset=0 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-24 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-24));
     // EBPF_OP_CALL pc=4 dst=r0 src=r0 offset=0 imm=19
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=5 dst=r10 src=r0 offset=-32 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-32));
     // EBPF_OP_LDXDW pc=6 dst=r1 src=r10 offset=-32 imm=0
-#line 67 "sample/callgraph_bpf2bpf.c"
+#line 62 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-32));
     // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=7 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
         goto label_2;
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=8 dst=r0 src=r0 offset=0 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     goto label_1;
 label_1:
     // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=-1
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     r1 = (uint64_t)4294967295;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-4 imm=0
-#line 68 "sample/callgraph_bpf2bpf.c"
+#line 63 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-36 imm=0
-#line 71 "sample/callgraph_bpf2bpf.c"
+#line 66 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=14 dst=r0 src=r0 offset=39 imm=0
-#line 74 "sample/callgraph_bpf2bpf.c"
+#line 69 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_2:
     // EBPF_OP_MOV64_REG pc=15 dst=r2 src=r10 offset=0 imm=0
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=16 dst=r2 src=r0 offset=0 imm=-24
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_LDDW pc=17 dst=r1 src=r1 offset=0 imm=1
-#line 77 "sample/callgraph_bpf2bpf.c"
+#line 72 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 84 "sample/callgraph_bpf2bpf.c"
+#line 79 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[0].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXDW pc=20 dst=r10 src=r0 offset=-48 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r0, OFFSET(-48));
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-48 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_JEQ_IMM pc=22 dst=r1 src=r0 offset=17 imm=0
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     if (r1 == IMMEDIATE(0)) {
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
         goto label_4;
-#line 85 "sample/callgraph_bpf2bpf.c"
+#line 80 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_JA pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 89 "sample/callgraph_bpf2bpf.c"
+#line 84 "sample/callgraph_bpf2bpf.c"
     goto label_3;
 label_3:
     // EBPF_OP_LDXDW pc=24 dst=r1 src=r10 offset=-48 imm=0
-#line 94 "sample/callgraph_bpf2bpf.c"
+#line 89 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r10, OFFSET(-48));
     // EBPF_OP_LDXDW pc=25 dst=r1 src=r1 offset=0 imm=0
-#line 95 "sample/callgraph_bpf2bpf.c"
+#line 90 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=26 dst=r1 src=r0 offset=0 imm=1
-#line 95 "sample/callgraph_bpf2bpf.c"
+#line 90 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXDW pc=27 dst=r10 src=r1 offset=-56 imm=0
-#line 102 "sample/callgraph_bpf2bpf.c"
+#line 97 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-56));
     // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-24
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=30 dst=r3 src=r10 offset=0 imm=0
-#line 104 "sample/callgraph_bpf2bpf.c"
+#line 99 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=31 dst=r3 src=r0 offset=0 imm=-56
-#line 107 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-56);
     // EBPF_OP_LDDW pc=32 dst=r1 src=r1 offset=0 imm=1
-#line 107 "sample/callgraph_bpf2bpf.c"
+#line 102 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=34 dst=r4 src=r0 offset=0 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=2
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=36 dst=r10 src=r0 offset=-4 imm=0
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_MOV64_IMM pc=37 dst=r1 src=r0 offset=0 imm=1
-#line 110 "sample/callgraph_bpf2bpf.c"
+#line 105 "sample/callgraph_bpf2bpf.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=38 dst=r10 src=r1 offset=-36 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r1, OFFSET(-36));
     // EBPF_OP_JA pc=39 dst=r0 src=r0 offset=13 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_4:
     // EBPF_OP_MOV64_IMM pc=40 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     r6 = IMMEDIATE(1);
     // EBPF_OP_STXDW pc=41 dst=r10 src=r6 offset=-64 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r6, OFFSET(-64));
     // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
-#line 111 "sample/callgraph_bpf2bpf.c"
+#line 106 "sample/callgraph_bpf2bpf.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-24
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r2 += IMMEDIATE(-24);
     // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r10 offset=0 imm=0
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r3 src=r0 offset=0 imm=-64
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r3 += IMMEDIATE(-64);
     // EBPF_OP_LDDW pc=46 dst=r1 src=r1 offset=0 imm=1
-#line 115 "sample/callgraph_bpf2bpf.c"
+#line 110 "sample/callgraph_bpf2bpf.c"
     r1 = POINTER(runtime_context->map_data[0].address);
     // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[1].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_STXW pc=50 dst=r10 src=r0 offset=-4 imm=0
-#line 116 "sample/callgraph_bpf2bpf.c"
+#line 111 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r0, OFFSET(-4));
     // EBPF_OP_STXW pc=51 dst=r10 src=r6 offset=-36 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_32(r10, (uint32_t)r6, OFFSET(-36));
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     goto label_5;
 label_5:
     // EBPF_OP_JA pc=53 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     goto label_6;
 label_6:
     // EBPF_OP_LDXW pc=54 dst=r0 src=r10 offset=-4 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_32(r0, r10, OFFSET(-4));
     // EBPF_OP_EXIT pc=55 dst=r0 src=r0 offset=0 imm=0
-#line 117 "sample/callgraph_bpf2bpf.c"
+#line 112 "sample/callgraph_bpf2bpf.c"
     return r0;
 }
 static helper_function_entry_t entry_program2_helpers[] = {
@@ -696,8 +664,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program2_program_type_guid = {
@@ -707,77 +673,77 @@ static GUID entry_program2_attach_type_guid = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 entry_program2(void* context, const program_runtime_context_t* runtime_context)
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
 {
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 157 "sample/callgraph_bpf2bpf.c"
+#line 145 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r0 offset=0 imm=19
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r0 = runtime_context->helper_data[3].address(r1, r2, r3, r4, r5, context);
     // EBPF_OP_MOV64_REG pc=3 dst=r1 src=r10 offset=0 imm=0
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r1 src=r0 offset=0 imm=-8
-#line 161 "sample/callgraph_bpf2bpf.c"
+#line 149 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=8 dst=r1 src=r0 offset=0 imm=32
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=9 dst=r0 src=r0 offset=0 imm=1
-#line 163 "sample/callgraph_bpf2bpf.c"
+#line 151 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=2
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(2)) {
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 165 "sample/callgraph_bpf2bpf.c"
+#line 153 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
-#line 169 "sample/callgraph_bpf2bpf.c"
-    return r0;
 #line 157 "sample/callgraph_bpf2bpf.c"
+    return r0;
+#line 145 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -815,8 +781,6 @@ ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
 static uint64_t
 ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
 update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
 
 static GUID entry_program3_program_type_guid = {
@@ -830,201 +794,74 @@ static uint16_t entry_program3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 entry_program3(void* context, const program_runtime_context_t* runtime_context)
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
 {
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     // Prologue.
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r1 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r2 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r3 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r4 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r5 = 0;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r10 = 0;
 
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = (uintptr_t)context;
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_LDXDW pc=0 dst=r1 src=r1 offset=16 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     READ_ONCE_64(r1, r1, OFFSET(16));
     // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
     // EBPF_OP_MOV64_REG pc=2 dst=r1 src=r10 offset=0 imm=0
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=3 dst=r1 src=r0 offset=0 imm=-8
-#line 175 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=6 dst=r1 src=r0 offset=0 imm=32
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=7 dst=r1 src=r0 offset=0 imm=32
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
-#line 178 "sample/callgraph_bpf2bpf.c"
+#line 166 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_JNE_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     if (r1 != IMMEDIATE(0)) {
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
         goto label_1;
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     }
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
-#line 180 "sample/callgraph_bpf2bpf.c"
+#line 168 "sample/callgraph_bpf2bpf.c"
     r0 = IMMEDIATE(0);
 label_1:
     // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 185 "sample/callgraph_bpf2bpf.c"
+#line 173 "sample/callgraph_bpf2bpf.c"
     return r0;
-#line 175 "sample/callgraph_bpf2bpf.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static helper_function_entry_t entry_program4_helpers[] = {
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-    {
-     {1, 40, 40}, // Version header.
-     0,
-     "",
-    },
-};
-
-// Forward references for local functions.
-static uint64_t
-ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS3(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-ScenarioS4(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-stack_frame_test(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-static uint64_t
-update_map(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint64_t r10, void* context, const program_runtime_context_t* runtime_context);
-
-static GUID entry_program4_program_type_guid = {
-    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
-static GUID entry_program4_attach_type_guid = {
-    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-#pragma code_seg(push, "bind/4")
-static uint64_t
-entry_program4(void* context, const program_runtime_context_t* runtime_context)
-#line 189 "sample/callgraph_bpf2bpf.c"
-{
-#line 189 "sample/callgraph_bpf2bpf.c"
-    // Prologue.
-#line 189 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r0 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r1 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r2 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r3 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r4 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r5 = 0;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    register uint64_t r10 = 0;
-
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r1 = (uintptr_t)context;
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=4660
-#line 189 "sample/callgraph_bpf2bpf.c"
-    r1 = IMMEDIATE(4660);
-    // EBPF_OP_STXDW pc=1 dst=r10 src=r1 offset=-8 imm=0
-#line 192 "sample/callgraph_bpf2bpf.c"
-    WRITE_ONCE_64(r10, (uint64_t)r1, OFFSET(-8));
-    // EBPF_OP_LDXDW pc=2 dst=r1 src=r10 offset=-8 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=10
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r0 = stack_frame_test(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
-    // EBPF_OP_MOV64_REG pc=4 dst=r1 src=r0 offset=0 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r1 = r0;
-    // EBPF_OP_MOV64_IMM pc=5 dst=r0 src=r0 offset=0 imm=1
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r0 = IMMEDIATE(1);
-    // EBPF_OP_MOV64_IMM pc=6 dst=r2 src=r0 offset=0 imm=1
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r2 = IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=1 imm=4661
-#line 193 "sample/callgraph_bpf2bpf.c"
-    if (r1 != IMMEDIATE(4661)) {
-#line 193 "sample/callgraph_bpf2bpf.c"
-        goto label_1;
-#line 193 "sample/callgraph_bpf2bpf.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=8 dst=r2 src=r0 offset=0 imm=0
-#line 193 "sample/callgraph_bpf2bpf.c"
-    r2 = IMMEDIATE(0);
-label_1:
-    // EBPF_OP_LDXDW pc=9 dst=r1 src=r10 offset=-8 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    READ_ONCE_64(r1, r10, OFFSET(-8));
-    // EBPF_OP_JNE_IMM pc=10 dst=r1 src=r0 offset=1 imm=4660
-#line 195 "sample/callgraph_bpf2bpf.c"
-    if (r1 != IMMEDIATE(4660)) {
-#line 195 "sample/callgraph_bpf2bpf.c"
-        goto label_2;
-#line 195 "sample/callgraph_bpf2bpf.c"
-    }
-    // EBPF_OP_MOV64_IMM pc=11 dst=r0 src=r0 offset=0 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    r0 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_OR64_REG pc=12 dst=r0 src=r2 offset=0 imm=0
-#line 195 "sample/callgraph_bpf2bpf.c"
-    r0 |= r2;
-    // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
-#line 200 "sample/callgraph_bpf2bpf.c"
-    return r0;
-#line 189 "sample/callgraph_bpf2bpf.c"
+#line 163 "sample/callgraph_bpf2bpf.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1076,21 +913,6 @@ static program_entry_t _programs[] = {
         &entry_program3_program_type_guid,
         &entry_program3_attach_type_guid,
     },
-    {
-        0,
-        {1, 154, 160}, // Version header.
-        entry_program4,
-        "bind/4",
-        "bind/4",
-        "entry_program4",
-        NULL,
-        0,
-        entry_program4_helpers,
-        4,
-        14,
-        &entry_program4_program_type_guid,
-        &entry_program4_attach_type_guid,
-    },
 };
 #pragma data_seg(pop)
 
@@ -1098,7 +920,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 4;
+    *count = 3;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
+++ b/tests/bpf2c_tests/expected/callgraph_bpf2bpf_sys.c
@@ -254,7 +254,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
 #line 124 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 124 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 4) + 7) / 8];
 #line 124 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 124 "sample/callgraph_bpf2bpf.c"
@@ -302,7 +302,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
     r1 = r6;
     // EBPF_OP_CALL pc=7 dst=r0 src=r1 offset=0 imm=9
 #line 132 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS1(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS1(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 132 "sample/callgraph_bpf2bpf.c"
     r7 = r0;
@@ -311,7 +311,7 @@ entry_program1(void* context, const program_runtime_context_t* runtime_context)
     r1 = r6;
     // EBPF_OP_CALL pc=10 dst=r0 src=r1 offset=0 imm=29
 #line 133 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS4(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS4(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_LSH64_IMM pc=11 dst=r7 src=r0 offset=0 imm=32
 #line 132 "sample/callgraph_bpf2bpf.c"
     r7 <<= (IMMEDIATE(32) & 63);
@@ -356,7 +356,7 @@ ScenarioS1(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=3 dst=r0 src=r1 offset=0 imm=1
 #line 62 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=4 dst=r0 src=r0 offset=0 imm=0
 #line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
@@ -376,7 +376,7 @@ ScenarioS2(uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4, uint64_t r5, uint
     READ_ONCE_64(r1, r10, OFFSET(-8));
     // EBPF_OP_CALL pc=2 dst=r0 src=r1 offset=0 imm=1
 #line 62 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS3(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS3(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_EXIT pc=3 dst=r0 src=r0 offset=0 imm=0
 #line 62 "sample/callgraph_bpf2bpf.c"
     return r0;
@@ -678,7 +678,7 @@ entry_program2(void* context, const program_runtime_context_t* runtime_context)
 #line 145 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 145 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 3) + 7) / 8];
 #line 145 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 145 "sample/callgraph_bpf2bpf.c"
@@ -716,7 +716,7 @@ entry_program2(void* context, const program_runtime_context_t* runtime_context)
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=5 dst=r0 src=r1 offset=0 imm=7
 #line 151 "sample/callgraph_bpf2bpf.c"
-    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = ScenarioS2(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=6 dst=r1 src=r0 offset=0 imm=0
 #line 151 "sample/callgraph_bpf2bpf.c"
     r1 = r0;
@@ -799,7 +799,7 @@ entry_program3(void* context, const program_runtime_context_t* runtime_context)
 #line 163 "sample/callgraph_bpf2bpf.c"
     // Prologue.
 #line 163 "sample/callgraph_bpf2bpf.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 163 "sample/callgraph_bpf2bpf.c"
     register uint64_t r0 = 0;
 #line 163 "sample/callgraph_bpf2bpf.c"
@@ -834,7 +834,7 @@ entry_program3(void* context, const program_runtime_context_t* runtime_context)
     r1 += IMMEDIATE(-8);
     // EBPF_OP_CALL pc=4 dst=r0 src=r1 offset=0 imm=7
 #line 166 "sample/callgraph_bpf2bpf.c"
-    r0 = update_map(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = update_map(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=5 dst=r1 src=r0 offset=0 imm=0
 #line 166 "sample/callgraph_bpf2bpf.c"
     r1 = r0;

--- a/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_dll.c
@@ -129,7 +129,7 @@ map_annotation_collision(void* context, const program_runtime_context_t* runtime
 #line 59 "sample/undocked/map_annotation_collision.c"
     // Prologue.
 #line 59 "sample/undocked/map_annotation_collision.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 59 "sample/undocked/map_annotation_collision.c"
     register uint64_t r0 = 0;
 #line 59 "sample/undocked/map_annotation_collision.c"
@@ -202,7 +202,7 @@ map_annotation_collision(void* context, const program_runtime_context_t* runtime
     READ_ONCE_32(r1, r10, OFFSET(-4));
     // EBPF_OP_CALL pc=12 dst=r0 src=r1 offset=0 imm=4
 #line 70 "sample/undocked/map_annotation_collision.c"
-    r0 = lookup_hash_value(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = lookup_hash_value(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=13 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/undocked/map_annotation_collision.c"
     r1 = r0;

--- a/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_raw.c
@@ -99,7 +99,7 @@ map_annotation_collision(void* context, const program_runtime_context_t* runtime
 #line 59 "sample/undocked/map_annotation_collision.c"
     // Prologue.
 #line 59 "sample/undocked/map_annotation_collision.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 59 "sample/undocked/map_annotation_collision.c"
     register uint64_t r0 = 0;
 #line 59 "sample/undocked/map_annotation_collision.c"
@@ -172,7 +172,7 @@ map_annotation_collision(void* context, const program_runtime_context_t* runtime
     READ_ONCE_32(r1, r10, OFFSET(-4));
     // EBPF_OP_CALL pc=12 dst=r0 src=r1 offset=0 imm=4
 #line 70 "sample/undocked/map_annotation_collision.c"
-    r0 = lookup_hash_value(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = lookup_hash_value(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=13 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/undocked/map_annotation_collision.c"
     r1 = r0;

--- a/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
+++ b/tests/bpf2c_tests/expected/map_annotation_collision_sys.c
@@ -254,7 +254,7 @@ map_annotation_collision(void* context, const program_runtime_context_t* runtime
 #line 59 "sample/undocked/map_annotation_collision.c"
     // Prologue.
 #line 59 "sample/undocked/map_annotation_collision.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+    uint64_t stack[((UBPF_STACK_SIZE * 2) + 7) / 8];
 #line 59 "sample/undocked/map_annotation_collision.c"
     register uint64_t r0 = 0;
 #line 59 "sample/undocked/map_annotation_collision.c"
@@ -327,7 +327,7 @@ map_annotation_collision(void* context, const program_runtime_context_t* runtime
     READ_ONCE_32(r1, r10, OFFSET(-4));
     // EBPF_OP_CALL pc=12 dst=r0 src=r1 offset=0 imm=4
 #line 70 "sample/undocked/map_annotation_collision.c"
-    r0 = lookup_hash_value(r1, r2, r3, r4, r5, r10, context, runtime_context);
+    r0 = lookup_hash_value(r1, r2, r3, r4, r5, r10 - UBPF_STACK_SIZE, context, runtime_context);
     // EBPF_OP_MOV64_REG pc=13 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/undocked/map_annotation_collision.c"
     r1 = r0;

--- a/tests/bpf2c_tests/raw_bpf.cpp
+++ b/tests/bpf2c_tests/raw_bpf.cpp
@@ -238,6 +238,8 @@ run_bpf_code_generator_test(const std::string& data_file)
 // Path to ubpf tests directory (tests that remain in ubpf/tests/)
 #define UBPF_TEST_PATH ".." SEPARATOR ".." SEPARATOR "external" SEPARATOR "ubpf" SEPARATOR "tests" SEPARATOR
 
+#define UBPF_EXTENSION_TEST_PATH UBPF_TEST_PATH "extensions" SEPARATOR
+
 // Path to bpf_conformance tests directory (tests moved to ubpf/external/bpf_conformance/tests/)
 #define CONFORMANCE_TEST_PATH                                                                \
     ".." SEPARATOR ".." SEPARATOR "external" SEPARATOR "ubpf" SEPARATOR "external" SEPARATOR \
@@ -267,6 +269,9 @@ run_bpf_code_generator_test(const std::string& data_file)
 
 // Tests in external/ubpf/tests/
 #define DECLARE_UBPF_TEST(FILE) DECLARE_TEST_PATH(FILE, UBPF_TEST_PATH)
+
+// Tests in external/ubpf/tests/extensions/
+#define DECLARE_UBPF_EXTENSION_TEST(FILE) DECLARE_TEST_PATH(FILE, UBPF_EXTENSION_TEST_PATH)
 
 // Tests in external/ubpf/external/bpf_conformance/tests/
 #define DECLARE_TEST(FILE) DECLARE_TEST_PATH(FILE, CONFORMANCE_TEST_PATH)
@@ -308,6 +313,7 @@ DECLARE_TEST("be64")
 // DECLARE_TEST("call")
 // DECLARE_TEST("call_unwind")
 DECLARE_TEST("call_unwind_fail")
+DECLARE_UBPF_EXTENSION_TEST("call_local_use_stack")
 DECLARE_TEST("div32-high-divisor")
 DECLARE_TEST("div32-imm")
 DECLARE_TEST("div32-reg")

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -872,12 +872,29 @@ _callgraph_bpf2bpf_test(ebpf_execution_type_t execution_type)
         bpf_object__close(unique_object.release());
     }
 
-    // Test entry_program4: verifies that a subprogram does not corrupt the caller's stack.
+    // Test stack_frame_test_entry: verifies that a subprogram does not corrupt the caller's stack.
     {
-        program_load_attach_helper_t program_helper;
-        program_helper.initialize(file_name, BPF_PROG_TYPE_BIND, "entry_program4", execution_type, nullptr, 0, hook);
+        program_info_provider_t sample_program_info;
+        REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+        single_instance_hook_t sample_hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+        REQUIRE(sample_hook.initialize() == EBPF_SUCCESS);
 
-        REQUIRE(emulate_bind(invoke, 4004, "callgraph_e4") == BIND_PERMIT_SOFT);
+        program_load_attach_helper_t program_helper;
+        const char* stack_frame_file_name =
+            (execution_type == EBPF_EXECUTION_NATIVE ? "bpf2bpf_loop_um.dll" : "bpf2bpf_loop.o");
+        program_helper.initialize(
+            stack_frame_file_name,
+            BPF_PROG_TYPE_SAMPLE,
+            "stack_frame_test_entry",
+            execution_type,
+            nullptr,
+            0,
+            sample_hook);
+
+        INITIALIZE_SAMPLE_CONTEXT;
+        uint32_t hook_result = 0;
+        REQUIRE(sample_hook.fire(ctx, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result == 0);
     }
 }
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -871,6 +871,14 @@ _callgraph_bpf2bpf_test(ebpf_execution_type_t execution_type)
         hook.detach_and_close_link(&link);
         bpf_object__close(unique_object.release());
     }
+
+    // Test entry_program4: verifies that a subprogram does not corrupt the caller's stack.
+    {
+        program_load_attach_helper_t program_helper;
+        program_helper.initialize(file_name, BPF_PROG_TYPE_BIND, "entry_program4", execution_type, nullptr, 0, hook);
+
+        REQUIRE(emulate_bind(invoke, 4004, "callgraph_e4") == BIND_PERMIT_SOFT);
+    }
 }
 
 void

--- a/tests/sample/callgraph_bpf2bpf.c
+++ b/tests/sample/callgraph_bpf2bpf.c
@@ -25,6 +25,8 @@
 // - One subprogram for map operations: update_map.
 //   - Calls bpf_get_current_pid_tgid, bpf_map_lookup_elem, bpf_map_update_elem.
 //   - entry_program3 invokes update_map.
+// - One subprogram for stack-frame isolation: stack_frame_test.
+//   - entry_program4 verifies that the caller's stack value survives the call.
 
 #include "bpf_helpers.h"
 #include "ebpf_nethooks.h"
@@ -51,6 +53,9 @@ ScenarioS4(uint64_t* pid);
 
 int
 update_map(uint64_t* pid_ptr);
+
+uint64_t
+stack_frame_test(uint64_t value);
 
 __attribute__((noinline)) bind_action_t __attribute__((optnone))
 ScenarioS3(uint64_t* pid)
@@ -117,6 +122,13 @@ update_map(uint64_t* pid_ptr)
     }
 }
 
+__attribute__((noinline)) uint64_t __attribute__((optnone))
+stack_frame_test(uint64_t value)
+{
+    uint64_t callee_value = value + 1;
+    return callee_value;
+}
+
 SEC("bind/1")
 bind_action_t
 entry_program1(bind_md_t* ctx)
@@ -170,4 +182,19 @@ entry_program3(bind_md_t* ctx)
     }
 
     return BIND_PERMIT_SOFT;
+}
+
+SEC("bind/4")
+bind_action_t
+entry_program4(bind_md_t* ctx)
+{
+    (void)ctx;
+    volatile uint64_t caller_value = 0x1234;
+    uint64_t callee_result = stack_frame_test(caller_value);
+
+    if (caller_value == 0x1234 && callee_result == 0x1235) {
+        return BIND_PERMIT_SOFT;
+    }
+
+    return BIND_DENY;
 }

--- a/tests/sample/callgraph_bpf2bpf.c
+++ b/tests/sample/callgraph_bpf2bpf.c
@@ -25,8 +25,6 @@
 // - One subprogram for map operations: update_map.
 //   - Calls bpf_get_current_pid_tgid, bpf_map_lookup_elem, bpf_map_update_elem.
 //   - entry_program3 invokes update_map.
-// - One subprogram for stack-frame isolation: stack_frame_test.
-//   - entry_program4 verifies that the caller's stack value survives the call.
 
 #include "bpf_helpers.h"
 #include "ebpf_nethooks.h"
@@ -53,9 +51,6 @@ ScenarioS4(uint64_t* pid);
 
 int
 update_map(uint64_t* pid_ptr);
-
-uint64_t
-stack_frame_test(uint64_t value);
 
 __attribute__((noinline)) bind_action_t __attribute__((optnone))
 ScenarioS3(uint64_t* pid)
@@ -122,13 +117,6 @@ update_map(uint64_t* pid_ptr)
     }
 }
 
-__attribute__((noinline)) uint64_t __attribute__((optnone))
-stack_frame_test(uint64_t value)
-{
-    uint64_t callee_value = value + 1;
-    return callee_value;
-}
-
 SEC("bind/1")
 bind_action_t
 entry_program1(bind_md_t* ctx)
@@ -182,19 +170,4 @@ entry_program3(bind_md_t* ctx)
     }
 
     return BIND_PERMIT_SOFT;
-}
-
-SEC("bind/4")
-bind_action_t
-entry_program4(bind_md_t* ctx)
-{
-    (void)ctx;
-    volatile uint64_t caller_value = 0x1234;
-    uint64_t callee_result = stack_frame_test(caller_value);
-
-    if (caller_value == 0x1234 && callee_result == 0x1235) {
-        return BIND_PERMIT_SOFT;
-    }
-
-    return BIND_DENY;
 }

--- a/tests/sample/undocked/bpf2bpf_loop.c
+++ b/tests/sample/undocked/bpf2bpf_loop.c
@@ -37,3 +37,20 @@ caller_with_loop(sample_program_context_t* ctx)
     bpf_map_update_elem(&bpf2bpf_loop_map, &key, &counter, 0);
     return counter;
 }
+
+__attribute__((noinline)) uint64_t
+stack_frame_test(uint64_t value)
+{
+    return value + 1;
+}
+
+SEC("sample_ext")
+int
+stack_frame_test_entry(sample_program_context_t* ctx)
+{
+    (void)ctx;
+    volatile uint64_t caller_value = 0x1234;
+    uint64_t callee_result = stack_frame_test(caller_value);
+
+    return caller_value == 0x1234 && callee_result == 0x1235 ? 0 : 1;
+}

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -28,6 +28,7 @@
 #pragma warning(pop)
 
 #include <windows.h>
+#include <algorithm>
 #include <cassert>
 #include <format>
 #include <iomanip>
@@ -1043,6 +1044,42 @@ bpf_code_generator::get_reachable_subprograms(const unsafe_string& entry_name) c
     return reachable;
 }
 
+size_t
+bpf_code_generator::get_maximum_call_depth(const unsafe_string& entry_name) const
+{
+    std::map<unsafe_string, size_t> maximum_depths;
+    std::set<unsafe_string> active_calls;
+    std::function<size_t(const unsafe_string&)> calculate_depth = [&](const unsafe_string& program_name) {
+        if (const auto it = maximum_depths.find(program_name); it != maximum_depths.end()) {
+            return it->second;
+        }
+        if (!active_calls.insert(program_name).second) {
+            throw bpf_code_generator_exception("recursive local function call");
+        }
+
+        const auto program = programs.find(program_name);
+        if (program == programs.end()) {
+            throw bpf_code_generator_exception("local function call target not found");
+        }
+
+        size_t maximum_depth = 1;
+        for (const auto& instruction : program->second.output_instructions) {
+            if (instruction.instruction.opcode == INST_OP_CALL && instruction.instruction.src == INST_CALL_LOCAL) {
+                if (instruction.relocation.empty()) {
+                    throw bpf_code_generator_exception("local function call target not found");
+                }
+                maximum_depth = std::max(maximum_depth, 1 + calculate_depth(instruction.relocation));
+            }
+        }
+
+        active_calls.erase(program_name);
+        maximum_depths.emplace(program_name, maximum_depth);
+        return maximum_depth;
+    };
+
+    return calculate_depth(entry_name);
+}
+
 void
 bpf_code_generator::build_global_helper_index()
 {
@@ -2006,7 +2043,9 @@ bpf_code_generator::bpf_code_generator_program::encode_instructions(
                 output.lines.push_back(
                     get_register_name(0) + " = " + function_name + "(" + get_register_name(1) + ", " +
                     get_register_name(2) + ", " + get_register_name(3) + ", " + get_register_name(4) + ", " +
-                    get_register_name(5) + ", " + get_register_name(10) + ", context, runtime_context);");
+                    get_register_name(5) + ", " + get_register_name(10) +
+                    " - UBPF_STACK_SIZE, context, "
+                    "runtime_context);");
             } else if (inst.opcode == INST_OP_EXIT) {
                 output.lines.push_back("return " + get_register_name(0) + ";");
             } else {
@@ -2582,7 +2621,11 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         program.get_register_name(1);
         program.get_register_name(10);
         output_stream << prolog_line_info << INDENT "// Prologue." << std::endl;
-        output_stream << prolog_line_info << INDENT "uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];" << std::endl;
+        const size_t maximum_call_depth = get_maximum_call_depth(program_name);
+        const std::string stack_size = maximum_call_depth == 1
+                                           ? "UBPF_STACK_SIZE"
+                                           : "(UBPF_STACK_SIZE * " + std::to_string(maximum_call_depth) + ")";
+        output_stream << prolog_line_info << INDENT "uint64_t stack[(" << stack_size << " + 7) / 8];" << std::endl;
         for (const auto& r : _register_names) {
             // Skip unused registers.
             if (program.referenced_registers.find(r) == program.referenced_registers.end()) {

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -1054,19 +1054,19 @@ bpf_code_generator::get_maximum_call_depth(const unsafe_string& entry_name) cons
             return it->second;
         }
         if (!active_calls.insert(program_name).second) {
-            throw bpf_code_generator_exception("recursive local function call");
+            throw bpf_code_generator_exception("recursive local function call: " + program_name.raw());
         }
 
         const auto program = programs.find(program_name);
         if (program == programs.end()) {
-            throw bpf_code_generator_exception("local function call target not found");
+            throw bpf_code_generator_exception("local function call target not found: " + program_name.raw());
         }
 
         size_t maximum_depth = 1;
         for (const auto& instruction : program->second.output_instructions) {
             if (instruction.instruction.opcode == INST_OP_CALL && instruction.instruction.src == INST_CALL_LOCAL) {
                 if (instruction.relocation.empty()) {
-                    throw bpf_code_generator_exception("local function call target not found");
+                    throw bpf_code_generator_exception("local function call target not found: " + program_name.raw());
                 }
                 maximum_depth = std::max(maximum_depth, 1 + calculate_depth(instruction.relocation));
             }

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -572,6 +572,15 @@ class bpf_code_generator
     std::set<unsafe_string>
     get_reachable_subprograms(const unsafe_string& entry_name) const;
 
+    /**
+     * @brief Get the maximum stack-frame depth reachable from an entry program.
+     *
+     * @param[in] entry_name Name of the entry program.
+     * @return Maximum number of BPF stack frames, including the entry program.
+     */
+    size_t
+    get_maximum_call_depth(const unsafe_string& entry_name) const;
+
     int pe_section_name_counter{};
     std::map<unsafe_string, bpf_code_generator_program> programs;
     ELFIO::elfio reader;


### PR DESCRIPTION
## Description

Fixes #5508

bpf2c now determines the maximum reachable BPF-to-BPF call-frame depth for each entry program, allocates that many 512-byte stack frames, and passes a decremented r10 to each local callee. This isolates caller and callee stack slots.

## Testing

- `bpf2c_tests.exe "call_local_use_stack_native"`
- `bpf2c_tests.exe "[elf_bpf_code_gen]"`

The existing local-call stack-isolation regression fixture is now exercised by bpf2c.

## Documentation

No documentation impact.

## Installation

No installer impact.