### PR TITLE
Fail setup on DuoNic installation errors

### DIFF
--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -282,7 +282,8 @@ function Install-eBPFComponentsOnVM
         [parameter(Mandatory=$true)][bool] $KmTracing,
         [parameter(Mandatory=$true)][string] $KmTraceType,
         [Parameter(Mandatory=$false)][bool] $VMIsRemote = $false,
-        [parameter(Mandatory=$false)][bool] $GranularTracing = $false
+        [parameter(Mandatory=$false)][bool] $GranularTracing = $false,
+        [parameter(Mandatory=$false)][bool] $TraceAlreadyStarted = $false
     )
 
     Write-Log "Installing eBPF components on $VMName"
@@ -294,15 +295,16 @@ function Install-eBPFComponentsOnVM
               [Parameter(Mandatory=$true)] [bool] $KmTracing,
               [Parameter(Mandatory=$true)] [string] $KmTraceType,
               [parameter(Mandatory=$true)][string] $TestMode,
-              [parameter(Mandatory=$false)][bool] $GranularTracing = $false)
+              [parameter(Mandatory=$false)][bool] $GranularTracing = $false,
+              [parameter(Mandatory=$false)][bool] $TraceAlreadyStarted = $false)
         $WorkingDirectory = "$env:SystemDrive\$WorkingDirectory"
         Import-Module $WorkingDirectory\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
         Import-Module $WorkingDirectory\install_ebpf.psm1 -ArgumentList ($WorkingDirectory, $LogFileName) -Force -WarningAction SilentlyContinue
 
-        Install-eBPFComponents -KmTracing $KmTracing -KmTraceType $KmTraceType -KMDFVerifier $true -TestMode $TestMode -GranularTracing $GranularTracing -ErrorAction Stop
+        Install-eBPFComponents -KmTracing $KmTracing -KmTraceType $KmTraceType -KMDFVerifier $true -TestMode $TestMode -GranularTracing $GranularTracing -TraceAlreadyStarted $TraceAlreadyStarted -ErrorAction Stop
     }
 
-    Invoke-CommandOnVM -VMName $VMName -Credential $TestCredential -VMIsRemote $VMIsRemote -ScriptBlock $scriptBlock -ArgumentList  ("eBPF", $LogFileName, $KmTracing, $KmTraceType, $TestMode, $GranularTracing) -ErrorAction Stop
+    Invoke-CommandOnVM -VMName $VMName -Credential $TestCredential -VMIsRemote $VMIsRemote -ScriptBlock $scriptBlock -ArgumentList  ("eBPF", $LogFileName, $KmTracing, $KmTraceType, $TestMode, $GranularTracing, $TraceAlreadyStarted) -ErrorAction Stop
 
     Write-Log "eBPF components installed on $VMName" -ForegroundColor Green
 }
@@ -711,15 +713,23 @@ function Initialize-NetworkInterfaces {
         [Parameter(Mandatory=$false)][bool] $ExecuteOnVM = $false,
         [Parameter(Mandatory=$false)] $VMList = @(),
         [Parameter(Mandatory=$true)][string] $TestWorkingDirectory,
-        [Parameter(Mandatory=$false)][bool] $VMIsRemote = $false
+        [Parameter(Mandatory=$false)][bool] $VMIsRemote = $false,
+        [Parameter(Mandatory=$false)][bool] $KmTracing = $false,
+        [Parameter(Mandatory=$false)][string] $KmTraceType = "file"
     )
 
     $commandScriptBlock = {
         param([Parameter(Mandatory=$true)] [string] $WorkingDirectory,
-              [Parameter(Mandatory=$true)][string] $LogFileName)
+              [Parameter(Mandatory=$true)][string] $LogFileName,
+              [Parameter(Mandatory=$true)][bool] $KmTracing,
+              [Parameter(Mandatory=$true)][string] $KmTraceType)
         Push-Location $WorkingDirectory
         try {
             Import-Module .\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
+            if ($KmTracing) {
+                Import-Module .\tracing_utils.psm1 -ArgumentList ($LogFileName, $WorkingDirectory) -Force -WarningAction SilentlyContinue
+                Start-WPRTrace -TraceType $KmTraceType -FailOnError
+            }
             Write-Log "Installing DuoNic driver"
             $LASTEXITCODE = 0
             .\duonic.ps1 -Install -NumNicPairs 2
@@ -732,7 +742,7 @@ function Initialize-NetworkInterfaces {
         }
     }
 
-    $argumentList = @($TestWorkingDirectory, $LogFileName)
+    $argumentList = @($TestWorkingDirectory, $LogFileName, $KmTracing, $KmTraceType)
 
     if ($ExecuteOnVM) {
         # Execute on VMs.

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -718,11 +718,18 @@ function Initialize-NetworkInterfaces {
         param([Parameter(Mandatory=$true)] [string] $WorkingDirectory,
               [Parameter(Mandatory=$true)][string] $LogFileName)
         Push-Location $WorkingDirectory
-        Import-Module .\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
-        Write-Log "Installing DuoNic driver"
-        .\duonic.ps1 -Install -NumNicPairs 2
-        Set-NetAdapterAdvancedProperty duo? -DisplayName Checksum -RegistryValue 0
-        Pop-Location
+        try {
+            Import-Module .\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
+            Write-Log "Installing DuoNic driver"
+            $LASTEXITCODE = 0
+            .\duonic.ps1 -Install -NumNicPairs 2
+            if ($LASTEXITCODE -ne 0) {
+                throw "DuoNic installation failed with exit code $LASTEXITCODE."
+            }
+            Set-NetAdapterAdvancedProperty duo? -DisplayName Checksum -RegistryValue 0
+        } finally {
+            Pop-Location
+        }
     }
 
     $argumentList = @($TestWorkingDirectory, $LogFileName)

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -282,8 +282,7 @@ function Install-eBPFComponentsOnVM
         [parameter(Mandatory=$true)][bool] $KmTracing,
         [parameter(Mandatory=$true)][string] $KmTraceType,
         [Parameter(Mandatory=$false)][bool] $VMIsRemote = $false,
-        [parameter(Mandatory=$false)][bool] $GranularTracing = $false,
-        [parameter(Mandatory=$false)][bool] $TraceAlreadyStarted = $false
+        [parameter(Mandatory=$false)][bool] $GranularTracing = $false
     )
 
     Write-Log "Installing eBPF components on $VMName"
@@ -295,16 +294,15 @@ function Install-eBPFComponentsOnVM
               [Parameter(Mandatory=$true)] [bool] $KmTracing,
               [Parameter(Mandatory=$true)] [string] $KmTraceType,
               [parameter(Mandatory=$true)][string] $TestMode,
-              [parameter(Mandatory=$false)][bool] $GranularTracing = $false,
-              [parameter(Mandatory=$false)][bool] $TraceAlreadyStarted = $false)
+              [parameter(Mandatory=$false)][bool] $GranularTracing = $false)
         $WorkingDirectory = "$env:SystemDrive\$WorkingDirectory"
         Import-Module $WorkingDirectory\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
         Import-Module $WorkingDirectory\install_ebpf.psm1 -ArgumentList ($WorkingDirectory, $LogFileName) -Force -WarningAction SilentlyContinue
 
-        Install-eBPFComponents -KmTracing $KmTracing -KmTraceType $KmTraceType -KMDFVerifier $true -TestMode $TestMode -GranularTracing $GranularTracing -TraceAlreadyStarted $TraceAlreadyStarted -ErrorAction Stop
+        Install-eBPFComponents -KmTracing $KmTracing -KmTraceType $KmTraceType -KMDFVerifier $true -TestMode $TestMode -GranularTracing $GranularTracing -ErrorAction Stop
     }
 
-    Invoke-CommandOnVM -VMName $VMName -Credential $TestCredential -VMIsRemote $VMIsRemote -ScriptBlock $scriptBlock -ArgumentList  ("eBPF", $LogFileName, $KmTracing, $KmTraceType, $TestMode, $GranularTracing, $TraceAlreadyStarted) -ErrorAction Stop
+    Invoke-CommandOnVM -VMName $VMName -Credential $TestCredential -VMIsRemote $VMIsRemote -ScriptBlock $scriptBlock -ArgumentList  ("eBPF", $LogFileName, $KmTracing, $KmTraceType, $TestMode, $GranularTracing) -ErrorAction Stop
 
     Write-Log "eBPF components installed on $VMName" -ForegroundColor Green
 }
@@ -723,12 +721,14 @@ function Initialize-NetworkInterfaces {
               [Parameter(Mandatory=$true)][string] $LogFileName,
               [Parameter(Mandatory=$true)][bool] $KmTracing,
               [Parameter(Mandatory=$true)][string] $KmTraceType)
+        $traceStarted = $false
         Push-Location $WorkingDirectory
         try {
             Import-Module .\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
             if ($KmTracing) {
                 Import-Module .\tracing_utils.psm1 -ArgumentList ($LogFileName, $WorkingDirectory) -Force -WarningAction SilentlyContinue
                 Start-WPRTrace -TraceType $KmTraceType -FailOnError
+                $traceStarted = $true
             }
             Write-Log "Installing DuoNic driver"
             $LASTEXITCODE = 0
@@ -738,7 +738,13 @@ function Initialize-NetworkInterfaces {
             }
             Set-NetAdapterAdvancedProperty duo? -DisplayName Checksum -RegistryValue 0
         } finally {
-            Pop-Location
+            try {
+                if ($traceStarted) {
+                    Stop-WPRTrace -FileName "initialize_network_interfaces"
+                }
+            } finally {
+                Pop-Location
+            }
         }
     }
 

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -191,15 +191,14 @@ function Install-eBPFComponents
           [parameter(Mandatory=$false)] [bool] $KMDFVerifier = $false,
           [parameter(Mandatory=$true)] [string] $TestMode,
           [parameter(Mandatory=$false)] [switch] $SkipRebootOperations,
-          [parameter(Mandatory=$false)] [bool] $GranularTracing = $false,
-          [parameter(Mandatory=$false)] [bool] $TraceAlreadyStarted = $false)
+          [parameter(Mandatory=$false)] [bool] $GranularTracing = $false)
 
     # Print the status of the eBPF drivers and services before installation.
     # This is useful for detecting issues with the runner baselines.
     Print-eBPFComponentsStatus "Querying the status of eBPF drivers and services before the installation (none should be present)..." | Out-Null
 
     # Start granular tracing before installation if enabled.
-    if ($GranularTracing -and -not $TraceAlreadyStarted) {
+    if ($GranularTracing) {
         Start-WPRTrace -KmTracing $KmTracing -KmTraceType $KmTraceType
     }
 
@@ -384,7 +383,7 @@ function Install-eBPFComponents
 
     if ($GranularTracing) {
         Stop-WPRTrace -FileName "install_ebpf"
-    } elseif (-not $TraceAlreadyStarted) {
+    } else {
         # Start regular KM tracing if not using granular tracing
         Start-WPRTrace -KmTracing $KmTracing -KmTraceType $KmTraceType
     }

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -191,14 +191,15 @@ function Install-eBPFComponents
           [parameter(Mandatory=$false)] [bool] $KMDFVerifier = $false,
           [parameter(Mandatory=$true)] [string] $TestMode,
           [parameter(Mandatory=$false)] [switch] $SkipRebootOperations,
-          [parameter(Mandatory=$false)] [bool] $GranularTracing = $false)
+          [parameter(Mandatory=$false)] [bool] $GranularTracing = $false,
+          [parameter(Mandatory=$false)] [bool] $TraceAlreadyStarted = $false)
 
     # Print the status of the eBPF drivers and services before installation.
     # This is useful for detecting issues with the runner baselines.
     Print-eBPFComponentsStatus "Querying the status of eBPF drivers and services before the installation (none should be present)..." | Out-Null
 
     # Start granular tracing before installation if enabled.
-    if ($GranularTracing) {
+    if ($GranularTracing -and -not $TraceAlreadyStarted) {
         Start-WPRTrace -KmTracing $KmTracing -KmTraceType $KmTraceType
     }
 
@@ -383,7 +384,7 @@ function Install-eBPFComponents
 
     if ($GranularTracing) {
         Stop-WPRTrace -FileName "install_ebpf"
-    } else {
+    } elseif (-not $TraceAlreadyStarted) {
         # Start regular KM tracing if not using granular tracing
         Start-WPRTrace -KmTracing $KmTracing -KmTraceType $KmTraceType
     }

--- a/scripts/setup_ebpf_cicd_tests.ps1
+++ b/scripts/setup_ebpf_cicd_tests.ps1
@@ -125,7 +125,7 @@ $Job = Start-Job -ScriptBlock {
         # Install eBPF components on host, but skip anything that requires reboot.
         # Note that installing ebpf components requires psexec which does not run in a powershell job.
         Write-Log "Installing eBPF components on host"
-        Install-eBPFComponents -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -SkipRebootOperations -GranularTracing:$GranularTracing -TraceAlreadyStarted:$KmTracing
+        Install-eBPFComponents -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -SkipRebootOperations -GranularTracing:$GranularTracing
         return
     }
 
@@ -137,7 +137,7 @@ $Job = Start-Job -ScriptBlock {
     # Install eBPF Components on the test VM.
     foreach($VM in $VMList) {
         $VMName = $VM.Name
-        Install-eBPFComponentsOnVM -VMName $VMName -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -VMIsRemote:$VMIsRemote -GranularTracing:$GranularTracing -TraceAlreadyStarted:$KmTracing -ErrorAction Stop
+        Install-eBPFComponentsOnVM -VMName $VMName -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -VMIsRemote:$VMIsRemote -GranularTracing:$GranularTracing -ErrorAction Stop
     }
 
     # Log OS build information on the test VMs.

--- a/scripts/setup_ebpf_cicd_tests.ps1
+++ b/scripts/setup_ebpf_cicd_tests.ps1
@@ -114,6 +114,8 @@ $Job = Start-Job -ScriptBlock {
         -VMList $VMList `
         -TestWorkingDirectory $(if ($ExecuteOnVM) { "C:\ebpf" } else { $WorkingDirectory }) `
         -VMIsRemote:$VMIsRemote `
+        -KmTracing $KmTracing `
+        -KmTraceType $KmTraceType `
         -ErrorAction Stop
 
     Write-Log "Network interfaces initialized"
@@ -123,7 +125,7 @@ $Job = Start-Job -ScriptBlock {
         # Install eBPF components on host, but skip anything that requires reboot.
         # Note that installing ebpf components requires psexec which does not run in a powershell job.
         Write-Log "Installing eBPF components on host"
-        Install-eBPFComponents -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -SkipRebootOperations -GranularTracing:$GranularTracing
+        Install-eBPFComponents -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -SkipRebootOperations -GranularTracing:$GranularTracing -TraceAlreadyStarted:$KmTracing
         return
     }
 
@@ -135,7 +137,7 @@ $Job = Start-Job -ScriptBlock {
     # Install eBPF Components on the test VM.
     foreach($VM in $VMList) {
         $VMName = $VM.Name
-        Install-eBPFComponentsOnVM -VMName $VMName -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -VMIsRemote:$VMIsRemote -GranularTracing:$GranularTracing -ErrorAction Stop
+        Install-eBPFComponentsOnVM -VMName $VMName -TestMode $TestMode -KmTracing $KmTracing -KmTraceType $KmTraceType -VMIsRemote:$VMIsRemote -GranularTracing:$GranularTracing -TraceAlreadyStarted:$KmTracing -ErrorAction Stop
     }
 
     # Log OS build information on the test VMs.

--- a/scripts/tracing_utils.psm1
+++ b/scripts/tracing_utils.psm1
@@ -28,7 +28,8 @@ function Start-WPRTrace {
         [Parameter(Mandatory=$false)] [string] $TraceType = "file",
         [Parameter(Mandatory=$false)] [string] $WprpFileName = "ebpfforwindows.wprp",
         [Parameter(Mandatory=$false)] [string] $TracingProfileName = "EbpfForWindows-Networking",
-        [Parameter(Mandatory=$false)] [int] $TimeoutSeconds = 60
+        [Parameter(Mandatory=$false)] [int] $TimeoutSeconds = 60,
+        [Parameter(Mandatory=$false)] [switch] $FailOnError
     )
 
     try {
@@ -58,9 +59,15 @@ function Start-WPRTrace {
             Write-Log "Successfully started trace"
         } else {
             Write-Log "Failed to start trace with exit code $exitCode"
+            if ($FailOnError) {
+                throw "Failed to start WPR trace with exit code $exitCode."
+            }
         }
     } catch {
         Write-Log "Exception starting WPR trace: $_" -ForegroundColor Red
+        if ($FailOnError) {
+            throw
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Fail CI setup when `duonic.ps1` returns a nonzero exit code so the workflow proceeds to post-test cleanup instead of continuing with an invalid network configuration.


Start the `EbpfForWindows-Networking` WPR profile on the target host or VM before DuoNic installation. This captures `Microsoft-Windows-TCPIP` events when installation fails and allows cleanup to stop and collect the trace.

This will help debugging transient errors in the duonic installation which cause pipeline to fail . Closes #5522

## Testing

CI/CD

## Documentation

NA

## Installation

NA