### PR TITLE
Separate flow classify hook requirements

### DIFF
--- a/docs/FlowClassifyHook.md
+++ b/docs/FlowClassifyHook.md
@@ -1,19 +1,21 @@
 
 # EBPF for Windows Stream Inspection Hook
 
+> **Status:** This proposal predates the expanded
+> [flow classification hook requirements](FlowClassifyHookRequirements.md). The design below will be revised in
+> follow-up work to satisfy them; it currently describes the original stream-only design.
 
 ## Contents
 
 1. [Purpose](#purpose)
-2. [Requirements](#requirements)
-3. [Alternative - Using existing Linux hooks](#alternative---using-existing-linux-hooks)
-4. [eBPF Design](#ebpf-design)
+2. [Alternative - Using existing Linux hooks](#alternative---using-existing-linux-hooks)
+3. [eBPF Design](#ebpf-design)
     - [Program Type](#program-type)
     - [Hook](#hook)
-5. [Architecture](#architecture)
+4. [Architecture](#architecture)
     - [Hook Integration and Flow](#hook-integration-and-flow)
     - [Stream Hook Lifecycle](#stream-hook-lifecycle)
-6. [WFP Implementation Details](#wfp-implementation-details)
+5. [WFP Implementation Details](#wfp-implementation-details)
 
 
 ---
@@ -24,23 +26,6 @@ Support an eBPF interface to support inspecting TCP stream data and then based o
 
 The new hooks will support security and observability related solutions that require parsing TCP stream data
 without incurring overhead for flows that can be ignored.
-
-## Requirements
-
-- Hook that allows choosing whether to classify a newly established TCP connection at the stream layer.
-- Hook that receives each stream layer data segment in-order for both ingress and egress traffic.
-  - 3 possible actions:
-    - Allow the connection and stop being invoked for this flow.
-    - Block the connection (no further invocations for this flow).
-    - Allow the segment but keep getting invoked for further data segments (need more data to classify).
-- Hook that supports cleanup of flows that were closed while still being classified.
-- No eBPF programs should be invoked for segments on flows not needing stream layer classification.
-- Multiple programs can be attached to the stream layer classify hooks at once.
-  - Each program will be invoked in attached order until the flow is blocked or the program has allowed the flow.
-- After a flow is allowed/blocked, there should be no further invocations of that program for the flow.
-  - If the flow is blocked, no further stream-layer eBPF programs will be invoked for the flow.
-  - If the flow is allowed, other stream layer programs that are still classifying the flow will continue to be invoked.
-- We do not currently need any stream mutation support for these hooks -- only inline inspect/allow/block.
 
 ## Alternative - Using existing Linux hooks
 

--- a/docs/FlowClassifyHookRequirements.md
+++ b/docs/FlowClassifyHookRequirements.md
@@ -1,0 +1,44 @@
+<!-- Copyright (c) eBPF for Windows contributors -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# eBPF for Windows Flow Classification Hook Requirements
+
+## Purpose
+
+Define the behavior required to classify network flows by inspecting transport payloads. The
+[current design proposal](FlowClassifyHook.md) describes the original stream-only design and will be updated separately
+to satisfy these requirements.
+
+## Traffic Coverage and Selection
+
+- Support flow classification for TCP streams and datagrams, including UDP.
+- Allow a program to select, per flow, whether payload classification is needed.
+- Allow classification in the ingress direction, egress direction, or both.
+- Do not invoke a classifier for unselected flows or directions.
+
+## Payload Delivery and Access
+
+- Deliver TCP stream data in order and preserve datagram boundaries.
+- Provide payload metadata and total length without requiring the full payload to be copied into contiguous memory.
+- Allow a classifier to request only the payload bytes it needs, deferring any required copy until that request.
+
+## Classification and Lifecycle
+
+- Support these synchronous results:
+  - **Allow** the flow and stop invoking the returning program for it.
+  - **Block** the flow and stop invoking all classifiers for it.
+  - **Need more data** by allowing the current payload and invoking the returning program for later payloads.
+- Allow a classifier to pend a flow so that an external component can be notified and complete classification
+  asynchronously.
+- Notify a classifier when a flow that it is still classifying is deleted so that per-flow state can be cleaned up.
+
+## Multiple Programs
+
+- Allow multiple programs to classify the same flow.
+- Invoke programs in attachment order until a program blocks the flow.
+- When a program allows a flow, stop invoking that program while continuing to invoke other programs that still need
+  data.
+
+## Scope
+
+Payload mutation, flow re-authorization, and redirection are out of scope.

--- a/docs/FlowClassifyHookRequirements.md
+++ b/docs/FlowClassifyHookRequirements.md
@@ -16,10 +16,23 @@ to satisfy these requirements.
 - Allow classification in the ingress direction, egress direction, or both.
 - Do not invoke a classifier for unselected flows or directions.
 
+## Flow Metadata
+
+Make the following metadata accessible when selecting or classifying a flow:
+
+- IP address family and local and remote IPv4 or IPv6 addresses.
+- Transport protocol and applicable protocol-specific metadata, including local and remote ports for TCP and UDP and
+  type and code for ICMP and ICMPv6.
+- Network compartment and interface identifiers.
+- Direction of the current payload and whether it is stream data or a datagram.
+- A stable flow identifier for correlating establishment, payload, deletion, and asynchronous completion events.
+- The lifecycle event represented by the invocation, including establishment, payload delivery, and deletion.
+- An unambiguous indication of which optional metadata is valid.
+
 ## Payload Delivery and Access
 
 - Deliver TCP stream data in order and preserve datagram boundaries.
-- Provide payload metadata and total length without requiring the full payload to be copied into contiguous memory.
+- Provide the total payload length without requiring the full payload to be copied into contiguous memory.
 - Allow a classifier to request only the payload bytes it needs, deferring any required copy until that request.
 
 ## Classification and Lifecycle


### PR DESCRIPTION
## Description

Separates flow classify hook requirements from the existing stream-only design proposal and expands them to cover datagram classification, on-demand payload access, traffic-direction selection, and asynchronous pending flows.

The design proposal is otherwise unchanged and marked for a follow-up update.

Closes #5513

## Testing

N/A (documentation only).

## Documentation

Adds `docs/FlowClassifyHookRequirements.md` and updates `docs/FlowClassifyHook.md`.

## Installation

N/A