### PR TITLE
fix(ci): retry OpenCppCoverage install and fail if binary missing

### DIFF
--- a/.azure/reusable-test.yml
+++ b/.azure/reusable-test.yml
@@ -117,21 +117,44 @@ jobs:
         displayName: 'Install ProcDump'
 
       - powershell: |
+          $ErrorActionPreference = 'Stop'
           $curlDependencies = Get-Content "$(Build.SourcesDirectory)\.github\curl-dependencies.json" | ConvertFrom-Json
           $version = $curlDependencies.opencppcoverage.version
           $expectedHash = $curlDependencies.opencppcoverage.hash
           $versionNumber = $version -replace '^release-', ''
           $url = "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/$version/OpenCppCoverageSetup-x64-$versionNumber.exe"
           $setupPath = "$(Build.SourcesDirectory)\OpenCppCoverageSetup.exe"
-          & $(Build.SourcesDirectory)\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $setupPath -ExpectedHash $expectedHash
-          $process = Start-Process -FilePath $setupPath -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART' -Wait -PassThru
-          if ($process.ExitCode -ne 0) { throw "OpenCppCoverage installer failed with exit code $($process.ExitCode)" }
-          Remove-Item -Path $setupPath -Force
-          echo '##vso[task.prependpath]C:\Program Files\OpenCppCoverage'
-          if (-not (Test-Path "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe")) { throw "OpenCppCoverage install failed" }
+          $installDir = "C:\Program Files\OpenCppCoverage"
+          $installExe = Join-Path $installDir "OpenCppCoverage.exe"
+          $maxInstallAttempts = 3
+          $installed = $false
+          for ($attempt = 1; $attempt -le $maxInstallAttempts; $attempt++) {
+            Write-Host "OpenCppCoverage install attempt $attempt of $maxInstallAttempts"
+            & $(Build.SourcesDirectory)\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $setupPath -ExpectedHash $expectedHash
+            $process = Start-Process -FilePath $setupPath -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/SP-' -Wait -PassThru
+            if ($null -eq $process) {
+              Write-Warning "OpenCppCoverage installer did not start (attempt $attempt)"
+            } elseif ($process.ExitCode -ne 0) {
+              Write-Warning "OpenCppCoverage installer exit code $($process.ExitCode) (attempt $attempt)"
+            }
+            if (Test-Path $installExe) {
+              $installed = $true
+              break
+            }
+            if ($attempt -lt $maxInstallAttempts) {
+              Start-Sleep -Seconds (5 * $attempt)
+            }
+          }
+          if (Test-Path $setupPath) { Remove-Item -Path $setupPath -Force -ErrorAction SilentlyContinue }
+          if (-not $installed) {
+            throw "OpenCppCoverage install failed after $maxInstallAttempts attempt(s): $installExe not found"
+          }
+          echo "##vso[task.prependpath]$installDir"
+          Write-Host "OpenCppCoverage installed at $installExe"
         condition: and(eq('${{parameters.code_coverage}}', 'true'), ne('${{parameters.environment}}', 'ebpf_cicd_tests'))
         name: set_up_opencppcoverage
         displayName: 'Set up OpenCppCoverage and add to PATH'
+
 
       - bash: |
           echo "*** All environment variables ***"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -162,19 +162,42 @@ jobs:
       - name: Set up OpenCppCoverage and add to PATH
         id: set_up_opencppcoverage
         if: (inputs.code_coverage == true) && (!contains(inputs.environment, 'ebpf_cicd') && !contains(inputs.environment, '1ES')) && (steps.skip_check.outputs.should_skip != 'true')
+        shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           $curlDependencies = Get-Content "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
           $version = $curlDependencies.opencppcoverage.version
           $expectedHash = $curlDependencies.opencppcoverage.hash
           $versionNumber = $version -replace '^release-', ''
           $url = "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/$version/OpenCppCoverageSetup-x64-$versionNumber.exe"
           $setupPath = "${{github.workspace}}\OpenCppCoverageSetup.exe"
-          & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $setupPath -ExpectedHash $expectedHash
-          $process = Start-Process -FilePath $setupPath -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART' -Wait -PassThru
-          if ($process.ExitCode -ne 0) { throw "OpenCppCoverage installer failed with exit code $($process.ExitCode)" }
-          Remove-Item -Path $setupPath -Force
-          echo "C:\Program Files\OpenCppCoverage" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          if (-not (Test-Path "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe")) { throw "OpenCppCoverage install failed" }
+          $installDir = "C:\Program Files\OpenCppCoverage"
+          $installExe = Join-Path $installDir "OpenCppCoverage.exe"
+          $maxInstallAttempts = 3
+          $installed = $false
+          for ($attempt = 1; $attempt -le $maxInstallAttempts; $attempt++) {
+            Write-Host "OpenCppCoverage install attempt $attempt of $maxInstallAttempts"
+            & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $setupPath -ExpectedHash $expectedHash
+            $process = Start-Process -FilePath $setupPath -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/SP-' -Wait -PassThru
+            if ($null -eq $process) {
+              Write-Warning "OpenCppCoverage installer did not start (attempt $attempt)"
+            } elseif ($process.ExitCode -ne 0) {
+              Write-Warning "OpenCppCoverage installer exit code $($process.ExitCode) (attempt $attempt)"
+            }
+            if (Test-Path $installExe) {
+              $installed = $true
+              break
+            }
+            if ($attempt -lt $maxInstallAttempts) {
+              Start-Sleep -Seconds (5 * $attempt)
+            }
+          }
+          if (Test-Path $setupPath) { Remove-Item -Path $setupPath -Force -ErrorAction SilentlyContinue }
+          if (-not $installed) {
+            throw "OpenCppCoverage install failed after $maxInstallAttempts attempt(s): $installExe not found"
+          }
+          echo $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host "OpenCppCoverage installed at $installExe"
 
       - name: Configure Windows Error Reporting to make a local copy of any crashes that occur.
         id: configure_windows_error_reporting


### PR DESCRIPTION
## Summary
- Retry OpenCppCoverage download+silent install up to 3 times (transient failures).
- Set $ErrorActionPreference = 'Stop' and only succeed when OpenCppCoverage.exe is present.
- Apply the same hardening on GitHub Actions and Azure Pipelines reusable test templates.

## Test plan
- [ ] CI unit_tests / coverage job installs OpenCppCoverage successfully
- [ ] Forced install failure surfaces as a failed step (not green)

Fixes #5330